### PR TITLE
V2C photovoltaic features

### DIFF
--- a/homeassistant/components/v2c/__init__.py
+++ b/homeassistant/components/v2c/__init__.py
@@ -33,7 +33,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: V2CConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    entry.async_on_unload(entry.add_update_listener(update_listener))
+
     return True
+
+
+async def update_listener(hass: HomeAssistant, entry: V2CConfigEntry) -> None:
+    """Handle options update."""
+    await hass.config_entries.async_reload(entry.entry_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: V2CConfigEntry) -> bool:

--- a/homeassistant/components/v2c/config_flow.py
+++ b/homeassistant/components/v2c/config_flow.py
@@ -59,3 +59,40 @@ class V2CConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
         )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            evse = Trydan(
+                host,
+                client=get_async_client(self.hass, verify_ssl=False),
+            )
+            try:
+                data = await evse.get_data()
+            except TrydanError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                if data.ID:
+                    await self.async_set_unique_id(data.ID)
+                    self._abort_if_unique_id_mismatch(reason="another_device")
+
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, reconfigure_entry.data
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/v2c/config_flow.py
+++ b/homeassistant/components/v2c/config_flow.py
@@ -7,11 +7,19 @@ from pytrydan import Trydan
 from pytrydan.exceptions import TrydanError
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_HOST
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult, OptionsFlow
+from homeassistant.const import CONF_HOST, Platform
+from homeassistant.core import callback
+from homeassistant.helpers import selector
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .const import DOMAIN
+from .const import (
+    CONF_CONTRACTED_POWER_ENTITY,
+    CONF_POWER_DEVIATION_ENTITY,
+    CONF_PV_AVAILABLE,
+    DOMAIN,
+)
+from .coordinator import V2CConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,7 +93,7 @@ class V2CConfigFlow(ConfigFlow, domain=DOMAIN):
                     await self.async_set_unique_id(data.ID)
                     self._abort_if_unique_id_mismatch(reason="another_device")
 
-                return self.async_update_reload_and_abort(
+                return self.async_update_and_abort(
                     reconfigure_entry, data_updates=user_input
                 )
 
@@ -96,3 +104,66 @@ class V2CConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             errors=errors,
         )
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(
+        config_entry: V2CConfigEntry,
+    ) -> V2COptionsFlowHandler:
+        """Create the options flow."""
+        return V2COptionsFlowHandler()
+
+
+class V2COptionsFlowHandler(OptionsFlow):
+    """Handle a V2C options flow."""
+
+    _pv_available: bool = False
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        options = self.config_entry.options
+
+        if user_input is not None:
+            self._pv_available = user_input[CONF_PV_AVAILABLE]
+            if self._pv_available:
+                return await self.async_step_pv()
+            return self.async_create_entry(data={CONF_PV_AVAILABLE: False})
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_PV_AVAILABLE,
+                        default=options.get(CONF_PV_AVAILABLE, False),
+                    ): selector.BooleanSelector(),
+                }
+            ),
+        )
+
+    async def async_step_pv(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Pick the helper entities."""
+        options = self.config_entry.options
+
+        if user_input is not None:
+            return self.async_create_entry(data={CONF_PV_AVAILABLE: True, **user_input})
+
+        number_selector = selector.EntitySelector(
+            selector.EntitySelectorConfig(domain=[Platform.NUMBER, "input_number"])
+        )
+        data_schema = self.add_suggested_values_to_schema(
+            vol.Schema(
+                {
+                    vol.Required(CONF_POWER_DEVIATION_ENTITY): number_selector,
+                    vol.Required(CONF_CONTRACTED_POWER_ENTITY): number_selector,
+                }
+            ),
+            options,
+        )
+
+        return self.async_show_form(step_id="pv", data_schema=data_schema)

--- a/homeassistant/components/v2c/const.py
+++ b/homeassistant/components/v2c/const.py
@@ -1,3 +1,7 @@
 """Constants for the V2C integration."""
 
 DOMAIN = "v2c"
+
+CONF_PV_AVAILABLE = "pv_available"
+CONF_POWER_DEVIATION_ENTITY = "power_deviation_entity"
+CONF_CONTRACTED_POWER_ENTITY = "contracted_power_entity"

--- a/homeassistant/components/v2c/select.py
+++ b/homeassistant/components/v2c/select.py
@@ -2,18 +2,30 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+import logging
 from typing import Any, override
 
 from pytrydan import Trydan, TrydanData
-from pytrydan.models.trydan import ChargeMode
+from pytrydan.exceptions import TrydanError
+from pytrydan.models.trydan import ChargeMode, DynamicPowerMode
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import EntityCategory
-from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, EntityCategory
+from homeassistant.core import Event, EventStateChangedData, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_state_change_event
 
+from .const import (
+    CONF_CONTRACTED_POWER_ENTITY,
+    CONF_POWER_DEVIATION_ENTITY,
+    CONF_PV_AVAILABLE,
+    DOMAIN,
+)
 from .coordinator import V2CConfigEntry, V2CUpdateCoordinator
 from .entity import V2CBaseEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def charge_mode_value(value: ChargeMode) -> str:
@@ -31,6 +43,7 @@ class V2CSelectEntityDescription(SelectEntityDescription):
 
 
 CHARGE_MODE_OPTIONS = [charge_mode_value(mode) for mode in ChargeMode]
+DYNAMIC_POWER_MODE_OPTIONS = [str(mode.value) for mode in DynamicPowerMode]
 
 TRYDAN_SELECTS = (
     V2CSelectEntityDescription(
@@ -68,6 +81,24 @@ async def async_setup_entry(
         if description.current_option_fn(data) is not None
     )
 
+    if (
+        coordinator.config_entry.options.get(CONF_PV_AVAILABLE)
+        and data.dynamic_power_mode is not None
+    ):
+        async_add_entities(
+            [
+                V2CDynamicPowerModeSelectEntity(
+                    coordinator,
+                    SelectEntityDescription(
+                        key="dynamic_power_mode",
+                        translation_key="dynamic_power_mode",
+                        entity_category=EntityCategory.CONFIG,
+                    ),
+                    config_entry.entry_id,
+                )
+            ]
+        )
+
 
 class V2CSelectEntity(V2CBaseEntity, SelectEntity):
     """Representation of V2C EVSE settings select entity."""
@@ -96,3 +127,181 @@ class V2CSelectEntity(V2CBaseEntity, SelectEntity):
         """Update the setting."""
         await self.entity_description.update_fn(self.coordinator.evse, option)
         await self.coordinator.async_request_refresh()
+
+
+class V2CDynamicPowerModeSelectEntity(V2CBaseEntity, SelectEntity):
+    """Specialized selector for dynamic power mode."""
+
+    _contracted_power_entity: str | None
+    _power_deviation_entity: str | None
+    _attr_options = DYNAMIC_POWER_MODE_OPTIONS
+
+    def __init__(
+        self,
+        coordinator: V2CUpdateCoordinator,
+        description: SelectEntityDescription,
+        entry_id: str,
+    ) -> None:
+        """Initialize the V2C select entity."""
+        super().__init__(coordinator, description)
+        self._attr_unique_id = f"{entry_id}_{description.key}"
+
+        self._contracted_power_entity = coordinator.config_entry.options.get(
+            CONF_CONTRACTED_POWER_ENTITY
+        )
+        self._power_deviation_entity = coordinator.config_entry.options.get(
+            CONF_POWER_DEVIATION_ENTITY
+        )
+
+    async def _contracted_power_changed(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
+            return
+        value = round(float(new_state.state))
+        try:
+            if not (evse_data := self.coordinator.evse.data):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="no_data"
+                )
+        except TrydanError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="no_data"
+            ) from err
+        if evse_data.dynamic_power_mode not in (
+            DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED,
+            DynamicPowerMode.TIMED_POWER_ENABLED,
+        ):
+            try:
+                await self.coordinator.evse.contracted_power(value)
+            finally:
+                await self.coordinator.async_request_refresh()
+
+    async def _power_deviation_changed(
+        self, event: Event[EventStateChangedData]
+    ) -> None:
+        new_state = event.data["new_state"]
+        if new_state is None or new_state.state in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
+            return
+        value = round(float(new_state.state))
+        try:
+            if not (evse_data := self.coordinator.evse.data):
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN, translation_key="no_data"
+                )
+        except TrydanError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="no_data"
+            ) from err
+        if (
+            evse_data.dynamic_power_mode
+            == DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED
+        ):
+            try:
+                await self.coordinator.evse.contracted_power(value)
+            finally:
+                await self.coordinator.async_request_refresh()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        if self._contracted_power_entity is not None:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    [self._contracted_power_entity],
+                    self._contracted_power_changed,
+                )
+            )
+        if self._power_deviation_entity is not None:
+            self.async_on_remove(
+                async_track_state_change_event(
+                    self.hass,
+                    [self._power_deviation_entity],
+                    self._power_deviation_changed,
+                )
+            )
+
+    async def _get_contracted_power(self, entity_id: str | None) -> int:
+        if not entity_id:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="no_dynamic_power_mode_helper",
+            )
+        if (state := self.hass.states.get(entity_id)) and state.state not in (
+            STATE_UNKNOWN,
+            STATE_UNAVAILABLE,
+        ):
+            return round(float(state.state))
+
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="no_state",
+            translation_placeholders={"entity_id": entity_id},
+        )
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Update the setting."""
+
+        evse = self.coordinator.evse
+        mode = DynamicPowerMode(int(option))
+
+        if mode == DynamicPowerMode.TIMED_POWER_ENABLED:
+            # The profile will set the contracted power
+            await evse.dynamic_power_mode(mode)
+        else:
+            if mode == DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED:
+                contracted_power = await self._get_contracted_power(
+                    self._power_deviation_entity
+                )
+            else:
+                contracted_power = await self._get_contracted_power(
+                    self._contracted_power_entity
+                )
+            previous_mode = (
+                self.coordinator.data.dynamic_power_mode
+                if self.coordinator.data
+                else None
+            )
+            await evse.dynamic_power_mode(mode)
+            try:
+                # Trigger API cached data refresh so it matches the mode just set because
+                # the contracted power validator depends on the mode.
+                await evse.get_data()
+                await evse.contracted_power(contracted_power)
+            except TrydanError as err:
+                # The mode was committed but the contracted power could not be
+                # applied. Try to restore the previous mode so the charger is not
+                # left with the new mode and a value under different semantics.
+                if previous_mode is not None:
+                    try:
+                        await evse.dynamic_power_mode(previous_mode)
+                    except TrydanError:
+                        _LOGGER.exception(
+                            "Failed to roll back dynamic power mode after error"
+                        )
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="dynamic_power_mode_update_failed",
+                ) from err
+            finally:
+                await self.coordinator.async_request_refresh()
+            return
+
+        await self.coordinator.async_request_refresh()
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the current dynamic power mode."""
+        if self.coordinator.data.dynamic_power_mode is not None:
+            return str(self.coordinator.data.dynamic_power_mode.value)
+        return None

--- a/homeassistant/components/v2c/strings.json
+++ b/homeassistant/components/v2c/strings.json
@@ -1,13 +1,23 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "another_device": "Reconfiguration was unsuccessful, the IP address/hostname of another Trydan device was used.",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "Hostname or IP address of your V2C Trydan EVSE."
+        }
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"

--- a/homeassistant/components/v2c/strings.json
+++ b/homeassistant/components/v2c/strings.json
@@ -70,6 +70,16 @@
           "monophasic": "Monophasic",
           "threephasic": "Three-phase"
         }
+      },
+      "dynamic_power_mode": {
+        "name": "Dynamic power mode",
+        "state": {
+          "0": "Profile",
+          "2": "PV + minimum power",
+          "3": "PV exclusive",
+          "4": "PV + grid",
+          "5": "Stop"
+        }
       }
     },
     "sensor": {
@@ -160,6 +170,20 @@
       "timer": {
         "name": "Charge point timer"
       }
+    }
+  },
+  "exceptions": {
+    "dynamic_power_mode_update_failed": {
+      "message": "Failed to apply the contracted power after changing the dynamic power mode."
+    },
+    "no_data": {
+      "message": "No data has been retrieved from the EVSE yet. Please try again in a few seconds."
+    },
+    "no_dynamic_power_mode_helper": {
+      "message": "No entities have been configured for contracted power and power deviation. Please check the integration options."
+    },
+    "no_state": {
+      "message": "Unknown {entity_id} state."
     }
   },
   "issues": {

--- a/homeassistant/components/v2c/strings.json
+++ b/homeassistant/components/v2c/strings.json
@@ -171,5 +171,28 @@
       "description": "The sensor {entity_name} (`{entity_id}`) is deprecated because it has been replaced with `{replacement_entity_id}`.\n\nThe sensor was used in the following automations or scripts:\n{items}\n\nUpdate the above automations or scripts to use the replacement entity, then disable the deprecated sensor to have it removed after the next restart.",
       "title": "[%key:component::v2c::issues::deprecated_sensor::title%]"
     }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "pv_available": "Photovoltaic installation"
+        },
+        "data_description": {
+          "pv_available": "The V2C Trydan EVSE photovoltaic installation option is enabled."
+        }
+      },
+      "pv": {
+        "data": {
+          "contracted_power_entity": "Contracted power entity",
+          "power_deviation_entity": "Power deviation entity for PV exclusive mode"
+        },
+        "data_description": {
+          "contracted_power_entity": "Number entity used as the contracted power in non-PV-exclusive modes.",
+          "power_deviation_entity": "Number entity used as the power deviation. Positive values will allow a grid consumption of the specified watts, while negative values will force an excess of the specified watts."
+        },
+        "title": "Photovoltaic settings"
+      }
+    }
   }
 }

--- a/tests/components/v2c/test_config_flow.py
+++ b/tests/components/v2c/test_config_flow.py
@@ -4,8 +4,14 @@ from unittest.mock import AsyncMock
 
 import pytest
 from pytrydan.exceptions import TrydanError
+import voluptuous as vol
 
-from homeassistant.components.v2c.const import DOMAIN
+from homeassistant.components.v2c.const import (
+    CONF_CONTRACTED_POWER_ENTITY,
+    CONF_POWER_DEVIATION_ENTITY,
+    CONF_PV_AVAILABLE,
+    DOMAIN,
+)
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -156,7 +162,6 @@ async def test_reconfigure_flow_another_device(
     mock_v2c_client: AsyncMock,
 ) -> None:
     """Test reconfiguring aborts when a different device is targeted."""
-    # The existing entry is bound to a different unique id than the client returns
     entry = MockConfigEntry(
         domain=DOMAIN,
         title="EVSE 1.1.1.1",
@@ -178,3 +183,207 @@ async def test_reconfigure_flow_another_device(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "another_device"
     assert entry.data == {CONF_HOST: "1.1.1.1"}
+
+
+@pytest.mark.usefixtures("mock_v2c_client")
+async def test_options_flow_pv_disabled(hass: HomeAssistant) -> None:
+    """Test the options flow finishes in one step when PV is not available."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_PV_AVAILABLE: False},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options == {CONF_PV_AVAILABLE: False}
+
+
+@pytest.mark.usefixtures("mock_v2c_client")
+async def test_options_flow_pv_enabled(hass: HomeAssistant) -> None:
+    """Test the options flow moves to the pv step and stores helper entities."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_PV_AVAILABLE: True},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pv"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+            CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options == {
+        CONF_PV_AVAILABLE: True,
+        CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+        CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+    }
+
+
+@pytest.mark.usefixtures("mock_v2c_client")
+async def test_options_flow_pv_step_requires_entities(hass: HomeAssistant) -> None:
+    """Test the pv step rejects submissions missing the helper entities."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_PV_AVAILABLE: True},
+    )
+    assert result["step_id"] == "pv"
+
+    with pytest.raises(vol.Invalid):
+        await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {},
+        )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+            CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options == {
+        CONF_PV_AVAILABLE: True,
+        CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+        CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+    }
+
+
+@pytest.mark.usefixtures("mock_v2c_client")
+async def test_options_flow_shows_existing_values(hass: HomeAssistant) -> None:
+    """Test the init step defaults to the currently stored pv_available value."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+        options={
+            CONF_PV_AVAILABLE: True,
+            CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+            CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    schema = result["data_schema"]({})
+    assert schema[CONF_PV_AVAILABLE] is True
+
+
+@pytest.mark.usefixtures("mock_v2c_client")
+async def test_options_flow_pv_step_prefilled(hass: HomeAssistant) -> None:
+    """Test the pv step pre-populates helper entities from the config entry."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+        options={
+            CONF_PV_AVAILABLE: True,
+            CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+            CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_PV_AVAILABLE: True},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pv"
+
+    # The previously stored helper entities are offered as suggested values.
+    suggested = {
+        marker.schema: marker.description["suggested_value"]
+        for marker in result["data_schema"].schema
+        if marker.description and "suggested_value" in marker.description
+    }
+    assert suggested == {
+        CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+        CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+    }
+
+
+@pytest.mark.usefixtures("mock_v2c_client")
+async def test_options_flow_disable_pv(hass: HomeAssistant) -> None:
+    """Test turning photovoltaic off from an entry that had it enabled."""
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+        options={
+            CONF_PV_AVAILABLE: True,
+            CONF_POWER_DEVIATION_ENTITY: "number.power_deviation",
+            CONF_CONTRACTED_POWER_ENTITY: "number.contracted_power",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {CONF_PV_AVAILABLE: False},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options == {CONF_PV_AVAILABLE: False}
+    assert CONF_POWER_DEVIATION_ENTITY not in entry.options
+    assert CONF_CONTRACTED_POWER_ENTITY not in entry.options

--- a/tests/components/v2c/test_config_flow.py
+++ b/tests/components/v2c/test_config_flow.py
@@ -11,6 +11,8 @@ from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from tests.common import MockConfigEntry
+
 
 async def test_full_flow(
     hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_v2c_client: AsyncMock
@@ -68,3 +70,111 @@ async def test_form_cannot_connect(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "EVSE 1.1.1.1"
     assert result["data"] == {CONF_HOST: "1.1.1.1"}
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+) -> None:
+    """Test reconfiguring an existing entry updates its data."""
+    # The mock client data returns ID "ABC123", so bind the entry to it
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "2.2.2.2"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {CONF_HOST: "2.2.2.2"}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        (TrydanError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    side_effect: type[Exception],
+    error: str,
+) -> None:
+    """Test the reconfigure flow recovers from connection errors."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="ABC123",
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_v2c_client.get_data.side_effect = side_effect
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "2.2.2.2"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": error}
+
+    mock_v2c_client.get_data.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "2.2.2.2"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data == {CONF_HOST: "2.2.2.2"}
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_another_device(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+) -> None:
+    """Test reconfiguring aborts when a different device is targeted."""
+    # The existing entry is bound to a different unique id than the client returns
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="EVSE 1.1.1.1",
+        unique_id="DIFFERENT_ID",
+        data={CONF_HOST: "1.1.1.1"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: "2.2.2.2"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "another_device"
+    assert entry.data == {CONF_HOST: "1.1.1.1"}

--- a/tests/components/v2c/test_select.py
+++ b/tests/components/v2c/test_select.py
@@ -2,21 +2,81 @@
 
 from unittest.mock import AsyncMock, patch
 
+import pytest
+from pytrydan import DynamicPowerMode
 from pytrydan.models.trydan import ChargeMode
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.input_number import (
+    ATTR_VALUE,
+    DOMAIN as INPUT_NUMBER_DOMAIN,
+    SERVICE_SET_VALUE,
+)
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
     SERVICE_SELECT_OPTION,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.components.v2c.const import (
+    CONF_CONTRACTED_POWER_ENTITY,
+    CONF_POWER_DEVIATION_ENTITY,
+    CONF_PV_AVAILABLE,
+    DOMAIN,
+)
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
 
 from . import init_integration
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+DYNAMIC_POWER_MODE_ENTITY = "select.evse_1_1_1_1_dynamic_power_mode"
+CONTRACTED_POWER_HELPER = "input_number.contracted_power"
+POWER_DEVIATION_HELPER = "input_number.power_deviation"
+
+
+async def _setup_helpers(hass: HomeAssistant) -> None:
+    """Set up the external input_number helper entities."""
+    assert await async_setup_component(
+        hass,
+        INPUT_NUMBER_DOMAIN,
+        {
+            INPUT_NUMBER_DOMAIN: {
+                "contracted_power": {
+                    "min": 0,
+                    "max": 10000,
+                    "step": 100,
+                    "initial": 4600,
+                },
+                "power_deviation": {
+                    "min": -5000,
+                    "max": 5000,
+                    "step": 100,
+                    "initial": 0,
+                },
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.fixture
+def mock_pv_config_entry() -> MockConfigEntry:
+    """Config entry with PV enabled and the helper entities configured."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="da58ee91f38c2406c2a36d0a1a7f8569",
+        title="EVSE 1.1.1.1",
+        data={CONF_HOST: "1.1.1.1"},
+        options={
+            CONF_PV_AVAILABLE: True,
+            CONF_CONTRACTED_POWER_ENTITY: CONTRACTED_POWER_HELPER,
+            CONF_POWER_DEVIATION_ENTITY: POWER_DEVIATION_HELPER,
+        },
+    )
 
 
 async def test_select(
@@ -70,3 +130,336 @@ async def test_select_not_created_when_missing(
     entity_id = "select.evse_1_1_1_1_charge_mode"
     assert entity_registry.async_get(entity_id) is None
     assert hass.states.get(entity_id) is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_created_when_pv_available(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test the dynamic power mode select is created when photovoltaic is enabled."""
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    state = hass.states.get(DYNAMIC_POWER_MODE_ENTITY)
+    assert state is not None
+    assert state.state == str(mock_v2c_client.data.dynamic_power_mode.value)
+
+
+async def test_dynamic_power_mode_not_created_without_pv(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the dynamic power mode select is absent without photovoltaic."""
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_config_entry)
+
+    assert hass.states.get(DYNAMIC_POWER_MODE_ENTITY) is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_not_created_when_data_missing(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test the select is not created when the device has no dynamic power mode."""
+    mock_v2c_client.get_data.return_value.dynamic_power_mode = None
+
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    assert hass.states.get(DYNAMIC_POWER_MODE_ENTITY) is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_profile(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test selecting the profile mode does not set the contracted power."""
+
+    # The V2C cloud profile is responsible for the contracted power.
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: DYNAMIC_POWER_MODE_ENTITY,
+            ATTR_OPTION: str(DynamicPowerMode.TIMED_POWER_ENABLED.value),
+        },
+        blocking=True,
+    )
+
+    mock_v2c_client.dynamic_power_mode.assert_awaited_once_with(
+        DynamicPowerMode.TIMED_POWER_ENABLED
+    )
+    mock_v2c_client.contracted_power.assert_not_called()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_fv_exclusive(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test FV exclusive mode reads the PV balance helper as contracted power."""
+    await _setup_helpers(hass)
+    await hass.services.async_call(
+        INPUT_NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: POWER_DEVIATION_HELPER, ATTR_VALUE: -500},
+        blocking=True,
+    )
+
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: DYNAMIC_POWER_MODE_ENTITY,
+            ATTR_OPTION: str(
+                DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED.value
+            ),
+        },
+        blocking=True,
+    )
+
+    mock_v2c_client.dynamic_power_mode.assert_awaited_once_with(
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED
+    )
+    method_names = [method_call[0] for method_call in mock_v2c_client.method_calls]
+    mode_call_index = method_names.index("dynamic_power_mode")
+    assert method_names[mode_call_index : mode_call_index + 3] == [
+        "dynamic_power_mode",
+        "get_data",
+        "contracted_power",
+    ]
+    mock_v2c_client.contracted_power.assert_awaited_once_with(-500)
+
+
+@pytest.mark.parametrize(
+    "mode",
+    [
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_MIN_MODE_SETTED,
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_GRID_MODE_SETTED,
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_STOP_MODE_SETTED,
+    ],
+)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_other_modes(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+    mode: DynamicPowerMode,
+) -> None:
+    """Test non-FV-exclusive modes read the contracted power helper value."""
+    await _setup_helpers(hass)
+    await hass.services.async_call(
+        INPUT_NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: CONTRACTED_POWER_HELPER, ATTR_VALUE: 6000},
+        blocking=True,
+    )
+    mock_v2c_client.contracted_power.reset_mock()
+
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {
+            ATTR_ENTITY_ID: DYNAMIC_POWER_MODE_ENTITY,
+            ATTR_OPTION: str(mode.value),
+        },
+        blocking=True,
+    )
+
+    mock_v2c_client.dynamic_power_mode.assert_awaited_once_with(mode)
+    mock_v2c_client.contracted_power.assert_awaited_once_with(6000)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_missing_helper_config(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+) -> None:
+    """Test changing mode raises when a helper entity is not configured."""
+
+    # With PV enabled but no helper entities set in the options,
+    # _get_contracted_power receives None and raises.
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="da58ee91f38c2406c2a36d0a1a7f8569",
+        title="EVSE 1.1.1.1",
+        data={CONF_HOST: "1.1.1.1"},
+        options={CONF_PV_AVAILABLE: True},
+    )
+
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, entry)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: DYNAMIC_POWER_MODE_ENTITY,
+                ATTR_OPTION: str(
+                    DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_GRID_MODE_SETTED.value
+                ),
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_dynamic_power_mode_helper_state_unknown(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test changing mode raises when the helper entity has no valid state."""
+
+    # The helper is configured in the options but has never been created, so
+    # hass.states.get returns None and _get_contracted_power raises.
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: DYNAMIC_POWER_MODE_ENTITY,
+                ATTR_OPTION: str(
+                    DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_GRID_MODE_SETTED.value
+                ),
+            },
+            blocking=True,
+        )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_contracted_power_helper_state_change(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test a contracted power helper change pushes to the API in non-excluded modes."""
+
+    # The device is in FV_MIN mode (from the mock data), so a change to the
+    # contracted power helper must be written through to the API.
+    mock_v2c_client.data.dynamic_power_mode = (
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_MIN_MODE_SETTED
+    )
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    mock_v2c_client.contracted_power.reset_mock()
+
+    await hass.services.async_call(
+        INPUT_NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: CONTRACTED_POWER_HELPER, ATTR_VALUE: 7000},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_v2c_client.contracted_power.assert_awaited_once_with(7000)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_contracted_power_helper_state_change_excluded_mode(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test a contracted power helper change is ignored in FV exclusive mode."""
+
+    # In FV exclusive (and profile) modes the contracted power helper does not
+    # map to the API contracted power, so no write must happen.
+    mock_v2c_client.data.dynamic_power_mode = (
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED
+    )
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    mock_v2c_client.contracted_power.reset_mock()
+
+    await hass.services.async_call(
+        INPUT_NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: CONTRACTED_POWER_HELPER, ATTR_VALUE: 7000},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_v2c_client.contracted_power.assert_not_called()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_power_deviation_helper_state_change(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test a PV balance helper change pushes to the API in FV exclusive mode."""
+    mock_v2c_client.data.dynamic_power_mode = (
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_EXCL_MODE_SETTED
+    )
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    mock_v2c_client.contracted_power.reset_mock()
+
+    await hass.services.async_call(
+        INPUT_NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: POWER_DEVIATION_HELPER, ATTR_VALUE: -300},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_v2c_client.contracted_power.assert_awaited_once_with(-300)
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_power_deviation_helper_state_change_other_mode(
+    hass: HomeAssistant,
+    mock_v2c_client: AsyncMock,
+    mock_pv_config_entry: MockConfigEntry,
+) -> None:
+    """Test a PV balance helper change is ignored outside FV exclusive mode."""
+    mock_v2c_client.data.dynamic_power_mode = (
+        DynamicPowerMode.TIMED_POWER_DISABLED_AND_FV_MIN_MODE_SETTED
+    )
+    await _setup_helpers(hass)
+    with patch("homeassistant.components.v2c.PLATFORMS", [Platform.SELECT]):
+        await init_integration(hass, mock_pv_config_entry)
+
+    mock_v2c_client.contracted_power.reset_mock()
+
+    await hass.services.async_call(
+        INPUT_NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: POWER_DEVIATION_HELPER, ATTR_VALUE: -300},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    mock_v2c_client.contracted_power.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

Add support for changing the dynamic power modes for installations with photovoltaic. As it is not possible to know if photovoltaic is enabled in the EVSE from the API it adds a selector to the options flow to let the user enable as needed.

Needs pytrydan >= 1.0.4: https://github.com/dgomes/pytrydan/releases/tag/v1.0.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

In the Trydan API the contracted power parameter has two different meanings depending on the dynamic power mode selected. When the FV exclusive mode is  selected it means the power balance to maintain:
  * If set to zero, all FV power is used for charging.
  * If set to -500, 500w are exported to the grid and the remaining is used to charge.
  * If set to 500, it allows to pull 500w from the grid in addition to the FV power.
In all other modes it means the total power, house + EVSE, that can be consumed from the grid.

This semantic difference complicates the usability. If the real API's contracted power is directly mapped to a number entity the user will have to change it every time the FV exclusive dynamic power mode is selected or deselected.

To avoid this problem and improve usability two external entities or helpers must be selected when PV is enabled, one for the PV deviation and another one for the contracted power. When the dynamic power mode is changed from the UI the select entity update_fn callback will also set the contracted power in the API depending on the selected mode.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [X] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [X] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
