### PR TITLE
Fix Rexel OAuth2 session expiring after a day in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/application_credentials.py
+++ b/homeassistant/components/overkiz/application_credentials.py
@@ -43,6 +43,6 @@ class OverkizOAuth2Implementation(LocalOAuth2ImplementationWithPkce):
         otherwise drop it.
         """
         return super().extra_authorize_data | {
-            "scope": REXEL_OAUTH_SCOPE,
+            "scope": f"{REXEL_OAUTH_SCOPE} offline_access",
             "p": REXEL_OAUTH_POLICY,
         }

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -8,6 +8,7 @@ from pyoverkiz.client import GatewayCandidate
 from pyoverkiz.const import (
     REXEL_OAUTH_AUTHORIZE_URL,
     REXEL_OAUTH_POLICY,
+    REXEL_OAUTH_SCOPE,
     REXEL_OAUTH_TOKEN_URL,
 )
 from pyoverkiz.exceptions import (
@@ -1116,6 +1117,8 @@ async def test_rexel_full_flow_single_gateway(
     # Azure AD B2C needs the policy on the authorize URL; the helper rebuilds
     # the query string, so it must survive via extra_authorize_data.
     assert f"p={REXEL_OAUTH_POLICY}" in result["url"]
+    # offline_access is required for B2C to return a refresh token.
+    assert f"{REXEL_OAUTH_SCOPE}+offline_access" in result["url"]
 
     await _async_rexel_oauth_external_step(
         hass, hass_client_no_auth, aioclient_mock, result["flow_id"]


### PR DESCRIPTION
## Proposed change

Rexel accounts required re-authentication about once a day. The authorize request was missing the `offline_access` scope, so Azure AD B2C never issued a refresh token and the access token could not be renewed once it expired, dropping the entry into a reauth flow.

This adds `offline_access` to the authorize scope so B2C returns a refresh token and the session refreshes silently. Confirmed together with Rexel against their live B2C tenant: without the scope no refresh token is stored, with it the session refreshes without reauth.

Note: only affects newly authorized entries — existing Rexel users must re-authenticate once.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
