### PR TITLE
Add override decorator to last_reset in melcloud_home

### DIFF
--- a/homeassistant/components/melcloud_home/sensor.py
+++ b/homeassistant/components/melcloud_home/sensor.py
@@ -189,6 +189,7 @@ class ATASensor(MelCloudHomeATAUnitEntity, SensorEntity):
         return self.entity_description.value_fn(self.unit, self.coordinator)
 
     @property
+    @override
     def last_reset(self) -> datetime | None:
         """Return start of month for TOTAL energy sensors."""
         if self.entity_description.state_class == SensorStateClass.TOTAL:
@@ -219,6 +220,7 @@ class ATWSensor(MelCloudHomeATWUnitEntity, SensorEntity):
         return self.entity_description.value_fn(self.unit, self.coordinator)
 
     @property
+    @override
     def last_reset(self) -> datetime | None:
         """Return start of month for TOTAL energy sensors."""
         if self.entity_description.state_class == SensorStateClass.TOTAL:

--- a/tests/components/melcloud_home/snapshots/test_sensor.ambr
+++ b/tests/components/melcloud_home/snapshots/test_sensor.ambr
@@ -6,7 +6,7 @@
     ]),
     'area_id': None,
     'capabilities': dict({
-      'state_class': <SensorStateClass.TOTAL: 'total'>,
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
     }),
     'config_entry_id': <ANY>,
     'config_subentry_id': <ANY>,
@@ -47,11 +47,11 @@
 # name: test_all_entities[sensor.heat_pump_energy_consumed_monthly-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'energy',
-      'friendly_name': 'Heat Pump Energy consumed (monthly)',
-      'last_reset': '2026-06-01T00:00:00+00:00',
-      'state_class': <SensorStateClass.TOTAL: 'total'>,
-      'unit_of_measurement': <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'energy',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Heat Pump Energy consumed (monthly)',
+      <SensorEntityStateAttribute.LAST_RESET: 'last_reset'>: '2026-06-01T00:00:00+00:00',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL: 'total'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_WATT_HOUR: 'kWh'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.heat_pump_energy_consumed_monthly',

--- a/tests/components/melcloud_home/test_sensor.py
+++ b/tests/components/melcloud_home/test_sensor.py
@@ -20,6 +20,7 @@ def enable_all_entities(entity_registry_enabled_by_default: None) -> None:
 
 
 @pytest.mark.usefixtures("mock_melcloud_client")
+@pytest.mark.freeze_time("2026-06-08 12:00:00+00:00")
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
## Breaking change

## Proposed change

Adds the `@override` decorator to the two `last_reset` property overrides in the `melcloud_home` sensor platform (`ATASensor` and `ATWSensor`), which override `SensorEntity.last_reset`. Without it, mypy's `explicit-override` check fails:

```
homeassistant/components/melcloud_home/sensor.py:192: error: Method "last_reset" is not using @override but is overriding a method in class "homeassistant.components.sensor.SensorEntity"  [explicit-override]
homeassistant/components/melcloud_home/sensor.py:222: error: Method "last_reset" is not using @override but is overriding a method in class "homeassistant.components.sensor.SensorEntity"  [explicit-override]
```

This matches the existing `native_value` overrides in the same file. `override` is already imported.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
