### PR TITLE
Add party mode entities to Music Assistant integration

### DIFF
--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -297,10 +297,6 @@ async def async_setup_entry(  # noqa: C901
         if current_instance_id and not party_mode_state["instance_id"]:
             party_mode_state["instance_id"] = current_instance_id
             add_party_mode(current_instance_id)
-        # If it was removed
-        elif not current_instance_id and party_mode_state["instance_id"]:
-            remove_party_mode(party_mode_state["instance_id"])
-            party_mode_state["instance_id"] = None
 
     entry.async_on_unload(
         mass.subscribe(handle_providers_updated, EventType.PROVIDERS_UPDATED)

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -49,9 +49,11 @@ if TYPE_CHECKING:
 
 PLATFORMS = [
     Platform.BUTTON,
+    Platform.IMAGE,
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.SELECT,
+    Platform.SENSOR,
     Platform.SWITCH,
     Platform.TEXT,
 ]
@@ -73,6 +75,7 @@ class MusicAssistantEntryData:
     listen_task: asyncio.Task
     discovered_players: set[str] = field(default_factory=set)
     platform_handlers: dict[Platform, PlayerAddCallback] = field(default_factory=dict)
+    party_handlers: dict[Platform, Callable[[str], None]] = field(default_factory=dict)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -245,12 +248,63 @@ async def async_setup_entry(  # noqa: C901
     player_ids = {player.player_id for player in all_player_configs}
     dev_reg = dr.async_get(hass)
     dev_entries = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+    party_provider = mass.get_provider("party")
+    party_instance_id = None
+    if party_provider and isinstance(party_provider.instance_id, str):
+        party_instance_id = party_provider.instance_id
+
     for device in dev_entries:
         for identifier in device.identifiers:
-            if identifier[0] == DOMAIN and identifier[1] not in player_ids:
+            if (
+                identifier[0] == DOMAIN
+                and identifier[1] not in player_ids
+                and identifier[1] != party_instance_id
+            ):
                 dev_reg.async_update_device(
                     device.id, remove_config_entry_id=entry.entry_id
                 )
+
+    def add_party_mode(instance_id: str) -> None:
+        """Handle adding Party Mode as HA device + entities."""
+        # run callback for each platform
+        for callback in entry.runtime_data.party_handlers.values():
+            callback(instance_id)
+
+    def remove_party_mode(instance_id: str) -> None:
+        """Handle removing Party Mode as HA device + entities."""
+        dev_reg = dr.async_get(hass)
+        if hass_device := dev_reg.async_get_device({(DOMAIN, instance_id)}):
+            dev_reg.async_update_device(
+                hass_device.id, remove_config_entry_id=entry.entry_id
+            )
+
+    # We use a mutable container to track if party mode was previously seen
+    party_mode_state = {"instance_id": party_instance_id}
+
+    if party_instance_id:
+        add_party_mode(party_instance_id)
+
+    def handle_providers_updated(event: MassEvent) -> None:
+        """Handle Mass Providers Updated event."""
+        current_party_provider = mass.get_provider("party")
+        current_instance_id = None
+        if current_party_provider and isinstance(
+            current_party_provider.instance_id, str
+        ):
+            current_instance_id = current_party_provider.instance_id
+
+        # If it was added
+        if current_instance_id and not party_mode_state["instance_id"]:
+            party_mode_state["instance_id"] = current_instance_id
+            add_party_mode(current_instance_id)
+        # If it was removed
+        elif not current_instance_id and party_mode_state["instance_id"]:
+            remove_party_mode(party_mode_state["instance_id"])
+            party_mode_state["instance_id"] = None
+
+    entry.async_on_unload(
+        mass.subscribe(handle_providers_updated, EventType.PROVIDERS_UPDATED)
+    )
 
     return True
 

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -11,7 +11,7 @@ from music_assistant_client.exceptions import (
     InvalidServerVersion,
     MusicAssistantClientException,
 )
-from music_assistant_models.config_entries import PlayerConfig
+from music_assistant_models.config_entries import PlayerConfig, ProviderConfig
 from music_assistant_models.enums import EventType
 from music_assistant_models.errors import (
     ActionUnavailable,
@@ -37,6 +37,7 @@ from homeassistant.helpers.issue_registry import (
     async_create_issue,
     async_delete_issue,
 )
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import ATTR_CONF_EXPOSE_PLAYER_TO_HA, DOMAIN, LOGGER
 from .helpers import get_music_assistant_client
@@ -76,6 +77,7 @@ class MusicAssistantEntryData:
     discovered_players: set[str] = field(default_factory=set)
     platform_handlers: dict[Platform, PlayerAddCallback] = field(default_factory=dict)
     party_handlers: dict[Platform, Callable[[str], None]] = field(default_factory=dict)
+    party_config_coordinator: DataUpdateCoordinator[PlayerConfig] | None = None
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -266,6 +268,21 @@ async def async_setup_entry(  # noqa: C901
 
     def add_party_mode(instance_id: str) -> None:
         """Handle adding Party Mode as HA device + entities."""
+        if not entry.runtime_data.party_config_coordinator:
+
+            async def _update_party_config() -> ProviderConfig:
+                return await mass.config.get_provider_config(instance_id)
+
+            entry.runtime_data.party_config_coordinator = DataUpdateCoordinator(
+                hass,
+                LOGGER,
+                name="Party Mode Config",
+                update_method=_update_party_config,
+            )
+            hass.async_create_task(
+                entry.runtime_data.party_config_coordinator.async_config_entry_first_refresh()
+            )
+
         # run callback for each platform
         for callback in entry.runtime_data.party_handlers.values():
             callback(instance_id)
@@ -289,6 +306,12 @@ async def async_setup_entry(  # noqa: C901
         if current_instance_id and not party_mode_state["instance_id"]:
             party_mode_state["instance_id"] = current_instance_id
             add_party_mode(current_instance_id)
+        elif (
+            current_instance_id
+            and party_mode_state["instance_id"] == current_instance_id
+        ):
+            if coordinator := entry.runtime_data.party_config_coordinator:
+                hass.async_create_task(coordinator.async_request_refresh())
 
     entry.async_on_unload(
         mass.subscribe(handle_providers_updated, EventType.PROVIDERS_UPDATED)

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -270,14 +270,6 @@ async def async_setup_entry(  # noqa: C901
         for callback in entry.runtime_data.party_handlers.values():
             callback(instance_id)
 
-    def remove_party_mode(instance_id: str) -> None:
-        """Handle removing Party Mode as HA device + entities."""
-        dev_reg = dr.async_get(hass)
-        if hass_device := dev_reg.async_get_device({(DOMAIN, instance_id)}):
-            dev_reg.async_update_device(
-                hass_device.id, remove_config_entry_id=entry.entry_id
-            )
-
     # We use a mutable container to track if party mode was previously seen
     party_mode_state = {"instance_id": party_instance_id}
 

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -1,9 +1,12 @@
 """Constants for Music Assistant Component."""
 
+from datetime import timedelta
 import logging
 
 DOMAIN = "music_assistant"
 DOMAIN_EVENT = f"{DOMAIN}_event"
+
+PARTY_URL_POLL_INTERVAL = timedelta(minutes=10)
 
 DEFAULT_NAME = "Music Assistant"
 

--- a/homeassistant/components/music_assistant/entity.py
+++ b/homeassistant/components/music_assistant/entity.py
@@ -9,12 +9,17 @@ from music_assistant_models.player import Player, PlayerOption
 from homeassistant.const import EntityCategory
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .const import DOMAIN
 from .helpers import get_party_device_info
 
 if TYPE_CHECKING:
     from music_assistant_client import MusicAssistantClient
+    from music_assistant_models.config_entries import ProviderConfig
 
 
 class MusicAssistantEntity(Entity):
@@ -170,3 +175,32 @@ class MusicAssistantPartyModeEntity(Entity):
 
     async def async_on_update(self) -> None:
         """Handle provider updates."""
+
+
+class MusicAssistantPartyModeConfigEntity(
+    CoordinatorEntity[DataUpdateCoordinator["ProviderConfig"]],
+):
+    """Base Entity for Music Assistant Party Mode config entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        coordinator: DataUpdateCoordinator[ProviderConfig],
+        instance_id: str,
+        unique_id_suffix: str,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize MusicAssistantPartyModeConfigEntity."""
+        super().__init__(coordinator, **kwargs)
+        self.mass = mass
+        self.instance_id = instance_id
+        self._attr_device_info = get_party_device_info(instance_id)
+        self._attr_unique_id = f"{instance_id}_{unique_id_suffix}"
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """When entity is added to hass."""
+        await super().async_added_to_hass()
+        self._handle_coordinator_update()

--- a/homeassistant/components/music_assistant/entity.py
+++ b/homeassistant/components/music_assistant/entity.py
@@ -1,6 +1,6 @@
 """Base entity model."""
 
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Any, override
 
 from music_assistant_models.enums import EventType
 from music_assistant_models.event import MassEvent
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
+from .helpers import get_party_device_info
 
 if TYPE_CHECKING:
     from music_assistant_client import MusicAssistantClient
@@ -129,3 +130,43 @@ class MusicAssistantPlayerOptionEntity(MusicAssistantEntity):
 
     def on_player_option_update(self, player_option: PlayerOption) -> None:
         """Callback for player option updates."""
+
+
+class MusicAssistantPartyModeEntity(Entity):
+    """Base Entity for Music Assistant Party Mode."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        unique_id_suffix: str,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize MusicAssistantPartyModeEntity."""
+        super().__init__(**kwargs)
+        self.mass = mass
+        self.instance_id = instance_id
+        self._attr_device_info = get_party_device_info(instance_id)
+        self._attr_unique_id = f"{instance_id}_{unique_id_suffix}"
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    async def async_on_update(self) -> None:
+        """Handle provider updates."""

--- a/homeassistant/components/music_assistant/helpers.py
+++ b/homeassistant/components/music_assistant/helpers.py
@@ -9,6 +9,9 @@ from music_assistant_models.errors import MusicAssistantError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
 
 if TYPE_CHECKING:
     from music_assistant_client import MusicAssistantClient
@@ -44,3 +47,12 @@ def get_music_assistant_client(
     if entry.state is not ConfigEntryState.LOADED:
         raise ServiceValidationError("Entry not loaded")
     return entry.runtime_data.mass
+
+
+def get_party_device_info(instance_id: str) -> DeviceInfo:
+    """Return device info for Party Mode."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, instance_id)},
+        name="Party Mode Plugin",
+        manufacturer="Music Assistant",
+    )

--- a/homeassistant/components/music_assistant/icons.json
+++ b/homeassistant/components/music_assistant/icons.json
@@ -4,14 +4,113 @@
       "favorite_now_playing": {
         "default": "mdi:heart-plus"
       }
+    },
+    "image": {
+      "party_mode_qr": {
+        "default": "mdi:qrcode"
+      }
+    },
+    "number": {
+      "party_mode_add_to_queue_limit": {
+        "default": "mdi:playlist-plus"
+      },
+      "party_mode_add_to_queue_refill_minutes": {
+        "default": "mdi:timer"
+      },
+      "party_mode_boost_limit": {
+        "default": "mdi:rocket-launch"
+      },
+      "party_mode_boost_refill_minutes": {
+        "default": "mdi:timer"
+      },
+      "party_mode_skip_song_limit": {
+        "default": "mdi:skip-next"
+      },
+      "party_mode_skip_song_refill_minutes": {
+        "default": "mdi:timer"
+      }
+    },
+    "select": {
+      "party_mode_boost_badge_color": {
+        "default": "mdi:palette"
+      },
+      "party_mode_party_player": {
+        "default": "mdi:speaker-multiple"
+      },
+      "party_mode_request_badge_color": {
+        "default": "mdi:palette"
+      }
+    },
+    "sensor": {
+      "party_mode_url": {
+        "default": "mdi:link"
+      }
+    },
+    "switch": {
+      "party_mode_anti_burn_in": {
+        "default": "mdi:television-shimmer"
+      },
+      "party_mode_display_lyrics": {
+        "default": "mdi:script-text"
+      },
+      "party_mode_enable_add_queue": {
+        "default": "mdi:playlist-plus"
+      },
+      "party_mode_enable_boost": {
+        "default": "mdi:rocket-launch"
+      },
+      "party_mode_enable_guest_access": {
+        "default": "mdi:account-group"
+      },
+      "party_mode_enable_rate_limiting": {
+        "default": "mdi:speedometer"
+      },
+      "party_mode_enable_skip_song": {
+        "default": "mdi:skip-next"
+      },
+      "party_mode_hide_back_button": {
+        "default": "mdi:arrow-left-box"
+      },
+      "party_mode_highlight_ahead": {
+        "default": "mdi:format-color-highlight"
+      },
+      "party_mode_karaoke_mode": {
+        "default": "mdi:microphone"
+      },
+      "party_mode_prevent_duplicate_tracks": {
+        "default": "mdi:playlist-check"
+      },
+      "party_mode_show_progress_bar": {
+        "default": "mdi:progress-clock"
+      }
+    },
+    "text": {
+      "party_mode_party_name": {
+        "default": "mdi:rename-box"
+      },
+      "party_mode_qr_text": {
+        "default": "mdi:text-box"
+      }
     }
   },
   "services": {
-    "get_library": { "service": "mdi:music-box-multiple" },
-    "get_queue": { "service": "mdi:playlist-music" },
-    "play_announcement": { "service": "mdi:bullhorn" },
-    "play_media": { "service": "mdi:play" },
-    "search": { "service": "mdi:magnify" },
-    "transfer_queue": { "service": "mdi:transfer" }
+    "get_library": {
+      "service": "mdi:music-box-multiple"
+    },
+    "get_queue": {
+      "service": "mdi:playlist-music"
+    },
+    "play_announcement": {
+      "service": "mdi:bullhorn"
+    },
+    "play_media": {
+      "service": "mdi:play"
+    },
+    "search": {
+      "service": "mdi:magnify"
+    },
+    "transfer_queue": {
+      "service": "mdi:transfer"
+    }
   }
 }

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -13,13 +13,13 @@ import segno
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER, PARTY_URL_POLL_INTERVAL
+from .const import LOGGER, PARTY_URL_POLL_INTERVAL
+from .helpers import get_party_device_info
 
 
 async def async_setup_entry(
@@ -69,11 +69,7 @@ class MusicAssistantPartyModeImage(ImageEntity):
         self.instance_id = instance_id
         self.entity_description = entity_description
         self._current_url: str | None = None
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, instance_id)},
-            name="Party Mode Plugin",
-            manufacturer="Music Assistant",
-        )
+        self._attr_device_info = get_party_device_info(instance_id)
         self._attr_unique_id = f"{instance_id}_{entity_description.key}"
         self._image_bytes: bytes | None = None
 

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -5,9 +5,7 @@ import io
 from typing import override
 
 from music_assistant_client.client import MusicAssistantClient
-from music_assistant_models.enums import EventType
 from music_assistant_models.errors import MusicAssistantError
-from music_assistant_models.event import MassEvent
 import segno
 
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
@@ -19,7 +17,7 @@ from homeassistant.util import dt as dt_util
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER, PARTY_URL_POLL_INTERVAL
-from .helpers import get_party_device_info
+from .entity import MusicAssistantPartyModeEntity
 
 
 async def async_setup_entry(
@@ -50,11 +48,9 @@ async def async_setup_entry(
     entry.runtime_data.party_handlers.setdefault(Platform.IMAGE, add_party_mode)
 
 
-class MusicAssistantPartyModeImage(ImageEntity):
+class MusicAssistantPartyModeImage(MusicAssistantPartyModeEntity, ImageEntity):
     """Representation of an Image entity for Party Mode QR Code."""
 
-    _attr_has_entity_name = True
-    _attr_should_poll = False
     _attr_content_type = "image/png"
 
     def __init__(
@@ -65,25 +61,20 @@ class MusicAssistantPartyModeImage(ImageEntity):
         entity_description: ImageEntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(hass)
-        self.mass = mass
-        self.instance_id = instance_id
+        super().__init__(
+            mass=mass,
+            instance_id=instance_id,
+            unique_id_suffix=entity_description.key,
+            hass=hass,
+        )
         self.entity_description = entity_description
         self._current_url: str | None = None
-        self._attr_device_info = get_party_device_info(instance_id)
-        self._attr_unique_id = f"{instance_id}_{entity_description.key}"
         self._image_bytes: bytes | None = None
 
     @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        await self.async_on_update()
-        self.async_on_remove(
-            self.mass.subscribe(
-                self.__on_mass_update,
-                EventType.PROVIDERS_UPDATED,
-            )
-        )
+        await super().async_added_to_hass()
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
@@ -97,11 +88,7 @@ class MusicAssistantPartyModeImage(ImageEntity):
         await self.async_on_update()
         self.async_write_ha_state()
 
-    async def __on_mass_update(self, event: MassEvent) -> None:
-        """Call when we receive an event from MusicAssistant."""
-        await self.async_on_update()
-        self.async_write_ha_state()
-
+    @override
     async def async_on_update(self) -> None:
         """Handle provider updates."""
         try:

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -1,0 +1,120 @@
+"""Music Assistant Image platform."""
+
+from __future__ import annotations
+
+import io
+
+from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.enums import EventType
+from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.event import MassEvent
+import segno
+
+from homeassistant.components.image import ImageEntity, ImageEntityDescription
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
+
+from . import MusicAssistantConfigEntry
+from .const import DOMAIN, LOGGER
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MusicAssistantConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Music Assistant Image Entities."""
+    mass = entry.runtime_data.mass
+
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+        async_add_entities(
+            [
+                MusicAssistantPartyModeImage(
+                    hass,
+                    mass,
+                    instance_id,
+                    entity_description=ImageEntityDescription(
+                        key="party_mode_qr",
+                        translation_key="party_mode_qr",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                )
+            ]
+        )
+
+    entry.runtime_data.party_handlers.setdefault(Platform.IMAGE, add_party_mode)
+
+
+class MusicAssistantPartyModeImage(ImageEntity):
+    """Representation of an Image entity for Party Mode QR Code."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        entity_description: ImageEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(hass)
+        self.mass = mass
+        self.instance_id = instance_id
+        self.entity_description = entity_description
+        self._current_url: str | None = None
+        
+        provider = self.mass.get_provider(instance_id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, instance_id)},
+            name=provider.name if provider else "Party Mode",
+            manufacturer="Music Assistant",
+        )
+        self._attr_unique_id = f"{instance_id}_{entity_description.key}"
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    async def async_on_update(self) -> None:
+        """Handle provider updates."""
+        try:
+            url = await self.mass.send_command("party/url")
+            if url != self._current_url:
+                self._current_url = url
+                qr = segno.make(url)
+                buffer = io.BytesIO()
+                qr.save(buffer, kind="png", scale=4)
+                self._attr_image_last_updated = dt_util.utcnow()
+                self._cached_image = buffer.getvalue()
+            self._attr_available = True
+        except MusicAssistantError as err:
+            LOGGER.debug("Failed to fetch party URL for QR: %s", err)
+            self._current_url = None
+            self._cached_image = None
+            self._attr_available = False
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Unexpected error fetching party URL for QR: %s", err)
+            self._current_url = None
+            self._cached_image = None
+            self._attr_available = False
+
+    async def async_image(self) -> bytes | None:
+        """Return bytes of image."""
+        return self._cached_image

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -55,6 +55,7 @@ class MusicAssistantPartyModeImage(ImageEntity):
 
     _attr_has_entity_name = True
     _attr_should_poll = False
+    _attr_content_type = "image/png"
 
     def __init__(
         self,

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -1,8 +1,8 @@
 """Music Assistant Image platform."""
 
-from __future__ import annotations
-
+from datetime import datetime, timedelta
 import io
+from typing import override
 
 from music_assistant_client.client import MusicAssistantClient
 from music_assistant_models.enums import EventType
@@ -15,6 +15,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from . import MusicAssistantConfigEntry
@@ -68,15 +69,15 @@ class MusicAssistantPartyModeImage(ImageEntity):
         self.instance_id = instance_id
         self.entity_description = entity_description
         self._current_url: str | None = None
-
-        provider = self.mass.get_provider(instance_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id)},
             name="Party Mode Plugin",
             manufacturer="Music Assistant",
         )
         self._attr_unique_id = f"{instance_id}_{entity_description.key}"
+        self._image_bytes: bytes | None = None
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await self.async_on_update()
@@ -86,6 +87,18 @@ class MusicAssistantPartyModeImage(ImageEntity):
                 EventType.PROVIDERS_UPDATED,
             )
         )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._handle_timer,
+                timedelta(hours=1),
+            )
+        )
+
+    async def _handle_timer(self, _now: datetime) -> None:
+        """Handle periodic update."""
+        await self.async_on_update()
+        self.async_write_ha_state()
 
     async def __on_mass_update(self, event: MassEvent) -> None:
         """Call when we receive an event from MusicAssistant."""
@@ -102,19 +115,20 @@ class MusicAssistantPartyModeImage(ImageEntity):
                 buffer = io.BytesIO()
                 qr.save(buffer, kind="png", scale=4)
                 self._attr_image_last_updated = dt_util.utcnow()
-                self._cached_image = buffer.getvalue()
+                self._image_bytes = buffer.getvalue()
             self._attr_available = True
         except MusicAssistantError as err:
             LOGGER.debug("Failed to fetch party URL for QR: %s", err)
             self._current_url = None
-            self._cached_image = None
+            self._image_bytes = None
             self._attr_available = False
         except Exception as err:  # noqa: BLE001
             LOGGER.debug("Unexpected error fetching party URL for QR: %s", err)
             self._current_url = None
-            self._cached_image = None
+            self._image_bytes = None
             self._attr_available = False
 
+    @override
     async def async_image(self) -> bytes | None:
         """Return bytes of image."""
-        return self._cached_image
+        return self._image_bytes

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -1,6 +1,6 @@
 """Music Assistant Image platform."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 import io
 from typing import override
 
@@ -19,7 +19,7 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, PARTY_URL_POLL_INTERVAL
 
 
 async def async_setup_entry(
@@ -91,7 +91,7 @@ class MusicAssistantPartyModeImage(ImageEntity):
             async_track_time_interval(
                 self.hass,
                 self._handle_timer,
-                timedelta(hours=1),
+                PARTY_URL_POLL_INTERVAL,
             )
         )
 

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -11,7 +11,7 @@ from music_assistant_models.event import MassEvent
 import segno
 
 from homeassistant.components.image import ImageEntity, ImageEntityDescription
-from homeassistant.const import EntityCategory, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -40,7 +40,7 @@ async def async_setup_entry(
                     entity_description=ImageEntityDescription(
                         key="party_mode_qr",
                         translation_key="party_mode_qr",
-                        entity_category=EntityCategory.DIAGNOSTIC,
+                        icon="mdi:qrcode",
                     ),
                 )
             ]
@@ -68,11 +68,11 @@ class MusicAssistantPartyModeImage(ImageEntity):
         self.instance_id = instance_id
         self.entity_description = entity_description
         self._current_url: str | None = None
-        
+
         provider = self.mass.get_provider(instance_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id)},
-            name=provider.name if provider else "Party Mode",
+            name="Party Mode Plugin",
             manufacturer="Music Assistant",
         )
         self._attr_unique_id = f"{instance_id}_{entity_description.key}"

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -39,7 +39,6 @@ async def async_setup_entry(
                     entity_description=ImageEntityDescription(
                         key="party_mode_qr",
                         translation_key="party_mode_qr",
-                        icon="mdi:qrcode",
                     ),
                 )
             ]

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "local_push",
   "loggers": ["music_assistant"],
   "quality_scale": "bronze",
-  "requirements": ["music-assistant-client==1.3.6"],
+  "requirements": ["music-assistant-client==1.3.6", "segno==1.6.1"],
   "zeroconf": ["_mass._tcp.local."]
 }

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -86,28 +86,35 @@ async def async_setup_entry(
     entry.runtime_data.platform_handlers.setdefault(Platform.NUMBER, add_player)
 
     def add_party_mode(instance_id: str) -> None:
-        """Handle add party mode."""
-        entities: list[MusicAssistantPartyModeNumber] = [
-            MusicAssistantPartyModeNumber(
-                mass,
-                instance_id,
-                config_key=number_key,
-                entity_description=NumberEntityDescription(
-                    key=number_key,
-                    translation_key=f"party_mode_{number_key}",
-                    native_min_value=min_val,
-                    native_max_value=max_val,
-                    native_step=1,
-                    entity_category=category,
-                ),
-            )
-            for number_key, (
-                min_val,
-                max_val,
-                category,
-            ) in PARTY_MODE_NUMBERS.items()
-        ]
-        async_add_entities(entities)
+        async def _add_entities() -> None:
+            entities: list[MusicAssistantPartyModeNumber] = []
+            if party_config := await mass.config.get_provider_config(instance_id):
+                for number_key, (
+                    min_val,
+                    max_val,
+                    category,
+                ) in PARTY_MODE_NUMBERS.items():
+                    if number_key not in party_config.values:
+                        continue
+
+                    entities.append(
+                        MusicAssistantPartyModeNumber(
+                            mass,
+                            instance_id,
+                            config_key=number_key,
+                            entity_description=NumberEntityDescription(
+                                key=number_key,
+                                translation_key=f"party_mode_{number_key}",
+                                native_min_value=min_val,
+                                native_max_value=max_val,
+                                native_step=1,
+                                entity_category=category,
+                            ),
+                        )
+                    )
+            async_add_entities(entities)
+
+        hass.create_task(_add_entities())
 
     entry.runtime_data.party_handlers.setdefault(Platform.NUMBER, add_party_mode)
 

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -29,12 +29,12 @@ PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
 }
 
 PARTY_MODE_NUMBERS = {
-    "add_to_queue_limit": ("mdi:playlist-plus", 5, 50, EntityCategory.CONFIG),
-    "add_to_queue_refill_minutes": ("mdi:timer", 1, 30, EntityCategory.CONFIG),
-    "boost_limit": ("mdi:rocket-launch", 1, 10, EntityCategory.CONFIG),
-    "boost_refill_minutes": ("mdi:timer", 5, 120, EntityCategory.CONFIG),
-    "skip_song_limit": ("mdi:skip-next", 1, 5, EntityCategory.CONFIG),
-    "skip_song_refill_minutes": ("mdi:timer", 15, 180, EntityCategory.CONFIG),
+    "add_to_queue_limit": (5, 50, EntityCategory.CONFIG),
+    "add_to_queue_refill_minutes": (1, 30, EntityCategory.CONFIG),
+    "boost_limit": (1, 10, EntityCategory.CONFIG),
+    "boost_refill_minutes": (5, 120, EntityCategory.CONFIG),
+    "skip_song_limit": (1, 5, EntityCategory.CONFIG),
+    "skip_song_refill_minutes": (15, 180, EntityCategory.CONFIG),
 }
 
 
@@ -95,7 +95,6 @@ async def async_setup_entry(
                 entity_description=NumberEntityDescription(
                     key=number_key,
                     translation_key=f"party_mode_{number_key}",
-                    icon=icon,
                     native_min_value=min_val,
                     native_max_value=max_val,
                     native_step=1,
@@ -103,7 +102,6 @@ async def async_setup_entry(
                 ),
             )
             for number_key, (
-                icon,
                 min_val,
                 max_val,
                 category,

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -3,14 +3,17 @@
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.enums import EventType
+from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import MusicAssistantConfigEntry
+from . import DOMAIN, MusicAssistantConfigEntry
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
@@ -25,6 +28,15 @@ PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
     "equalizer_mid": False,
     "subwoofer_volume": True,
     "treble": True,
+}
+
+PARTY_MODE_NUMBERS = {
+    "party_add_queue_limit": ("mdi:playlist-plus", 5, 50, EntityCategory.CONFIG),
+    "party_add_queue_refill_minutes": ("mdi:timer", 1, 30, EntityCategory.CONFIG),
+    "party_boost_limit": ("mdi:rocket-launch", 1, 10, EntityCategory.CONFIG),
+    "party_boost_refill_minutes": ("mdi:timer", 5, 120, EntityCategory.CONFIG),
+    "party_skip_song_limit": ("mdi:skip-next", 1, 5, EntityCategory.CONFIG),
+    "party_skip_song_refill_minutes": ("mdi:timer", 15, 180, EntityCategory.CONFIG),
 }
 
 
@@ -75,6 +87,34 @@ async def async_setup_entry(
     # register callback to add players when they are discovered
     entry.runtime_data.platform_handlers.setdefault(Platform.NUMBER, add_player)
 
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+        entities: list[MusicAssistantPartyModeNumber] = [
+            MusicAssistantPartyModeNumber(
+                mass,
+                instance_id,
+                config_key=number_key.replace("party_", ""),
+                entity_description=NumberEntityDescription(
+                    key=number_key,
+                    translation_key=f"party_mode_{number_key}",
+                    icon=icon,
+                    native_min_value=min_val,
+                    native_max_value=max_val,
+                    native_step=1,
+                    entity_category=category,
+                ),
+            )
+            for number_key, (
+                icon,
+                min_val,
+                max_val,
+                category,
+            ) in PARTY_MODE_NUMBERS.items()
+        ]
+        async_add_entities(entities)
+
+    entry.runtime_data.party_handlers.setdefault(Platform.NUMBER, add_party_mode)
+
 
 class MusicAssistantPlayerConfigNumber(MusicAssistantPlayerOptionEntity, NumberEntity):
     """Representation of a Number entity to control player settings."""
@@ -116,4 +156,68 @@ class MusicAssistantPlayerConfigNumber(MusicAssistantPlayerOptionEntity, NumberE
             player_option.value
             if isinstance(player_option.value, (int, float))
             else None
+        )
+
+
+class MusicAssistantPartyModeNumber(NumberEntity):
+    """Representation of a Number entity to control party mode settings."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        config_key: str,
+        entity_description: NumberEntityDescription,
+    ) -> None:
+        """Initialize."""
+        self.mass = mass
+        self.instance_id = instance_id
+        self.config_key = config_key
+        self.entity_description = entity_description
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, instance_id)},
+            name="Party Mode Plugin",
+            manufacturer="Music Assistant",
+        )
+        self._attr_unique_id = f"{instance_id}_{config_key}"
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    @catch_musicassistant_error
+    async def async_on_update(self) -> None:
+        """Update number state."""
+        try:
+            party_config = await self.mass.config.get_provider_config(self.instance_id)
+            value = party_config.get_value(self.config_key)
+            if isinstance(value, (int, float, str)):
+                self._attr_native_value = float(value)
+            self._attr_available = True
+        except Exception:  # noqa: BLE001
+            self._attr_available = False
+
+    @catch_musicassistant_error
+    @override
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new value."""
+        await self.mass.config.save_provider_config(
+            provider_domain="party",
+            instance_id=self.instance_id,
+            values={self.config_key: int(value)},
         )

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -1,6 +1,6 @@
 """Music Assistant Number platform."""
 
-from typing import Final, override
+from typing import Any, Final, override
 
 from music_assistant_client.client import MusicAssistantClient
 from music_assistant_models.player import PlayerOption, PlayerOptionType
@@ -12,7 +12,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .entity import (
+    MusicAssistantPartyModeConfigEntity,
+    MusicAssistantPlayerOptionEntity,
+)
 from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
@@ -100,6 +103,7 @@ async def async_setup_entry(
                     entities.append(
                         MusicAssistantPartyModeNumber(
                             mass,
+                            entry.runtime_data.party_config_coordinator,
                             instance_id,
                             config_key=number_key,
                             entity_description=NumberEntityDescription(
@@ -162,26 +166,37 @@ class MusicAssistantPlayerConfigNumber(MusicAssistantPlayerOptionEntity, NumberE
         )
 
 
-class MusicAssistantPartyModeNumber(MusicAssistantPartyModeEntity, NumberEntity):
+class MusicAssistantPartyModeNumber(MusicAssistantPartyModeConfigEntity, NumberEntity):
     """Representation of a Number entity to control party mode settings."""
 
     def __init__(
         self,
         mass: MusicAssistantClient,
+        coordinator: Any,
         instance_id: str,
         config_key: str,
         entity_description: NumberEntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(mass, instance_id, unique_id_suffix=config_key)
+        super().__init__(
+            mass=mass,
+            coordinator=coordinator,
+            instance_id=instance_id,
+            unique_id_suffix=config_key,
+        )
         self.config_key = config_key
         self.entity_description = entity_description
+        self._attr_native_value = None
 
     @override
-    async def async_on_update(self) -> None:
+    def _handle_coordinator_update(self) -> None:
         """Update number state."""
+        if not (party_config := self.coordinator.data):
+            self._attr_available = False
+            super()._handle_coordinator_update()
+            return
+
         try:
-            party_config = await self.mass.config.get_provider_config(self.instance_id)
             value = party_config.get_value(self.config_key)
             if isinstance(value, (int, float, str)):
                 self._attr_native_value = float(value)
@@ -189,6 +204,8 @@ class MusicAssistantPartyModeNumber(MusicAssistantPartyModeEntity, NumberEntity)
         except Exception as err:  # noqa: BLE001
             LOGGER.debug("Error in number update: %s", err)
             self._attr_available = False
+
+        super()._handle_coordinator_update()
 
     @catch_musicassistant_error
     @override

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -196,7 +196,6 @@ class MusicAssistantPartyModeNumber(NumberEntity):
         await self.async_on_update()
         self.async_write_ha_state()
 
-    @catch_musicassistant_error
     async def async_on_update(self) -> None:
         """Update number state."""
         try:

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -3,8 +3,6 @@
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
-from music_assistant_models.enums import EventType
-from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
@@ -14,8 +12,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error, get_party_device_info
+from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -159,11 +157,8 @@ class MusicAssistantPlayerConfigNumber(MusicAssistantPlayerOptionEntity, NumberE
         )
 
 
-class MusicAssistantPartyModeNumber(NumberEntity):
+class MusicAssistantPartyModeNumber(MusicAssistantPartyModeEntity, NumberEntity):
     """Representation of a Number entity to control party mode settings."""
-
-    _attr_has_entity_name = True
-    _attr_should_poll = False
 
     def __init__(
         self,
@@ -173,29 +168,11 @@ class MusicAssistantPartyModeNumber(NumberEntity):
         entity_description: NumberEntityDescription,
     ) -> None:
         """Initialize."""
-        self.mass = mass
-        self.instance_id = instance_id
+        super().__init__(mass, instance_id, unique_id_suffix=config_key)
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = get_party_device_info(instance_id)
-        self._attr_unique_id = f"{instance_id}_{config_key}"
 
     @override
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await self.async_on_update()
-        self.async_on_remove(
-            self.mass.subscribe(
-                self.__on_mass_update,
-                EventType.PROVIDERS_UPDATED,
-            )
-        )
-
-    async def __on_mass_update(self, event: MassEvent) -> None:
-        """Call when we receive an event from MusicAssistant."""
-        await self.async_on_update()
-        self.async_write_ha_state()
-
     async def async_on_update(self) -> None:
         """Update number state."""
         try:

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -1,5 +1,6 @@
 """Music Assistant Number platform."""
 
+import logging
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
@@ -17,6 +18,8 @@ from . import DOMAIN, MusicAssistantConfigEntry
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
+LOGGER = logging.getLogger(__name__)
+
 PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
     "bass": True,
@@ -31,12 +34,12 @@ PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
 }
 
 PARTY_MODE_NUMBERS = {
-    "party_add_queue_limit": ("mdi:playlist-plus", 5, 50, EntityCategory.CONFIG),
-    "party_add_queue_refill_minutes": ("mdi:timer", 1, 30, EntityCategory.CONFIG),
-    "party_boost_limit": ("mdi:rocket-launch", 1, 10, EntityCategory.CONFIG),
-    "party_boost_refill_minutes": ("mdi:timer", 5, 120, EntityCategory.CONFIG),
-    "party_skip_song_limit": ("mdi:skip-next", 1, 5, EntityCategory.CONFIG),
-    "party_skip_song_refill_minutes": ("mdi:timer", 15, 180, EntityCategory.CONFIG),
+    "add_to_queue_limit": ("mdi:playlist-plus", 5, 50, EntityCategory.CONFIG),
+    "add_to_queue_refill_minutes": ("mdi:timer", 1, 30, EntityCategory.CONFIG),
+    "boost_limit": ("mdi:rocket-launch", 1, 10, EntityCategory.CONFIG),
+    "boost_refill_minutes": ("mdi:timer", 5, 120, EntityCategory.CONFIG),
+    "skip_song_limit": ("mdi:skip-next", 1, 5, EntityCategory.CONFIG),
+    "skip_song_refill_minutes": ("mdi:timer", 15, 180, EntityCategory.CONFIG),
 }
 
 
@@ -93,7 +96,7 @@ async def async_setup_entry(
             MusicAssistantPartyModeNumber(
                 mass,
                 instance_id,
-                config_key=number_key.replace("party_", ""),
+                config_key=number_key,
                 entity_description=NumberEntityDescription(
                     key=number_key,
                     translation_key=f"party_mode_{number_key}",
@@ -209,7 +212,8 @@ class MusicAssistantPartyModeNumber(NumberEntity):
             if isinstance(value, (int, float, str)):
                 self._attr_native_value = float(value)
             self._attr_available = True
-        except Exception:  # noqa: BLE001
+        except Exception as e:  # noqa: BLE001
+            LOGGER.debug("ERROR IN NUMBER UPDATE: %s", e)
             self._attr_available = False
 
     @catch_musicassistant_error

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -1,6 +1,5 @@
 """Music Assistant Number platform."""
 
-import logging
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
@@ -14,11 +13,10 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, MusicAssistantConfigEntry
+from . import MusicAssistantConfigEntry
+from .const import DOMAIN, LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
-
-LOGGER = logging.getLogger(__name__)
 
 PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -212,14 +210,17 @@ class MusicAssistantPartyModeNumber(NumberEntity):
             if isinstance(value, (int, float, str)):
                 self._attr_native_value = float(value)
             self._attr_available = True
-        except Exception as e:  # noqa: BLE001
-            LOGGER.debug("ERROR IN NUMBER UPDATE: %s", e)
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Error in number update: %s", err)
             self._attr_available = False
 
     @catch_musicassistant_error
     @override
     async def async_set_native_value(self, value: float) -> None:
-        """Set a new value."""
+        """Update the current value."""
+        LOGGER.debug(
+            "Setting number %s to %s for %s", self.config_key, value, self.instance_id
+        )
         await self.mass.config.save_provider_config(
             provider_domain="party",
             instance_id=self.instance_id,

--- a/homeassistant/components/music_assistant/number.py
+++ b/homeassistant/components/music_assistant/number.py
@@ -10,13 +10,12 @@ from music_assistant_models.player import PlayerOption, PlayerOptionType
 from homeassistant.components.number import NumberEntity, NumberEntityDescription
 from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error
+from .helpers import catch_musicassistant_error, get_party_device_info
 
 PLAYER_OPTIONS_NUMBER: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -178,11 +177,7 @@ class MusicAssistantPartyModeNumber(NumberEntity):
         self.instance_id = instance_id
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, instance_id)},
-            name="Party Mode Plugin",
-            manufacturer="Music Assistant",
-        )
+        self._attr_device_info = get_party_device_info(instance_id)
         self._attr_unique_id = f"{instance_id}_{config_key}"
 
     @override

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -107,23 +107,30 @@ async def async_setup_entry(
     entry.runtime_data.platform_handlers.setdefault(Platform.SELECT, add_player)
 
     def add_party_mode(instance_id: str) -> None:
-        """Handle add party mode."""
-        entities: list[MusicAssistantPartyModeSelect] = [
-            MusicAssistantPartyModeSelect(
-                mass,
-                instance_id,
-                config_key=select_key,
-                entity_description=SelectEntityDescription(
-                    key=f"party_mode_{select_key}",
-                    translation_key=f"party_mode_{select_key}"
-                    if select_key != "player"
-                    else "party_mode_party_player",
-                    entity_category=category,
-                ),
-            )
-            for select_key, category in PARTY_MODE_SELECTS.items()
-        ]
-        async_add_entities(entities)
+        async def _add_entities() -> None:
+            entities: list[MusicAssistantPartyModeSelect] = []
+            if party_config := await mass.config.get_provider_config(instance_id):
+                for select_key, category in PARTY_MODE_SELECTS.items():
+                    if select_key not in party_config.values:
+                        continue
+
+                    entities.append(
+                        MusicAssistantPartyModeSelect(
+                            mass,
+                            instance_id,
+                            config_key=select_key,
+                            entity_description=SelectEntityDescription(
+                                key=f"party_mode_{select_key}",
+                                translation_key=f"party_mode_{select_key}"
+                                if select_key != "player"
+                                else "party_mode_party_player",
+                                entity_category=category,
+                            ),
+                        )
+                    )
+            async_add_entities(entities)
+
+        hass.create_task(_add_entities())
 
     entry.runtime_data.party_handlers.setdefault(Platform.SELECT, add_party_mode)
 

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -3,14 +3,17 @@
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.enums import EventType
+from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import MusicAssistantConfigEntry
+from . import DOMAIN, MusicAssistantConfigEntry
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
@@ -24,6 +27,29 @@ PLAYER_OPTIONS_SELECT: Final[dict[str, bool]] = {
     "sleep": False,
     "surround_decoder_type": False,
     "tone_control_mode": True,
+}
+
+PARTY_MODE_SELECTS = {
+    "player": ("mdi:speaker-multiple", None),
+    "request_badge_color": ("mdi:palette", EntityCategory.CONFIG),
+    "boost_badge_color": ("mdi:palette", EntityCategory.CONFIG),
+}
+
+BADGE_COLORS = {
+    "2d6a4f": "#2D6A4F",
+    "b55522": "#B55522",
+    "e91e63": "#E91E63",
+    "f06292": "#F06292",
+    "9c27b0": "#9C27B0",
+    "673ab7": "#673AB7",
+    "3f51b5": "#3F51B5",
+    "00bcd4": "#00BCD4",
+    "009688": "#009688",
+    "4caf50": "#4CAF50",
+    "8bc34a": "#8BC34A",
+    "e64a19": "#E64A19",
+    "ffc107": "#FFC107",
+    "ffeb3b": "#FFEB3B",
 }
 
 
@@ -80,6 +106,28 @@ async def async_setup_entry(
     # register callback to add players when they are discovered
     entry.runtime_data.platform_handlers.setdefault(Platform.SELECT, add_player)
 
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+        entities: list[MusicAssistantPartyModeSelect] = [
+            MusicAssistantPartyModeSelect(
+                mass,
+                instance_id,
+                config_key=select_key,
+                entity_description=SelectEntityDescription(
+                    key=f"party_mode_{select_key}",
+                    translation_key=f"party_mode_{select_key}"
+                    if select_key != "player"
+                    else "party_mode_party_player",
+                    icon=icon,
+                    entity_category=category,
+                ),
+            )
+            for select_key, (icon, category) in PARTY_MODE_SELECTS.items()
+        ]
+        async_add_entities(entities)
+
+    entry.runtime_data.party_handlers.setdefault(Platform.SELECT, add_party_mode)
+
 
 class MusicAssistantPlayerConfigSelect(MusicAssistantPlayerOptionEntity, SelectEntity):
     """Representation of a select entity to control player settings."""
@@ -126,4 +174,107 @@ class MusicAssistantPlayerConfigSelect(MusicAssistantPlayerOptionEntity, SelectE
             self._option_key_to_translation_key_mapping.get(player_option.value)
             if isinstance(player_option.value, str)
             else None
+        )
+
+
+class MusicAssistantPartyModeSelect(SelectEntity):
+    """Representation of a select entity to control party mode settings."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        config_key: str,
+        entity_description: SelectEntityDescription,
+    ) -> None:
+        """Initialize."""
+        self.mass = mass
+        self.instance_id = instance_id
+        self.config_key = config_key
+        self.entity_description = entity_description
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, instance_id)},
+            name="Party Mode Plugin",
+            manufacturer="Music Assistant",
+        )
+        self._attr_unique_id = f"{instance_id}_{config_key}"
+        if self.config_key != "player":
+            self._attr_options = list(BADGE_COLORS.keys())
+        else:
+            self._attr_options = []
+        self._option_name_to_id: dict[str, str] = {}
+        self._option_id_to_name: dict[str, str] = {}
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+        if self.config_key == "player":
+            self.async_on_remove(
+                self.mass.subscribe(
+                    self.__on_mass_update,
+                    (
+                        EventType.PLAYER_ADDED,
+                        EventType.PLAYER_REMOVED,
+                        EventType.PLAYER_UPDATED,
+                    ),
+                )
+            )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    @catch_musicassistant_error
+    async def async_on_update(self) -> None:
+        """Update select state."""
+        try:
+            if self.config_key == "player":
+                players = sorted(
+                    self.mass.players,
+                    key=lambda p: p.name.lower(),
+                )
+                self._option_name_to_id = {"Auto": "auto"}
+                self._option_id_to_name = {"auto": "Auto"}
+                for p in players:
+                    self._option_name_to_id[p.name] = p.player_id
+                    self._option_id_to_name[p.player_id] = p.name
+                self._attr_options = list(self._option_name_to_id.keys())
+
+            party_config = await self.mass.config.get_provider_config(self.instance_id)
+            if value := party_config.get_value(self.config_key):
+                if self.config_key == "player":
+                    self._attr_current_option = self._option_id_to_name.get(
+                        str(value), "Auto"
+                    )
+                elif isinstance(value, str):
+                    # value is hex, strip the "#" and lowercase it
+                    self._attr_current_option = value.replace("#", "").lower()
+            self._attr_available = True
+        except Exception:  # noqa: BLE001
+            self._attr_available = False
+
+    @catch_musicassistant_error
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Select an option."""
+        if self.config_key == "player":
+            value = self._option_name_to_id.get(option, "auto")
+        else:
+            value = BADGE_COLORS[option]
+
+        await self.mass.config.save_provider_config(
+            provider_domain="party",
+            instance_id=self.instance_id,
+            values={self.config_key: value},
         )

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -14,8 +14,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error, get_party_device_info
+from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_SELECT: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -177,11 +177,8 @@ class MusicAssistantPlayerConfigSelect(MusicAssistantPlayerOptionEntity, SelectE
         )
 
 
-class MusicAssistantPartyModeSelect(SelectEntity):
+class MusicAssistantPartyModeSelect(MusicAssistantPartyModeEntity, SelectEntity):
     """Representation of a select entity to control party mode settings."""
-
-    _attr_has_entity_name = True
-    _attr_should_poll = False
 
     def __init__(
         self,
@@ -191,12 +188,9 @@ class MusicAssistantPartyModeSelect(SelectEntity):
         entity_description: SelectEntityDescription,
     ) -> None:
         """Initialize."""
-        self.mass = mass
-        self.instance_id = instance_id
+        super().__init__(mass, instance_id, unique_id_suffix=config_key)
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = get_party_device_info(instance_id)
-        self._attr_unique_id = f"{instance_id}_{config_key}"
         if self.config_key != "player":
             self._attr_options = list(BADGE_COLORS.keys())
         else:
@@ -207,17 +201,11 @@ class MusicAssistantPartyModeSelect(SelectEntity):
     @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        await self.async_on_update()
-        self.async_on_remove(
-            self.mass.subscribe(
-                self.__on_mass_update,
-                EventType.PROVIDERS_UPDATED,
-            )
-        )
+        await super().async_added_to_hass()
         if self.config_key == "player":
             self.async_on_remove(
                 self.mass.subscribe(
-                    self.__on_mass_update,
+                    self._on_player_update,
                     (
                         EventType.PLAYER_ADDED,
                         EventType.PLAYER_REMOVED,
@@ -226,11 +214,12 @@ class MusicAssistantPartyModeSelect(SelectEntity):
                 )
             )
 
-    async def __on_mass_update(self, event: MassEvent) -> None:
+    async def _on_player_update(self, event: MassEvent) -> None:
         """Call when we receive an event from MusicAssistant."""
         await self.async_on_update()
         self.async_write_ha_state()
 
+    @override
     async def async_on_update(self) -> None:
         """Update select state."""
         try:

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -231,7 +231,6 @@ class MusicAssistantPartyModeSelect(SelectEntity):
         await self.async_on_update()
         self.async_write_ha_state()
 
-    @catch_musicassistant_error
     async def async_on_update(self) -> None:
         """Update select state."""
         try:

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -13,7 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, MusicAssistantConfigEntry
+from . import MusicAssistantConfigEntry
+from .const import DOMAIN, LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
@@ -261,7 +262,8 @@ class MusicAssistantPartyModeSelect(SelectEntity):
                 # value is hex, strip the "#" and lowercase it
                 self._attr_current_option = value.replace("#", "").lower()
             self._attr_available = True
-        except Exception:  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Error in select update: %s", err)
             self._attr_available = False
 
     @catch_musicassistant_error
@@ -273,6 +275,9 @@ class MusicAssistantPartyModeSelect(SelectEntity):
         else:
             value = BADGE_COLORS[option]
 
+        LOGGER.debug(
+            "Setting select %s to %s for %s", self.config_key, value, self.instance_id
+        )
         await self.mass.config.save_provider_config(
             provider_domain="party",
             instance_id=self.instance_id,

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -1,6 +1,6 @@
 """Music Assistant select platform."""
 
-from typing import Final, override
+from typing import Any, Final, override
 
 from music_assistant_client.client import MusicAssistantClient
 from music_assistant_models.enums import EventType
@@ -14,7 +14,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .entity import (
+    MusicAssistantPartyModeConfigEntity,
+    MusicAssistantPlayerOptionEntity,
+)
 from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_SELECT: Final[dict[str, bool]] = {
@@ -117,6 +120,7 @@ async def async_setup_entry(
                     entities.append(
                         MusicAssistantPartyModeSelect(
                             mass,
+                            entry.runtime_data.party_config_coordinator,
                             instance_id,
                             config_key=select_key,
                             entity_description=SelectEntityDescription(
@@ -183,20 +187,27 @@ class MusicAssistantPlayerConfigSelect(MusicAssistantPlayerOptionEntity, SelectE
         )
 
 
-class MusicAssistantPartyModeSelect(MusicAssistantPartyModeEntity, SelectEntity):
+class MusicAssistantPartyModeSelect(MusicAssistantPartyModeConfigEntity, SelectEntity):
     """Representation of a select entity to control party mode settings."""
 
     def __init__(
         self,
         mass: MusicAssistantClient,
+        coordinator: Any,
         instance_id: str,
         config_key: str,
         entity_description: SelectEntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(mass, instance_id, unique_id_suffix=config_key)
+        super().__init__(
+            mass=mass,
+            coordinator=coordinator,
+            instance_id=instance_id,
+            unique_id_suffix=config_key,
+        )
         self.config_key = config_key
         self.entity_description = entity_description
+        self._attr_current_option = None
         if self.config_key != "player":
             self._attr_options = list(BADGE_COLORS.keys())
         else:
@@ -222,12 +233,16 @@ class MusicAssistantPartyModeSelect(MusicAssistantPartyModeEntity, SelectEntity)
 
     async def _on_player_update(self, event: MassEvent) -> None:
         """Call when we receive an event from MusicAssistant."""
-        await self.async_on_update()
-        self.async_write_ha_state()
+        self._handle_coordinator_update()
 
     @override
-    async def async_on_update(self) -> None:
+    def _handle_coordinator_update(self) -> None:
         """Update select state."""
+        if not (party_config := self.coordinator.data):
+            self._attr_available = False
+            super()._handle_coordinator_update()
+            return
+
         try:
             if self.config_key == "player":
                 players = sorted(
@@ -241,7 +256,6 @@ class MusicAssistantPartyModeSelect(MusicAssistantPartyModeEntity, SelectEntity)
                     self._option_id_to_name[p.player_id] = p.name
                 self._attr_options = list(self._option_name_to_id.keys())
 
-            party_config = await self.mass.config.get_provider_config(self.instance_id)
             value = party_config.get_value(self.config_key)
             if self.config_key == "player":
                 self._attr_current_option = self._option_id_to_name.get(
@@ -254,6 +268,8 @@ class MusicAssistantPartyModeSelect(MusicAssistantPartyModeEntity, SelectEntity)
         except Exception as err:  # noqa: BLE001
             LOGGER.debug("Error in select update: %s", err)
             self._attr_available = False
+
+        super()._handle_coordinator_update()
 
     @catch_musicassistant_error
     @override

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -252,14 +252,14 @@ class MusicAssistantPartyModeSelect(SelectEntity):
                 self._attr_options = list(self._option_name_to_id.keys())
 
             party_config = await self.mass.config.get_provider_config(self.instance_id)
-            if value := party_config.get_value(self.config_key):
-                if self.config_key == "player":
-                    self._attr_current_option = self._option_id_to_name.get(
-                        str(value), "Auto"
-                    )
-                elif isinstance(value, str):
-                    # value is hex, strip the "#" and lowercase it
-                    self._attr_current_option = value.replace("#", "").lower()
+            value = party_config.get_value(self.config_key)
+            if self.config_key == "player":
+                self._attr_current_option = self._option_id_to_name.get(
+                    str(value), "Auto"
+                )
+            elif value and isinstance(value, str):
+                # value is hex, strip the "#" and lowercase it
+                self._attr_current_option = value.replace("#", "").lower()
             self._attr_available = True
         except Exception:  # noqa: BLE001
             self._attr_available = False

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -30,9 +30,9 @@ PLAYER_OPTIONS_SELECT: Final[dict[str, bool]] = {
 }
 
 PARTY_MODE_SELECTS = {
-    "player": ("mdi:speaker-multiple", None),
-    "request_badge_color": ("mdi:palette", EntityCategory.CONFIG),
-    "boost_badge_color": ("mdi:palette", EntityCategory.CONFIG),
+    "player": None,
+    "request_badge_color": EntityCategory.CONFIG,
+    "boost_badge_color": EntityCategory.CONFIG,
 }
 
 BADGE_COLORS = {
@@ -118,11 +118,10 @@ async def async_setup_entry(
                     translation_key=f"party_mode_{select_key}"
                     if select_key != "player"
                     else "party_mode_party_player",
-                    icon=icon,
                     entity_category=category,
                 ),
             )
-            for select_key, (icon, category) in PARTY_MODE_SELECTS.items()
+            for select_key, category in PARTY_MODE_SELECTS.items()
         ]
         async_add_entities(entities)
 

--- a/homeassistant/components/music_assistant/select.py
+++ b/homeassistant/components/music_assistant/select.py
@@ -10,13 +10,12 @@ from music_assistant_models.player import PlayerOption, PlayerOptionType
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error
+from .helpers import catch_musicassistant_error, get_party_device_info
 
 PLAYER_OPTIONS_SELECT: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -196,11 +195,7 @@ class MusicAssistantPartyModeSelect(SelectEntity):
         self.instance_id = instance_id
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, instance_id)},
-            name="Party Mode Plugin",
-            manufacturer="Music Assistant",
-        )
+        self._attr_device_info = get_party_device_info(instance_id)
         self._attr_unique_id = f"{instance_id}_{config_key}"
         if self.config_key != "player":
             self._attr_options = list(BADGE_COLORS.keys())

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -1,0 +1,100 @@
+"""Music Assistant Sensor platform."""
+
+from __future__ import annotations
+
+from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.enums import EventType
+from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.event import MassEvent
+
+from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import MusicAssistantConfigEntry
+from .const import DOMAIN, LOGGER
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MusicAssistantConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Music Assistant Sensor Entities."""
+    mass = entry.runtime_data.mass
+
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+        async_add_entities(
+            [
+                MusicAssistantPartyModeSensor(
+                    mass,
+                    instance_id,
+                    entity_description=SensorEntityDescription(
+                        key="party_mode_url",
+                        translation_key="party_mode_url",
+                        entity_category=EntityCategory.DIAGNOSTIC,
+                    ),
+                )
+            ]
+        )
+
+    entry.runtime_data.party_handlers.setdefault(Platform.SENSOR, add_party_mode)
+
+
+class MusicAssistantPartyModeSensor(SensorEntity):
+    """Representation of a Sensor entity for Party Mode URL."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        entity_description: SensorEntityDescription,
+    ) -> None:
+        """Initialize."""
+        self.mass = mass
+        self.instance_id = instance_id
+        self.entity_description = entity_description
+        
+        provider = self.mass.get_provider(instance_id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, instance_id)},
+            name=provider.name if provider else "Party Mode",
+            manufacturer="Music Assistant",
+        )
+        self._attr_unique_id = f"{instance_id}_{entity_description.key}"
+
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    async def async_on_update(self) -> None:
+        """Handle provider updates."""
+        try:
+            url = await self.mass.send_command("party/url")
+            self._attr_native_value = url
+            self._attr_available = True
+        except MusicAssistantError as err:
+            LOGGER.debug("Failed to fetch party URL: %s", err)
+            self._attr_native_value = None
+            self._attr_available = False
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Unexpected error fetching party URL: %s", err)
+            self._attr_native_value = None
+            self._attr_available = False

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -1,6 +1,7 @@
 """Music Assistant Sensor platform."""
 
-from __future__ import annotations
+from datetime import datetime, timedelta
+from typing import override
 
 from music_assistant_client.client import MusicAssistantClient
 from music_assistant_models.enums import EventType
@@ -12,6 +13,7 @@ from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
 
 from . import MusicAssistantConfigEntry
 from .const import DOMAIN, LOGGER
@@ -60,8 +62,6 @@ class MusicAssistantPartyModeSensor(SensorEntity):
         self.mass = mass
         self.instance_id = instance_id
         self.entity_description = entity_description
-
-        provider = self.mass.get_provider(instance_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id)},
             name="Party Mode Plugin",
@@ -69,6 +69,7 @@ class MusicAssistantPartyModeSensor(SensorEntity):
         )
         self._attr_unique_id = f"{instance_id}_{entity_description.key}"
 
+    @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
         await self.async_on_update()
@@ -78,6 +79,18 @@ class MusicAssistantPartyModeSensor(SensorEntity):
                 EventType.PROVIDERS_UPDATED,
             )
         )
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._handle_timer,
+                timedelta(hours=1),
+            )
+        )
+
+    async def _handle_timer(self, _now: datetime) -> None:
+        """Handle periodic update."""
+        await self.async_on_update()
+        self.async_write_ha_state()
 
     async def __on_mass_update(self, event: MassEvent) -> None:
         """Call when we receive an event from MusicAssistant."""

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -8,7 +8,7 @@ from music_assistant_models.errors import MusicAssistantError
 from music_assistant_models.event import MassEvent
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
-from homeassistant.const import EntityCategory, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -35,7 +35,7 @@ async def async_setup_entry(
                     entity_description=SensorEntityDescription(
                         key="party_mode_url",
                         translation_key="party_mode_url",
-                        entity_category=EntityCategory.DIAGNOSTIC,
+                        icon="mdi:link",
                     ),
                 )
             ]
@@ -60,11 +60,11 @@ class MusicAssistantPartyModeSensor(SensorEntity):
         self.mass = mass
         self.instance_id = instance_id
         self.entity_description = entity_description
-        
+
         provider = self.mass.get_provider(instance_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id)},
-            name=provider.name if provider else "Party Mode",
+            name="Party Mode Plugin",
             manufacturer="Music Assistant",
         )
         self._attr_unique_id = f"{instance_id}_{entity_description.key}"

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -11,12 +11,12 @@ from music_assistant_models.event import MassEvent
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER, PARTY_URL_POLL_INTERVAL
+from .const import LOGGER, PARTY_URL_POLL_INTERVAL
+from .helpers import get_party_device_info
 
 
 async def async_setup_entry(
@@ -62,11 +62,7 @@ class MusicAssistantPartyModeSensor(SensorEntity):
         self.mass = mass
         self.instance_id = instance_id
         self.entity_description = entity_description
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, instance_id)},
-            name="Party Mode Plugin",
-            manufacturer="Music Assistant",
-        )
+        self._attr_device_info = get_party_device_info(instance_id)
         self._attr_unique_id = f"{instance_id}_{entity_description.key}"
 
     @override

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -35,7 +35,6 @@ async def async_setup_entry(
                     entity_description=SensorEntityDescription(
                         key="party_mode_url",
                         translation_key="party_mode_url",
-                        icon="mdi:link",
                     ),
                 )
             ]

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -4,9 +4,7 @@ from datetime import datetime
 from typing import override
 
 from music_assistant_client.client import MusicAssistantClient
-from music_assistant_models.enums import EventType
 from music_assistant_models.errors import MusicAssistantError
-from music_assistant_models.event import MassEvent
 
 from homeassistant.components.sensor import SensorEntity, SensorEntityDescription
 from homeassistant.const import Platform
@@ -16,7 +14,7 @@ from homeassistant.helpers.event import async_track_time_interval
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER, PARTY_URL_POLL_INTERVAL
-from .helpers import get_party_device_info
+from .entity import MusicAssistantPartyModeEntity
 
 
 async def async_setup_entry(
@@ -46,11 +44,8 @@ async def async_setup_entry(
     entry.runtime_data.party_handlers.setdefault(Platform.SENSOR, add_party_mode)
 
 
-class MusicAssistantPartyModeSensor(SensorEntity):
+class MusicAssistantPartyModeSensor(MusicAssistantPartyModeEntity, SensorEntity):
     """Representation of a Sensor entity for Party Mode URL."""
-
-    _attr_has_entity_name = True
-    _attr_should_poll = False
 
     def __init__(
         self,
@@ -59,22 +54,13 @@ class MusicAssistantPartyModeSensor(SensorEntity):
         entity_description: SensorEntityDescription,
     ) -> None:
         """Initialize."""
-        self.mass = mass
-        self.instance_id = instance_id
+        super().__init__(mass, instance_id, unique_id_suffix=entity_description.key)
         self.entity_description = entity_description
-        self._attr_device_info = get_party_device_info(instance_id)
-        self._attr_unique_id = f"{instance_id}_{entity_description.key}"
 
     @override
     async def async_added_to_hass(self) -> None:
         """Register callbacks."""
-        await self.async_on_update()
-        self.async_on_remove(
-            self.mass.subscribe(
-                self.__on_mass_update,
-                EventType.PROVIDERS_UPDATED,
-            )
-        )
+        await super().async_added_to_hass()
         self.async_on_remove(
             async_track_time_interval(
                 self.hass,
@@ -88,11 +74,7 @@ class MusicAssistantPartyModeSensor(SensorEntity):
         await self.async_on_update()
         self.async_write_ha_state()
 
-    async def __on_mass_update(self, event: MassEvent) -> None:
-        """Call when we receive an event from MusicAssistant."""
-        await self.async_on_update()
-        self.async_write_ha_state()
-
+    @override
     async def async_on_update(self) -> None:
         """Handle provider updates."""
         try:

--- a/homeassistant/components/music_assistant/sensor.py
+++ b/homeassistant/components/music_assistant/sensor.py
@@ -1,6 +1,6 @@
 """Music Assistant Sensor platform."""
 
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import override
 
 from music_assistant_client.client import MusicAssistantClient
@@ -16,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.event import async_track_time_interval
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, PARTY_URL_POLL_INTERVAL
 
 
 async def async_setup_entry(
@@ -83,7 +83,7 @@ class MusicAssistantPartyModeSensor(SensorEntity):
             async_track_time_interval(
                 self.hass,
                 self._handle_timer,
-                timedelta(hours=1),
+                PARTY_URL_POLL_INTERVAL,
             )
         )
 

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -145,22 +145,22 @@
       "equalizer_mid": {
         "name": "Equalizer mid"
       },
-      "party_mode_party_add_queue_limit": {
+      "party_mode_add_to_queue_limit": {
         "name": "Add to Queue Limit"
       },
-      "party_mode_party_add_queue_refill_minutes": {
+      "party_mode_add_to_queue_refill_minutes": {
         "name": "Add to Queue Refill (Minutes)"
       },
-      "party_mode_party_boost_limit": {
+      "party_mode_boost_limit": {
         "name": "Boost Limit"
       },
-      "party_mode_party_boost_refill_minutes": {
+      "party_mode_boost_refill_minutes": {
         "name": "Boost Refill (Minutes)"
       },
-      "party_mode_party_skip_song_limit": {
+      "party_mode_skip_song_limit": {
         "name": "Skip Song Limit"
       },
-      "party_mode_party_skip_song_refill_minutes": {
+      "party_mode_skip_song_refill_minutes": {
         "name": "Skip Song Refill (Minutes)"
       },
       "subwoofer_volume": {
@@ -311,6 +311,9 @@
       },
       "party_mode_anti_burn_in": {
         "name": "Anti burn-in"
+      },
+      "party_mode_display_lyrics": {
+        "name": "Display Lyrics"
       },
       "party_mode_enable_add_queue": {
         "name": "Enable guest add to queue"

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -211,7 +211,7 @@
         }
       },
       "party_mode_boost_badge_color": {
-        "name": "Boost Badge Color",
+        "name": "Boost badge color",
         "state": {
           "00bcd4": "Cyan",
           "2d6a4f": "Green (Dark)",
@@ -230,10 +230,10 @@
         }
       },
       "party_mode_party_player": {
-        "name": "Party Player"
+        "name": "Party player"
       },
       "party_mode_request_badge_color": {
-        "name": "Request Badge Color",
+        "name": "Request badge color",
         "state": {
           "00bcd4": "Cyan",
           "2d6a4f": "Green (Dark)",
@@ -313,7 +313,7 @@
         "name": "Anti burn-in"
       },
       "party_mode_display_lyrics": {
-        "name": "Display Lyrics"
+        "name": "Display lyrics"
       },
       "party_mode_enable_add_queue": {
         "name": "Enable guest add to queue"
@@ -363,10 +363,10 @@
         "name": "Network name"
       },
       "party_mode_party_name": {
-        "name": "Party Name"
+        "name": "Party name"
       },
       "party_mode_qr_text": {
-        "name": "QR Text"
+        "name": "QR text"
       }
     }
   },

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -56,7 +56,7 @@
     },
     "image": {
       "party_mode_qr": {
-        "name": "Guest qr code"
+        "name": "Guest QR code"
       }
     },
     "media_player": {
@@ -146,22 +146,22 @@
         "name": "Equalizer mid"
       },
       "party_mode_add_to_queue_limit": {
-        "name": "Add to Queue Limit"
+        "name": "Add to queue limit"
       },
       "party_mode_add_to_queue_refill_minutes": {
-        "name": "Add to Queue Refill (Minutes)"
+        "name": "Add to queue refill (minutes)"
       },
       "party_mode_boost_limit": {
-        "name": "Boost Limit"
+        "name": "Boost limit"
       },
       "party_mode_boost_refill_minutes": {
-        "name": "Boost Refill (Minutes)"
+        "name": "Boost refill (minutes)"
       },
       "party_mode_skip_song_limit": {
-        "name": "Skip Song Limit"
+        "name": "Skip song limit"
       },
       "party_mode_skip_song_refill_minutes": {
-        "name": "Skip Song Refill (Minutes)"
+        "name": "Skip song refill (minutes)"
       },
       "subwoofer_volume": {
         "name": "Subwoofer volume"
@@ -287,7 +287,7 @@
     },
     "sensor": {
       "party_mode_url": {
-        "name": "Guest url"
+        "name": "Guest URL"
       }
     },
     "switch": {

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -328,22 +328,22 @@
         "name": "Enable rate limiting"
       },
       "party_mode_enable_skip_song": {
-        "name": "Enable Skip Song"
+        "name": "Enable skip song"
       },
       "party_mode_hide_back_button": {
-        "name": "Hide Back Button"
+        "name": "Hide back button"
       },
       "party_mode_highlight_ahead": {
-        "name": "Highlight Ahead"
+        "name": "Highlight ahead"
       },
       "party_mode_karaoke_mode": {
         "name": "Karaoke mode"
       },
       "party_mode_prevent_duplicate_tracks": {
-        "name": "Prevent Duplicate Tracks"
+        "name": "Prevent duplicate tracks"
       },
       "party_mode_show_progress_bar": {
-        "name": "Show Progress Bar"
+        "name": "Show progress bar"
       },
       "pure_direct": {
         "name": "Pure direct"

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -145,6 +145,24 @@
       "equalizer_mid": {
         "name": "Equalizer mid"
       },
+      "party_mode_party_add_queue_limit": {
+        "name": "Add to Queue Limit"
+      },
+      "party_mode_party_add_queue_refill_minutes": {
+        "name": "Add to Queue Refill (Minutes)"
+      },
+      "party_mode_party_boost_limit": {
+        "name": "Boost Limit"
+      },
+      "party_mode_party_boost_refill_minutes": {
+        "name": "Boost Refill (Minutes)"
+      },
+      "party_mode_party_skip_song_limit": {
+        "name": "Skip Song Limit"
+      },
+      "party_mode_party_skip_song_refill_minutes": {
+        "name": "Skip Song Refill (Minutes)"
+      },
       "subwoofer_volume": {
         "name": "Subwoofer volume"
       },
@@ -190,6 +208,47 @@
           "speed": "Speed",
           "stability": "Stability",
           "standard": "Standard"
+        }
+      },
+      "party_mode_boost_badge_color": {
+        "name": "Boost Badge Color",
+        "state": {
+          "00bcd4": "Cyan",
+          "2d6a4f": "Green (Dark)",
+          "3f51b5": "Indigo",
+          "4caf50": "Green (Light)",
+          "8bc34a": "Lime",
+          "9c27b0": "Purple",
+          "673ab7": "Deep Purple",
+          "009688": "Teal",
+          "b55522": "Orange",
+          "e64a19": "Deep Orange",
+          "e91e63": "Magenta",
+          "f06292": "Pink",
+          "ffc107": "Amber",
+          "ffeb3b": "Yellow"
+        }
+      },
+      "party_mode_party_player": {
+        "name": "Party Player"
+      },
+      "party_mode_request_badge_color": {
+        "name": "Request Badge Color",
+        "state": {
+          "00bcd4": "Cyan",
+          "2d6a4f": "Green (Dark)",
+          "3f51b5": "Indigo",
+          "4caf50": "Green (Light)",
+          "8bc34a": "Lime",
+          "9c27b0": "Purple",
+          "673ab7": "Deep Purple",
+          "009688": "Teal",
+          "b55522": "Orange",
+          "e64a19": "Deep Orange",
+          "e91e63": "Magenta",
+          "f06292": "Pink",
+          "ffc107": "Amber",
+          "ffeb3b": "Yellow"
         }
       },
       "sleep": {
@@ -265,8 +324,23 @@
       "party_mode_enable_rate_limiting": {
         "name": "Enable rate limiting"
       },
+      "party_mode_enable_skip_song": {
+        "name": "Enable Skip Song"
+      },
+      "party_mode_hide_back_button": {
+        "name": "Hide Back Button"
+      },
+      "party_mode_highlight_ahead": {
+        "name": "Highlight Ahead"
+      },
       "party_mode_karaoke_mode": {
         "name": "Karaoke mode"
+      },
+      "party_mode_prevent_duplicate_tracks": {
+        "name": "Prevent Duplicate Tracks"
+      },
+      "party_mode_show_progress_bar": {
+        "name": "Show Progress Bar"
       },
       "pure_direct": {
         "name": "Pure direct"
@@ -284,6 +358,12 @@
     "text": {
       "network_name": {
         "name": "Network name"
+      },
+      "party_mode_party_name": {
+        "name": "Party Name"
+      },
+      "party_mode_qr_text": {
+        "name": "QR Text"
       }
     }
   },

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -56,7 +56,7 @@
     },
     "image": {
       "party_mode_qr": {
-        "name": "Party mode guest QR code"
+        "name": "Guest qr code"
       }
     },
     "media_player": {
@@ -228,7 +228,7 @@
     },
     "sensor": {
       "party_mode_url": {
-        "name": "Party mode guest URL"
+        "name": "Guest url"
       }
     },
     "switch": {
@@ -251,22 +251,22 @@
         "name": "Party mode"
       },
       "party_mode_anti_burn_in": {
-        "name": "Party mode anti burn-in"
+        "name": "Anti burn-in"
       },
       "party_mode_enable_add_queue": {
-        "name": "Party mode enable guest add to queue"
+        "name": "Enable guest add to queue"
       },
       "party_mode_enable_boost": {
-        "name": "Party mode enable guest boost"
+        "name": "Enable guest boost"
       },
       "party_mode_enable_guest_access": {
-        "name": "Party mode enable guest access"
+        "name": "Enable guest access"
       },
       "party_mode_enable_rate_limiting": {
-        "name": "Party mode enable rate limiting"
+        "name": "Enable rate limiting"
       },
       "party_mode_karaoke_mode": {
-        "name": "Party mode karaoke mode"
+        "name": "Karaoke mode"
       },
       "pure_direct": {
         "name": "Pure direct"

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -54,6 +54,11 @@
         "name": "Favorite current song"
       }
     },
+    "image": {
+      "party_mode_qr": {
+        "name": "Party mode guest QR code"
+      }
+    },
     "media_player": {
       "media_player": {
         "state_attributes": {
@@ -221,6 +226,11 @@
         }
       }
     },
+    "sensor": {
+      "party_mode_url": {
+        "name": "Party mode guest URL"
+      }
+    },
     "switch": {
       "adaptive_drc": {
         "name": "Adaptive DRC"
@@ -239,6 +249,24 @@
       },
       "party_mode": {
         "name": "Party mode"
+      },
+      "party_mode_anti_burn_in": {
+        "name": "Party mode anti burn-in"
+      },
+      "party_mode_enable_add_queue": {
+        "name": "Party mode enable guest add to queue"
+      },
+      "party_mode_enable_boost": {
+        "name": "Party mode enable guest boost"
+      },
+      "party_mode_enable_guest_access": {
+        "name": "Party mode enable guest access"
+      },
+      "party_mode_enable_rate_limiting": {
+        "name": "Party mode enable rate limiting"
+      },
+      "party_mode_karaoke_mode": {
+        "name": "Party mode karaoke mode"
       },
       "pure_direct": {
         "name": "Pure direct"

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -3,8 +3,6 @@
 from typing import Any, Final, override
 
 from music_assistant_client.client import MusicAssistantClient
-from music_assistant_models.enums import EventType
-from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
@@ -14,8 +12,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error, get_party_device_info
+from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_SWITCH: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -146,11 +144,8 @@ PARTY_MODE_SWITCHES = {
 }
 
 
-class MusicAssistantPartyModeSwitch(SwitchEntity):
+class MusicAssistantPartyModeSwitch(MusicAssistantPartyModeEntity, SwitchEntity):
     """Representation of a Switch entity to control party mode settings."""
-
-    _attr_has_entity_name = True
-    _attr_should_poll = False
 
     def __init__(
         self,
@@ -160,29 +155,11 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
         entity_description: SwitchEntityDescription,
     ) -> None:
         """Initialize."""
-        self.mass = mass
-        self.instance_id = instance_id
+        super().__init__(mass, instance_id, unique_id_suffix=config_key)
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = get_party_device_info(instance_id)
-        self._attr_unique_id = f"{instance_id}_{config_key}"
 
     @override
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await self.async_on_update()
-        self.async_on_remove(
-            self.mass.subscribe(
-                self.__on_mass_update,
-                EventType.PROVIDERS_UPDATED,
-            )
-        )
-
-    async def __on_mass_update(self, event: MassEvent) -> None:
-        """Call when we receive an event from MusicAssistant."""
-        await self.async_on_update()
-        self.async_write_ha_state()
-
     async def async_on_update(self) -> None:
         """Update switch state."""
         try:

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -183,7 +183,6 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
         await self.async_on_update()
         self.async_write_ha_state()
 
-    @catch_musicassistant_error
     async def async_on_update(self) -> None:
         """Update switch state."""
         try:

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -8,7 +8,7 @@ from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -86,9 +86,10 @@ async def async_setup_entry(
                     key=f"party_mode_{switch_key}",
                     translation_key=f"party_mode_{switch_key}",
                     icon=icon,
+                    entity_category=category,
                 ),
             )
-            for switch_key, icon in PARTY_MODE_SWITCHES.items()
+            for switch_key, (icon, category) in PARTY_MODE_SWITCHES.items()
         ]
         async_add_entities(entities)
 
@@ -131,12 +132,17 @@ class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchE
 
 
 PARTY_MODE_SWITCHES = {
-    "enable_guest_access": "mdi:account-group",
-    "karaoke_mode": "mdi:microphone",
-    "enable_rate_limiting": "mdi:speedometer",
-    "enable_boost": "mdi:rocket-launch",
-    "enable_add_queue": "mdi:playlist-plus",
-    "anti_burn_in": "mdi:television-shimmer",
+    "enable_guest_access": ("mdi:account-group", None),
+    "karaoke_mode": ("mdi:microphone", None),
+    "highlight_ahead": ("mdi:format-color-highlight", EntityCategory.CONFIG),
+    "hide_back_button": ("mdi:arrow-left-box", EntityCategory.CONFIG),
+    "show_progress_bar": ("mdi:progress-clock", EntityCategory.CONFIG),
+    "enable_rate_limiting": ("mdi:speedometer", EntityCategory.CONFIG),
+    "enable_add_queue": ("mdi:playlist-plus", EntityCategory.CONFIG),
+    "prevent_duplicate_tracks": ("mdi:playlist-check", EntityCategory.CONFIG),
+    "enable_boost": ("mdi:rocket-launch", EntityCategory.CONFIG),
+    "enable_skip_song": ("mdi:skip-next", EntityCategory.CONFIG),
+    "anti_burn_in": ("mdi:television-shimmer", EntityCategory.CONFIG),
 }
 
 

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -10,13 +10,12 @@ from music_assistant_models.player import PlayerOption, PlayerOptionType
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error
+from .helpers import catch_musicassistant_error, get_party_device_info
 
 PLAYER_OPTIONS_SWITCH: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -165,11 +164,7 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
         self.instance_id = instance_id
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, instance_id)},
-            name="Party Mode Plugin",
-            manufacturer="Music Assistant",
-        )
+        self._attr_device_info = get_party_device_info(instance_id)
         self._attr_unique_id = f"{instance_id}_{config_key}"
 
     @override

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -73,21 +73,28 @@ async def async_setup_entry(
     entry.runtime_data.platform_handlers.setdefault(Platform.SWITCH, add_player)
 
     def add_party_mode(instance_id: str) -> None:
-        """Handle add party mode."""
-        entities: list[MusicAssistantPartyModeSwitch] = [
-            MusicAssistantPartyModeSwitch(
-                mass,
-                instance_id,
-                config_key=switch_key,
-                entity_description=SwitchEntityDescription(
-                    key=f"party_mode_{switch_key}",
-                    translation_key=f"party_mode_{switch_key}",
-                    entity_category=category,
-                ),
-            )
-            for switch_key, category in PARTY_MODE_SWITCHES.items()
-        ]
-        async_add_entities(entities)
+        async def _add_entities() -> None:
+            entities: list[MusicAssistantPartyModeSwitch] = []
+            if party_config := await mass.config.get_provider_config(instance_id):
+                for switch_key, category in PARTY_MODE_SWITCHES.items():
+                    if switch_key not in party_config.values:
+                        continue
+
+                    entities.append(
+                        MusicAssistantPartyModeSwitch(
+                            mass,
+                            instance_id,
+                            config_key=switch_key,
+                            entity_description=SwitchEntityDescription(
+                                key=f"party_mode_{switch_key}",
+                                translation_key=f"party_mode_{switch_key}",
+                                entity_category=category,
+                            ),
+                        )
+                    )
+            async_add_entities(entities)
+
+        hass.create_task(_add_entities())
 
     entry.runtime_data.party_handlers.setdefault(Platform.SWITCH, add_party_mode)
 

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -82,11 +82,10 @@ async def async_setup_entry(
                 entity_description=SwitchEntityDescription(
                     key=f"party_mode_{switch_key}",
                     translation_key=f"party_mode_{switch_key}",
-                    icon=icon,
                     entity_category=category,
                 ),
             )
-            for switch_key, (icon, category) in PARTY_MODE_SWITCHES.items()
+            for switch_key, category in PARTY_MODE_SWITCHES.items()
         ]
         async_add_entities(entities)
 
@@ -129,18 +128,18 @@ class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchE
 
 
 PARTY_MODE_SWITCHES = {
-    "enable_guest_access": ("mdi:account-group", None),
-    "karaoke_mode": ("mdi:microphone", None),
-    "highlight_ahead": ("mdi:format-color-highlight", EntityCategory.CONFIG),
-    "hide_back_button": ("mdi:arrow-left-box", EntityCategory.CONFIG),
-    "show_progress_bar": ("mdi:progress-clock", EntityCategory.CONFIG),
-    "enable_rate_limiting": ("mdi:speedometer", EntityCategory.CONFIG),
-    "enable_add_queue": ("mdi:playlist-plus", EntityCategory.CONFIG),
-    "prevent_duplicate_tracks": ("mdi:playlist-check", EntityCategory.CONFIG),
-    "enable_boost": ("mdi:rocket-launch", EntityCategory.CONFIG),
-    "enable_skip_song": ("mdi:skip-next", EntityCategory.CONFIG),
-    "anti_burn_in": ("mdi:television-shimmer", EntityCategory.CONFIG),
-    "display_lyrics": ("mdi:script-text", EntityCategory.CONFIG),
+    "enable_guest_access": None,
+    "karaoke_mode": None,
+    "highlight_ahead": EntityCategory.CONFIG,
+    "hide_back_button": EntityCategory.CONFIG,
+    "show_progress_bar": EntityCategory.CONFIG,
+    "enable_rate_limiting": EntityCategory.CONFIG,
+    "enable_add_queue": EntityCategory.CONFIG,
+    "prevent_duplicate_tracks": EntityCategory.CONFIG,
+    "enable_boost": EntityCategory.CONFIG,
+    "enable_skip_song": EntityCategory.CONFIG,
+    "anti_burn_in": EntityCategory.CONFIG,
+    "display_lyrics": EntityCategory.CONFIG,
 }
 
 

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -3,14 +3,18 @@
 from typing import Any, Final, override
 
 from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.enums import EventType
+from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
+from .const import DOMAIN
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
@@ -71,6 +75,24 @@ async def async_setup_entry(
     # register callback to add players when they are discovered
     entry.runtime_data.platform_handlers.setdefault(Platform.SWITCH, add_player)
 
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+        entities: list[MusicAssistantPartyModeSwitch] = [
+            MusicAssistantPartyModeSwitch(
+                mass,
+                instance_id,
+                config_key=switch_key,
+                entity_description=SwitchEntityDescription(
+                    key=f"party_mode_{switch_key}",
+                    translation_key=f"party_mode_{switch_key}",
+                ),
+            )
+            for switch_key in PARTY_MODE_SWITCHES
+        ]
+        async_add_entities(entities)
+
+    entry.runtime_data.party_handlers.setdefault(Platform.SWITCH, add_party_mode)
+
 
 class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchEntity):
     """Representation of a Switch entity to control player settings."""
@@ -104,4 +126,89 @@ class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchE
         """Update on player option update."""
         self._attr_is_on = (
             player_option.value if isinstance(player_option.value, bool) else None
+        )
+
+
+PARTY_MODE_SWITCHES = [
+    "enable_guest_access",
+    "karaoke_mode",
+    "enable_rate_limiting",
+    "enable_boost",
+    "enable_add_queue",
+    "anti_burn_in",
+]
+
+
+class MusicAssistantPartyModeSwitch(SwitchEntity):
+    """Representation of a Switch entity to control party mode settings."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        config_key: str,
+        entity_description: SwitchEntityDescription,
+    ) -> None:
+        """Initialize."""
+        self.mass = mass
+        self.instance_id = instance_id
+        self.config_key = config_key
+        self.entity_description = entity_description
+
+        provider = self.mass.get_provider(instance_id)
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, instance_id)},
+            name=provider.name if provider else "Party Mode",
+            manufacturer="Music Assistant",
+        )
+        self._attr_unique_id = f"{instance_id}_{config_key}"
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    @catch_musicassistant_error
+    async def async_on_update(self) -> None:
+        """Update switch state."""
+        try:
+            party_config = await self.mass.config.get_provider_config(self.instance_id)
+            self._attr_is_on = bool(party_config.get_value(self.config_key))
+            self._attr_available = True
+        except Exception:  # noqa: BLE001
+            self._attr_available = False
+
+    @catch_musicassistant_error
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Handle turn on command."""
+        await self._async_set_state(True)
+
+    @catch_musicassistant_error
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Handle turn off command."""
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, state: bool) -> None:
+        """Set state."""
+        await self.mass.config.save_provider_config(
+            provider_domain="party",
+            instance_id=self.instance_id,
+            values={self.config_key: state},
         )

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -8,7 +8,7 @@ from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.const import EntityCategory, Platform
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -85,9 +85,10 @@ async def async_setup_entry(
                 entity_description=SwitchEntityDescription(
                     key=f"party_mode_{switch_key}",
                     translation_key=f"party_mode_{switch_key}",
+                    icon=icon,
                 ),
             )
-            for switch_key in PARTY_MODE_SWITCHES
+            for switch_key, icon in PARTY_MODE_SWITCHES.items()
         ]
         async_add_entities(entities)
 
@@ -129,21 +130,20 @@ class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchE
         )
 
 
-PARTY_MODE_SWITCHES = [
-    "enable_guest_access",
-    "karaoke_mode",
-    "enable_rate_limiting",
-    "enable_boost",
-    "enable_add_queue",
-    "anti_burn_in",
-]
+PARTY_MODE_SWITCHES = {
+    "enable_guest_access": "mdi:account-group",
+    "karaoke_mode": "mdi:microphone",
+    "enable_rate_limiting": "mdi:speedometer",
+    "enable_boost": "mdi:rocket-launch",
+    "enable_add_queue": "mdi:playlist-plus",
+    "anti_burn_in": "mdi:television-shimmer",
+}
 
 
 class MusicAssistantPartyModeSwitch(SwitchEntity):
     """Representation of a Switch entity to control party mode settings."""
 
     _attr_has_entity_name = True
-    _attr_entity_category = EntityCategory.CONFIG
     _attr_should_poll = False
 
     def __init__(
@@ -162,7 +162,7 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
         provider = self.mass.get_provider(instance_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id)},
-            name=provider.name if provider else "Party Mode",
+            name="Party Mode Plugin",
             manufacturer="Music Assistant",
         )
         self._attr_unique_id = f"{instance_id}_{config_key}"

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN
+from .const import DOMAIN, LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
@@ -195,7 +195,8 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
             party_config = await self.mass.config.get_provider_config(self.instance_id)
             self._attr_is_on = bool(party_config.get_value(self.config_key))
             self._attr_available = True
-        except Exception:  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Error in switch update: %s", err)
             self._attr_available = False
 
     @catch_musicassistant_error
@@ -212,6 +213,9 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
 
     async def _async_set_state(self, state: bool) -> None:
         """Set state."""
+        LOGGER.debug(
+            "Setting switch %s to %s for %s", self.config_key, state, self.instance_id
+        )
         await self.mass.config.save_provider_config(
             provider_domain="party",
             instance_id=self.instance_id,

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -158,8 +158,6 @@ class MusicAssistantPartyModeSwitch(SwitchEntity):
         self.instance_id = instance_id
         self.config_key = config_key
         self.entity_description = entity_description
-
-        provider = self.mass.get_provider(instance_id)
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, instance_id)},
             name="Party Mode Plugin",

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -143,6 +143,7 @@ PARTY_MODE_SWITCHES = {
     "enable_boost": ("mdi:rocket-launch", EntityCategory.CONFIG),
     "enable_skip_song": ("mdi:skip-next", EntityCategory.CONFIG),
     "anti_burn_in": ("mdi:television-shimmer", EntityCategory.CONFIG),
+    "display_lyrics": ("mdi:script-text", EntityCategory.CONFIG),
 }
 
 

--- a/homeassistant/components/music_assistant/switch.py
+++ b/homeassistant/components/music_assistant/switch.py
@@ -12,7 +12,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .entity import (
+    MusicAssistantPartyModeConfigEntity,
+    MusicAssistantPlayerOptionEntity,
+)
 from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_SWITCH: Final[dict[str, bool]] = {
@@ -27,6 +30,21 @@ PLAYER_OPTIONS_SWITCH: Final[dict[str, bool]] = {
     "speaker_a": True,
     "speaker_b": True,
     "surround_3d": False,
+}
+
+PARTY_MODE_SWITCHES = {
+    "enable_guest_access": None,
+    "karaoke_mode": None,
+    "highlight_ahead": EntityCategory.CONFIG,
+    "hide_back_button": EntityCategory.CONFIG,
+    "show_progress_bar": EntityCategory.CONFIG,
+    "enable_rate_limiting": EntityCategory.CONFIG,
+    "enable_add_queue": EntityCategory.CONFIG,
+    "prevent_duplicate_tracks": EntityCategory.CONFIG,
+    "enable_boost": EntityCategory.CONFIG,
+    "enable_skip_song": EntityCategory.CONFIG,
+    "anti_burn_in": EntityCategory.CONFIG,
+    "display_lyrics": EntityCategory.CONFIG,
 }
 
 
@@ -83,6 +101,7 @@ async def async_setup_entry(
                     entities.append(
                         MusicAssistantPartyModeSwitch(
                             mass,
+                            entry.runtime_data.party_config_coordinator,
                             instance_id,
                             config_key=switch_key,
                             entity_description=SwitchEntityDescription(
@@ -134,47 +153,44 @@ class MusicAssistantPlayerConfigSwitch(MusicAssistantPlayerOptionEntity, SwitchE
         )
 
 
-PARTY_MODE_SWITCHES = {
-    "enable_guest_access": None,
-    "karaoke_mode": None,
-    "highlight_ahead": EntityCategory.CONFIG,
-    "hide_back_button": EntityCategory.CONFIG,
-    "show_progress_bar": EntityCategory.CONFIG,
-    "enable_rate_limiting": EntityCategory.CONFIG,
-    "enable_add_queue": EntityCategory.CONFIG,
-    "prevent_duplicate_tracks": EntityCategory.CONFIG,
-    "enable_boost": EntityCategory.CONFIG,
-    "enable_skip_song": EntityCategory.CONFIG,
-    "anti_burn_in": EntityCategory.CONFIG,
-    "display_lyrics": EntityCategory.CONFIG,
-}
-
-
-class MusicAssistantPartyModeSwitch(MusicAssistantPartyModeEntity, SwitchEntity):
+class MusicAssistantPartyModeSwitch(MusicAssistantPartyModeConfigEntity, SwitchEntity):
     """Representation of a Switch entity to control party mode settings."""
 
     def __init__(
         self,
         mass: MusicAssistantClient,
+        coordinator: Any,
         instance_id: str,
         config_key: str,
         entity_description: SwitchEntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(mass, instance_id, unique_id_suffix=config_key)
+        super().__init__(
+            mass=mass,
+            coordinator=coordinator,
+            instance_id=instance_id,
+            unique_id_suffix=config_key,
+        )
         self.config_key = config_key
         self.entity_description = entity_description
+        self._attr_is_on = None
 
     @override
-    async def async_on_update(self) -> None:
-        """Update switch state."""
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if not (party_config := self.coordinator.data):
+            self._attr_available = False
+            super()._handle_coordinator_update()
+            return
+
         try:
-            party_config = await self.mass.config.get_provider_config(self.instance_id)
             self._attr_is_on = bool(party_config.get_value(self.config_key))
             self._attr_available = True
         except Exception as err:  # noqa: BLE001
             LOGGER.debug("Error in switch update: %s", err)
             self._attr_available = False
+
+        super()._handle_coordinator_update()
 
     @catch_musicassistant_error
     @override

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -169,7 +169,6 @@ class MusicAssistantPartyModeText(TextEntity):
         await self.async_on_update()
         self.async_write_ha_state()
 
-    @catch_musicassistant_error
     async def async_on_update(self) -> None:
         """Update text state."""
         try:

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -21,8 +21,8 @@ PLAYER_OPTIONS_TEXT: Final[dict[str, bool]] = {
 }
 
 PARTY_MODE_TEXTS = {
-    "party_name": ("mdi:rename-box", None),
-    "qr_text": ("mdi:text-box", EntityCategory.CONFIG),
+    "party_name": None,
+    "qr_text": EntityCategory.CONFIG,
 }
 
 
@@ -75,7 +75,7 @@ async def async_setup_entry(
         async def _add_entities() -> None:
             entities: list[MusicAssistantPartyModeText] = []
             if party_config := await mass.config.get_provider_config(instance_id):
-                for text_key, (icon, category) in PARTY_MODE_TEXTS.items():
+                for text_key, category in PARTY_MODE_TEXTS.items():
                     if text_key not in party_config.values:
                         continue
 
@@ -87,7 +87,6 @@ async def async_setup_entry(
                             entity_description=TextEntityDescription(
                                 key=f"party_mode_{text_key}",
                                 translation_key=f"party_mode_{text_key}",
-                                icon=icon,
                                 entity_category=category,
                             ),
                         )

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -3,20 +3,28 @@
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.enums import EventType
+from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.text import TextEntity, TextEntityDescription
-from homeassistant.const import Platform
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import MusicAssistantConfigEntry
+from . import DOMAIN, MusicAssistantConfigEntry
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_TEXT: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
     "network_name": True
+}
+
+PARTY_MODE_TEXTS = {
+    "party_name": ("mdi:rename-box", None),
+    "qr_text": ("mdi:text-box", EntityCategory.CONFIG),
 }
 
 
@@ -63,6 +71,37 @@ async def async_setup_entry(
     # register callback to add players when they are discovered
     entry.runtime_data.platform_handlers.setdefault(Platform.TEXT, add_player)
 
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+
+        async def _add_entities() -> None:
+            entities: list[MusicAssistantPartyModeText] = []
+            if party_config := await mass.config.get_provider_config(instance_id):
+                for text_key, (icon, category) in PARTY_MODE_TEXTS.items():
+                    if text_key not in party_config.values:
+                        continue
+
+                    entities.append(
+                        MusicAssistantPartyModeText(
+                            mass,
+                            instance_id,
+                            config_key=text_key,
+                            entity_description=TextEntityDescription(
+                                key=f"party_mode_{text_key}",
+                                translation_key=f"party_mode_{text_key}",
+                                icon=icon,
+                                entity_category=category,
+                            ),
+                        )
+                    )
+            async_add_entities(entities)
+
+        entry.async_create_background_task(
+            hass, _add_entities(), "music_assistant_party_mode_texts"
+        )
+
+    entry.runtime_data.party_handlers.setdefault(Platform.TEXT, add_party_mode)
+
 
 class MusicAssistantPlayerConfigText(MusicAssistantPlayerOptionEntity, TextEntity):
     """Representation of a text entity to control player provider dependent settings."""
@@ -90,4 +129,69 @@ class MusicAssistantPlayerConfigText(MusicAssistantPlayerOptionEntity, TextEntit
         """Update on player option update."""
         self._attr_native_value = (
             player_option.value if isinstance(player_option.value, str) else None
+        )
+
+
+class MusicAssistantPartyModeText(TextEntity):
+    """Representation of a Text entity to control party mode settings."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        config_key: str,
+        entity_description: TextEntityDescription,
+    ) -> None:
+        """Initialize."""
+        self.mass = mass
+        self.instance_id = instance_id
+        self.config_key = config_key
+        self.entity_description = entity_description
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, instance_id)},
+            name="Party Mode Plugin",
+            manufacturer="Music Assistant",
+        )
+        self._attr_unique_id = f"{instance_id}_{config_key}"
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    @catch_musicassistant_error
+    async def async_on_update(self) -> None:
+        """Update text state."""
+        try:
+            party_config = await self.mass.config.get_provider_config(self.instance_id)
+            if value := party_config.get_value(self.config_key):
+                self._attr_native_value = str(value)
+            else:
+                self._attr_native_value = ""
+            self._attr_available = True
+        except Exception:  # noqa: BLE001
+            self._attr_available = False
+
+    @catch_musicassistant_error
+    @override
+    async def async_set_value(self, value: str) -> None:
+        """Set a new value."""
+        await self.mass.config.save_provider_config(
+            provider_domain="party",
+            instance_id=self.instance_id,
+            values={self.config_key: value},
         )

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -3,8 +3,6 @@
 from typing import Final, override
 
 from music_assistant_client.client import MusicAssistantClient
-from music_assistant_models.enums import EventType
-from music_assistant_models.event import MassEvent
 from music_assistant_models.player import PlayerOption, PlayerOptionType
 
 from homeassistant.components.text import TextEntity, TextEntityDescription
@@ -14,8 +12,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error, get_party_device_info
+from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_TEXT: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -132,11 +130,8 @@ class MusicAssistantPlayerConfigText(MusicAssistantPlayerOptionEntity, TextEntit
         )
 
 
-class MusicAssistantPartyModeText(TextEntity):
+class MusicAssistantPartyModeText(MusicAssistantPartyModeEntity, TextEntity):
     """Representation of a Text entity to control party mode settings."""
-
-    _attr_has_entity_name = True
-    _attr_should_poll = False
 
     def __init__(
         self,
@@ -146,29 +141,11 @@ class MusicAssistantPartyModeText(TextEntity):
         entity_description: TextEntityDescription,
     ) -> None:
         """Initialize."""
-        self.mass = mass
-        self.instance_id = instance_id
+        super().__init__(mass, instance_id, unique_id_suffix=config_key)
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = get_party_device_info(instance_id)
-        self._attr_unique_id = f"{instance_id}_{config_key}"
 
     @override
-    async def async_added_to_hass(self) -> None:
-        """Register callbacks."""
-        await self.async_on_update()
-        self.async_on_remove(
-            self.mass.subscribe(
-                self.__on_mass_update,
-                EventType.PROVIDERS_UPDATED,
-            )
-        )
-
-    async def __on_mass_update(self, event: MassEvent) -> None:
-        """Call when we receive an event from MusicAssistant."""
-        await self.async_on_update()
-        self.async_write_ha_state()
-
     async def async_on_update(self) -> None:
         """Update text state."""
         try:

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -10,13 +10,12 @@ from music_assistant_models.player import PlayerOption, PlayerOptionType
 from homeassistant.components.text import TextEntity, TextEntityDescription
 from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
-from .const import DOMAIN, LOGGER
+from .const import LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
-from .helpers import catch_musicassistant_error
+from .helpers import catch_musicassistant_error, get_party_device_info
 
 PLAYER_OPTIONS_TEXT: Final[dict[str, bool]] = {
     # translation_key: enabled_by_default
@@ -151,11 +150,7 @@ class MusicAssistantPartyModeText(TextEntity):
         self.instance_id = instance_id
         self.config_key = config_key
         self.entity_description = entity_description
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, instance_id)},
-            name="Party Mode Plugin",
-            manufacturer="Music Assistant",
-        )
+        self._attr_device_info = get_party_device_info(instance_id)
         self._attr_unique_id = f"{instance_id}_{config_key}"
 
     @override

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -13,7 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from . import DOMAIN, MusicAssistantConfigEntry
+from . import MusicAssistantConfigEntry
+from .const import DOMAIN, LOGGER
 from .entity import MusicAssistantPlayerOptionEntity
 from .helpers import catch_musicassistant_error
 
@@ -183,13 +184,17 @@ class MusicAssistantPartyModeText(TextEntity):
             else:
                 self._attr_native_value = ""
             self._attr_available = True
-        except Exception:  # noqa: BLE001
+        except Exception as err:  # noqa: BLE001
+            LOGGER.debug("Error in text update: %s", err)
             self._attr_available = False
 
     @catch_musicassistant_error
     @override
     async def async_set_value(self, value: str) -> None:
         """Set a new value."""
+        LOGGER.debug(
+            "Setting text %s to %s for %s", self.config_key, value, self.instance_id
+        )
         await self.mass.config.save_provider_config(
             provider_domain="party",
             instance_id=self.instance_id,

--- a/homeassistant/components/music_assistant/text.py
+++ b/homeassistant/components/music_assistant/text.py
@@ -1,6 +1,6 @@
 """Music Assistant text platform."""
 
-from typing import Final, override
+from typing import Any, Final, override
 
 from music_assistant_client.client import MusicAssistantClient
 from music_assistant_models.player import PlayerOption, PlayerOptionType
@@ -12,7 +12,10 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import MusicAssistantConfigEntry
 from .const import LOGGER
-from .entity import MusicAssistantPartyModeEntity, MusicAssistantPlayerOptionEntity
+from .entity import (
+    MusicAssistantPartyModeConfigEntity,
+    MusicAssistantPlayerOptionEntity,
+)
 from .helpers import catch_musicassistant_error
 
 PLAYER_OPTIONS_TEXT: Final[dict[str, bool]] = {
@@ -82,6 +85,7 @@ async def async_setup_entry(
                     entities.append(
                         MusicAssistantPartyModeText(
                             mass,
+                            entry.runtime_data.party_config_coordinator,
                             instance_id,
                             config_key=text_key,
                             entity_description=TextEntityDescription(
@@ -129,34 +133,45 @@ class MusicAssistantPlayerConfigText(MusicAssistantPlayerOptionEntity, TextEntit
         )
 
 
-class MusicAssistantPartyModeText(MusicAssistantPartyModeEntity, TextEntity):
+class MusicAssistantPartyModeText(MusicAssistantPartyModeConfigEntity, TextEntity):
     """Representation of a Text entity to control party mode settings."""
 
     def __init__(
         self,
         mass: MusicAssistantClient,
+        coordinator: Any,
         instance_id: str,
         config_key: str,
         entity_description: TextEntityDescription,
     ) -> None:
         """Initialize."""
-        super().__init__(mass, instance_id, unique_id_suffix=config_key)
+        super().__init__(
+            mass=mass,
+            coordinator=coordinator,
+            instance_id=instance_id,
+            unique_id_suffix=config_key,
+        )
         self.config_key = config_key
         self.entity_description = entity_description
+        self._attr_native_value = None
 
     @override
-    async def async_on_update(self) -> None:
+    def _handle_coordinator_update(self) -> None:
         """Update text state."""
+        if not (party_config := self.coordinator.data):
+            self._attr_available = False
+            super()._handle_coordinator_update()
+            return
+
         try:
-            party_config = await self.mass.config.get_provider_config(self.instance_id)
-            if value := party_config.get_value(self.config_key):
-                self._attr_native_value = str(value)
-            else:
-                self._attr_native_value = ""
+            value = party_config.get_value(self.config_key)
+            self._attr_native_value = str(value) if value is not None else None
             self._attr_available = True
         except Exception as err:  # noqa: BLE001
             LOGGER.debug("Error in text update: %s", err)
             self._attr_available = False
+
+        super()._handle_coordinator_update()
 
     @catch_musicassistant_error
     @override

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2959,6 +2959,9 @@ screenlogicpy==0.10.2
 # homeassistant.components.backup
 securetar==2026.4.1
 
+# homeassistant.components.music_assistant
+segno==1.6.1
+
 # homeassistant.components.sendgrid
 sendgrid==6.8.2
 

--- a/tests/components/music_assistant/common.py
+++ b/tests/components/music_assistant/common.py
@@ -81,6 +81,7 @@ async def setup_integration_from_fixtures(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    music_assistant_client.send_command.reset_mock()
     return config_entry
 
 

--- a/tests/components/music_assistant/conftest.py
+++ b/tests/components/music_assistant/conftest.py
@@ -8,7 +8,13 @@ from music_assistant_client.music import Music
 from music_assistant_client.player_queues import PlayerQueues
 from music_assistant_client.players import Players
 from music_assistant_models.api import ServerInfoMessage
-from music_assistant_models.config_entries import PlayerConfig
+from music_assistant_models.config_entries import (
+    ConfigEntry,
+    PlayerConfig,
+    ProviderConfig,
+)
+from music_assistant_models.enums import ConfigEntryType, ProviderType
+from music_assistant_models.provider import ProviderInstance
 import pytest
 
 from homeassistant.components.music_assistant.config_flow import CONF_URL
@@ -84,7 +90,156 @@ async def music_assistant_client_fixture() -> AsyncGenerator[MagicMock]:
                 for player in client.players
             ]
 
-        client.config.get_player_configs = get_player_configs
+        client.config.get_player_configs = AsyncMock(side_effect=get_player_configs)
+
+        async def get_provider_config(instance_id: str) -> ProviderConfig | None:
+            if instance_id == "party_instance":
+                return ProviderConfig(
+                    type=ProviderType.PLUGIN,
+                    domain="party",
+                    instance_id="party_instance",
+                    values={
+                        # Switches
+                        "enable_guest_access": ConfigEntry(
+                            key="enable_guest_access",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=True,
+                        ),
+                        "karaoke_mode": ConfigEntry(
+                            key="karaoke_mode",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=False,
+                        ),
+                        "highlight_ahead": ConfigEntry(
+                            key="highlight_ahead",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=True,
+                        ),
+                        "hide_back_button": ConfigEntry(
+                            key="hide_back_button",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=False,
+                        ),
+                        "show_progress_bar": ConfigEntry(
+                            key="show_progress_bar",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=True,
+                        ),
+                        "enable_rate_limiting": ConfigEntry(
+                            key="enable_rate_limiting",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=False,
+                        ),
+                        "enable_add_queue": ConfigEntry(
+                            key="enable_add_queue",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=True,
+                        ),
+                        "prevent_duplicate_tracks": ConfigEntry(
+                            key="prevent_duplicate_tracks",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=True,
+                        ),
+                        "enable_boost": ConfigEntry(
+                            key="enable_boost",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=False,
+                        ),
+                        "enable_skip_song": ConfigEntry(
+                            key="enable_skip_song",
+                            type=ConfigEntryType.BOOLEAN,
+                            value=False,
+                        ),
+                        "anti_burn_in": ConfigEntry(
+                            key="anti_burn_in", type=ConfigEntryType.BOOLEAN, value=True
+                        ),
+                        # Texts
+                        "party_name": ConfigEntry(
+                            key="party_name", type=ConfigEntryType.STRING, value="Party"
+                        ),
+                        "qr_text": ConfigEntry(
+                            key="qr_text",
+                            type=ConfigEntryType.STRING,
+                            value="Scan to join",
+                        ),
+                        # Numbers
+                        "add_to_queue_limit": ConfigEntry(
+                            key="add_to_queue_limit",
+                            type=ConfigEntryType.INTEGER,
+                            value=20,
+                        ),
+                        "add_to_queue_refill_minutes": ConfigEntry(
+                            key="add_to_queue_refill_minutes",
+                            type=ConfigEntryType.INTEGER,
+                            value=5,
+                        ),
+                        "boost_limit": ConfigEntry(
+                            key="boost_limit", type=ConfigEntryType.INTEGER, value=8
+                        ),
+                        "boost_refill_minutes": ConfigEntry(
+                            key="boost_refill_minutes",
+                            type=ConfigEntryType.INTEGER,
+                            value=10,
+                        ),
+                        "skip_song_limit": ConfigEntry(
+                            key="skip_song_limit", type=ConfigEntryType.INTEGER, value=5
+                        ),
+                        "skip_song_refill_minutes": ConfigEntry(
+                            key="skip_song_refill_minutes",
+                            type=ConfigEntryType.INTEGER,
+                            value=15,
+                        ),
+                        # Selects
+                        "player": ConfigEntry(
+                            key="player",
+                            type=ConfigEntryType.STRING,
+                            value="00:00:00:00:00:01",
+                        ),
+                        "request_badge_color": ConfigEntry(
+                            key="request_badge_color",
+                            type=ConfigEntryType.STRING,
+                            value="2d6a4f",
+                        ),
+                        "boost_badge_color": ConfigEntry(
+                            key="boost_badge_color",
+                            type=ConfigEntryType.STRING,
+                            value="3f51b5",
+                        ),
+                    },
+                )
+            return None
+
+        client.config.get_provider_config = AsyncMock(side_effect=get_provider_config)
+        client.config.save_provider_config = AsyncMock()
+
+        async def get_providers() -> list[ProviderInstance]:
+            """Mock get providers."""
+            return [
+                ProviderInstance(
+                    type=ProviderType.PLUGIN,
+                    domain="party",
+                    name="Party Mode",
+                    instance_id="party_instance",
+                    supported_features=set(),
+                    available=True,
+                )
+            ]
+
+        client.get_providers = AsyncMock(side_effect=get_providers)
+
+        def get_provider(domain: str) -> ProviderInstance | None:
+            if domain == "party":
+                return ProviderInstance(
+                    type=ProviderType.PLUGIN,
+                    domain="party",
+                    name="Party Mode Plugin",
+                    instance_id="party_instance",
+                    supported_features=set(),
+                    available=True,
+                )
+            return None
+
+        client.get_provider = MagicMock(side_effect=get_provider)
 
         yield client
 

--- a/tests/components/music_assistant/snapshots/test_image.ambr
+++ b/tests/components/music_assistant/snapshots/test_image.ambr
@@ -1,0 +1,54 @@
+# serializer version: 1
+# name: test_image_entities[image.party_mode_plugin_guest_qr_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.party_mode_plugin_guest_qr_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Guest qr code',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:qrcode',
+    'original_name': 'Guest qr code',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_qr',
+    'unique_id': 'party_instance_party_mode_qr',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_image_entities[image.party_mode_plugin_guest_qr_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: 'f4ccae1b5a598eba4a2f156d8169c448bc040865ae4e52e49a4e0e65ab474d2b',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=f4ccae1b5a598eba4a2f156d8169c448bc040865ae4e52e49a4e0e65ab474d2b',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest qr code',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:qrcode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.party_mode_plugin_guest_qr_code',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-07-08T14:09:21.263041+00:00',
+  })
+# ---

--- a/tests/components/music_assistant/snapshots/test_image.ambr
+++ b/tests/components/music_assistant/snapshots/test_image.ambr
@@ -25,7 +25,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:qrcode',
+    'original_icon': None,
     'original_name': 'Guest qr code',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -39,16 +39,15 @@
 # name: test_image_entities[image.party_mode_plugin_guest_qr_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '89a86aec9339b1408ca1a7f0bdb0754c613e106be66e18406a53461b5acd8e71',
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=89a86aec9339b1408ca1a7f0bdb0754c613e106be66e18406a53461b5acd8e71',
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=1',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest qr code',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:qrcode',
     }),
     'context': <ANY>,
     'entity_id': 'image.party_mode_plugin_guest_qr_code',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-07-08T14:22:30.809349+00:00',
+    'state': '2024-01-01T12:00:00+00:00',
   })
 # ---

--- a/tests/components/music_assistant/snapshots/test_image.ambr
+++ b/tests/components/music_assistant/snapshots/test_image.ambr
@@ -39,8 +39,8 @@
 # name: test_image_entities[image.party_mode_plugin_guest_qr_code-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: 'f4ccae1b5a598eba4a2f156d8169c448bc040865ae4e52e49a4e0e65ab474d2b',
-      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=f4ccae1b5a598eba4a2f156d8169c448bc040865ae4e52e49a4e0e65ab474d2b',
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '89a86aec9339b1408ca1a7f0bdb0754c613e106be66e18406a53461b5acd8e71',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=89a86aec9339b1408ca1a7f0bdb0754c613e106be66e18406a53461b5acd8e71',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest qr code',
       <EntityStateAttribute.ICON: 'icon'>: 'mdi:qrcode',
     }),
@@ -49,6 +49,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '2026-07-08T14:09:21.263041+00:00',
+    'state': '2026-07-08T14:22:30.809349+00:00',
   })
 # ---

--- a/tests/components/music_assistant/snapshots/test_image.ambr
+++ b/tests/components/music_assistant/snapshots/test_image.ambr
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Guest qr code',
+    'object_id_base': 'Guest QR code',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Guest qr code',
+    'original_name': 'Guest QR code',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -41,7 +41,7 @@
     'attributes': ReadOnlyDict({
       <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
       <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=1',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest qr code',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest QR code',
     }),
     'context': <ANY>,
     'entity_id': 'image.party_mode_plugin_guest_qr_code',

--- a/tests/components/music_assistant/snapshots/test_number.ambr
+++ b/tests/components/music_assistant/snapshots/test_number.ambr
@@ -30,7 +30,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:playlist-plus',
+    'original_icon': None,
     'original_name': 'Add to Queue Limit',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -45,7 +45,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to Queue Limit',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:playlist-plus',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 50,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -90,7 +89,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:timer',
+    'original_icon': None,
     'original_name': 'Add to Queue Refill (Minutes)',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -105,7 +104,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to Queue Refill (Minutes)',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:timer',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 30,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -150,7 +148,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:rocket-launch',
+    'original_icon': None,
     'original_name': 'Boost Limit',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -165,7 +163,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Limit',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:rocket-launch',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 10,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -210,7 +207,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:timer',
+    'original_icon': None,
     'original_name': 'Boost Refill (Minutes)',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -225,7 +222,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Refill (Minutes)',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:timer',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 120,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -270,7 +266,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:skip-next',
+    'original_icon': None,
     'original_name': 'Skip Song Limit',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -285,7 +281,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip Song Limit',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:skip-next',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 5,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -330,7 +325,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:timer',
+    'original_icon': None,
     'original_name': 'Skip Song Refill (Minutes)',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -345,7 +340,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip Song Refill (Minutes)',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:timer',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 180,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 15,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,

--- a/tests/components/music_assistant/snapshots/test_number.ambr
+++ b/tests/components/music_assistant/snapshots/test_number.ambr
@@ -26,12 +26,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Add to Queue Limit',
+    'object_id_base': 'Add to queue limit',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Add to Queue Limit',
+    'original_name': 'Add to queue limit',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -44,7 +44,7 @@
 # name: test_number_entities[number.party_mode_plugin_add_to_queue_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to Queue Limit',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to queue limit',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 50,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -85,12 +85,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Add to Queue Refill (Minutes)',
+    'object_id_base': 'Add to queue refill (minutes)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Add to Queue Refill (Minutes)',
+    'original_name': 'Add to queue refill (minutes)',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -103,7 +103,7 @@
 # name: test_number_entities[number.party_mode_plugin_add_to_queue_refill_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to Queue Refill (Minutes)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to queue refill (minutes)',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 30,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -144,12 +144,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Boost Limit',
+    'object_id_base': 'Boost limit',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Boost Limit',
+    'original_name': 'Boost limit',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -162,7 +162,7 @@
 # name: test_number_entities[number.party_mode_plugin_boost_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Limit',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost limit',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 10,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -203,12 +203,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Boost Refill (Minutes)',
+    'object_id_base': 'Boost refill (minutes)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Boost Refill (Minutes)',
+    'original_name': 'Boost refill (minutes)',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -221,7 +221,7 @@
 # name: test_number_entities[number.party_mode_plugin_boost_refill_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Refill (Minutes)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost refill (minutes)',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 120,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -262,12 +262,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Skip Song Limit',
+    'object_id_base': 'Skip song limit',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Skip Song Limit',
+    'original_name': 'Skip song limit',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -280,7 +280,7 @@
 # name: test_number_entities[number.party_mode_plugin_skip_song_limit-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip Song Limit',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip song limit',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 5,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
@@ -321,12 +321,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Skip Song Refill (Minutes)',
+    'object_id_base': 'Skip song refill (minutes)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Skip Song Refill (Minutes)',
+    'original_name': 'Skip song refill (minutes)',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -339,7 +339,7 @@
 # name: test_number_entities[number.party_mode_plugin_skip_song_refill_minutes-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip Song Refill (Minutes)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip song refill (minutes)',
       <NumberEntityCapabilityAttribute.MAX: 'max'>: 180,
       <NumberEntityCapabilityAttribute.MIN: 'min'>: 15,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,

--- a/tests/components/music_assistant/snapshots/test_number.ambr
+++ b/tests/components/music_assistant/snapshots/test_number.ambr
@@ -1,4 +1,364 @@
 # serializer version: 1
+# name: test_number_entities[number.party_mode_plugin_add_to_queue_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 50,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.party_mode_plugin_add_to_queue_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Add to Queue Limit',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:playlist-plus',
+    'original_name': 'Add to Queue Limit',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_add_to_queue_limit',
+    'unique_id': 'party_instance_add_to_queue_limit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_add_to_queue_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to Queue Limit',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:playlist-plus',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 50,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.party_mode_plugin_add_to_queue_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '20.0',
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_add_to_queue_refill_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 30,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.party_mode_plugin_add_to_queue_refill_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Add to Queue Refill (Minutes)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer',
+    'original_name': 'Add to Queue Refill (Minutes)',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_add_to_queue_refill_minutes',
+    'unique_id': 'party_instance_add_to_queue_refill_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_add_to_queue_refill_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Add to Queue Refill (Minutes)',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:timer',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 30,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.party_mode_plugin_add_to_queue_refill_minutes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.0',
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_boost_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 10,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.party_mode_plugin_boost_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boost Limit',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:rocket-launch',
+    'original_name': 'Boost Limit',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_boost_limit',
+    'unique_id': 'party_instance_boost_limit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_boost_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Limit',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:rocket-launch',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 10,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.party_mode_plugin_boost_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8.0',
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_boost_refill_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 120,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.party_mode_plugin_boost_refill_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boost Refill (Minutes)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer',
+    'original_name': 'Boost Refill (Minutes)',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_boost_refill_minutes',
+    'unique_id': 'party_instance_boost_refill_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_boost_refill_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Refill (Minutes)',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:timer',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 120,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 5,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.party_mode_plugin_boost_refill_minutes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10.0',
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_skip_song_limit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 5,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.party_mode_plugin_skip_song_limit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Skip Song Limit',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:skip-next',
+    'original_name': 'Skip Song Limit',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_skip_song_limit',
+    'unique_id': 'party_instance_skip_song_limit',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_skip_song_limit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip Song Limit',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:skip-next',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 5,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 1,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.party_mode_plugin_skip_song_limit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.0',
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_skip_song_refill_minutes-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 180,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 15,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.party_mode_plugin_skip_song_refill_minutes',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Skip Song Refill (Minutes)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:timer',
+    'original_name': 'Skip Song Refill (Minutes)',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_skip_song_refill_minutes',
+    'unique_id': 'party_instance_skip_song_refill_minutes',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_number_entities[number.party_mode_plugin_skip_song_refill_minutes-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Skip Song Refill (Minutes)',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:timer',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 180,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 15,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1,
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.party_mode_plugin_skip_song_refill_minutes',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15.0',
+  })
+# ---
 # name: test_number_entities[number.test_player_1_bass-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/music_assistant/snapshots/test_select.ambr
+++ b/tests/components/music_assistant/snapshots/test_select.ambr
@@ -38,12 +38,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Boost Badge Color',
+    'object_id_base': 'Boost badge color',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Boost Badge Color',
+    'original_name': 'Boost badge color',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -56,7 +56,7 @@
 # name: test_select_entities[select.party_mode_plugin_boost_badge_color-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Badge Color',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost badge color',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '2d6a4f',
         'b55522',
@@ -111,12 +111,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Party Player',
+    'object_id_base': 'Party player',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Party Player',
+    'original_name': 'Party player',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -129,7 +129,7 @@
 # name: test_select_entities[select.party_mode_plugin_party_player-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party Player',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party player',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Auto',
         'My Super Test Player 2',
@@ -184,12 +184,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Request Badge Color',
+    'object_id_base': 'Request badge color',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Request Badge Color',
+    'original_name': 'Request badge color',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -202,7 +202,7 @@
 # name: test_select_entities[select.party_mode_plugin_request_badge_color-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Request Badge Color',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Request badge color',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '2d6a4f',
         'b55522',

--- a/tests/components/music_assistant/snapshots/test_select.ambr
+++ b/tests/components/music_assistant/snapshots/test_select.ambr
@@ -1,4 +1,236 @@
 # serializer version: 1
+# name: test_select_entities[select.party_mode_plugin_boost_badge_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        '2d6a4f',
+        'b55522',
+        'e91e63',
+        'f06292',
+        '9c27b0',
+        '673ab7',
+        '3f51b5',
+        '00bcd4',
+        '009688',
+        '4caf50',
+        '8bc34a',
+        'e64a19',
+        'ffc107',
+        'ffeb3b',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.party_mode_plugin_boost_badge_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Boost Badge Color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:palette',
+    'original_name': 'Boost Badge Color',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_boost_badge_color',
+    'unique_id': 'party_instance_boost_badge_color',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_entities[select.party_mode_plugin_boost_badge_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Badge Color',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:palette',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        '2d6a4f',
+        'b55522',
+        'e91e63',
+        'f06292',
+        '9c27b0',
+        '673ab7',
+        '3f51b5',
+        '00bcd4',
+        '009688',
+        '4caf50',
+        '8bc34a',
+        'e64a19',
+        'ffc107',
+        'ffeb3b',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.party_mode_plugin_boost_badge_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '3f51b5',
+  })
+# ---
+# name: test_select_entities[select.party_mode_plugin_party_player-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'Auto',
+        'My Super Test Player 2',
+        'Test Group Player 1',
+        'Test Player 1',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.party_mode_plugin_party_player',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Party Player',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:speaker-multiple',
+    'original_name': 'Party Player',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_party_player',
+    'unique_id': 'party_instance_player',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_entities[select.party_mode_plugin_party_player-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party Player',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:speaker-multiple',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'Auto',
+        'My Super Test Player 2',
+        'Test Group Player 1',
+        'Test Player 1',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.party_mode_plugin_party_player',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Test Player 1',
+  })
+# ---
+# name: test_select_entities[select.party_mode_plugin_request_badge_color-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        '2d6a4f',
+        'b55522',
+        'e91e63',
+        'f06292',
+        '9c27b0',
+        '673ab7',
+        '3f51b5',
+        '00bcd4',
+        '009688',
+        '4caf50',
+        '8bc34a',
+        'e64a19',
+        'ffc107',
+        'ffeb3b',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.party_mode_plugin_request_badge_color',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Request Badge Color',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:palette',
+    'original_name': 'Request Badge Color',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_request_badge_color',
+    'unique_id': 'party_instance_request_badge_color',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_select_entities[select.party_mode_plugin_request_badge_color-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Request Badge Color',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:palette',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        '2d6a4f',
+        'b55522',
+        'e91e63',
+        'f06292',
+        '9c27b0',
+        '673ab7',
+        '3f51b5',
+        '00bcd4',
+        '009688',
+        '4caf50',
+        '8bc34a',
+        'e64a19',
+        'ffc107',
+        'ffeb3b',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.party_mode_plugin_request_badge_color',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2d6a4f',
+  })
+# ---
 # name: test_select_entities[select.test_player_1_link_audio_delay-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/music_assistant/snapshots/test_select.ambr
+++ b/tests/components/music_assistant/snapshots/test_select.ambr
@@ -42,7 +42,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:palette',
+    'original_icon': None,
     'original_name': 'Boost Badge Color',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -57,7 +57,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Boost Badge Color',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:palette',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '2d6a4f',
         'b55522',
@@ -116,7 +115,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:speaker-multiple',
+    'original_icon': None,
     'original_name': 'Party Player',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -131,7 +130,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party Player',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:speaker-multiple',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'Auto',
         'My Super Test Player 2',
@@ -190,7 +188,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:palette',
+    'original_icon': None,
     'original_name': 'Request Badge Color',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -205,7 +203,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Request Badge Color',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:palette',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         '2d6a4f',
         'b55522',

--- a/tests/components/music_assistant/snapshots/test_sensor.ambr
+++ b/tests/components/music_assistant/snapshots/test_sensor.ambr
@@ -25,7 +25,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:link',
+    'original_icon': None,
     'original_name': 'Guest url',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -40,7 +40,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest url',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:link',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.party_mode_plugin_guest_url',

--- a/tests/components/music_assistant/snapshots/test_sensor.ambr
+++ b/tests/components/music_assistant/snapshots/test_sensor.ambr
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Guest url',
+    'object_id_base': 'Guest URL',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Guest url',
+    'original_name': 'Guest URL',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -39,7 +39,7 @@
 # name: test_sensor_entities[sensor.party_mode_plugin_guest_url-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest url',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest URL',
     }),
     'context': <ANY>,
     'entity_id': 'sensor.party_mode_plugin_guest_url',

--- a/tests/components/music_assistant/snapshots/test_sensor.ambr
+++ b/tests/components/music_assistant/snapshots/test_sensor.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_sensor_entities[sensor.party_mode_plugin_guest_url-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.party_mode_plugin_guest_url',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Guest url',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:link',
+    'original_name': 'Guest url',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_url',
+    'unique_id': 'party_instance_party_mode_url',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities[sensor.party_mode_plugin_guest_url-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest url',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:link',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.party_mode_plugin_guest_url',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'http://mock-party-url',
+  })
+# ---

--- a/tests/components/music_assistant/snapshots/test_switch.ambr
+++ b/tests/components/music_assistant/snapshots/test_switch.ambr
@@ -1,4 +1,616 @@
 # serializer version: 1
+# name: test_switch_entities[switch.party_mode_plugin_anti_burn_in-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_anti_burn_in',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Anti burn-in',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:television-shimmer',
+    'original_name': 'Anti burn-in',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_anti_burn_in',
+    'unique_id': 'party_instance_anti_burn_in',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_anti_burn_in-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Anti burn-in',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:television-shimmer',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_anti_burn_in',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_display_lyrics-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_display_lyrics',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Display Lyrics',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:script-text',
+    'original_name': 'Display Lyrics',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_display_lyrics',
+    'unique_id': 'party_instance_display_lyrics',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_display_lyrics-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Display Lyrics',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:script-text',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_display_lyrics',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_guest_access-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.party_mode_plugin_enable_guest_access',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Enable guest access',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:account-group',
+    'original_name': 'Enable guest access',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_enable_guest_access',
+    'unique_id': 'party_instance_enable_guest_access',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_guest_access-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable guest access',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:account-group',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_enable_guest_access',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_guest_add_to_queue-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_enable_guest_add_to_queue',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Enable guest add to queue',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:playlist-plus',
+    'original_name': 'Enable guest add to queue',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_enable_add_queue',
+    'unique_id': 'party_instance_enable_add_queue',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_guest_add_to_queue-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable guest add to queue',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:playlist-plus',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_enable_guest_add_to_queue',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_guest_boost-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_enable_guest_boost',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Enable guest boost',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:rocket-launch',
+    'original_name': 'Enable guest boost',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_enable_boost',
+    'unique_id': 'party_instance_enable_boost',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_guest_boost-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable guest boost',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:rocket-launch',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_enable_guest_boost',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_rate_limiting-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_enable_rate_limiting',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Enable rate limiting',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:speedometer',
+    'original_name': 'Enable rate limiting',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_enable_rate_limiting',
+    'unique_id': 'party_instance_enable_rate_limiting',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_rate_limiting-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable rate limiting',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:speedometer',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_enable_rate_limiting',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_skip_song-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_enable_skip_song',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Enable Skip Song',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:skip-next',
+    'original_name': 'Enable Skip Song',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_enable_skip_song',
+    'unique_id': 'party_instance_enable_skip_song',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_enable_skip_song-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable Skip Song',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:skip-next',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_enable_skip_song',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_hide_back_button-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_hide_back_button',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Hide Back Button',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:arrow-left-box',
+    'original_name': 'Hide Back Button',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_hide_back_button',
+    'unique_id': 'party_instance_hide_back_button',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_hide_back_button-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Hide Back Button',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:arrow-left-box',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_hide_back_button',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_highlight_ahead-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_highlight_ahead',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Highlight Ahead',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:format-color-highlight',
+    'original_name': 'Highlight Ahead',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_highlight_ahead',
+    'unique_id': 'party_instance_highlight_ahead',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_highlight_ahead-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Highlight Ahead',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:format-color-highlight',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_highlight_ahead',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_karaoke_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': None,
+    'entity_id': 'switch.party_mode_plugin_karaoke_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Karaoke mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:microphone',
+    'original_name': 'Karaoke mode',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_karaoke_mode',
+    'unique_id': 'party_instance_karaoke_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_karaoke_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Karaoke mode',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:microphone',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_karaoke_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_prevent_duplicate_tracks-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_prevent_duplicate_tracks',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Prevent Duplicate Tracks',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:playlist-check',
+    'original_name': 'Prevent Duplicate Tracks',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_prevent_duplicate_tracks',
+    'unique_id': 'party_instance_prevent_duplicate_tracks',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_prevent_duplicate_tracks-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Prevent Duplicate Tracks',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:playlist-check',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_prevent_duplicate_tracks',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_show_progress_bar-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.party_mode_plugin_show_progress_bar',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Show Progress Bar',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:progress-clock',
+    'original_name': 'Show Progress Bar',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_show_progress_bar',
+    'unique_id': 'party_instance_show_progress_bar',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_switch_entities[switch.party_mode_plugin_show_progress_bar-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Show Progress Bar',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:progress-clock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.party_mode_plugin_show_progress_bar',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_switch_entities[switch.test_player_1_enhancer-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/music_assistant/snapshots/test_switch.ambr
+++ b/tests/components/music_assistant/snapshots/test_switch.ambr
@@ -25,7 +25,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:television-shimmer',
+    'original_icon': None,
     'original_name': 'Anti burn-in',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -40,7 +40,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Anti burn-in',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:television-shimmer',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_anti_burn_in',
@@ -76,7 +75,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:script-text',
+    'original_icon': None,
     'original_name': 'Display Lyrics',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -91,7 +90,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Display Lyrics',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:script-text',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_display_lyrics',
@@ -127,7 +125,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:account-group',
+    'original_icon': None,
     'original_name': 'Enable guest access',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -142,7 +140,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable guest access',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:account-group',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_enable_guest_access',
@@ -178,7 +175,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:playlist-plus',
+    'original_icon': None,
     'original_name': 'Enable guest add to queue',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -193,7 +190,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable guest add to queue',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:playlist-plus',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_enable_guest_add_to_queue',
@@ -229,7 +225,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:rocket-launch',
+    'original_icon': None,
     'original_name': 'Enable guest boost',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -244,7 +240,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable guest boost',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:rocket-launch',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_enable_guest_boost',
@@ -280,7 +275,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:speedometer',
+    'original_icon': None,
     'original_name': 'Enable rate limiting',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -295,7 +290,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable rate limiting',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:speedometer',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_enable_rate_limiting',
@@ -331,7 +325,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:skip-next',
+    'original_icon': None,
     'original_name': 'Enable Skip Song',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -346,7 +340,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable Skip Song',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:skip-next',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_enable_skip_song',
@@ -382,7 +375,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:arrow-left-box',
+    'original_icon': None,
     'original_name': 'Hide Back Button',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -397,7 +390,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Hide Back Button',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:arrow-left-box',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_hide_back_button',
@@ -433,7 +425,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:format-color-highlight',
+    'original_icon': None,
     'original_name': 'Highlight Ahead',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -448,7 +440,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Highlight Ahead',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:format-color-highlight',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_highlight_ahead',
@@ -484,7 +475,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:microphone',
+    'original_icon': None,
     'original_name': 'Karaoke mode',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -499,7 +490,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Karaoke mode',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:microphone',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_karaoke_mode',
@@ -535,7 +525,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:playlist-check',
+    'original_icon': None,
     'original_name': 'Prevent Duplicate Tracks',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -550,7 +540,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Prevent Duplicate Tracks',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:playlist-check',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_prevent_duplicate_tracks',
@@ -586,7 +575,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:progress-clock',
+    'original_icon': None,
     'original_name': 'Show Progress Bar',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -601,7 +590,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Show Progress Bar',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:progress-clock',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_show_progress_bar',

--- a/tests/components/music_assistant/snapshots/test_switch.ambr
+++ b/tests/components/music_assistant/snapshots/test_switch.ambr
@@ -271,12 +271,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Enable Skip Song',
+    'object_id_base': 'Enable skip song',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Enable Skip Song',
+    'original_name': 'Enable skip song',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -289,7 +289,7 @@
 # name: test_switch_entities[switch.party_mode_plugin_enable_skip_song-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable Skip Song',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Enable skip song',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_enable_skip_song',
@@ -321,12 +321,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Hide Back Button',
+    'object_id_base': 'Hide back button',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Hide Back Button',
+    'original_name': 'Hide back button',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -339,7 +339,7 @@
 # name: test_switch_entities[switch.party_mode_plugin_hide_back_button-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Hide Back Button',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Hide back button',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_hide_back_button',
@@ -371,12 +371,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Highlight Ahead',
+    'object_id_base': 'Highlight ahead',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Highlight Ahead',
+    'original_name': 'Highlight ahead',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -389,7 +389,7 @@
 # name: test_switch_entities[switch.party_mode_plugin_highlight_ahead-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Highlight Ahead',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Highlight ahead',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_highlight_ahead',
@@ -471,12 +471,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Prevent Duplicate Tracks',
+    'object_id_base': 'Prevent duplicate tracks',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Prevent Duplicate Tracks',
+    'original_name': 'Prevent duplicate tracks',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -489,7 +489,7 @@
 # name: test_switch_entities[switch.party_mode_plugin_prevent_duplicate_tracks-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Prevent Duplicate Tracks',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Prevent duplicate tracks',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_prevent_duplicate_tracks',
@@ -521,12 +521,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Show Progress Bar',
+    'object_id_base': 'Show progress bar',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Show Progress Bar',
+    'original_name': 'Show progress bar',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -539,7 +539,7 @@
 # name: test_switch_entities[switch.party_mode_plugin_show_progress_bar-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Show Progress Bar',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Show progress bar',
     }),
     'context': <ANY>,
     'entity_id': 'switch.party_mode_plugin_show_progress_bar',

--- a/tests/components/music_assistant/snapshots/test_switch.ambr
+++ b/tests/components/music_assistant/snapshots/test_switch.ambr
@@ -49,56 +49,6 @@
     'state': 'on',
   })
 # ---
-# name: test_switch_entities[switch.party_mode_plugin_display_lyrics-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'switch',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'switch.party_mode_plugin_display_lyrics',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Display Lyrics',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Display Lyrics',
-    'platform': 'music_assistant',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'party_mode_display_lyrics',
-    'unique_id': 'party_instance_display_lyrics',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_switch_entities[switch.party_mode_plugin_display_lyrics-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Display Lyrics',
-    }),
-    'context': <ANY>,
-    'entity_id': 'switch.party_mode_plugin_display_lyrics',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_switch_entities[switch.party_mode_plugin_enable_guest_access-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/music_assistant/snapshots/test_text.ambr
+++ b/tests/components/music_assistant/snapshots/test_text.ambr
@@ -30,7 +30,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:rename-box',
+    'original_icon': None,
     'original_name': 'Party Name',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -45,7 +45,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party Name',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:rename-box',
       <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
       <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
       <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
@@ -90,7 +89,7 @@
     'options': dict({
     }),
     'original_device_class': None,
-    'original_icon': 'mdi:text-box',
+    'original_icon': None,
     'original_name': 'QR Text',
     'platform': 'music_assistant',
     'previous_unique_id': None,
@@ -105,7 +104,6 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin QR Text',
-      <EntityStateAttribute.ICON: 'icon'>: 'mdi:text-box',
       <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
       <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
       <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,

--- a/tests/components/music_assistant/snapshots/test_text.ambr
+++ b/tests/components/music_assistant/snapshots/test_text.ambr
@@ -1,4 +1,124 @@
 # serializer version: 1
+# name: test_text_entities[text.party_mode_plugin_party_name-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
+      <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
+      <TextEntityCapabilityAttribute.PATTERN: 'pattern'>: None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': None,
+    'entity_id': 'text.party_mode_plugin_party_name',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Party Name',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:rename-box',
+    'original_name': 'Party Name',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_party_name',
+    'unique_id': 'party_instance_party_name',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_text_entities[text.party_mode_plugin_party_name-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party Name',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:rename-box',
+      <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
+      <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
+      <TextEntityCapabilityAttribute.PATTERN: 'pattern'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.party_mode_plugin_party_name',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Party',
+  })
+# ---
+# name: test_text_entities[text.party_mode_plugin_qr_text-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
+      <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
+      <TextEntityCapabilityAttribute.PATTERN: 'pattern'>: None,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'text',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'text.party_mode_plugin_qr_text',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'QR Text',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': 'mdi:text-box',
+    'original_name': 'QR Text',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_qr_text',
+    'unique_id': 'party_instance_qr_text',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_text_entities[text.party_mode_plugin_qr_text-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin QR Text',
+      <EntityStateAttribute.ICON: 'icon'>: 'mdi:text-box',
+      <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
+      <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
+      <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
+      <TextEntityCapabilityAttribute.PATTERN: 'pattern'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'text.party_mode_plugin_qr_text',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'Scan to join',
+  })
+# ---
 # name: test_text_entities[text.test_player_1_network_name-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/music_assistant/snapshots/test_text.ambr
+++ b/tests/components/music_assistant/snapshots/test_text.ambr
@@ -26,12 +26,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Party Name',
+    'object_id_base': 'Party name',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Party Name',
+    'original_name': 'Party name',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -44,7 +44,7 @@
 # name: test_text_entities[text.party_mode_plugin_party_name-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party Name',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Party name',
       <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
       <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
       <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,
@@ -85,12 +85,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'QR Text',
+    'object_id_base': 'QR text',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'QR Text',
+    'original_name': 'QR text',
     'platform': 'music_assistant',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -103,7 +103,7 @@
 # name: test_text_entities[text.party_mode_plugin_qr_text-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin QR Text',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin QR text',
       <TextEntityCapabilityAttribute.MAX: 'max'>: 255,
       <TextEntityCapabilityAttribute.MIN: 'min'>: 0,
       <TextEntityCapabilityAttribute.MODE: 'mode'>: <TextMode.TEXT: 'text'>,

--- a/tests/components/music_assistant/test_image.py
+++ b/tests/components/music_assistant/test_image.py
@@ -1,0 +1,52 @@
+"""Test Music Assistant image entities."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from .common import setup_integration_from_fixtures, snapshot_music_assistant_entities
+
+from tests.common import async_fire_time_changed
+
+
+async def test_image_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test image entities."""
+    music_assistant_client.send_command.return_value = "http://mock-party-url"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    snapshot_music_assistant_entities(hass, entity_registry, snapshot, Platform.IMAGE)
+
+
+async def test_image_url_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test image updates when URL changes."""
+    music_assistant_client.send_command.return_value = "http://mock-party-url-1"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    last_updated = state.state
+    assert last_updated is not None
+
+    # Simulate URL change
+    music_assistant_client.send_command.return_value = "http://mock-party-url-2"
+
+    # Fast forward time to trigger periodic update
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state != last_updated

--- a/tests/components/music_assistant/test_image.py
+++ b/tests/components/music_assistant/test_image.py
@@ -1,8 +1,11 @@
 """Test Music Assistant image entities."""
 
+from collections.abc import Generator
 from datetime import timedelta
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
@@ -15,13 +18,25 @@ from .common import setup_integration_from_fixtures, snapshot_music_assistant_en
 from tests.common import async_fire_time_changed
 
 
+@pytest.fixture(autouse=True)
+def mock_getrandbits() -> Generator[None]:
+    """Mock image access token which normally is randomized."""
+    with patch(
+        "homeassistant.components.image.SystemRandom.getrandbits",
+        return_value=1,
+    ):
+        yield
+
+
 async def test_image_entities(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
     music_assistant_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test image entities."""
+    freezer.move_to("2024-01-01T12:00:00+00:00")
     music_assistant_client.send_command.return_value = "http://mock-party-url"
     await setup_integration_from_fixtures(hass, music_assistant_client)
     snapshot_music_assistant_entities(hass, entity_registry, snapshot, Platform.IMAGE)

--- a/tests/components/music_assistant/test_number.py
+++ b/tests/components/music_assistant/test_number.py
@@ -1,6 +1,6 @@
 """Test Music Assistant number entities."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 from music_assistant_models.enums import EventType
 import pytest
@@ -49,6 +49,7 @@ async def test_number_set_action(
     option_value = 3
 
     await setup_integration_from_fixtures(hass, music_assistant_client)
+    music_assistant_client.send_command.reset_mock()
     state = hass.states.get(entity_id)
     assert state
 
@@ -132,8 +133,8 @@ async def test_ignored(
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry_id=config_entry.entry_id
     )
-    # we only have two non read-only player options, bass and treble
-    assert sum(1 for entry in registry_entries if entry.domain == NUMBER_DOMAIN) == 2
+    # we only have two non read-only player options, bass and treble + 6 party options
+    assert sum(1 for entry in registry_entries if entry.domain == NUMBER_DOMAIN) == 8
 
 
 async def test_name_translation_availability(
@@ -149,3 +150,59 @@ async def test_name_translation_availability(
         assert translations.get(f"{prefix}{translation_key}.name") is not None, (
             f"{translation_key} is missing in strings.json for platform number"
         )
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "config_key", "value", "expected_initial"),
+    [
+        ("number.party_mode_plugin_boost_limit", "boost_limit", 5, 8),
+        ("number.party_mode_plugin_add_to_queue_limit", "add_to_queue_limit", 25, 20),
+        ("number.party_mode_plugin_skip_song_limit", "skip_song_limit", 3, 5),
+    ],
+)
+async def test_party_number_action_and_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    entity_id: str,
+    config_key: str,
+    value: int,
+    expected_initial: int,
+) -> None:
+    """Test party number action and update."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    state = hass.states.get(entity_id)
+    assert state
+    assert int(float(state.state)) == expected_initial
+
+    # test action
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_VALUE: value,
+        },
+        blocking=True,
+    )
+    assert music_assistant_client.config.save_provider_config.call_count == 1
+    assert music_assistant_client.config.save_provider_config.call_args == call(
+        provider_domain="party",
+        instance_id="party_instance",
+        values={config_key: value},
+    )
+
+    # test external update
+    provider_config = await music_assistant_client.config.get_provider_config(
+        "party_instance"
+    )
+    provider_config.values[config_key].value = 25
+    music_assistant_client.config.get_provider_config = AsyncMock(
+        return_value=provider_config
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PROVIDERS_UPDATED, "party_instance"
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert int(float(state.state)) == 25

--- a/tests/components/music_assistant/test_select.py
+++ b/tests/components/music_assistant/test_select.py
@@ -1,6 +1,6 @@
 """Test Music Assistant select entities."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 from music_assistant_models.enums import EventType
 import pytest
@@ -50,6 +50,7 @@ async def test_select_action(
     option_sub_key = "balanced"
 
     await setup_integration_from_fixtures(hass, music_assistant_client)
+    music_assistant_client.send_command.reset_mock()
     state = hass.states.get(entity_id)
     assert state
     assert state.state != option_sub_translation_key
@@ -134,8 +135,8 @@ async def test_ignored(
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry_id=config_entry.entry_id
     )
-    # we only have a single non read-only and non-boolean player option
-    assert sum(1 for entry in registry_entries if entry.domain == SELECT_DOMAIN) == 1
+    # we only have a single non read-only and non-boolean player option + 3 party selects
+    assert sum(1 for entry in registry_entries if entry.domain == SELECT_DOMAIN) == 4
 
 
 async def test_name_translation_availability(
@@ -151,3 +152,48 @@ async def test_name_translation_availability(
         assert translations.get(f"{prefix}{translation_key}.name") is not None, (
             f"{translation_key} is missing in strings.json for platform select"
         )
+
+
+async def test_party_select_action_and_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test party select action and update."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "select.party_mode_plugin_party_player"
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Test Player 1"
+
+    # test action
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_OPTION: "My Super Test Player 2",
+        },
+        blocking=True,
+    )
+    assert music_assistant_client.config.save_provider_config.call_count == 1
+    assert music_assistant_client.config.save_provider_config.call_args == call(
+        provider_domain="party",
+        instance_id="party_instance",
+        values={"player": "00:00:00:00:00:02"},
+    )
+
+    # test external update
+    provider_config = await music_assistant_client.config.get_provider_config(
+        "party_instance"
+    )
+    provider_config.values["player"].value = "test_group_player_1"
+    music_assistant_client.config.get_provider_config = AsyncMock(
+        return_value=provider_config
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PROVIDERS_UPDATED, "party_instance"
+    )
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Test Group Player 1"

--- a/tests/components/music_assistant/test_sensor.py
+++ b/tests/components/music_assistant/test_sensor.py
@@ -1,0 +1,51 @@
+"""Test Music Assistant sensor entities."""
+
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from .common import setup_integration_from_fixtures, snapshot_music_assistant_entities
+
+from tests.common import async_fire_time_changed
+
+
+async def test_sensor_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test sensor entities."""
+    music_assistant_client.send_command.return_value = "http://mock-party-url"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    snapshot_music_assistant_entities(hass, entity_registry, snapshot, Platform.SENSOR)
+
+
+async def test_sensor_url_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test sensor updates URL when timer expires."""
+    music_assistant_client.send_command.return_value = "http://mock-party-url-1"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    state = hass.states.get("sensor.party_mode_plugin_guest_url")
+    assert state
+    assert state.state == "http://mock-party-url-1"
+
+    # Simulate URL change
+    music_assistant_client.send_command.return_value = "http://mock-party-url-2"
+
+    # Fast forward time to trigger periodic update
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.party_mode_plugin_guest_url")
+    assert state
+    assert state.state == "http://mock-party-url-2"

--- a/tests/components/music_assistant/test_switch.py
+++ b/tests/components/music_assistant/test_switch.py
@@ -113,8 +113,8 @@ async def test_ignored(
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry_id=config_entry.entry_id
     )
-    # only a single player option available + 12 party switches
-    assert sum(1 for entry in registry_entries if entry.domain == SWITCH_DOMAIN) == 13
+    # only a single player option available + 11 party switches
+    assert sum(1 for entry in registry_entries if entry.domain == SWITCH_DOMAIN) == 12
 
 
 async def test_name_translation_availability(

--- a/tests/components/music_assistant/test_switch.py
+++ b/tests/components/music_assistant/test_switch.py
@@ -1,6 +1,6 @@
 """Test Music Assistant switch entities."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 from music_assistant_models.enums import EventType
 from syrupy.assertion import SnapshotAssertion
@@ -41,6 +41,7 @@ async def test_switch_action(
     entity_id = "switch.test_player_1_enhancer"
 
     await setup_integration_from_fixtures(hass, music_assistant_client)
+    music_assistant_client.send_command.reset_mock()
     state = hass.states.get(entity_id)
     assert state
     assert state.state == STATE_OFF
@@ -112,8 +113,8 @@ async def test_ignored(
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry_id=config_entry.entry_id
     )
-    # only a single player option available
-    assert sum(1 for entry in registry_entries if entry.domain == SWITCH_DOMAIN) == 1
+    # only a single player option available + 12 party switches
+    assert sum(1 for entry in registry_entries if entry.domain == SWITCH_DOMAIN) == 13
 
 
 async def test_name_translation_availability(
@@ -129,3 +130,55 @@ async def test_name_translation_availability(
         assert translations.get(f"{prefix}{translation_key}.name") is not None, (
             f"{translation_key} is missing in strings.json for platform switch"
         )
+
+
+async def test_party_switch_action(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test party switch set action."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "switch.party_mode_plugin_enable_guest_access"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+    # toggle on -> off and verify
+    await hass.services.async_call(
+        SWITCH_DOMAIN, SERVICE_TOGGLE, {ATTR_ENTITY_ID: entity_id}, blocking=True
+    )
+    assert music_assistant_client.config.save_provider_config.call_count == 1
+    assert music_assistant_client.config.save_provider_config.call_args == call(
+        provider_domain="party",
+        instance_id="party_instance",
+        values={"enable_guest_access": False},
+    )
+
+
+async def test_party_switch_external_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test party switch external update."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    entity_id = "switch.party_mode_plugin_enable_guest_access"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_ON
+
+    # Simulate external update
+    provider_config = await music_assistant_client.config.get_provider_config(
+        "party_instance"
+    )
+    provider_config.values["enable_guest_access"].value = False
+    music_assistant_client.config.get_provider_config = AsyncMock(
+        return_value=provider_config
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PROVIDERS_UPDATED, "party_instance"
+    )
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF

--- a/tests/components/music_assistant/test_text.py
+++ b/tests/components/music_assistant/test_text.py
@@ -1,6 +1,6 @@
 """Test Music Assistant text entities."""
 
-from unittest.mock import MagicMock, call
+from unittest.mock import AsyncMock, MagicMock, call
 
 from music_assistant_models.enums import EventType
 from syrupy.assertion import SnapshotAssertion
@@ -47,6 +47,7 @@ async def test_text_set_action(
     option_value = "new name"
 
     await setup_integration_from_fixtures(hass, music_assistant_client)
+    music_assistant_client.send_command.reset_mock()
     state = hass.states.get(entity_id)
     assert state
 
@@ -113,8 +114,8 @@ async def test_ignored(
     registry_entries = er.async_entries_for_config_entry(
         entity_registry, config_entry_id=config_entry.entry_id
     )
-    # we only have a single non read-only player option
-    assert sum(1 for entry in registry_entries if entry.domain == TEXT_DOMAIN) == 1
+    # we only have a single non read-only player option + 2 party texts
+    assert sum(1 for entry in registry_entries if entry.domain == TEXT_DOMAIN) == 3
 
 
 async def test_name_translation_availability(
@@ -130,3 +131,48 @@ async def test_name_translation_availability(
         assert translations.get(f"{prefix}{translation_key}.name") is not None, (
             f"{translation_key} is missing in strings.json for platform text"
         )
+
+
+async def test_party_text_action_and_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test party text action and update."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "text.party_mode_plugin_qr_text"
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Scan to join"
+
+    # test action
+    await hass.services.async_call(
+        TEXT_DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            ATTR_VALUE: "New Text",
+        },
+        blocking=True,
+    )
+    assert music_assistant_client.config.save_provider_config.call_count == 1
+    assert music_assistant_client.config.save_provider_config.call_args == call(
+        provider_domain="party",
+        instance_id="party_instance",
+        values={"qr_text": "New Text"},
+    )
+
+    # test external update
+    provider_config = await music_assistant_client.config.get_provider_config(
+        "party_instance"
+    )
+    provider_config.values["qr_text"].value = "Updated"
+    music_assistant_client.config.get_provider_config = AsyncMock(
+        return_value=provider_config
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PROVIDERS_UPDATED, "party_instance"
+    )
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Updated"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Music Assistant has [Party Mode](https://www.music-assistant.io/plugins/party/#for-guests) which allows guests to add songs to the queue.

This PR adds a new _Party Mode Plugin_ device to the Music Assistant integration if the user has the plugin enabled on Music Assistant. All of the party mode configuration variables are synced to Home Assistant, and are updatable from there.

Notably, this PR adds a guest QR code based on the guest URL that is set in Music Assistant allowing users to display it on dashboards for guests to scan.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ x ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/orgs/music-assistant/discussions/5228
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46737
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ x ] I understand the code I am submitting and can explain how it works.
- [ x ] The code change is tested and works locally.
- [ x ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
