### PR TITLE
Bump modbus-connection to 3.4.1

### DIFF
--- a/homeassistant/components/modbus_connection/manifest.json
+++ b/homeassistant/components/modbus_connection/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["modbus_connection", "tmodbus"],
   "quality_scale": "bronze",
-  "requirements": ["modbus-connection[tmodbus]==3.4.0"]
+  "requirements": ["modbus-connection[tmodbus]==3.4.1"]
 }

--- a/homeassistant/components/modbus_connection/manifest.json
+++ b/homeassistant/components/modbus_connection/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_polling",
   "loggers": ["modbus_connection", "tmodbus"],
   "quality_scale": "bronze",
-  "requirements": ["modbus-connection[tmodbus]==3.3.0"]
+  "requirements": ["modbus-connection[tmodbus]==3.4.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1589,7 +1589,7 @@ mitsubishi-comfort==0.3.2
 moat-ble==0.1.1
 
 # homeassistant.components.modbus_connection
-modbus-connection[tmodbus]==3.4.0
+modbus-connection[tmodbus]==3.4.1
 
 # homeassistant.components.moehlenhoff_alpha2
 moehlenhoff-alpha2==1.4.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1589,7 +1589,7 @@ mitsubishi-comfort==0.3.2
 moat-ble==0.1.1
 
 # homeassistant.components.modbus_connection
-modbus-connection[tmodbus]==3.3.0
+modbus-connection[tmodbus]==3.4.0
 
 # homeassistant.components.moehlenhoff_alpha2
 moehlenhoff-alpha2==1.4.0


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps the `modbus-connection` library used by the Modbus Connection integration from 3.3.0 — the version it shipped with in #175407 — to 3.4.1.

No integration code changes are needed: none of the API the integration calls (`connect_tcp` / `connect_serial`, `for_unit`, `on_connection_lost`, `close`) changed signature across this range. The new runtime capability added in 3.4.x (backend-neutral per-unit message spacing) is consumer-side and does not apply to this connection-owner hub, so this is a plain dependency bump.

Diff since the last used release (3.3.0 → 3.4.1): https://github.com/home-assistant-libs/modbus-connection/compare/3.3.0...3.4.1

Included releases:

- 3.4.0 — https://github.com/home-assistant-libs/modbus-connection/releases/tag/3.4.0 (backend-neutral request pacing, incl. new per-unit message spacing; CLI query helpers)
- 3.4.1 — https://github.com/home-assistant-libs/modbus-connection/releases/tag/3.4.1 (fix types and enforce mypy in CI)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qv1boX8MQ3jzHSLDreDEpB

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qv1boX8MQ3jzHSLDreDEpB)_