### PR TITLE
Add input color helper

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -870,6 +870,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/input_boolean/ @home-assistant/core
 /homeassistant/components/input_button/ @home-assistant/core
 /tests/components/input_button/ @home-assistant/core
+/homeassistant/components/input_color/ @home-assistant/core
+/tests/components/input_color/ @home-assistant/core
 /homeassistant/components/input_datetime/ @home-assistant/core
 /tests/components/input_datetime/ @home-assistant/core
 /homeassistant/components/input_number/ @home-assistant/core

--- a/homeassistant/components/input_color/__init__.py
+++ b/homeassistant/components/input_color/__init__.py
@@ -182,13 +182,9 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         schema=RELOAD_SERVICE_SCHEMA,
     )
 
-    strip_keys = {"area_id", "device_id", "entity_id", "floor_id", "label_id"}
-
     async def set_color(entity: InputColor, call: ServiceCall) -> None:
         """Set an input color from a service call."""
-        color_shape = {
-            key: value for key, value in call.data.items() if key not in strip_keys
-        }
+        color_shape = homeassistant.helpers.service.remove_entity_service_fields(call)
         try:
             await entity.async_set_color(**color_shape)
         except ColorInputError as err:

--- a/homeassistant/components/input_color/__init__.py
+++ b/homeassistant/components/input_color/__init__.py
@@ -1,0 +1,443 @@
+"""Support to store reusable color values."""
+
+import logging
+from typing import Any, Self, override
+
+import voluptuous as vol
+
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    CONF_ICON,
+    CONF_ID,
+    CONF_NAME,
+    SERVICE_RELOAD,
+)
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import collection, config_validation as cv
+from homeassistant.helpers.entity_component import EntityComponent
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+import homeassistant.helpers.service
+from homeassistant.helpers.storage import Store
+from homeassistant.helpers.typing import ConfigType, VolDictType
+
+from .color_math import (
+    FIELD_COLOR_NAME,
+    FIELD_HEX,
+    FIELD_HS,
+    FIELD_KELVIN,
+    FIELD_RGB,
+    FIELD_XY,
+    MAX_KELVIN,
+    MIN_KELVIN,
+    CanonicalColor,
+    ColorInputError,
+    compute_source_hex,
+    derive_hex,
+    derive_hs,
+    derive_kelvin,
+    derive_rgb,
+    normalize,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "input_color"
+
+CONF_INITIAL_BRIGHTNESS = "initial_brightness"
+CONF_INITIAL_COLOR = "initial_color"
+CONF_INITIAL_KELVIN = "initial_kelvin"
+
+ATTR_BRIGHTNESS = "brightness"
+ATTR_COLOR_TEMP_KELVIN = "color_temp_kelvin"
+ATTR_HEX_COLOR = "hex_color"
+ATTR_HS_COLOR = "hs_color"
+ATTR_KIND = "kind"
+ATTR_RGB_COLOR = "rgb_color"
+ATTR_SOURCE_HEX = "source_hex"
+ATTR_XY_COLOR = "xy_color"
+
+DEFAULT_HEX = "#FFFFFF"
+DEFAULT_KELVIN = 4000
+
+SERVICE_CLEAR_BRIGHTNESS = "clear_brightness"
+SERVICE_SET_BRIGHTNESS = "set_brightness"
+SERVICE_SET_COLOR = "set_color"
+
+STATE_SCHEMA_VERSION = 1
+STORAGE_KEY = DOMAIN
+STORAGE_VERSION = 1
+
+STORAGE_FIELDS: VolDictType = {
+    vol.Required(CONF_NAME): vol.All(str, vol.Length(min=1)),
+    vol.Optional(CONF_INITIAL_COLOR): cv.string,
+    vol.Optional(CONF_INITIAL_KELVIN): vol.All(
+        vol.Coerce(int), vol.Range(min=MIN_KELVIN, max=MAX_KELVIN)
+    ),
+    vol.Optional(CONF_INITIAL_BRIGHTNESS): vol.All(
+        vol.Coerce(int), vol.Range(min=0, max=255)
+    ),
+    vol.Optional(CONF_ICON): cv.icon,
+}
+
+
+def _cv_input_color(config: dict[str, Any]) -> dict[str, Any]:
+    """Validate input color configuration."""
+    has_color = config.get(CONF_INITIAL_COLOR) is not None
+    has_kelvin = config.get(CONF_INITIAL_KELVIN) is not None
+    if has_color and has_kelvin:
+        raise vol.Invalid("Only one of initial_color or initial_kelvin is allowed")
+    if has_color:
+        try:
+            normalize({FIELD_HEX: config[CONF_INITIAL_COLOR]})
+        except ColorInputError as err:
+            raise vol.Invalid(str(err)) from err
+    return config
+
+
+CONFIG_SCHEMA = vol.Schema(
+    {
+        DOMAIN: cv.schema_with_slug_keys(
+            vol.All(
+                lambda value: value or {},
+                {
+                    vol.Optional(CONF_NAME): cv.string,
+                    vol.Optional(CONF_INITIAL_COLOR): cv.string,
+                    vol.Optional(CONF_INITIAL_KELVIN): vol.All(
+                        vol.Coerce(int), vol.Range(min=MIN_KELVIN, max=MAX_KELVIN)
+                    ),
+                    vol.Optional(CONF_INITIAL_BRIGHTNESS): vol.All(
+                        vol.Coerce(int), vol.Range(min=0, max=255)
+                    ),
+                    vol.Optional(CONF_ICON): cv.icon,
+                },
+                _cv_input_color,
+            )
+        )
+    },
+    extra=vol.ALLOW_EXTRA,
+)
+
+RELOAD_SERVICE_SCHEMA = vol.Schema({})
+
+SET_COLOR_SCHEMA = {
+    vol.Optional(FIELD_HEX): cv.string,
+    vol.Optional(FIELD_RGB): vol.All(
+        cv.ensure_list,
+        vol.Length(min=3, max=3),
+        [vol.All(vol.Coerce(int), vol.Range(min=0, max=255))],
+    ),
+    vol.Optional(FIELD_HS): vol.All(
+        cv.ensure_list,
+        vol.Length(min=2, max=2),
+        [vol.Coerce(float)],
+    ),
+    vol.Optional(FIELD_XY): vol.All(
+        cv.ensure_list,
+        vol.Length(min=2, max=2),
+        [vol.All(vol.Coerce(float), vol.Range(min=0.0, max=1.0))],
+    ),
+    vol.Optional(FIELD_KELVIN): vol.All(
+        vol.Coerce(int), vol.Range(min=MIN_KELVIN, max=MAX_KELVIN)
+    ),
+    vol.Optional(FIELD_COLOR_NAME): cv.string,
+    vol.Optional(ATTR_BRIGHTNESS): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
+}
+
+SET_BRIGHTNESS_SCHEMA = {
+    vol.Required(ATTR_BRIGHTNESS): vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
+}
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up input color."""
+    component = EntityComponent[InputColor](_LOGGER, DOMAIN, hass)
+
+    id_manager = collection.IDManager()
+
+    yaml_collection = collection.YamlCollection(
+        logging.getLogger(f"{__name__}.yaml_collection"), id_manager
+    )
+    collection.sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, yaml_collection, InputColor
+    )
+
+    storage_collection = InputColorStorageCollection(
+        Store(hass, STORAGE_VERSION, STORAGE_KEY),
+        id_manager,
+    )
+    collection.sync_entity_lifecycle(
+        hass, DOMAIN, DOMAIN, component, storage_collection, InputColor
+    )
+
+    await yaml_collection.async_load(
+        [{CONF_ID: id_, **(conf or {})} for id_, conf in config.get(DOMAIN, {}).items()]
+    )
+    await storage_collection.async_load()
+
+    collection.DictStorageCollectionWebsocket(
+        storage_collection, DOMAIN, DOMAIN, STORAGE_FIELDS, STORAGE_FIELDS
+    ).async_setup(hass)
+
+    async def reload_service_handler(service_call: ServiceCall) -> None:
+        """Reload yaml entities."""
+        conf = await component.async_prepare_reload(skip_reset=True)
+        await yaml_collection.async_load(
+            [{CONF_ID: id_, **(cfg or {})} for id_, cfg in conf.get(DOMAIN, {}).items()]
+        )
+
+    homeassistant.helpers.service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        SERVICE_RELOAD,
+        reload_service_handler,
+        schema=RELOAD_SERVICE_SCHEMA,
+    )
+
+    strip_keys = {"area_id", "device_id", "entity_id", "floor_id", "label_id"}
+
+    async def set_color(entity: InputColor, call: ServiceCall) -> None:
+        """Set an input color from a service call."""
+        color_shape = {
+            key: value for key, value in call.data.items() if key not in strip_keys
+        }
+        try:
+            await entity.async_set_color(**color_shape)
+        except ColorInputError as err:
+            raise HomeAssistantError(str(err)) from err
+
+    async def clear_brightness(entity: InputColor, call: ServiceCall) -> None:
+        """Clear stored brightness."""
+        await entity.async_set_brightness(None)
+
+    component.async_register_entity_service(
+        SERVICE_SET_COLOR, SET_COLOR_SCHEMA, set_color
+    )
+    component.async_register_entity_service(
+        SERVICE_SET_BRIGHTNESS, SET_BRIGHTNESS_SCHEMA, "async_set_brightness"
+    )
+    component.async_register_entity_service(
+        SERVICE_CLEAR_BRIGHTNESS, {}, clear_brightness
+    )
+
+    return True
+
+
+class InputColorStorageCollection(collection.DictStorageCollection):
+    """Input color storage collection."""
+
+    CREATE_UPDATE_SCHEMA = vol.Schema(vol.All(STORAGE_FIELDS, _cv_input_color))
+
+    @override
+    async def _process_create_data(self, data: dict[str, Any]) -> dict[str, Any]:
+        """Validate the config is valid."""
+        return self.CREATE_UPDATE_SCHEMA(data)  # type: ignore[no-any-return]
+
+    @callback
+    @override
+    def _get_suggested_id(self, info: dict[str, Any]) -> str:
+        """Suggest an ID based on the config."""
+        return info[CONF_NAME]  # type: ignore[no-any-return]
+
+    @override
+    async def _update_data(
+        self, item: dict[str, Any], update_data: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return a new updated data object."""
+        update_data = self.CREATE_UPDATE_SCHEMA(update_data)
+        return {CONF_ID: item[CONF_ID]} | update_data
+
+
+class _StoredColor(ExtraStoredData):
+    """Restore payload preserving canonical precision across restarts."""
+
+    def __init__(
+        self,
+        canonical: CanonicalColor,
+        brightness: int | None,
+        source_hex: str | None,
+    ) -> None:
+        """Initialize stored color data."""
+        self.canonical = canonical
+        self.brightness = brightness
+        self.source_hex = source_hex
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the stored color."""
+        return {
+            "brightness": self.brightness,
+            "kind": self.canonical.kind,
+            "kelvin": self.canonical.kelvin,
+            "source_hex": self.source_hex,
+            "version": STATE_SCHEMA_VERSION,
+            "xy": list(self.canonical.xy),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> _StoredColor | None:
+        """Create stored color data from a dict."""
+        try:
+            xy = data["xy"]
+            canonical = CanonicalColor(
+                xy=(float(xy[0]), float(xy[1])),
+                kind=str(data["kind"]),
+                kelvin=int(data["kelvin"]) if data.get("kelvin") is not None else None,
+            )
+            brightness = data.get("brightness")
+            if brightness is not None:
+                brightness = int(brightness)
+            source_hex = data.get("source_hex")
+            if source_hex is not None:
+                source_hex = str(source_hex)
+        except KeyError, TypeError, ValueError:
+            return None
+        return cls(canonical, brightness, source_hex)
+
+
+class InputColor(collection.CollectionEntity, RestoreEntity):
+    """Represent a stored color value."""
+
+    _unrecorded_attributes = frozenset({ATTR_EDITABLE})
+
+    _attr_should_poll = False
+    editable: bool
+
+    def __init__(self, config: ConfigType) -> None:
+        """Initialize an input color."""
+        self._config = config
+        self._canonical = self._initial_canonical(config)
+        self._brightness = self._initial_brightness(config)
+        self._source_hex = self._initial_source_hex(config)
+
+    @classmethod
+    @override
+    def from_storage(cls, config: ConfigType) -> Self:
+        """Return entity instance initialized from storage."""
+        input_color: Self = cls(config)
+        input_color.editable = True
+        return input_color
+
+    @classmethod
+    @override
+    def from_yaml(cls, config: ConfigType) -> Self:
+        """Return entity instance initialized from yaml."""
+        input_color: Self = cls(config)
+        input_color.entity_id = f"{DOMAIN}.{config[CONF_ID]}"
+        input_color.editable = False
+        return input_color
+
+    @staticmethod
+    def _initial_canonical(config: ConfigType) -> CanonicalColor:
+        """Return the initial canonical color."""
+        if CONF_INITIAL_KELVIN in config:
+            return normalize({FIELD_KELVIN: config[CONF_INITIAL_KELVIN]})
+        return normalize({FIELD_HEX: config.get(CONF_INITIAL_COLOR, DEFAULT_HEX)})
+
+    @staticmethod
+    def _initial_brightness(config: ConfigType) -> int | None:
+        """Return initial brightness."""
+        brightness = config.get(CONF_INITIAL_BRIGHTNESS)
+        if brightness is None:
+            return None
+        return max(0, min(255, int(brightness)))
+
+    @staticmethod
+    def _initial_source_hex(config: ConfigType) -> str | None:
+        """Return source hex for the initial color."""
+        if CONF_INITIAL_KELVIN in config:
+            return None
+        initial_color = config.get(CONF_INITIAL_COLOR)
+        if initial_color is None:
+            return compute_source_hex({FIELD_HEX: DEFAULT_HEX})
+        return compute_source_hex({FIELD_HEX: initial_color})
+
+    @property
+    @override
+    def name(self) -> str | None:
+        """Return the name of the color input entity."""
+        return self._config.get(CONF_NAME)
+
+    @property
+    @override
+    def icon(self) -> str | None:
+        """Return the icon to be used for this entity."""
+        return self._config.get(CONF_ICON)
+
+    @property
+    @override
+    def state(self) -> str:
+        """Return the state of the entity."""
+        return self._source_hex or derive_hex(self._canonical)
+
+    @property
+    @override
+    def unique_id(self) -> str:
+        """Return unique id for the entity."""
+        return self._config[CONF_ID]  # type: ignore[no-any-return]
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        x, y = self._canonical.xy
+        r, g, b = derive_rgb(self._canonical)
+        h, s = derive_hs(self._canonical)
+        return {
+            ATTR_BRIGHTNESS: self._brightness,
+            ATTR_COLOR_TEMP_KELVIN: derive_kelvin(self._canonical),
+            ATTR_EDITABLE: self.editable,
+            ATTR_HEX_COLOR: self.state,
+            ATTR_HS_COLOR: [round(h, 2), round(s, 2)],
+            ATTR_KIND: self._canonical.kind,
+            ATTR_RGB_COLOR: [r, g, b],
+            ATTR_SOURCE_HEX: self._source_hex,
+            ATTR_XY_COLOR: [round(x, 4), round(y, 4)],
+        }
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> ExtraStoredData | None:
+        """Return entity data to restore."""
+        return _StoredColor(self._canonical, self._brightness, self._source_hex)
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        if (
+            self._config.get(CONF_INITIAL_COLOR) is not None
+            or self._config.get(CONF_INITIAL_KELVIN) is not None
+        ):
+            return
+
+        last_extra = await self.async_get_last_extra_data()
+        if last_extra is not None:
+            stored = _StoredColor.from_dict(last_extra.as_dict())
+            if stored is not None:
+                self._canonical = stored.canonical
+                self._brightness = stored.brightness
+                self._source_hex = stored.source_hex
+
+    async def async_set_color(self, **shape: Any) -> None:
+        """Set the color from one accepted input shape."""
+        color_shape = dict(shape)
+        brightness = color_shape.pop(ATTR_BRIGHTNESS, None)
+        self._canonical = normalize(color_shape)
+        self._source_hex = compute_source_hex(color_shape)
+        if brightness is not None:
+            self._brightness = max(0, min(255, int(brightness)))
+        self.async_write_ha_state()
+
+    async def async_set_brightness(self, brightness: int | None) -> None:
+        """Set or clear the stored brightness."""
+        if brightness is None:
+            self._brightness = None
+        else:
+            self._brightness = max(0, min(255, int(brightness)))
+        self.async_write_ha_state()
+
+    @override
+    async def async_update_config(self, config: ConfigType) -> None:
+        """Handle when the config is updated."""
+        self._config = config
+        self.async_write_ha_state()

--- a/homeassistant/components/input_color/__init__.py
+++ b/homeassistant/components/input_color/__init__.py
@@ -1,22 +1,15 @@
 """Support to store reusable color values."""
 
 import logging
-from typing import Any, Self, override
+from typing import Any, override
 
 import voluptuous as vol
 
-from homeassistant.const import (
-    ATTR_EDITABLE,
-    CONF_ICON,
-    CONF_ID,
-    CONF_NAME,
-    SERVICE_RELOAD,
-)
+from homeassistant.const import CONF_ICON, CONF_ID, CONF_NAME, SERVICE_RELOAD
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import collection, config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 import homeassistant.helpers.service
 from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType, VolDictType
@@ -30,13 +23,7 @@ from .color_math import (
     FIELD_XY,
     MAX_KELVIN,
     MIN_KELVIN,
-    CanonicalColor,
     ColorInputError,
-    compute_source_hex,
-    derive_hex,
-    derive_hs,
-    derive_kelvin,
-    derive_rgb,
     normalize,
 )
 
@@ -58,7 +45,6 @@ ATTR_SOURCE_HEX = "source_hex"
 ATTR_XY_COLOR = "xy_color"
 
 DEFAULT_HEX = "#FFFFFF"
-DEFAULT_KELVIN = 4000
 
 SERVICE_CLEAR_BRIGHTNESS = "clear_brightness"
 SERVICE_SET_BRIGHTNESS = "set_brightness"
@@ -120,7 +106,7 @@ CONFIG_SCHEMA = vol.Schema(
 
 RELOAD_SERVICE_SCHEMA = vol.Schema({})
 
-SET_COLOR_SCHEMA = {
+SET_COLOR_SCHEMA: VolDictType = {
     vol.Optional(FIELD_HEX): cv.string,
     vol.Optional(FIELD_RGB): vol.All(
         cv.ensure_list,
@@ -144,9 +130,11 @@ SET_COLOR_SCHEMA = {
     vol.Optional(ATTR_BRIGHTNESS): vol.All(vol.Coerce(int), vol.Range(min=0, max=255)),
 }
 
-SET_BRIGHTNESS_SCHEMA = {
+SET_BRIGHTNESS_SCHEMA: VolDictType = {
     vol.Required(ATTR_BRIGHTNESS): vol.All(vol.Coerce(int), vol.Range(min=0, max=255))
 }
+
+from .entity import InputColor  # noqa: E402
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -231,13 +219,13 @@ class InputColorStorageCollection(collection.DictStorageCollection):
     @override
     async def _process_create_data(self, data: dict[str, Any]) -> dict[str, Any]:
         """Validate the config is valid."""
-        return self.CREATE_UPDATE_SCHEMA(data)  # type: ignore[no-any-return]
+        return self.CREATE_UPDATE_SCHEMA(data)
 
     @callback
     @override
     def _get_suggested_id(self, info: dict[str, Any]) -> str:
         """Suggest an ID based on the config."""
-        return info[CONF_NAME]  # type: ignore[no-any-return]
+        return info[CONF_NAME]
 
     @override
     async def _update_data(
@@ -246,198 +234,3 @@ class InputColorStorageCollection(collection.DictStorageCollection):
         """Return a new updated data object."""
         update_data = self.CREATE_UPDATE_SCHEMA(update_data)
         return {CONF_ID: item[CONF_ID]} | update_data
-
-
-class _StoredColor(ExtraStoredData):
-    """Restore payload preserving canonical precision across restarts."""
-
-    def __init__(
-        self,
-        canonical: CanonicalColor,
-        brightness: int | None,
-        source_hex: str | None,
-    ) -> None:
-        """Initialize stored color data."""
-        self.canonical = canonical
-        self.brightness = brightness
-        self.source_hex = source_hex
-
-    def as_dict(self) -> dict[str, Any]:
-        """Return a dict representation of the stored color."""
-        return {
-            "brightness": self.brightness,
-            "kind": self.canonical.kind,
-            "kelvin": self.canonical.kelvin,
-            "source_hex": self.source_hex,
-            "version": STATE_SCHEMA_VERSION,
-            "xy": list(self.canonical.xy),
-        }
-
-    @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> _StoredColor | None:
-        """Create stored color data from a dict."""
-        try:
-            xy = data["xy"]
-            canonical = CanonicalColor(
-                xy=(float(xy[0]), float(xy[1])),
-                kind=str(data["kind"]),
-                kelvin=int(data["kelvin"]) if data.get("kelvin") is not None else None,
-            )
-            brightness = data.get("brightness")
-            if brightness is not None:
-                brightness = int(brightness)
-            source_hex = data.get("source_hex")
-            if source_hex is not None:
-                source_hex = str(source_hex)
-        except KeyError, TypeError, ValueError:
-            return None
-        return cls(canonical, brightness, source_hex)
-
-
-class InputColor(collection.CollectionEntity, RestoreEntity):
-    """Represent a stored color value."""
-
-    _unrecorded_attributes = frozenset({ATTR_EDITABLE})
-
-    _attr_should_poll = False
-    editable: bool
-
-    def __init__(self, config: ConfigType) -> None:
-        """Initialize an input color."""
-        self._config = config
-        self._canonical = self._initial_canonical(config)
-        self._brightness = self._initial_brightness(config)
-        self._source_hex = self._initial_source_hex(config)
-
-    @classmethod
-    @override
-    def from_storage(cls, config: ConfigType) -> Self:
-        """Return entity instance initialized from storage."""
-        input_color: Self = cls(config)
-        input_color.editable = True
-        return input_color
-
-    @classmethod
-    @override
-    def from_yaml(cls, config: ConfigType) -> Self:
-        """Return entity instance initialized from yaml."""
-        input_color: Self = cls(config)
-        input_color.entity_id = f"{DOMAIN}.{config[CONF_ID]}"
-        input_color.editable = False
-        return input_color
-
-    @staticmethod
-    def _initial_canonical(config: ConfigType) -> CanonicalColor:
-        """Return the initial canonical color."""
-        if CONF_INITIAL_KELVIN in config:
-            return normalize({FIELD_KELVIN: config[CONF_INITIAL_KELVIN]})
-        return normalize({FIELD_HEX: config.get(CONF_INITIAL_COLOR, DEFAULT_HEX)})
-
-    @staticmethod
-    def _initial_brightness(config: ConfigType) -> int | None:
-        """Return initial brightness."""
-        brightness = config.get(CONF_INITIAL_BRIGHTNESS)
-        if brightness is None:
-            return None
-        return max(0, min(255, int(brightness)))
-
-    @staticmethod
-    def _initial_source_hex(config: ConfigType) -> str | None:
-        """Return source hex for the initial color."""
-        if CONF_INITIAL_KELVIN in config:
-            return None
-        initial_color = config.get(CONF_INITIAL_COLOR)
-        if initial_color is None:
-            return compute_source_hex({FIELD_HEX: DEFAULT_HEX})
-        return compute_source_hex({FIELD_HEX: initial_color})
-
-    @property
-    @override
-    def name(self) -> str | None:
-        """Return the name of the color input entity."""
-        return self._config.get(CONF_NAME)
-
-    @property
-    @override
-    def icon(self) -> str | None:
-        """Return the icon to be used for this entity."""
-        return self._config.get(CONF_ICON)
-
-    @property
-    @override
-    def state(self) -> str:
-        """Return the state of the entity."""
-        return self._source_hex or derive_hex(self._canonical)
-
-    @property
-    @override
-    def unique_id(self) -> str:
-        """Return unique id for the entity."""
-        return self._config[CONF_ID]  # type: ignore[no-any-return]
-
-    @property
-    @override
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return the state attributes."""
-        x, y = self._canonical.xy
-        r, g, b = derive_rgb(self._canonical)
-        h, s = derive_hs(self._canonical)
-        return {
-            ATTR_BRIGHTNESS: self._brightness,
-            ATTR_COLOR_TEMP_KELVIN: derive_kelvin(self._canonical),
-            ATTR_EDITABLE: self.editable,
-            ATTR_HEX_COLOR: self.state,
-            ATTR_HS_COLOR: [round(h, 2), round(s, 2)],
-            ATTR_KIND: self._canonical.kind,
-            ATTR_RGB_COLOR: [r, g, b],
-            ATTR_SOURCE_HEX: self._source_hex,
-            ATTR_XY_COLOR: [round(x, 4), round(y, 4)],
-        }
-
-    @property
-    @override
-    def extra_restore_state_data(self) -> ExtraStoredData | None:
-        """Return entity data to restore."""
-        return _StoredColor(self._canonical, self._brightness, self._source_hex)
-
-    @override
-    async def async_added_to_hass(self) -> None:
-        """Run when entity about to be added to hass."""
-        await super().async_added_to_hass()
-        if (
-            self._config.get(CONF_INITIAL_COLOR) is not None
-            or self._config.get(CONF_INITIAL_KELVIN) is not None
-        ):
-            return
-
-        last_extra = await self.async_get_last_extra_data()
-        if last_extra is not None:
-            stored = _StoredColor.from_dict(last_extra.as_dict())
-            if stored is not None:
-                self._canonical = stored.canonical
-                self._brightness = stored.brightness
-                self._source_hex = stored.source_hex
-
-    async def async_set_color(self, **shape: Any) -> None:
-        """Set the color from one accepted input shape."""
-        color_shape = dict(shape)
-        brightness = color_shape.pop(ATTR_BRIGHTNESS, None)
-        self._canonical = normalize(color_shape)
-        self._source_hex = compute_source_hex(color_shape)
-        if brightness is not None:
-            self._brightness = max(0, min(255, int(brightness)))
-        self.async_write_ha_state()
-
-    async def async_set_brightness(self, brightness: int | None) -> None:
-        """Set or clear the stored brightness."""
-        if brightness is None:
-            self._brightness = None
-        else:
-            self._brightness = max(0, min(255, int(brightness)))
-        self.async_write_ha_state()
-
-    @override
-    async def async_update_config(self, config: ConfigType) -> None:
-        """Handle when the config is updated."""
-        self._config = config
-        self.async_write_ha_state()

--- a/homeassistant/components/input_color/color_math.py
+++ b/homeassistant/components/input_color/color_math.py
@@ -1,0 +1,201 @@
+"""Color normalization for the Input Color helper."""
+
+from dataclasses import dataclass
+from typing import Any
+
+from homeassistant.util import color as color_util
+
+FIELD_COLOR_NAME = "color_name"
+FIELD_HEX = "hex_value"
+FIELD_HS = "hs_color"
+FIELD_KELVIN = "color_temp_kelvin"
+FIELD_RGB = "rgb_color"
+FIELD_XY = "xy_color"
+
+KIND_CHROMATIC = "chromatic"
+KIND_WHITE = "white"
+
+MIN_KELVIN = 1000
+MAX_KELVIN = 20000
+
+
+@dataclass(frozen=True)
+class CanonicalColor:
+    """Canonical color: chromaticity, kind, and optional kelvin value."""
+
+    xy: tuple[float, float]
+    kind: str
+    kelvin: int | None = None
+
+
+class ColorInputError(ValueError):
+    """Raised when a color input is missing, ambiguous, or out of range."""
+
+
+def _strip_hex(hex_value: str) -> str:
+    """Strip and validate a hex color."""
+    hex_str = hex_value.strip().lstrip("#")
+    if len(hex_str) != 6 or any(
+        char not in "0123456789abcdefABCDEF" for char in hex_str
+    ):
+        raise ColorInputError(f"Invalid hex color: {hex_value!r}")
+    return hex_str
+
+
+def _hex_to_rgb(hex_value: str) -> tuple[int, int, int]:
+    """Convert a hex color to RGB."""
+    hex_str = _strip_hex(hex_value)
+    return int(hex_str[0:2], 16), int(hex_str[2:4], 16), int(hex_str[4:6], 16)
+
+
+def _validate_rgb(rgb: Any) -> tuple[int, int, int]:
+    """Validate an RGB value."""
+    if not isinstance(rgb, (list, tuple)) or len(rgb) != 3:
+        raise ColorInputError(f"rgb_color must be a 3-element sequence, got {rgb!r}")
+    r, g, b = (int(value) for value in rgb)
+    if not all(0 <= value <= 255 for value in (r, g, b)):
+        raise ColorInputError("rgb_color components must be 0-255")
+    return r, g, b
+
+
+def _validate_hs(hs: Any) -> tuple[float, float]:
+    """Validate an HS value."""
+    if not isinstance(hs, (list, tuple)) or len(hs) != 2:
+        raise ColorInputError(f"hs_color must be a 2-element sequence, got {hs!r}")
+    h, s = float(hs[0]), float(hs[1])
+    if not 0 <= h <= 360:
+        raise ColorInputError("hs_color hue must be 0-360")
+    if not 0 <= s <= 100:
+        raise ColorInputError("hs_color saturation must be 0-100")
+    return h, s
+
+
+def _validate_xy(xy: Any) -> tuple[float, float]:
+    """Validate a CIE xy value."""
+    if not isinstance(xy, (list, tuple)) or len(xy) != 2:
+        raise ColorInputError(f"xy_color must be a 2-element sequence, got {xy!r}")
+    x, y = float(xy[0]), float(xy[1])
+    if not (0.0 <= x <= 1.0 and 0.0 <= y <= 1.0):
+        raise ColorInputError("xy_color components must be in [0, 1]")
+    return x, y
+
+
+def _validate_kelvin(kelvin: Any) -> int:
+    """Validate a kelvin color temperature value."""
+    try:
+        kelvin_int = int(kelvin)
+    except (TypeError, ValueError) as err:
+        raise ColorInputError(
+            f"color_temp_kelvin must be an int, got {kelvin!r}"
+        ) from err
+    if not MIN_KELVIN <= kelvin_int <= MAX_KELVIN:
+        raise ColorInputError(
+            f"color_temp_kelvin must be in [{MIN_KELVIN}, {MAX_KELVIN}]"
+        )
+    return kelvin_int
+
+
+def normalize(inputs: dict[str, Any]) -> CanonicalColor:
+    """Normalize exactly one accepted color shape to canonical form."""
+    keys = {
+        FIELD_HEX,
+        FIELD_RGB,
+        FIELD_HS,
+        FIELD_XY,
+        FIELD_KELVIN,
+        FIELD_COLOR_NAME,
+    }
+    present = {
+        key: value for key, value in inputs.items() if key in keys and value is not None
+    }
+    if not present:
+        raise ColorInputError(f"Provide exactly one of: {', '.join(sorted(keys))}")
+    if len(present) > 1:
+        raise ColorInputError(
+            f"Provide only one color input; got multiple: {sorted(present)}"
+        )
+
+    field, value = next(iter(present.items()))
+
+    if field == FIELD_KELVIN:
+        kelvin = _validate_kelvin(value)
+        r, g, b = color_util.color_temperature_to_rgb(kelvin)
+        x, y = color_util.color_RGB_to_xy(int(r), int(g), int(b))
+        return CanonicalColor(xy=(x, y), kind=KIND_WHITE, kelvin=kelvin)
+
+    if field == FIELD_HEX:
+        r, g, b = _hex_to_rgb(str(value))
+    elif field == FIELD_RGB:
+        r, g, b = _validate_rgb(value)
+    elif field == FIELD_HS:
+        h, s = _validate_hs(value)
+        r, g, b = color_util.color_hs_to_RGB(h, s)
+    elif field == FIELD_XY:
+        x, y = _validate_xy(value)
+        return CanonicalColor(xy=(x, y), kind=KIND_CHROMATIC)
+    elif field == FIELD_COLOR_NAME:
+        try:
+            r, g, b = color_util.color_name_to_rgb(str(value))
+        except ValueError as err:
+            raise ColorInputError(f"Unknown color name: {value!r}") from err
+    else:  # pragma: no cover
+        raise ColorInputError(f"Unhandled color input: {field}")
+
+    x, y = color_util.color_RGB_to_xy(int(r), int(g), int(b))
+    return CanonicalColor(xy=(x, y), kind=KIND_CHROMATIC)
+
+
+def derive_rgb(canonical: CanonicalColor) -> tuple[int, int, int]:
+    """Return display-grade sRGB for the color."""
+    if canonical.kind == KIND_WHITE and canonical.kelvin is not None:
+        r, g, b = color_util.color_temperature_to_rgb(canonical.kelvin)
+        return int(r), int(g), int(b)
+    return color_util.color_xy_to_RGB(*canonical.xy)
+
+
+def derive_hs(canonical: CanonicalColor) -> tuple[float, float]:
+    """Return HS for the color."""
+    r, g, b = derive_rgb(canonical)
+    return color_util.color_RGB_to_hs(r, g, b)
+
+
+def derive_kelvin(canonical: CanonicalColor) -> int | None:
+    """Return stored kelvin for white colors."""
+    if canonical.kind == KIND_WHITE and canonical.kelvin is not None:
+        return canonical.kelvin
+    return None
+
+
+def derive_hex(canonical: CanonicalColor) -> str:
+    """Return a hex string for the color."""
+    r, g, b = derive_rgb(canonical)
+    return "#" + color_util.color_rgb_to_hex(r, g, b).upper()
+
+
+def compute_source_hex(inputs: dict[str, Any]) -> str | None:
+    """Return the literal hex equivalent of the input, if one exists."""
+    if FIELD_HEX in inputs and inputs[FIELD_HEX] is not None:
+        try:
+            r, g, b = _hex_to_rgb(str(inputs[FIELD_HEX]))
+        except ColorInputError:
+            return None
+    elif FIELD_RGB in inputs and inputs[FIELD_RGB] is not None:
+        try:
+            r, g, b = _validate_rgb(inputs[FIELD_RGB])
+        except ColorInputError:
+            return None
+    elif FIELD_HS in inputs and inputs[FIELD_HS] is not None:
+        try:
+            h, s = _validate_hs(inputs[FIELD_HS])
+        except ColorInputError:
+            return None
+        r, g, b = color_util.color_hs_to_RGB(h, s)
+    elif FIELD_COLOR_NAME in inputs and inputs[FIELD_COLOR_NAME] is not None:
+        try:
+            r, g, b = color_util.color_name_to_rgb(str(inputs[FIELD_COLOR_NAME]))
+        except ValueError:
+            return None
+    else:
+        return None
+
+    return "#" + color_util.color_rgb_to_hex(int(r), int(g), int(b)).upper()

--- a/homeassistant/components/input_color/entity.py
+++ b/homeassistant/components/input_color/entity.py
@@ -1,0 +1,232 @@
+"""Entity support for the input color helper."""
+
+from typing import Any, Self, override
+
+from homeassistant.const import ATTR_EDITABLE, CONF_ICON, CONF_ID, CONF_NAME
+from homeassistant.helpers import collection
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
+from homeassistant.helpers.typing import ConfigType
+
+from . import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HEX_COLOR,
+    ATTR_HS_COLOR,
+    ATTR_KIND,
+    ATTR_RGB_COLOR,
+    ATTR_SOURCE_HEX,
+    ATTR_XY_COLOR,
+    CONF_INITIAL_BRIGHTNESS,
+    CONF_INITIAL_COLOR,
+    CONF_INITIAL_KELVIN,
+    DEFAULT_HEX,
+    DOMAIN,
+    STATE_SCHEMA_VERSION,
+)
+from .color_math import (
+    FIELD_HEX,
+    FIELD_KELVIN,
+    CanonicalColor,
+    compute_source_hex,
+    derive_hex,
+    derive_hs,
+    derive_kelvin,
+    derive_rgb,
+    normalize,
+)
+
+
+class _StoredColor(ExtraStoredData):
+    """Restore payload preserving canonical precision across restarts."""
+
+    def __init__(
+        self,
+        canonical: CanonicalColor,
+        brightness: int | None,
+        source_hex: str | None,
+    ) -> None:
+        """Initialize stored color data."""
+        self.canonical = canonical
+        self.brightness = brightness
+        self.source_hex = source_hex
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the stored color."""
+        return {
+            "brightness": self.brightness,
+            "kind": self.canonical.kind,
+            "kelvin": self.canonical.kelvin,
+            "source_hex": self.source_hex,
+            "version": STATE_SCHEMA_VERSION,
+            "xy": list(self.canonical.xy),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> _StoredColor | None:
+        """Create stored color data from a dict."""
+        try:
+            xy = data["xy"]
+            canonical = CanonicalColor(
+                xy=(float(xy[0]), float(xy[1])),
+                kind=str(data["kind"]),
+                kelvin=int(data["kelvin"]) if data.get("kelvin") is not None else None,
+            )
+            brightness = data.get("brightness")
+            if brightness is not None:
+                brightness = int(brightness)
+            source_hex = data.get("source_hex")
+            if source_hex is not None:
+                source_hex = str(source_hex)
+        except KeyError, TypeError, ValueError:
+            return None
+        return cls(canonical, brightness, source_hex)
+
+
+class InputColor(collection.CollectionEntity, RestoreEntity):
+    """Represent a stored color value."""
+
+    _unrecorded_attributes = frozenset({ATTR_EDITABLE})
+
+    _attr_should_poll = False
+    editable: bool
+
+    def __init__(self, config: ConfigType) -> None:
+        """Initialize an input color."""
+        self._config = config
+        self._canonical = self._initial_canonical(config)
+        self._brightness = self._initial_brightness(config)
+        self._source_hex = self._initial_source_hex(config)
+
+    @classmethod
+    @override
+    def from_storage(cls, config: ConfigType) -> Self:
+        """Return entity instance initialized from storage."""
+        input_color = cls(config)
+        input_color.editable = True
+        return input_color
+
+    @classmethod
+    @override
+    def from_yaml(cls, config: ConfigType) -> Self:
+        """Return entity instance initialized from yaml."""
+        input_color = cls(config)
+        input_color.entity_id = f"{DOMAIN}.{config[CONF_ID]}"
+        input_color.editable = False
+        return input_color
+
+    @staticmethod
+    def _initial_canonical(config: ConfigType) -> CanonicalColor:
+        """Return the initial canonical color."""
+        if CONF_INITIAL_KELVIN in config:
+            return normalize({FIELD_KELVIN: config[CONF_INITIAL_KELVIN]})
+        return normalize({FIELD_HEX: config.get(CONF_INITIAL_COLOR, DEFAULT_HEX)})
+
+    @staticmethod
+    def _initial_brightness(config: ConfigType) -> int | None:
+        """Return initial brightness."""
+        brightness = config.get(CONF_INITIAL_BRIGHTNESS)
+        if brightness is None:
+            return None
+        return max(0, min(255, int(brightness)))
+
+    @staticmethod
+    def _initial_source_hex(config: ConfigType) -> str | None:
+        """Return source hex for the initial color."""
+        if CONF_INITIAL_KELVIN in config:
+            return None
+        initial_color = config.get(CONF_INITIAL_COLOR)
+        if initial_color is None:
+            return compute_source_hex({FIELD_HEX: DEFAULT_HEX})
+        return compute_source_hex({FIELD_HEX: initial_color})
+
+    @property
+    @override
+    def name(self) -> str | None:
+        """Return the name of the color input entity."""
+        return self._config.get(CONF_NAME)
+
+    @property
+    @override
+    def icon(self) -> str | None:
+        """Return the icon to be used for this entity."""
+        return self._config.get(CONF_ICON)
+
+    @property
+    @override
+    def state(self) -> str:
+        """Return the state of the entity."""
+        return self._source_hex or derive_hex(self._canonical)
+
+    @property
+    @override
+    def unique_id(self) -> str:
+        """Return unique id for the entity."""
+        return self._config[CONF_ID]
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return the state attributes."""
+        x, y = self._canonical.xy
+        r, g, b = derive_rgb(self._canonical)
+        h, s = derive_hs(self._canonical)
+        return {
+            ATTR_BRIGHTNESS: self._brightness,
+            ATTR_COLOR_TEMP_KELVIN: derive_kelvin(self._canonical),
+            ATTR_EDITABLE: self.editable,
+            ATTR_HEX_COLOR: self.state,
+            ATTR_HS_COLOR: [round(h, 2), round(s, 2)],
+            ATTR_KIND: self._canonical.kind,
+            ATTR_RGB_COLOR: [r, g, b],
+            ATTR_SOURCE_HEX: self._source_hex,
+            ATTR_XY_COLOR: [round(x, 4), round(y, 4)],
+        }
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> ExtraStoredData | None:
+        """Return entity data to restore."""
+        return _StoredColor(self._canonical, self._brightness, self._source_hex)
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        if (
+            self._config.get(CONF_INITIAL_COLOR) is not None
+            or self._config.get(CONF_INITIAL_KELVIN) is not None
+        ):
+            return
+
+        last_extra = await self.async_get_last_extra_data()
+        if last_extra is not None:
+            stored = _StoredColor.from_dict(last_extra.as_dict())
+            if stored is not None:
+                self._canonical = stored.canonical
+                self._brightness = stored.brightness
+                self._source_hex = stored.source_hex
+
+    async def async_set_color(self, **shape: Any) -> None:
+        """Set the color from one accepted input shape."""
+        color_shape = dict(shape)
+        brightness = color_shape.pop(ATTR_BRIGHTNESS, None)
+        self._canonical = normalize(color_shape)
+        self._source_hex = compute_source_hex(color_shape)
+        if brightness is not None:
+            self._brightness = max(0, min(255, int(brightness)))
+        self.async_write_ha_state()
+
+    async def async_set_brightness(self, brightness: int | None) -> None:
+        """Set or clear the stored brightness."""
+        if brightness is None:
+            self._brightness = None
+        else:
+            self._brightness = max(0, min(255, int(brightness)))
+        self.async_write_ha_state()
+
+    @override
+    async def async_update_config(self, config: ConfigType) -> None:
+        """Handle when the config is updated."""
+        self._config = config
+        self.async_write_ha_state()

--- a/homeassistant/components/input_color/icons.json
+++ b/homeassistant/components/input_color/icons.json
@@ -1,0 +1,16 @@
+{
+  "services": {
+    "clear_brightness": {
+      "service": "mdi:brightness-6"
+    },
+    "reload": {
+      "service": "mdi:reload"
+    },
+    "set_brightness": {
+      "service": "mdi:brightness-6"
+    },
+    "set_color": {
+      "service": "mdi:palette"
+    }
+  }
+}

--- a/homeassistant/components/input_color/manifest.json
+++ b/homeassistant/components/input_color/manifest.json
@@ -4,6 +4,5 @@
   "codeowners": ["@home-assistant/core"],
   "documentation": "https://www.home-assistant.io/integrations/input_color",
   "integration_type": "helper",
-  "iot_class": "local_push",
   "quality_scale": "internal"
 }

--- a/homeassistant/components/input_color/manifest.json
+++ b/homeassistant/components/input_color/manifest.json
@@ -1,0 +1,9 @@
+{
+  "domain": "input_color",
+  "name": "Input Color",
+  "codeowners": ["@home-assistant/core"],
+  "documentation": "https://www.home-assistant.io/integrations/input_color",
+  "integration_type": "helper",
+  "iot_class": "local_push",
+  "quality_scale": "internal"
+}

--- a/homeassistant/components/input_color/reproduce_state.py
+++ b/homeassistant/components/input_color/reproduce_state.py
@@ -1,0 +1,97 @@
+"""Reproduce an Input Color state."""
+
+import asyncio
+from collections.abc import Iterable
+import logging
+from typing import Any
+
+from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.core import Context, HomeAssistant, State
+
+from . import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HEX_COLOR,
+    DOMAIN,
+    SERVICE_CLEAR_BRIGHTNESS,
+    SERVICE_SET_BRIGHTNESS,
+    SERVICE_SET_COLOR,
+)
+from .color_math import FIELD_HEX, FIELD_KELVIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _async_reproduce_state(
+    hass: HomeAssistant,
+    state: State,
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
+) -> None:
+    """Reproduce a single state."""
+    if (cur_state := hass.states.get(state.entity_id)) is None:
+        _LOGGER.warning("Unable to find entity %s", state.entity_id)
+        return
+
+    if cur_state.state == state.state and cur_state.attributes.get(
+        ATTR_BRIGHTNESS
+    ) == state.attributes.get(ATTR_BRIGHTNESS):
+        return
+
+    service_data: dict[str, Any]
+    if (kelvin := state.attributes.get(ATTR_COLOR_TEMP_KELVIN)) is not None:
+        service_data = {ATTR_ENTITY_ID: state.entity_id, FIELD_KELVIN: kelvin}
+    else:
+        service_data = {
+            ATTR_ENTITY_ID: state.entity_id,
+            FIELD_HEX: state.attributes.get(ATTR_HEX_COLOR, state.state),
+        }
+
+    if (brightness := state.attributes.get(ATTR_BRIGHTNESS)) is not None:
+        service_data[ATTR_BRIGHTNESS] = brightness
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_SET_COLOR, service_data, context=context, blocking=True
+    )
+
+    if (
+        ATTR_BRIGHTNESS in state.attributes
+        and state.attributes[ATTR_BRIGHTNESS] is None
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_CLEAR_BRIGHTNESS,
+            {ATTR_ENTITY_ID: state.entity_id},
+            context=context,
+            blocking=True,
+        )
+    elif ATTR_BRIGHTNESS in state.attributes:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_BRIGHTNESS,
+            {
+                ATTR_ENTITY_ID: state.entity_id,
+                ATTR_BRIGHTNESS: state.attributes[ATTR_BRIGHTNESS],
+            },
+            context=context,
+            blocking=True,
+        )
+
+
+async def async_reproduce_states(
+    hass: HomeAssistant,
+    states: Iterable[State],
+    *,
+    context: Context | None = None,
+    reproduce_options: dict[str, Any] | None = None,
+) -> None:
+    """Reproduce Input Color states."""
+    await asyncio.gather(
+        *(
+            _async_reproduce_state(
+                hass, state, context=context, reproduce_options=reproduce_options
+            )
+            for state in states
+        )
+    )

--- a/homeassistant/components/input_color/reproduce_state.py
+++ b/homeassistant/components/input_color/reproduce_state.py
@@ -48,9 +48,6 @@ async def _async_reproduce_state(
             FIELD_HEX: state.attributes.get(ATTR_HEX_COLOR, state.state),
         }
 
-    if (brightness := state.attributes.get(ATTR_BRIGHTNESS)) is not None:
-        service_data[ATTR_BRIGHTNESS] = brightness
-
     await hass.services.async_call(
         DOMAIN, SERVICE_SET_COLOR, service_data, context=context, blocking=True
     )

--- a/homeassistant/components/input_color/services.yaml
+++ b/homeassistant/components/input_color/services.yaml
@@ -1,0 +1,61 @@
+set_color:
+  target:
+    entity:
+      integration: input_color
+      domain: input_color
+  fields:
+    hex_value:
+      example: "#FF8000"
+      selector:
+        text:
+    rgb_color:
+      example: "[255, 128, 0]"
+      selector:
+        color_rgb:
+    hs_color:
+      example: "[30, 100]"
+      selector:
+        object:
+    xy_color:
+      example: "[0.5, 0.4]"
+      selector:
+        object:
+    color_temp_kelvin:
+      example: 4000
+      selector:
+        color_temp:
+          unit: kelvin
+          min: 1000
+          max: 20000
+    color_name:
+      example: crimson
+      selector:
+        text:
+    brightness:
+      example: 200
+      selector:
+        number:
+          min: 0
+          max: 255
+          mode: slider
+
+set_brightness:
+  target:
+    entity:
+      integration: input_color
+      domain: input_color
+  fields:
+    brightness:
+      required: true
+      example: 180
+      selector:
+        number:
+          min: 0
+          max: 255
+          mode: slider
+
+clear_brightness:
+  target:
+    entity:
+      integration: input_color
+      domain: input_color

--- a/homeassistant/components/input_color/services.yaml
+++ b/homeassistant/components/input_color/services.yaml
@@ -1,3 +1,5 @@
+reload:
+
 set_color:
   target:
     entity:

--- a/homeassistant/components/input_color/strings.json
+++ b/homeassistant/components/input_color/strings.json
@@ -1,0 +1,99 @@
+{
+  "entity_component": {
+    "_": {
+      "name": "[%key:component::input_color::title%]",
+      "state_attributes": {
+        "brightness": {
+          "name": "Brightness"
+        },
+        "color_temp_kelvin": {
+          "name": "Color temperature"
+        },
+        "editable": {
+          "name": "[%key:common::generic::ui_managed%]",
+          "state": {
+            "false": "[%key:common::state::no%]",
+            "true": "[%key:common::state::yes%]"
+          }
+        },
+        "hex_color": {
+          "name": "Hex color"
+        },
+        "hs_color": {
+          "name": "HS color"
+        },
+        "kind": {
+          "name": "Kind",
+          "state": {
+            "chromatic": "Chromatic",
+            "white": "White"
+          }
+        },
+        "rgb_color": {
+          "name": "RGB color"
+        },
+        "source_hex": {
+          "name": "Source hex"
+        },
+        "xy_color": {
+          "name": "CIE xy color"
+        }
+      }
+    }
+  },
+  "services": {
+    "reload": {
+      "description": "Reloads helpers from the YAML-configuration.",
+      "name": "Reload input colors"
+    },
+    "set_color": {
+      "name": "Set color",
+      "description": "Set the stored color.",
+      "fields": {
+        "hex_value": {
+          "name": "Hex",
+          "description": "Hex color, for example #FF8000."
+        },
+        "rgb_color": {
+          "name": "RGB",
+          "description": "RGB triplet, components 0-255."
+        },
+        "hs_color": {
+          "name": "HS",
+          "description": "Hue (0-360) and saturation (0-100)."
+        },
+        "xy_color": {
+          "name": "CIE xy",
+          "description": "CIE 1931 chromaticity (x, y), each 0-1."
+        },
+        "color_temp_kelvin": {
+          "name": "Color temperature",
+          "description": "Color temperature in Kelvin."
+        },
+        "color_name": {
+          "name": "Color name",
+          "description": "CSS3 color name, for example crimson."
+        },
+        "brightness": {
+          "name": "Brightness",
+          "description": "Optional brightness 0-255 stored alongside the color."
+        }
+      }
+    },
+    "set_brightness": {
+      "name": "Set brightness",
+      "description": "Set the stored brightness.",
+      "fields": {
+        "brightness": {
+          "name": "Brightness",
+          "description": "Brightness 0-255."
+        }
+      }
+    },
+    "clear_brightness": {
+      "name": "Clear brightness",
+      "description": "Clear the stored brightness."
+    }
+  },
+  "title": "Input color"
+}

--- a/homeassistant/components/input_color/strings.json
+++ b/homeassistant/components/input_color/strings.json
@@ -42,57 +42,57 @@
     }
   },
   "services": {
+    "clear_brightness": {
+      "description": "Clear the stored brightness.",
+      "name": "Clear brightness"
+    },
     "reload": {
       "description": "Reloads helpers from the YAML-configuration.",
       "name": "Reload input colors"
     },
-    "set_color": {
-      "name": "Set color",
-      "description": "Set the stored color.",
-      "fields": {
-        "hex_value": {
-          "name": "Hex",
-          "description": "Hex color, for example #FF8000."
-        },
-        "rgb_color": {
-          "name": "RGB",
-          "description": "RGB triplet, components 0-255."
-        },
-        "hs_color": {
-          "name": "HS",
-          "description": "Hue (0-360) and saturation (0-100)."
-        },
-        "xy_color": {
-          "name": "CIE xy",
-          "description": "CIE 1931 chromaticity (x, y), each 0-1."
-        },
-        "color_temp_kelvin": {
-          "name": "Color temperature",
-          "description": "Color temperature in Kelvin."
-        },
-        "color_name": {
-          "name": "Color name",
-          "description": "CSS3 color name, for example crimson."
-        },
-        "brightness": {
-          "name": "Brightness",
-          "description": "Optional brightness 0-255 stored alongside the color."
-        }
-      }
-    },
     "set_brightness": {
-      "name": "Set brightness",
       "description": "Set the stored brightness.",
       "fields": {
         "brightness": {
-          "name": "Brightness",
-          "description": "Brightness 0-255."
+          "description": "Brightness 0-255.",
+          "name": "Brightness"
         }
-      }
+      },
+      "name": "Set brightness"
     },
-    "clear_brightness": {
-      "name": "Clear brightness",
-      "description": "Clear the stored brightness."
+    "set_color": {
+      "description": "Set the stored color.",
+      "fields": {
+        "brightness": {
+          "description": "Optional brightness 0-255 stored alongside the color.",
+          "name": "Brightness"
+        },
+        "color_name": {
+          "description": "CSS3 color name, for example crimson.",
+          "name": "Color name"
+        },
+        "color_temp_kelvin": {
+          "description": "Color temperature in Kelvin.",
+          "name": "Color temperature"
+        },
+        "hex_value": {
+          "description": "Hex color, for example #FF8000.",
+          "name": "Hex"
+        },
+        "hs_color": {
+          "description": "Hue (0-360) and saturation (0-100).",
+          "name": "HS"
+        },
+        "rgb_color": {
+          "description": "RGB triplet, components 0-255.",
+          "name": "RGB"
+        },
+        "xy_color": {
+          "description": "CIE 1931 chromaticity (x, y), each 0-1.",
+          "name": "CIE xy"
+        }
+      },
+      "name": "Set color"
     }
   },
   "title": "Input color"

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -8384,8 +8384,7 @@
     },
     "input_color": {
       "integration_type": "helper",
-      "config_flow": false,
-      "iot_class": "local_push"
+      "config_flow": false
     },
     "input_datetime": {
       "integration_type": "helper",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -8382,6 +8382,11 @@
       "integration_type": "helper",
       "config_flow": false
     },
+    "input_color": {
+      "integration_type": "helper",
+      "config_flow": false,
+      "iot_class": "local_push"
+    },
     "input_datetime": {
       "integration_type": "helper",
       "config_flow": false
@@ -8499,6 +8504,7 @@
     "homekit_controller",
     "input_boolean",
     "input_button",
+    "input_color",
     "input_datetime",
     "input_number",
     "input_select",

--- a/script/hassfest/manifest.py
+++ b/script/hassfest/manifest.py
@@ -93,6 +93,7 @@ NO_IOT_CLASS = [
     "image_upload",
     "input_boolean",
     "input_button",
+    "input_color",
     "input_datetime",
     "input_number",
     "input_select",

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -2047,6 +2047,7 @@ NO_QUALITY_SCALE = [
     "image_upload",
     "input_boolean",
     "input_button",
+    "input_color",
     "input_datetime",
     "input_number",
     "input_select",

--- a/tests/components/input_color/__init__.py
+++ b/tests/components/input_color/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the input_color component."""

--- a/tests/components/input_color/test_color_math.py
+++ b/tests/components/input_color/test_color_math.py
@@ -1,0 +1,76 @@
+"""Test input_color color math."""
+
+import pytest
+
+from homeassistant.components.input_color.color_math import (
+    FIELD_COLOR_NAME,
+    FIELD_HEX,
+    FIELD_HS,
+    FIELD_KELVIN,
+    FIELD_RGB,
+    FIELD_XY,
+    KIND_CHROMATIC,
+    KIND_WHITE,
+    ColorInputError,
+    compute_source_hex,
+    derive_hex,
+    derive_kelvin,
+    derive_rgb,
+    normalize,
+)
+
+
+def test_normalize_hex() -> None:
+    """Test normalizing a hex color."""
+    canonical = normalize({FIELD_HEX: "#FF8000"})
+
+    assert canonical.kind == KIND_CHROMATIC
+    assert derive_hex(canonical) == "#FF8201"
+    assert derive_kelvin(canonical) is None
+    assert compute_source_hex({FIELD_HEX: "#ff8000"}) == "#FF8000"
+
+
+def test_normalize_rgb_hs_and_name_source_hex() -> None:
+    """Test normalizing RGB, HS, and color names."""
+    assert compute_source_hex({FIELD_RGB: [255, 0, 0]}) == "#FF0000"
+    assert compute_source_hex({FIELD_HS: [120, 100]}) == "#00FF00"
+    assert compute_source_hex({FIELD_COLOR_NAME: "blue"}) == "#0000FF"
+
+
+def test_normalize_xy() -> None:
+    """Test normalizing CIE xy."""
+    canonical = normalize({FIELD_XY: [0.5, 0.4]})
+
+    assert canonical.kind == KIND_CHROMATIC
+    assert canonical.xy == (0.5, 0.4)
+    assert compute_source_hex({FIELD_XY: [0.5, 0.4]}) is None
+
+
+def test_normalize_kelvin() -> None:
+    """Test normalizing a kelvin color temperature."""
+    canonical = normalize({FIELD_KELVIN: 2700})
+
+    assert canonical.kind == KIND_WHITE
+    assert canonical.kelvin == 2700
+    assert derive_kelvin(canonical) == 2700
+    assert compute_source_hex({FIELD_KELVIN: 2700}) is None
+    assert len(derive_rgb(canonical)) == 3
+
+
+@pytest.mark.parametrize(
+    "color_input",
+    [
+        {},
+        {FIELD_HEX: "#NOPE"},
+        {FIELD_HEX: "#FFFFFF", FIELD_RGB: [255, 255, 255]},
+        {FIELD_RGB: [256, 0, 0]},
+        {FIELD_HS: [361, 100]},
+        {FIELD_XY: [1.2, 0.4]},
+        {FIELD_KELVIN: 999},
+        {FIELD_COLOR_NAME: "not-a-color"},
+    ],
+)
+def test_normalize_rejects_invalid_inputs(color_input) -> None:
+    """Test invalid color input validation."""
+    with pytest.raises(ColorInputError):
+        normalize(color_input)

--- a/tests/components/input_color/test_init.py
+++ b/tests/components/input_color/test_init.py
@@ -1,0 +1,368 @@
+"""The tests for the input_color component."""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.input_color import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HEX_COLOR,
+    ATTR_KIND,
+    ATTR_RGB_COLOR,
+    ATTR_SOURCE_HEX,
+    ATTR_XY_COLOR,
+    CONF_INITIAL_COLOR,
+    DOMAIN,
+    SERVICE_CLEAR_BRIGHTNESS,
+    SERVICE_SET_BRIGHTNESS,
+    SERVICE_SET_COLOR,
+)
+from homeassistant.const import (
+    ATTR_EDITABLE,
+    ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
+    ATTR_ICON,
+    SERVICE_RELOAD,
+)
+from homeassistant.core import Context, CoreState, HomeAssistant, State
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockUser, mock_restore_cache_with_extra_data
+
+
+@pytest.fixture
+def storage_setup(hass: HomeAssistant, hass_storage: dict[str, Any]):
+    """Storage setup."""
+
+    async def _storage(items=None, config=None):
+        if items is None:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {
+                    "items": [
+                        {
+                            "id": "from_storage",
+                            "name": "from storage",
+                            "initial_color": "#FF8000",
+                        }
+                    ]
+                },
+            }
+        else:
+            hass_storage[DOMAIN] = {
+                "key": DOMAIN,
+                "version": 1,
+                "data": {"items": items},
+            }
+        if config is None:
+            config = {DOMAIN: {}}
+        return await async_setup_component(hass, DOMAIN, config)
+
+    return _storage
+
+
+async def async_set_color(
+    hass: HomeAssistant, entity_id: str, data: dict[str, Any]
+) -> None:
+    """Set input_color color."""
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_COLOR,
+        {ATTR_ENTITY_ID: entity_id, **data},
+        blocking=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "invalid_config",
+    [
+        None,
+        {"name with space": None},
+        {"test_1": {"initial_color": "#NOPE"}},
+        {"test_1": {"initial_color": "#FFFFFF", "initial_kelvin": 2700}},
+        {"test_1": {"initial_kelvin": 999}},
+        {"test_1": {"initial_brightness": 256}},
+    ],
+)
+async def test_config(hass: HomeAssistant, invalid_config) -> None:
+    """Test config validation."""
+    assert not await async_setup_component(hass, DOMAIN, {DOMAIN: invalid_config})
+
+
+async def test_config_options(hass: HomeAssistant) -> None:
+    """Test configuration options."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test_1": None,
+                "test_2": {
+                    "name": "Evening",
+                    "icon": "mdi:palette",
+                    "initial_color": "#FF8000",
+                    "initial_brightness": 180,
+                },
+                "test_3": {"initial_kelvin": 2700},
+            }
+        },
+    )
+
+    state_1 = hass.states.get("input_color.test_1")
+    state_2 = hass.states.get("input_color.test_2")
+    state_3 = hass.states.get("input_color.test_3")
+
+    assert state_1 is not None
+    assert state_1.state == "#FFFFFF"
+    assert state_1.attributes[ATTR_SOURCE_HEX] == "#FFFFFF"
+
+    assert state_2 is not None
+    assert state_2.state == "#FF8000"
+    assert state_2.attributes[ATTR_FRIENDLY_NAME] == "Evening"
+    assert state_2.attributes[ATTR_ICON] == "mdi:palette"
+    assert state_2.attributes[ATTR_BRIGHTNESS] == 180
+    assert state_2.attributes[ATTR_HEX_COLOR] == "#FF8000"
+    assert state_2.attributes[ATTR_RGB_COLOR] == [255, 130, 1]
+
+    assert state_3 is not None
+    assert state_3.attributes[ATTR_KIND] == "white"
+    assert state_3.attributes[ATTR_COLOR_TEMP_KELVIN] == 2700
+    assert state_3.attributes[ATTR_SOURCE_HEX] is None
+
+
+async def test_set_color(hass: HomeAssistant) -> None:
+    """Test set_color service."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test_1": None}})
+    entity_id = "input_color.test_1"
+
+    await async_set_color(hass, entity_id, {"hex_value": "#FF8000", "brightness": 200})
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "#FF8000"
+    assert state.attributes[ATTR_HEX_COLOR] == "#FF8000"
+    assert state.attributes[ATTR_SOURCE_HEX] == "#FF8000"
+    assert state.attributes[ATTR_BRIGHTNESS] == 200
+
+    await async_set_color(hass, entity_id, {"rgb_color": [0, 255, 0]})
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "#00FF00"
+    assert state.attributes[ATTR_SOURCE_HEX] == "#00FF00"
+    assert state.attributes[ATTR_BRIGHTNESS] == 200
+
+    await async_set_color(hass, entity_id, {"color_temp_kelvin": 2700})
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_KIND] == "white"
+    assert state.attributes[ATTR_COLOR_TEMP_KELVIN] == 2700
+    assert state.attributes[ATTR_SOURCE_HEX] is None
+
+
+async def test_set_color_rejects_missing_or_ambiguous_input(
+    hass: HomeAssistant,
+) -> None:
+    """Test set_color rejects invalid color shapes."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test_1": None}})
+    entity_id = "input_color.test_1"
+
+    with pytest.raises(HomeAssistantError):
+        await async_set_color(hass, entity_id, {})
+
+    with pytest.raises(HomeAssistantError):
+        await async_set_color(
+            hass, entity_id, {"hex_value": "#FFFFFF", "rgb_color": [255, 255, 255]}
+        )
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "#FFFFFF"
+
+
+async def test_brightness_services(hass: HomeAssistant) -> None:
+    """Test brightness services."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {"test_1": {"initial_color": "#FF8000", "initial_brightness": 100}}},
+    )
+    entity_id = "input_color.test_1"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_BRIGHTNESS,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 220},
+        blocking=True,
+    )
+    assert hass.states.get(entity_id).attributes[ATTR_BRIGHTNESS] == 220
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CLEAR_BRIGHTNESS,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    assert hass.states.get(entity_id).attributes[ATTR_BRIGHTNESS] is None
+
+
+async def test_restore_state(hass: HomeAssistant) -> None:
+    """Ensure states are restored on startup."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State("input_color.restored", "#00FF00"),
+                {
+                    "version": 1,
+                    "xy": [0.1724, 0.7468],
+                    "kind": "chromatic",
+                    "kelvin": None,
+                    "brightness": 123,
+                    "source_hex": "#00FF00",
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+
+    await async_setup_component(hass, DOMAIN, {DOMAIN: {"restored": None}})
+
+    state = hass.states.get("input_color.restored")
+    assert state is not None
+    assert state.state == "#00FF00"
+    assert state.attributes[ATTR_BRIGHTNESS] == 123
+    assert state.attributes[ATTR_SOURCE_HEX] == "#00FF00"
+
+
+async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:
+    """Ensure initial config overrules restored state."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        (
+            (
+                State("input_color.restored", "#00FF00"),
+                {
+                    "version": 1,
+                    "xy": [0.1724, 0.7468],
+                    "kind": "chromatic",
+                    "kelvin": None,
+                    "brightness": 123,
+                    "source_hex": "#00FF00",
+                },
+            ),
+        ),
+    )
+
+    hass.set_state(CoreState.starting)
+
+    await async_setup_component(
+        hass, DOMAIN, {DOMAIN: {"restored": {CONF_INITIAL_COLOR: "#FF0000"}}}
+    )
+
+    state = hass.states.get("input_color.restored")
+    assert state is not None
+    assert state.state == "#FF0000"
+    assert state.attributes[ATTR_SOURCE_HEX] == "#FF0000"
+
+
+async def test_input_color_context(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
+    """Test that input_color context works."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test_1": None}})
+    entity_id = "input_color.test_1"
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_COLOR,
+        {ATTR_ENTITY_ID: entity_id, "hex_value": "#00FF00"},
+        True,
+        Context(user_id=hass_admin_user.id),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.context.user_id == hass_admin_user.id
+
+
+async def test_reload(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, hass_admin_user: MockUser
+) -> None:
+    """Test reload service."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {
+            DOMAIN: {
+                "test_1": None,
+                "test_2": {"name": "Evening", "initial_color": "#FF8000"},
+            }
+        },
+    )
+
+    assert hass.states.get("input_color.test_1") is not None
+    assert hass.states.get("input_color.test_2").state == "#FF8000"
+    assert hass.states.get("input_color.test_3") is None
+    assert entity_registry.async_get_entity_id(DOMAIN, DOMAIN, "test_1") is not None
+
+    with patch(
+        "homeassistant.config.load_yaml_config_file",
+        autospec=True,
+        return_value={
+            DOMAIN: {
+                "test_2": {"name": "Evening reloaded", "initial_color": "#0000FF"},
+                "test_3": None,
+            }
+        },
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_RELOAD,
+            blocking=True,
+            context=Context(user_id=hass_admin_user.id),
+        )
+
+    assert hass.states.get("input_color.test_1") is None
+    assert hass.states.get("input_color.test_2").state == "#FF8000"
+    assert (
+        hass.states.get("input_color.test_2").attributes[ATTR_FRIENDLY_NAME]
+        == "Evening reloaded"
+    )
+    assert hass.states.get("input_color.test_3") is not None
+
+
+async def test_storage_load(storage_setup) -> None:
+    """Test loading input_color from storage."""
+    assert await storage_setup()
+
+
+async def test_editable_attribute(hass: HomeAssistant, storage_setup) -> None:
+    """Test editable attribute for storage and yaml helpers."""
+    assert await storage_setup(
+        config={DOMAIN: {"from_yaml": {"name": "from yaml"}}},
+    )
+
+    yaml_state = hass.states.get("input_color.from_yaml")
+    storage_state = hass.states.get("input_color.from_storage")
+    assert yaml_state is not None
+    assert storage_state is not None
+    assert yaml_state.attributes[ATTR_EDITABLE] is False
+    assert storage_state.attributes[ATTR_EDITABLE] is True
+    assert storage_state.attributes[ATTR_FRIENDLY_NAME] == "from storage"
+
+
+async def test_xy_attrs_are_rounded(hass: HomeAssistant) -> None:
+    """Test xy attributes are rounded for state output."""
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {"test_1": None}})
+    entity_id = "input_color.test_1"
+
+    await async_set_color(hass, entity_id, {"xy_color": [0.123456, 0.654321]})
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.attributes[ATTR_XY_COLOR] == [0.1235, 0.6543]

--- a/tests/components/input_color/test_reproduce_state.py
+++ b/tests/components/input_color/test_reproduce_state.py
@@ -1,0 +1,70 @@
+"""Test reproduce state for Input Color."""
+
+import pytest
+
+from homeassistant.components.input_color import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ATTR_HEX_COLOR,
+    ATTR_KIND,
+    DOMAIN,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.state import async_reproduce_state
+from homeassistant.setup import async_setup_component
+
+
+async def test_reproducing_states(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test reproducing Input Color states."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {"test_color": {"initial_color": "#FF0000"}}},
+    )
+
+    await async_reproduce_state(
+        hass,
+        [
+            State("input_color.test_color", "#FF0000"),
+            State("input_color.non_existing", "#00FF00"),
+        ],
+    )
+    assert hass.states.get("input_color.test_color").state == "#FF0000"
+
+    await async_reproduce_state(
+        hass,
+        [
+            State(
+                "input_color.test_color",
+                "#00FF00",
+                {
+                    ATTR_HEX_COLOR: "#00FF00",
+                    ATTR_KIND: "chromatic",
+                    ATTR_BRIGHTNESS: 150,
+                },
+            )
+        ],
+    )
+    state = hass.states.get("input_color.test_color")
+    assert state.state == "#00FF00"
+    assert state.attributes[ATTR_BRIGHTNESS] == 150
+
+    await async_reproduce_state(
+        hass,
+        [
+            State(
+                "input_color.test_color",
+                "#FFD7B5",
+                {
+                    ATTR_COLOR_TEMP_KELVIN: 2700,
+                    ATTR_BRIGHTNESS: None,
+                },
+            )
+        ],
+    )
+    state = hass.states.get("input_color.test_color")
+    assert state.attributes[ATTR_KIND] == "white"
+    assert state.attributes[ATTR_COLOR_TEMP_KELVIN] == 2700
+    assert state.attributes[ATTR_BRIGHTNESS] is None


### PR DESCRIPTION
## Proposed change

Adds a new `input_color` helper integration for storing reusable color values in Home Assistant.

The helper supports YAML and storage-backed configuration, color and color-temperature initial values, optional brightness, restore state, services for color/brightness updates, reproduce-state support, service translations, service icons, generated integration metadata, and CODEOWNERS entries.

Frontend companion: home-assistant/frontend#53063
Documentation companion: home-assistant/home-assistant.io#46743

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#46743
- Link to developer documentation pull request: 
- Link to frontend pull request: home-assistant/frontend#53063

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

## Validation

- `uv run --managed-python --python 3.14.2 prek run --files CODEOWNERS homeassistant/components/input_color/__init__.py homeassistant/components/input_color/entity.py homeassistant/components/input_color/color_math.py homeassistant/components/input_color/reproduce_state.py homeassistant/components/input_color/services.yaml homeassistant/components/input_color/strings.json homeassistant/components/input_color/icons.json homeassistant/components/input_color/manifest.json homeassistant/generated/integrations.json script/hassfest/manifest.py script/hassfest/quality_scale.py`
- `uv run --managed-python --python 3.14.2 python -m pytest tests/components/input_color`
- `uv run --managed-python --python 3.14.2 python -m pytest tests/components/input_text/test_init.py -q`
- `uv run --managed-python --python 3.14.2 python -m script.hassfest --integration-path homeassistant/components/input_color`

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr