### PR TITLE
Add total water sensor for Tuya water timers

### DIFF
--- a/homeassistant/components/alarm_control_panel/translations/en.json
+++ b/homeassistant/components/alarm_control_panel/translations/en.json
@@ -1,0 +1,325 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least"
+    },
+    "conditions": {
+        "is_armed": {
+            "description": "Tests if one or more alarms are armed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is armed"
+        },
+        "is_armed_away": {
+            "description": "Tests if one or more alarms are armed in away mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is armed away"
+        },
+        "is_armed_home": {
+            "description": "Tests if one or more alarms are armed in home mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is armed home"
+        },
+        "is_armed_night": {
+            "description": "Tests if one or more alarms are armed in night mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is armed night"
+        },
+        "is_armed_vacation": {
+            "description": "Tests if one or more alarms are armed in vacation mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is armed vacation"
+        },
+        "is_disarmed": {
+            "description": "Tests if one or more alarms are disarmed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is disarmed"
+        },
+        "is_triggered": {
+            "description": "Tests if one or more alarms are triggered.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm is triggered"
+        }
+    },
+    "device_automation": {
+        "action_type": {
+            "arm_away": "Arm {entity_name} away",
+            "arm_home": "Arm {entity_name} home",
+            "arm_night": "Arm {entity_name} night",
+            "arm_vacation": "Arm {entity_name} vacation",
+            "disarm": "Disarm {entity_name}",
+            "trigger": "Trigger {entity_name}"
+        },
+        "condition_type": {
+            "is_armed_away": "{entity_name} is armed away",
+            "is_armed_home": "{entity_name} is armed home",
+            "is_armed_night": "{entity_name} is armed night",
+            "is_armed_vacation": "{entity_name} is armed vacation",
+            "is_disarmed": "{entity_name} is disarmed",
+            "is_triggered": "{entity_name} is triggered"
+        },
+        "extra_fields": {
+            "code": "Code",
+            "for": "Duration"
+        },
+        "trigger_type": {
+            "armed_away": "{entity_name} armed away",
+            "armed_home": "{entity_name} armed home",
+            "armed_night": "{entity_name} armed night",
+            "armed_vacation": "{entity_name} armed vacation",
+            "disarmed": "{entity_name} disarmed",
+            "triggered": "{entity_name} triggered"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Alarm control panel",
+            "state": {
+                "armed": "Armed",
+                "armed_away": "Armed away",
+                "armed_custom_bypass": "Armed custom bypass",
+                "armed_home": "Armed home",
+                "armed_night": "Armed night",
+                "armed_vacation": "Armed vacation",
+                "arming": "Arming",
+                "disarmed": "Disarmed",
+                "disarming": "Disarming",
+                "pending": "Pending",
+                "triggered": "Triggered"
+            },
+            "state_attributes": {
+                "changed_by": {
+                    "name": "Changed by"
+                },
+                "code_arm_required": {
+                    "name": "Code for arming",
+                    "state": {
+                        "false": "Not required",
+                        "true": "Required"
+                    }
+                },
+                "code_format": {
+                    "name": "Code format",
+                    "state": {
+                        "number": "Number",
+                        "text": "Text"
+                    }
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "code_arm_required": {
+            "message": "Arming requires a code but none was given for {entity_id}."
+        }
+    },
+    "services": {
+        "alarm_arm_away": {
+            "description": "Arms an alarm in the away mode.",
+            "fields": {
+                "code": {
+                    "description": "Code to arm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Arm alarm away"
+        },
+        "alarm_arm_custom_bypass": {
+            "description": "Arms an alarm while allowing to bypass a custom area.",
+            "fields": {
+                "code": {
+                    "description": "Code to arm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Arm alarm with custom bypass"
+        },
+        "alarm_arm_home": {
+            "description": "Arms an alarm in the home mode.",
+            "fields": {
+                "code": {
+                    "description": "Code to arm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Arm alarm home"
+        },
+        "alarm_arm_night": {
+            "description": "Arms an alarm in the night mode.",
+            "fields": {
+                "code": {
+                    "description": "Code to arm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Arm alarm night"
+        },
+        "alarm_arm_vacation": {
+            "description": "Arms an alarm in the vacation mode.",
+            "fields": {
+                "code": {
+                    "description": "Code to arm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Arm alarm vacation"
+        },
+        "alarm_disarm": {
+            "description": "Disarms an alarm.",
+            "fields": {
+                "code": {
+                    "description": "Code to disarm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Disarm alarm"
+        },
+        "alarm_trigger": {
+            "description": "Triggers an alarm manually.",
+            "fields": {
+                "code": {
+                    "description": "Code to arm the alarm.",
+                    "name": "Code"
+                }
+            },
+            "name": "Trigger alarm"
+        }
+    },
+    "title": "Alarm control panel",
+    "triggers": {
+        "armed": {
+            "description": "Triggers when one or more alarms become armed, regardless of the mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm armed"
+        },
+        "armed_away": {
+            "description": "Triggers when one or more alarms become armed in away mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm armed away"
+        },
+        "armed_home": {
+            "description": "Triggers when one or more alarms become armed in home mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm armed home"
+        },
+        "armed_night": {
+            "description": "Triggers when one or more alarms become armed in night mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm armed night"
+        },
+        "armed_vacation": {
+            "description": "Triggers when one or more alarms become armed in vacation mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm armed vacation"
+        },
+        "disarmed": {
+            "description": "Triggers when one or more alarms become disarmed.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm disarmed"
+        },
+        "triggered": {
+            "description": "Triggers when one or more alarms become triggered.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Alarm triggered"
+        }
+    }
+}

--- a/homeassistant/components/binary_sensor/translations/en.json
+++ b/homeassistant/components/binary_sensor/translations/en.json
@@ -1,0 +1,321 @@
+{
+    "device_automation": {
+        "condition_type": {
+            "is_bat_low": "{entity_name} battery is low",
+            "is_charging": "{entity_name} is charging",
+            "is_co": "{entity_name} is detecting carbon monoxide",
+            "is_cold": "{entity_name} is cold",
+            "is_connected": "{entity_name} is connected",
+            "is_gas": "{entity_name} is detecting gas",
+            "is_hot": "{entity_name} is hot",
+            "is_light": "{entity_name} is detecting light",
+            "is_locked": "{entity_name} is locked",
+            "is_moist": "{entity_name} is moist",
+            "is_motion": "{entity_name} is detecting motion",
+            "is_moving": "{entity_name} is moving",
+            "is_no_co": "{entity_name} is not detecting carbon monoxide",
+            "is_no_gas": "{entity_name} is not detecting gas",
+            "is_no_light": "{entity_name} is not detecting light",
+            "is_no_motion": "{entity_name} is not detecting motion",
+            "is_no_problem": "{entity_name} is not detecting problem",
+            "is_no_smoke": "{entity_name} is not detecting smoke",
+            "is_no_sound": "{entity_name} is not detecting sound",
+            "is_no_update": "{entity_name} is up-to-date",
+            "is_no_vibration": "{entity_name} is not detecting vibration",
+            "is_not_bat_low": "{entity_name} battery is normal",
+            "is_not_charging": "{entity_name} is not charging",
+            "is_not_cold": "{entity_name} is not cold",
+            "is_not_connected": "{entity_name} is disconnected",
+            "is_not_hot": "{entity_name} is not hot",
+            "is_not_locked": "{entity_name} is unlocked",
+            "is_not_moist": "{entity_name} is dry",
+            "is_not_moving": "{entity_name} is not moving",
+            "is_not_occupied": "{entity_name} is not occupied",
+            "is_not_open": "{entity_name} is closed",
+            "is_not_plugged_in": "{entity_name} is unplugged",
+            "is_not_powered": "{entity_name} is not powered",
+            "is_not_present": "{entity_name} is not present",
+            "is_not_running": "{entity_name} is not running",
+            "is_not_tampered": "{entity_name} is not detecting tampering",
+            "is_not_unsafe": "{entity_name} is safe",
+            "is_occupied": "{entity_name} is occupied",
+            "is_off": "{entity_name} is off",
+            "is_on": "{entity_name} is on",
+            "is_open": "{entity_name} is open",
+            "is_plugged_in": "{entity_name} is plugged in",
+            "is_powered": "{entity_name} is powered",
+            "is_present": "{entity_name} is present",
+            "is_problem": "{entity_name} is detecting problem",
+            "is_running": "{entity_name} is running",
+            "is_smoke": "{entity_name} is detecting smoke",
+            "is_sound": "{entity_name} is detecting sound",
+            "is_tampered": "{entity_name} is detecting tampering",
+            "is_unsafe": "{entity_name} is unsafe",
+            "is_update": "{entity_name} has an update available",
+            "is_vibration": "{entity_name} is detecting vibration"
+        },
+        "extra_fields": {
+            "for": "Duration"
+        },
+        "trigger_type": {
+            "bat_low": "{entity_name} battery low",
+            "charging": "{entity_name} charging",
+            "co": "{entity_name} started detecting carbon monoxide",
+            "cold": "{entity_name} became cold",
+            "connected": "{entity_name} connected",
+            "gas": "{entity_name} started detecting gas",
+            "hot": "{entity_name} became hot",
+            "light": "{entity_name} started detecting light",
+            "locked": "{entity_name} locked",
+            "moist": "{entity_name} became moist",
+            "motion": "{entity_name} started detecting motion",
+            "moving": "{entity_name} started moving",
+            "no_co": "{entity_name} stopped detecting carbon monoxide",
+            "no_gas": "{entity_name} stopped detecting gas",
+            "no_light": "{entity_name} stopped detecting light",
+            "no_motion": "{entity_name} stopped detecting motion",
+            "no_problem": "{entity_name} stopped detecting problem",
+            "no_smoke": "{entity_name} stopped detecting smoke",
+            "no_sound": "{entity_name} stopped detecting sound",
+            "no_update": "{entity_name} became up-to-date",
+            "no_vibration": "{entity_name} stopped detecting vibration",
+            "not_bat_low": "{entity_name} battery normal",
+            "not_charging": "{entity_name} not charging",
+            "not_cold": "{entity_name} became not cold",
+            "not_connected": "{entity_name} disconnected",
+            "not_hot": "{entity_name} became not hot",
+            "not_locked": "{entity_name} unlocked",
+            "not_moist": "{entity_name} became dry",
+            "not_moving": "{entity_name} stopped moving",
+            "not_occupied": "{entity_name} became not occupied",
+            "not_opened": "{entity_name} closed",
+            "not_plugged_in": "{entity_name} unplugged",
+            "not_powered": "{entity_name} not powered",
+            "not_present": "{entity_name} not present",
+            "not_running": "{entity_name} is no longer running",
+            "not_tampered": "{entity_name} stopped detecting tampering",
+            "not_unsafe": "{entity_name} became safe",
+            "occupied": "{entity_name} became occupied",
+            "opened": "{entity_name} opened",
+            "plugged_in": "{entity_name} plugged in",
+            "powered": "{entity_name} powered",
+            "present": "{entity_name} present",
+            "problem": "{entity_name} started detecting problem",
+            "running": "{entity_name} started running",
+            "smoke": "{entity_name} started detecting smoke",
+            "sound": "{entity_name} started detecting sound",
+            "tampered": "{entity_name} started detecting tampering",
+            "turned_off": "{entity_name} turned off",
+            "turned_on": "{entity_name} turned on",
+            "unsafe": "{entity_name} became unsafe",
+            "update": "{entity_name} got an update available",
+            "vibration": "{entity_name} started detecting vibration"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Binary sensor",
+            "state": {
+                "off": "Off",
+                "on": "On"
+            }
+        },
+        "battery": {
+            "name": "Battery",
+            "state": {
+                "off": "Normal",
+                "on": "Low"
+            }
+        },
+        "battery_charging": {
+            "name": "Charging",
+            "state": {
+                "off": "Not charging",
+                "on": "Charging"
+            }
+        },
+        "carbon_monoxide": {
+            "name": "Carbon monoxide",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "cold": {
+            "name": "Cold",
+            "state": {
+                "off": "Normal",
+                "on": "Cold"
+            }
+        },
+        "connectivity": {
+            "name": "Connectivity",
+            "state": {
+                "off": "Disconnected",
+                "on": "Connected"
+            }
+        },
+        "door": {
+            "name": "Door",
+            "state": {
+                "off": "Closed",
+                "on": "Open"
+            }
+        },
+        "garage_door": {
+            "name": "Garage door",
+            "state": {
+                "off": "Closed",
+                "on": "Open"
+            }
+        },
+        "gas": {
+            "name": "Gas",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "heat": {
+            "name": "Heat",
+            "state": {
+                "off": "Normal",
+                "on": "Hot"
+            }
+        },
+        "light": {
+            "name": "Light",
+            "state": {
+                "off": "No light",
+                "on": "Light detected"
+            }
+        },
+        "lock": {
+            "name": "Lock",
+            "state": {
+                "off": "Locked",
+                "on": "Unlocked"
+            }
+        },
+        "moisture": {
+            "name": "Moisture",
+            "state": {
+                "off": "Dry",
+                "on": "Wet"
+            }
+        },
+        "motion": {
+            "name": "Motion",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "moving": {
+            "name": "Moving",
+            "state": {
+                "off": "Not moving",
+                "on": "Moving"
+            }
+        },
+        "occupancy": {
+            "name": "Occupancy",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "opening": {
+            "name": "Opening",
+            "state": {
+                "off": "Closed",
+                "on": "Open"
+            }
+        },
+        "plug": {
+            "name": "Plug",
+            "state": {
+                "off": "Unplugged",
+                "on": "Plugged in"
+            }
+        },
+        "power": {
+            "name": "Power",
+            "state": {
+                "off": "Off",
+                "on": "On"
+            }
+        },
+        "presence": {
+            "name": "Presence",
+            "state": {
+                "off": "Away",
+                "on": "Home"
+            }
+        },
+        "problem": {
+            "name": "Problem",
+            "state": {
+                "off": "OK",
+                "on": "Problem"
+            }
+        },
+        "running": {
+            "name": "Running",
+            "state": {
+                "off": "Not running",
+                "on": "Running"
+            }
+        },
+        "safety": {
+            "name": "Safety",
+            "state": {
+                "off": "Safe",
+                "on": "Unsafe"
+            }
+        },
+        "smoke": {
+            "name": "Smoke",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "sound": {
+            "name": "Sound",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "tamper": {
+            "name": "Tamper",
+            "state": {
+                "off": "Clear",
+                "on": "Tampering detected"
+            }
+        },
+        "update": {
+            "name": "Update",
+            "state": {
+                "off": "Up-to-date",
+                "on": "Update available"
+            }
+        },
+        "vibration": {
+            "name": "Vibration",
+            "state": {
+                "off": "Clear",
+                "on": "Detected"
+            }
+        },
+        "window": {
+            "name": "Window",
+            "state": {
+                "off": "Closed",
+                "on": "Open"
+            }
+        }
+    },
+    "title": "Binary sensor"
+}

--- a/homeassistant/components/button/translations/en.json
+++ b/homeassistant/components/button/translations/en.json
@@ -1,0 +1,37 @@
+{
+    "device_automation": {
+        "action_type": {
+            "press": "Press {entity_name} button"
+        },
+        "trigger_type": {
+            "pressed": "{entity_name} has been pressed"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Button"
+        },
+        "identify": {
+            "name": "Identify"
+        },
+        "restart": {
+            "name": "Restart"
+        },
+        "update": {
+            "name": "Update"
+        }
+    },
+    "services": {
+        "press": {
+            "description": "Presses a button.",
+            "name": "Press button"
+        }
+    },
+    "title": "Button",
+    "triggers": {
+        "pressed": {
+            "description": "Triggers when one or more buttons are pressed.",
+            "name": "Button pressed"
+        }
+    }
+}

--- a/homeassistant/components/camera/translations/en.json
+++ b/homeassistant/components/camera/translations/en.json
@@ -1,0 +1,111 @@
+{
+    "entity_component": {
+        "_": {
+            "name": "Camera",
+            "state": {
+                "idle": "Idle",
+                "recording": "Recording",
+                "streaming": "Streaming"
+            },
+            "state_attributes": {
+                "access_token": {
+                    "name": "Access token"
+                },
+                "brand": {
+                    "name": "Brand"
+                },
+                "frontend_stream_type": {
+                    "name": "Stream type",
+                    "state": {
+                        "hls": "HLS",
+                        "webrtc": "WebRTC"
+                    }
+                },
+                "model_name": {
+                    "name": "Model"
+                },
+                "motion_detection": {
+                    "name": "Motion detection",
+                    "state": {
+                        "false": "Disabled",
+                        "true": "Enabled"
+                    }
+                }
+            }
+        }
+    },
+    "issues": {
+        "deprecated_filename_template": {
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "The pre-defined template variable `entity_id` was used when performing action `{service}` targeting camera entity `{entity_id}`. The pre-defined template variable `entity_id` is being removed from the `filename` parameter of `{service}`.\n\nPlease update your automations and scripts to use a manually defined variable instead and select **Submit** to close this issue.",
+                        "title": "Detected use of deprecated template variable"
+                    }
+                }
+            },
+            "title": "Detected use of deprecated template variable"
+        }
+    },
+    "services": {
+        "disable_motion_detection": {
+            "description": "Disables the motion detection of a camera.",
+            "name": "Disable camera motion detection"
+        },
+        "enable_motion_detection": {
+            "description": "Enables the motion detection of a camera.",
+            "name": "Enable camera motion detection"
+        },
+        "play_stream": {
+            "description": "Plays a camera stream on a supported media player.",
+            "fields": {
+                "format": {
+                    "description": "Stream format supported by the media player.",
+                    "name": "Format"
+                },
+                "media_player": {
+                    "description": "Media player to stream to.",
+                    "name": "Media player"
+                }
+            },
+            "name": "Play camera stream"
+        },
+        "record": {
+            "description": "Creates a recording of a live camera feed.",
+            "fields": {
+                "duration": {
+                    "description": "Planned duration of the recording. The actual duration may vary.",
+                    "name": "Duration"
+                },
+                "filename": {
+                    "description": "Full path to filename. Must be mp4.",
+                    "name": "Filename"
+                },
+                "lookback": {
+                    "description": "Planned lookback period to include in the recording (in addition to the duration). Only available if there is currently an active HLS stream. The actual length of the lookback period may vary.",
+                    "name": "Lookback"
+                }
+            },
+            "name": "Record camera feed"
+        },
+        "snapshot": {
+            "description": "Takes a snapshot from a camera.",
+            "fields": {
+                "filename": {
+                    "description": "Full path to filename.",
+                    "name": "Filename"
+                }
+            },
+            "name": "Take camera snapshot"
+        },
+        "turn_off": {
+            "description": "Turns off a camera.",
+            "name": "Turn off camera"
+        },
+        "turn_on": {
+            "description": "Turns on a camera.",
+            "name": "Turn on camera"
+        }
+    },
+    "title": "Camera"
+}

--- a/homeassistant/components/climate/translations/en.json
+++ b/homeassistant/components/climate/translations/en.json
@@ -1,0 +1,523 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "condition_threshold_name": "Threshold type",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least",
+        "trigger_threshold_name": "Threshold type"
+    },
+    "conditions": {
+        "is_cooling": {
+            "description": "Tests if one or more thermostats are cooling.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat is cooling"
+        },
+        "is_drying": {
+            "description": "Tests if one or more thermostats are drying.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat is drying"
+        },
+        "is_heating": {
+            "description": "Tests if one or more thermostats are heating.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat is heating"
+        },
+        "is_hvac_mode": {
+            "description": "Tests if one or more thermostats are set to a specific HVAC mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "hvac_mode": {
+                    "description": "The HVAC modes to test for.",
+                    "name": "Modes"
+                }
+            },
+            "name": "Thermostat HVAC mode"
+        },
+        "is_off": {
+            "description": "Tests if one or more thermostats are off.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat is off"
+        },
+        "is_on": {
+            "description": "Tests if one or more thermostats are on.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat is on"
+        },
+        "is_target_humidity": {
+            "description": "Tests the humidity setpoint of one or more thermostats.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Thermostat target humidity"
+        },
+        "is_target_temperature": {
+            "description": "Tests the temperature setpoint of one or more thermostats.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Thermostat target temperature"
+        }
+    },
+    "device_automation": {
+        "action_type": {
+            "set_hvac_mode": "Change HVAC mode on {entity_name}",
+            "set_preset_mode": "Change preset on {entity_name}"
+        },
+        "condition_type": {
+            "is_hvac_mode": "{entity_name} is set to a specific HVAC mode",
+            "is_preset_mode": "{entity_name} is set to a specific preset mode"
+        },
+        "extra_fields": {
+            "above": "Above",
+            "below": "Below",
+            "for": "Duration",
+            "hvac_mode": "HVAC mode",
+            "preset_mode": "Preset mode",
+            "to": "To"
+        },
+        "trigger_type": {
+            "current_humidity_changed": "{entity_name} measured humidity changed",
+            "current_temperature_changed": "{entity_name} measured temperature changed",
+            "hvac_mode_changed": "{entity_name} HVAC mode changed"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Thermostat",
+            "state": {
+                "auto": "Auto",
+                "cool": "Cool",
+                "dry": "Dry",
+                "fan_only": "Fan only",
+                "heat": "Heat",
+                "heat_cool": "Heat/Cool",
+                "off": "Off"
+            },
+            "state_attributes": {
+                "current_humidity": {
+                    "name": "Current humidity"
+                },
+                "current_temperature": {
+                    "name": "Current temperature"
+                },
+                "fan_mode": {
+                    "name": "Fan mode",
+                    "state": {
+                        "auto": "Auto",
+                        "diffuse": "Diffuse",
+                        "focus": "Focus",
+                        "high": "High",
+                        "low": "Low",
+                        "medium": "Medium",
+                        "middle": "Middle",
+                        "off": "Off",
+                        "on": "On",
+                        "top": "Top"
+                    }
+                },
+                "fan_modes": {
+                    "name": "Fan modes"
+                },
+                "humidity": {
+                    "name": "Target humidity"
+                },
+                "hvac_action": {
+                    "name": "Current action",
+                    "state": {
+                        "cooling": "Cooling",
+                        "defrosting": "Defrosting",
+                        "drying": "Drying",
+                        "fan": "Fan",
+                        "heating": "Heating",
+                        "idle": "Idle",
+                        "off": "Off",
+                        "preheating": "Preheating"
+                    }
+                },
+                "hvac_modes": {
+                    "name": "HVAC modes"
+                },
+                "max_humidity": {
+                    "name": "Max target humidity"
+                },
+                "max_temp": {
+                    "name": "Max target temperature"
+                },
+                "min_humidity": {
+                    "name": "Min target humidity"
+                },
+                "min_temp": {
+                    "name": "Min target temperature"
+                },
+                "preset_mode": {
+                    "name": "Preset",
+                    "state": {
+                        "activity": "Activity",
+                        "away": "Away",
+                        "boost": "Boost",
+                        "comfort": "Comfort",
+                        "eco": "Eco",
+                        "home": "Home",
+                        "none": "None",
+                        "sleep": "Sleep"
+                    }
+                },
+                "preset_modes": {
+                    "name": "Presets"
+                },
+                "swing_horizontal_mode": {
+                    "name": "Horizontal swing mode",
+                    "state": {
+                        "off": "Off",
+                        "on": "On"
+                    }
+                },
+                "swing_horizontal_modes": {
+                    "name": "Horizontal swing modes"
+                },
+                "swing_mode": {
+                    "name": "Swing mode",
+                    "state": {
+                        "both": "Both",
+                        "horizontal": "Horizontal",
+                        "off": "Off",
+                        "on": "On",
+                        "vertical": "Vertical"
+                    }
+                },
+                "swing_modes": {
+                    "name": "Swing modes"
+                },
+                "target_temp_high": {
+                    "name": "Upper target temperature"
+                },
+                "target_temp_low": {
+                    "name": "Lower target temperature"
+                },
+                "target_temp_step": {
+                    "name": "Target temperature step"
+                },
+                "temperature": {
+                    "name": "Target temperature"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "humidity_out_of_range": {
+            "message": "Provided humidity {humidity} is not valid. Accepted range is {min_humidity} to {max_humidity}."
+        },
+        "low_temp_higher_than_high_temp": {
+            "message": "'Lower target temperature' cannot be higher than 'Upper target temperature'."
+        },
+        "missing_target_temperature_entity_feature": {
+            "message": "Set temperature action was used with the 'Target temperature' parameter but the entity does not support it."
+        },
+        "missing_target_temperature_range_entity_feature": {
+            "message": "Set temperature action was used with the 'Lower/Upper target temperature' parameter but the entity does not support it."
+        },
+        "not_valid_fan_mode": {
+            "message": "Fan mode {mode} is not valid. Valid fan modes are: {modes}."
+        },
+        "not_valid_horizontal_swing_mode": {
+            "message": "Horizontal swing mode {mode} is not valid. Valid horizontal swing modes are: {modes}."
+        },
+        "not_valid_hvac_mode": {
+            "message": "HVAC mode {mode} is not valid. Valid HVAC modes are: {modes}."
+        },
+        "not_valid_preset_mode": {
+            "message": "Preset mode {mode} is not valid. Valid preset modes are: {modes}."
+        },
+        "not_valid_swing_mode": {
+            "message": "Swing mode {mode} is not valid. Valid swing modes are: {modes}."
+        },
+        "temp_out_of_range": {
+            "message": "Provided temperature {check_temp} is not valid. Accepted range is {min_temp} to {max_temp}."
+        }
+    },
+    "services": {
+        "set_fan_mode": {
+            "description": "Sets the fan mode of a thermostat.",
+            "fields": {
+                "fan_mode": {
+                    "description": "Fan operation mode.",
+                    "name": "Fan mode"
+                }
+            },
+            "name": "Set thermostat fan mode"
+        },
+        "set_humidity": {
+            "description": "Sets the target humidity of a thermostat.",
+            "fields": {
+                "humidity": {
+                    "description": "Target humidity.",
+                    "name": "Humidity"
+                }
+            },
+            "name": "Set thermostat target humidity"
+        },
+        "set_hvac_mode": {
+            "description": "Sets the HVAC mode of a thermostat.",
+            "fields": {
+                "hvac_mode": {
+                    "description": "HVAC operation mode.",
+                    "name": "HVAC mode"
+                }
+            },
+            "name": "Set thermostat HVAC mode"
+        },
+        "set_preset_mode": {
+            "description": "Sets the preset mode of a thermostat.",
+            "fields": {
+                "preset_mode": {
+                    "description": "Preset mode.",
+                    "name": "Preset mode"
+                }
+            },
+            "name": "Set thermostat preset mode"
+        },
+        "set_swing_horizontal_mode": {
+            "description": "Sets the horizontal swing mode of a thermostat.",
+            "fields": {
+                "swing_horizontal_mode": {
+                    "description": "Horizontal swing operation mode.",
+                    "name": "Horizontal swing mode"
+                }
+            },
+            "name": "Set thermostat horizontal swing mode"
+        },
+        "set_swing_mode": {
+            "description": "Sets the swing mode of a thermostat.",
+            "fields": {
+                "swing_mode": {
+                    "description": "Swing operation mode.",
+                    "name": "Swing mode"
+                }
+            },
+            "name": "Set thermostat swing mode"
+        },
+        "set_temperature": {
+            "description": "Sets the target temperature of a thermostat.",
+            "fields": {
+                "hvac_mode": {
+                    "description": "HVAC operation mode.",
+                    "name": "HVAC mode"
+                },
+                "target_temp_high": {
+                    "description": "The max temperature setpoint.",
+                    "name": "Upper target temperature"
+                },
+                "target_temp_low": {
+                    "description": "The min temperature setpoint.",
+                    "name": "Lower target temperature"
+                },
+                "temperature": {
+                    "description": "The temperature setpoint.",
+                    "name": "Target temperature"
+                }
+            },
+            "name": "Set thermostat target temperature",
+            "sections": {
+                "temperature_range": {
+                    "name": "Temperature range"
+                }
+            }
+        },
+        "toggle": {
+            "description": "Toggles a thermostat on/off.",
+            "name": "Toggle thermostat"
+        },
+        "turn_off": {
+            "description": "Turns off a thermostat.",
+            "name": "Turn off thermostat"
+        },
+        "turn_on": {
+            "description": "Turns on a thermostat.",
+            "name": "Turn on thermostat"
+        }
+    },
+    "title": "Climate",
+    "triggers": {
+        "hvac_mode_changed": {
+            "description": "Triggers when the mode of one or more thermostats changes.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "hvac_mode": {
+                    "description": "The HVAC modes to trigger on.",
+                    "name": "Modes"
+                }
+            },
+            "name": "Thermostat mode changed"
+        },
+        "started_cooling": {
+            "description": "Triggers when one or more thermostats start cooling.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat started cooling"
+        },
+        "started_drying": {
+            "description": "Triggers when one or more thermostats start drying.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat started drying"
+        },
+        "started_heating": {
+            "description": "Triggers when one or more thermostats start heating.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat started heating"
+        },
+        "target_humidity_changed": {
+            "description": "Triggers when the humidity setpoint of one or more thermostats changes.",
+            "fields": {
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Thermostat target humidity changed"
+        },
+        "target_humidity_crossed_threshold": {
+            "description": "Triggers when the humidity setpoint of one or more thermostats crosses a threshold.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Thermostat target humidity crossed threshold"
+        },
+        "target_temperature_changed": {
+            "description": "Triggers when the temperature setpoint of one or more thermostats changes.",
+            "fields": {
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Thermostat target temperature changed"
+        },
+        "target_temperature_crossed_threshold": {
+            "description": "Triggers when the temperature setpoint of one or more thermostats crosses a threshold.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Thermostat target temperature crossed threshold"
+        },
+        "turned_off": {
+            "description": "Triggers when one or more thermostats turn off.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat turned off"
+        },
+        "turned_on": {
+            "description": "Triggers when one or more thermostats turn on, regardless of the mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Thermostat turned on"
+        }
+    }
+}

--- a/homeassistant/components/cover/translations/en.json
+++ b/homeassistant/components/cover/translations/en.json
@@ -1,0 +1,390 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least"
+    },
+    "conditions": {
+        "awning_is_closed": {
+            "description": "Tests if one or more awnings are closed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Awning is closed"
+        },
+        "awning_is_open": {
+            "description": "Tests if one or more awnings are open.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Awning is open"
+        },
+        "blind_is_closed": {
+            "description": "Tests if one or more blinds are closed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Blind is closed"
+        },
+        "blind_is_open": {
+            "description": "Tests if one or more blinds are open.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Blind is open"
+        },
+        "curtain_is_closed": {
+            "description": "Tests if one or more curtains are closed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Curtain is closed"
+        },
+        "curtain_is_open": {
+            "description": "Tests if one or more curtains are open.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Curtain is open"
+        },
+        "shade_is_closed": {
+            "description": "Tests if one or more shades are closed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shade is closed"
+        },
+        "shade_is_open": {
+            "description": "Tests if one or more shades are open.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shade is open"
+        },
+        "shutter_is_closed": {
+            "description": "Tests if one or more shutters are closed.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shutter is closed"
+        },
+        "shutter_is_open": {
+            "description": "Tests if one or more shutters are open.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shutter is open"
+        }
+    },
+    "device_automation": {
+        "action_type": {
+            "close": "Close {entity_name}",
+            "close_tilt": "Close {entity_name} tilt",
+            "open": "Open {entity_name}",
+            "open_tilt": "Open {entity_name} tilt",
+            "set_position": "Set {entity_name} position",
+            "set_tilt_position": "Set {entity_name} tilt position",
+            "stop": "Stop {entity_name}"
+        },
+        "condition_type": {
+            "is_closed": "{entity_name} is closed",
+            "is_closing": "{entity_name} is closing",
+            "is_open": "{entity_name} is open",
+            "is_opening": "{entity_name} is opening",
+            "is_position": "Current {entity_name} position is",
+            "is_tilt_position": "Current {entity_name} tilt position is"
+        },
+        "extra_fields": {
+            "above": "Above",
+            "below": "Below",
+            "for": "Duration",
+            "position": "Position"
+        },
+        "trigger_type": {
+            "closed": "{entity_name} closed",
+            "closing": "{entity_name} closing",
+            "opened": "{entity_name} opened",
+            "opening": "{entity_name} opening",
+            "position": "{entity_name} position changes",
+            "tilt_position": "{entity_name} tilt position changes"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Cover",
+            "state": {
+                "closed": "Closed",
+                "closing": "Closing",
+                "open": "Open",
+                "opening": "Opening",
+                "stopped": "Stopped"
+            },
+            "state_attributes": {
+                "current_position": {
+                    "name": "Position"
+                },
+                "current_tilt_position": {
+                    "name": "Tilt position"
+                }
+            }
+        },
+        "awning": {
+            "name": "Awning"
+        },
+        "blind": {
+            "name": "Blind"
+        },
+        "curtain": {
+            "name": "Curtain"
+        },
+        "damper": {
+            "name": "Damper"
+        },
+        "door": {
+            "name": "Door"
+        },
+        "garage": {
+            "name": "Garage"
+        },
+        "gate": {
+            "name": "Gate"
+        },
+        "shade": {
+            "name": "Shade"
+        },
+        "shutter": {
+            "name": "Shutter"
+        },
+        "window": {
+            "name": "Window"
+        }
+    },
+    "services": {
+        "close_cover": {
+            "description": "Closes a cover.",
+            "name": "Close cover"
+        },
+        "close_cover_tilt": {
+            "description": "Tilts a cover to close.",
+            "name": "Close cover tilt"
+        },
+        "open_cover": {
+            "description": "Opens a cover.",
+            "name": "Open cover"
+        },
+        "open_cover_tilt": {
+            "description": "Tilts a cover open.",
+            "name": "Open cover tilt"
+        },
+        "set_cover_position": {
+            "description": "Moves a cover to a specific position.",
+            "fields": {
+                "position": {
+                    "description": "Target position.",
+                    "name": "Position"
+                }
+            },
+            "name": "Set cover position"
+        },
+        "set_cover_tilt_position": {
+            "description": "Moves a cover tilt to a specific position.",
+            "fields": {
+                "tilt_position": {
+                    "description": "Target tilt positition.",
+                    "name": "Tilt position"
+                }
+            },
+            "name": "Set cover tilt position"
+        },
+        "stop_cover": {
+            "description": "Stops a cover's movement.",
+            "name": "Stop cover"
+        },
+        "stop_cover_tilt": {
+            "description": "Stops a tilting cover movement.",
+            "name": "Stop cover tilt"
+        },
+        "toggle": {
+            "description": "Toggles a cover open/closed.",
+            "name": "Toggle cover"
+        },
+        "toggle_cover_tilt": {
+            "description": "Toggles a cover tilt open/closed.",
+            "name": "Toggle cover tilt"
+        }
+    },
+    "title": "Cover",
+    "triggers": {
+        "awning_closed": {
+            "description": "Triggers when one or more awnings close.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Awning closed"
+        },
+        "awning_opened": {
+            "description": "Triggers when one or more awnings open.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Awning opened"
+        },
+        "blind_closed": {
+            "description": "Triggers when one or more blinds close.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Blind closed"
+        },
+        "blind_opened": {
+            "description": "Triggers when one or more blinds open.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Blind opened"
+        },
+        "curtain_closed": {
+            "description": "Triggers when one or more curtains close.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Curtain closed"
+        },
+        "curtain_opened": {
+            "description": "Triggers when one or more curtains open.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Curtain opened"
+        },
+        "shade_closed": {
+            "description": "Triggers when one or more shades close.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shade closed"
+        },
+        "shade_opened": {
+            "description": "Triggers when one or more shades open.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shade opened"
+        },
+        "shutter_closed": {
+            "description": "Triggers when one or more shutters close.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shutter closed"
+        },
+        "shutter_opened": {
+            "description": "Triggers when one or more shutters open.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Shutter opened"
+        }
+    }
+}

--- a/homeassistant/components/homeassistant/translations/en.json
+++ b/homeassistant/components/homeassistant/translations/en.json
@@ -1,0 +1,335 @@
+{
+    "config": {
+        "abort": {
+            "single_instance_allowed": "Already configured. Only a single configuration is possible."
+        }
+    },
+    "exceptions": {
+        "component_import_err": {
+            "message": "Unable to import {domain}: {error}"
+        },
+        "config_platform_import_err": {
+            "message": "Error importing config platform {domain}: {error}"
+        },
+        "config_schema_unknown_err": {
+            "message": "Unknown error calling {domain} CONFIG_SCHEMA - {error}."
+        },
+        "config_validation_err": {
+            "message": "Invalid config for integration {domain} at {config_file}, line {line}: {error}."
+        },
+        "config_validator_unknown_err": {
+            "message": "Unknown error calling {domain} config validator - {error}."
+        },
+        "core_config_reload_failed": {
+            "message": "Failed to reload the Home Assistant Core configuration - {error}"
+        },
+        "max_length_exceeded": {
+            "message": "Value {value} for property {property_name} has a maximum length of {max_length} characters."
+        },
+        "multiple_integration_config_errors": {
+            "message": "Failed to process config for integration {domain} due to multiple ({errors}) errors. Check the logs for more information."
+        },
+        "oauth2_helper_reauth_required": {
+            "message": "Credentials are invalid, re-authentication required"
+        },
+        "oauth2_helper_refresh_failed": {
+            "message": "OAuth2 token refresh failed for {domain}"
+        },
+        "oauth2_helper_refresh_transient": {
+            "message": "Temporary error refreshing credentials for {domain}, try again later"
+        },
+        "platform_component_load_err": {
+            "message": "Platform error: {domain} - {error}."
+        },
+        "platform_component_load_exc": {
+            "message": "Platform error: {domain} - {error}."
+        },
+        "platform_config_validation_err": {
+            "message": "Invalid config for {domain} from integration {p_name} at file {config_file}, line {line}: {error}. Check the logs for more information."
+        },
+        "platform_schema_validator_err": {
+            "message": "Unknown error when validating config for {domain} from integration {p_name} - {error}."
+        },
+        "scene_config_reload_failed": {
+            "message": "Failed to reload the Home Assistant scene platform configuration - {error}"
+        },
+        "service_config_entry_not_found": {
+            "message": "Integration {domain} config entry with ID {entry_id} was not found."
+        },
+        "service_config_entry_not_loaded": {
+            "message": "Config entry {entry_title} for integration {domain} is not loaded."
+        },
+        "service_config_entry_wrong_domain": {
+            "message": "Config entry {entry_title} does not belong to integration {domain}."
+        },
+        "service_does_not_support_response": {
+            "message": "An action which does not return responses can't be called with {return_response}."
+        },
+        "service_found_multiple_config_entry_for_domain": {
+            "message": "Found multiple config entries for integration {domain}."
+        },
+        "service_found_no_config_entry_for_domain": {
+            "message": "Could not find config entry for integration {domain}."
+        },
+        "service_lacks_response_request": {
+            "message": "The action requires responses and must be called with {return_response}."
+        },
+        "service_not_found": {
+            "message": "Action {domain}.{service} not found."
+        },
+        "service_not_supported": {
+            "message": "Entity {entity_id} does not support action {domain}.{service}."
+        },
+        "service_reponse_invalid": {
+            "message": "Failed to process the returned action response data, expected a dictionary, but got {response_data_type}."
+        },
+        "service_should_be_blocking": {
+            "message": "A non-blocking action call with argument {non_blocking_argument} can't be used together with argument {return_response}."
+        }
+    },
+    "issues": {
+        "config_entry_only": {
+            "description": "The {domain} integration does not support configuration via YAML file. You may not notice any obvious issues with the integration, but any configuration settings defined in YAML are not actually applied.\n\nTo resolve this:\n\n1. If you've not already done so, [set up the integration]({add_integration}).\n\n2. Remove `{domain}:` from your YAML configuration file.\n\n3. Restart Home Assistant.",
+            "title": "The {domain} integration does not support YAML configuration"
+        },
+        "config_entry_reauth": {
+            "description": "Reauthentication is needed",
+            "title": "Authentication expired for {name}"
+        },
+        "config_entry_unique_id_collision": {
+            "description": "There are multiple {domain} config entries with the same unique ID.\nThe config entries are named {titles}.\n\nTo fix this error, [configure the integration]({configure_url}) and remove all except one of the duplicates.\n\nNote: Another group of duplicates may be revealed after removing these duplicates.",
+            "title": "Multiple {domain} config entries with same unique ID"
+        },
+        "config_entry_unique_id_collision_many": {
+            "description": "There are multiple ({number_of_entries}) {domain} config entries with the same unique ID.\nThe first {title_limit} config entries are named {titles}.\n\nTo fix this error, [configure the integration]({configure_url}) and remove all except one of the duplicates.\n\nNote: Another group of duplicates may be revealed after removing these duplicates.",
+            "title": "Multiple {domain} config entries with same unique ID"
+        },
+        "country_not_configured": {
+            "description": "No country has been configured. Click the \"Learn more\" button below to set your country.",
+            "title": "The country has not been configured"
+        },
+        "deprecated_architecture": {
+            "description": "This system uses 32-bit hardware (`{arch}`), which has been deprecated and will no longer receive updates after the release of Home Assistant 2025.12. As your hardware is no longer capable of running newer versions of Home Assistant, you will need to migrate to new hardware.",
+            "title": "Deprecation notice: 32-bit architecture"
+        },
+        "deprecated_container": {
+            "description": "This system is running on a 32-bit operating system (`{arch}`), which has been deprecated and will no longer receive updates after the release of Home Assistant 2025.12. Check if your system is capable of running a 64-bit operating system. If not, you will need to migrate to new hardware.",
+            "title": "Deprecation notice: 32-bit architecture"
+        },
+        "deprecated_method": {
+            "description": "This system is using the {installation_type} installation type, which has been unsupported since Home Assistant 2025.12. To continue receiving updates and support, migrate to a supported installation method.",
+            "title": "Unsupported installation method"
+        },
+        "deprecated_method_architecture": {
+            "description": "This system is using the {installation_type} installation type, and 32-bit hardware (`{arch}`), both of which have been unsupported since Home Assistant 2025.12. To continue receiving updates and support, migrate to supported hardware and use a supported installation method.",
+            "title": "Unsupported installation method and architecture"
+        },
+        "deprecated_os_aarch64": {
+            "description": "This system is running on a 32-bit operating system (`armv7`), which has been deprecated and will no longer receive updates after the release of Home Assistant 2025.12. To continue using Home Assistant on this hardware, you will need to install a 64-bit operating system. Please refer to our [installation guide]({installation_guide}).",
+            "title": "Deprecation notice: 32-bit architecture"
+        },
+        "deprecated_os_armv7": {
+            "description": "This system is running on a 32-bit operating system (`armv7`), which has been deprecated and will no longer receive updates after the release of Home Assistant 2025.12. As your hardware is no longer capable of running newer versions of Home Assistant, you will need to migrate to new hardware.",
+            "title": "Deprecation notice: 32-bit architecture"
+        },
+        "deprecated_system_packages_config_flow_integration": {
+            "description": "The {integration_title} integration is being removed as it depends on system packages that can only be installed on systems running a deprecated architecture. To resolve this, remove all \"{integration_title}\" config entries.",
+            "title": "The {integration_title} integration is being removed"
+        },
+        "deprecated_system_packages_yaml_integration": {
+            "description": "The {integration_title} integration is being removed as it depends on system packages that can only be installed on systems running a deprecated architecture. To resolve this, remove the {domain} entry from your configuration.yaml file and restart Home Assistant.",
+            "title": "The {integration_title} integration is being removed"
+        },
+        "deprecated_trigger_behavior": {
+            "description": "An automation, script or template entity uses the trigger behavior option `{deprecated_behavior}`, which has been renamed to `{new_behavior}`. The old value still works for now, but support for it will be removed in a future release.\n\nTo fix this issue, open each affected automation or script in the editor and save it again; Home Assistant will automatically detect and update the deprecated option. Alternatively, edit your configuration files (for example `automations.yaml`) directly and change `behavior: {deprecated_behavior}` to `behavior: {new_behavior}`. Restart Home Assistant afterwards.",
+            "title": "Deprecated trigger behavior option in use"
+        },
+        "deprecated_yaml": {
+            "description": "Configuring {integration_title} using YAML is being removed.\n\nYour existing YAML configuration has been imported into the UI automatically.\n\nRemove the `{domain}` configuration from your configuration.yaml file and restart Home Assistant to fix this issue.",
+            "title": "The {integration_title} YAML configuration is being removed"
+        },
+        "historic_currency": {
+            "description": "The currency {currency} is no longer in use, please reconfigure the currency configuration.",
+            "title": "The configured currency is no longer in use"
+        },
+        "imperial_unit_system": {
+            "description": "The imperial unit system is deprecated and your system is currently using US customary. Please update your configuration to use the US customary unit system and reload the Core configuration to fix this issue.",
+            "title": "The imperial unit system is deprecated"
+        },
+        "integration_not_found": {
+            "fix_flow": {
+                "abort": {
+                    "issue_ignored": "Non-existent integration {domain} ignored."
+                },
+                "step": {
+                    "init": {
+                        "description": "The integration `{domain}` could not be found. This happens when a (custom) integration was removed from Home Assistant, but there are still configurations for this `integration`. Please use the buttons below to either remove the previous configurations for `{domain}` or ignore this.",
+                        "menu_options": {
+                            "confirm": "Remove previous configurations",
+                            "ignore": "Ignore"
+                        },
+                        "title": "Integration {domain} not found"
+                    }
+                }
+            },
+            "title": "Integration {domain} not found"
+        },
+        "legacy_templates_false": {
+            "description": "Nothing will change with your templates.\n\nRemove the `legacy_templates` key from the `homeassistant` configuration in your configuration.yaml file and restart Home Assistant to fix this issue.",
+            "title": "legacy_templates config key is being removed"
+        },
+        "legacy_templates_true": {
+            "description": "Please do the following steps:\n- Adopt your configuration to support template rendering to native python types.\n- Remove the `legacy_templates` key from the `homeassistant` configuration in your configuration.yaml file.\n- Restart Home Assistant to fix this issue.",
+            "title": "The support for legacy templates is being removed"
+        },
+        "orphaned_ignored_config_entry": {
+            "fix_flow": {
+                "abort": {
+                    "issue_ignored": "Non-existent integration {domain} ignored."
+                },
+                "step": {
+                    "init": {
+                        "description": "There is an ignored orphaned config entry for the `{domain}` integration. This can happen when an integration is removed, but the config entry is still present in Home Assistant.\n\nTo resolve this, press **Remove** to clean up the orphaned entry.",
+                        "menu_options": {
+                            "confirm": "Remove",
+                            "ignore": "Ignore"
+                        },
+                        "title": "Orphaned ignored config entry for {domain}"
+                    }
+                }
+            },
+            "title": "Orphaned ignored config entry for {domain}"
+        },
+        "platform_config_not_supported": {
+            "description": "Configuring the {integration_domain} integration by adding `{platform_key}` under the `{platform_domain}:` key is not supported. The {integration_domain} integration must be configured under its own `{integration_domain}:` key instead.\n\nTo resolve this:\n\n1. Remove the following from your YAML configuration file:\n\n{yaml_example}\n\n2. Move the configuration under the `{integration_domain}:` key instead.\n\n3. Restart Home Assistant.\n\nTo see the detailed documentation, select Learn more.",
+            "title": "Unsupported YAML configuration for the {integration_domain} integration"
+        },
+        "platform_only": {
+            "description": "The {domain} integration does not support configuration under its own key, it must be configured under its supported platforms.\n\nTo resolve this:\n\n1. Remove `{domain}:` from your YAML configuration file.\n\n2. Restart Home Assistant.",
+            "title": "The {domain} integration does not support YAML configuration under its own key"
+        },
+        "platform_setup_not_supported": {
+            "description": "It's not possible to configure {integration_domain} {platform_domain} by adding `{platform_key}` to the {platform_domain} configuration. Please check the documentation for more information on how to set up this integration.\n\nTo resolve this:\n\n1. Remove `{platform_key}` occurrences from the `{platform_domain}:` configuration in your YAML configuration file.\n\n2. Restart Home Assistant.",
+            "title": "Unused YAML configuration for the {integration_domain} integration"
+        },
+        "storage_corruption": {
+            "fix_flow": {
+                "step": {
+                    "confirm": {
+                        "description": "The `{storage_key}` storage could not be parsed and has been renamed to `{corrupt_path}` to allow Home Assistant to continue.\n\nA default `{storage_key}` may have been created automatically.\n\nIf you made manual edits to the storage file, fix any syntax errors in `{corrupt_path}`, restore the file to the original path `{original_path}`, and restart Home Assistant. Otherwise, restore the system from a backup.\n\nSelect **Submit** below to confirm you have repaired the file or restored from a backup.\n\nThe exact error was: {error}",
+                        "title": "Storage corruption detected for {storage_key}"
+                    }
+                }
+            },
+            "title": "Storage corruption detected for {storage_key}"
+        },
+        "unsupported_local_deps": {
+            "description": "This system is running Home Assistant outside a virtual environment or a Docker container. This is not supported and will not work after the release of Home Assistant 2026.11.",
+            "title": "Deprecation notice: Installation method"
+        }
+    },
+    "services": {
+        "check_config": {
+            "description": "Checks the Home Assistant YAML-configuration files for errors. Errors will be shown in the Home Assistant logs.",
+            "name": "Check Home Assistant configuration"
+        },
+        "reload_all": {
+            "description": "Reloads all YAML configuration that can be reloaded without restarting Home Assistant.",
+            "name": "Reload all Home Assistant configuration"
+        },
+        "reload_config_entry": {
+            "description": "Reloads any explicitly provided config entry ID and any config entries referenced by entities or devices in the target. If both are provided, the union of those config entries is reloaded.",
+            "fields": {
+                "entry_id": {
+                    "description": "Optional configuration entry ID to reload.",
+                    "name": "Config entry ID"
+                }
+            },
+            "name": "Reload config entry"
+        },
+        "reload_core_config": {
+            "description": "Reloads the Core configuration from the YAML-configuration.",
+            "name": "Reload Core configuration"
+        },
+        "reload_custom_templates": {
+            "description": "Reloads Jinja2 templates found in the `custom_templates` folder in your config. New values will be applied on the next render of the template.",
+            "name": "Reload custom Jinja2 templates"
+        },
+        "restart": {
+            "description": "Restarts Home Assistant.",
+            "fields": {
+                "safe_mode": {
+                    "description": "Disable custom integrations and custom cards.",
+                    "name": "Safe mode"
+                }
+            },
+            "name": "Restart Home Assistant"
+        },
+        "save_persistent_states": {
+            "description": "Saves the persistent states immediately. Maintains the normal periodic saving interval.",
+            "name": "Save persistent states"
+        },
+        "set_location": {
+            "description": "Updates the Home Assistant location.",
+            "fields": {
+                "elevation": {
+                    "description": "Elevation of your location above sea level.",
+                    "name": "Elevation"
+                },
+                "latitude": {
+                    "description": "Latitude of your location.",
+                    "name": "Latitude"
+                },
+                "longitude": {
+                    "description": "Longitude of your location.",
+                    "name": "Longitude"
+                }
+            },
+            "name": "Set Home Assistant location"
+        },
+        "stop": {
+            "description": "Stops Home Assistant.",
+            "name": "Stop Home Assistant"
+        },
+        "toggle": {
+            "description": "Generic action to toggle devices on/off under any domain.",
+            "name": "Generic toggle"
+        },
+        "turn_off": {
+            "description": "Generic action to turn devices off under any domain.",
+            "name": "Generic turn off"
+        },
+        "turn_on": {
+            "description": "Generic action to turn devices on under any domain.",
+            "name": "Generic turn on"
+        },
+        "update_entity": {
+            "description": "Forces one or more entities to update their data.",
+            "fields": {
+                "entity_id": {
+                    "description": "List of entities to force update.",
+                    "name": "Entities to update"
+                }
+            },
+            "name": "Update entity"
+        }
+    },
+    "system_health": {
+        "info": {
+            "arch": "CPU architecture",
+            "config_dir": "Configuration directory",
+            "container_arch": "Container architecture",
+            "dev": "Development",
+            "docker": "Docker",
+            "hassio": "Supervisor",
+            "installation_type": "Installation type",
+            "os_name": "Operating system family",
+            "os_version": "Operating system version",
+            "python_version": "Python version",
+            "timezone": "Timezone",
+            "user": "User",
+            "version": "Version",
+            "virtualenv": "Virtual environment"
+        }
+    }
+}

--- a/homeassistant/components/humidifier/translations/en.json
+++ b/homeassistant/components/humidifier/translations/en.json
@@ -1,0 +1,278 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "condition_threshold_name": "Threshold type",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least"
+    },
+    "conditions": {
+        "is_drying": {
+            "description": "Tests if one or more humidifiers are drying.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier is drying"
+        },
+        "is_humidifying": {
+            "description": "Tests if one or more humidifiers are humidifying.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier is humidifying"
+        },
+        "is_mode": {
+            "description": "Tests if one or more humidifiers are set to a specific mode.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "mode": {
+                    "description": "The operation modes to check for.",
+                    "name": "Mode"
+                }
+            },
+            "name": "Humidifier is in mode"
+        },
+        "is_off": {
+            "description": "Tests if one or more humidifiers are off.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier is off"
+        },
+        "is_on": {
+            "description": "Tests if one or more humidifiers are on.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier is on"
+        },
+        "is_target_humidity": {
+            "description": "Tests the target humidity of one or more humidifiers.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Humidifier target humidity"
+        }
+    },
+    "device_automation": {
+        "action_type": {
+            "set_humidity": "Set humidity for {entity_name}",
+            "set_mode": "Change mode on {entity_name}",
+            "toggle": "Toggle {entity_name}",
+            "turn_off": "Turn off {entity_name}",
+            "turn_on": "Turn on {entity_name}"
+        },
+        "condition_type": {
+            "is_mode": "{entity_name} is set to a specific mode",
+            "is_off": "{entity_name} is off",
+            "is_on": "{entity_name} is on"
+        },
+        "extra_fields": {
+            "above": "Above",
+            "below": "Below",
+            "for": "Duration",
+            "humidity": "Humidity",
+            "mode": "Mode"
+        },
+        "trigger_type": {
+            "changed_states": "{entity_name} turned on or off",
+            "target_humidity_changed": "{entity_name} target humidity changed",
+            "turned_off": "{entity_name} turned off",
+            "turned_on": "{entity_name} turned on"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Humidifier",
+            "state": {
+                "off": "Off",
+                "on": "On"
+            },
+            "state_attributes": {
+                "action": {
+                    "name": "Action",
+                    "state": {
+                        "drying": "Drying",
+                        "humidifying": "Humidifying",
+                        "idle": "Idle",
+                        "off": "Off"
+                    }
+                },
+                "available_modes": {
+                    "name": "Available modes"
+                },
+                "current_humidity": {
+                    "name": "Current humidity"
+                },
+                "humidity": {
+                    "name": "Target humidity"
+                },
+                "max_humidity": {
+                    "name": "Max target humidity"
+                },
+                "min_humidity": {
+                    "name": "Min target humidity"
+                },
+                "mode": {
+                    "name": "Mode",
+                    "state": {
+                        "auto": "Auto",
+                        "away": "Away",
+                        "baby": "Baby",
+                        "boost": "Boost",
+                        "comfort": "Comfort",
+                        "eco": "Eco",
+                        "home": "Home",
+                        "normal": "Normal",
+                        "sleep": "Sleep"
+                    }
+                }
+            }
+        },
+        "dehumidifier": {
+            "name": "Dehumidifier"
+        },
+        "humidifier": {
+            "name": "Humidifier"
+        }
+    },
+    "exceptions": {
+        "humidity_out_of_range": {
+            "message": "Provided humidity {humidity} is not valid. Accepted range is {min_humidity} to {max_humidity}."
+        }
+    },
+    "services": {
+        "set_humidity": {
+            "description": "Sets the target humidity of a humidifier.",
+            "fields": {
+                "humidity": {
+                    "description": "Target humidity.",
+                    "name": "Humidity"
+                }
+            },
+            "name": "Set humidifier target humidity"
+        },
+        "set_mode": {
+            "description": "Sets the mode of a humidifier.",
+            "fields": {
+                "mode": {
+                    "description": "Operation mode. For example, \"normal\", \"eco\", or \"away\". For a list of possible values, refer to the integration documentation.",
+                    "name": "Mode"
+                }
+            },
+            "name": "Set humidifier mode"
+        },
+        "toggle": {
+            "description": "Toggles a humidifier on/off.",
+            "name": "Toggle humidifier"
+        },
+        "turn_off": {
+            "description": "Turns off a humidifier.",
+            "name": "Turn off humidifier"
+        },
+        "turn_on": {
+            "description": "Turns on a humidifier.",
+            "name": "Turn on humidifier"
+        }
+    },
+    "title": "Humidifier",
+    "triggers": {
+        "mode_changed": {
+            "description": "Triggers when the operation mode of one or more humidifiers changes.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "mode": {
+                    "description": "The operation modes to trigger on.",
+                    "name": "Mode"
+                }
+            },
+            "name": "Humidifier mode changed"
+        },
+        "started_drying": {
+            "description": "Triggers when one or more humidifiers start drying.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier started drying"
+        },
+        "started_humidifying": {
+            "description": "Triggers when one or more humidifiers start humidifying.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier started humidifying"
+        },
+        "turned_off": {
+            "description": "Triggers when one or more humidifiers turn off.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier turned off"
+        },
+        "turned_on": {
+            "description": "Triggers when one or more humidifiers turn on.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Humidifier turned on"
+        }
+    }
+}

--- a/homeassistant/components/light/translations/en.json
+++ b/homeassistant/components/light/translations/en.json
@@ -1,0 +1,550 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "condition_threshold_name": "Threshold type",
+        "field_brightness_description": "Number indicating brightness, where 0 turns the light off, 1 is the minimum brightness, and 255 is the maximum brightness.",
+        "field_brightness_name": "Brightness value",
+        "field_brightness_pct_description": "Number indicating the percentage of full brightness, where 0 turns the light off, 1 is the minimum brightness, and 100 is the maximum brightness.",
+        "field_brightness_pct_name": "Brightness",
+        "field_brightness_step_description": "Change brightness by an amount.",
+        "field_brightness_step_name": "Brightness step value",
+        "field_brightness_step_pct_description": "Change brightness by a percentage.",
+        "field_brightness_step_pct_name": "Brightness step",
+        "field_color_name_description": "A human-readable color name.",
+        "field_color_name_name": "Color name",
+        "field_color_temp_kelvin_description": "Color temperature in Kelvin.",
+        "field_color_temp_kelvin_name": "Color temperature",
+        "field_effect_description": "Light effect.",
+        "field_effect_name": "Effect",
+        "field_flash_description": "Tell light to flash, can be either value short or long.",
+        "field_flash_name": "Flash",
+        "field_hs_color_description": "Color in hue/sat format. A list of two integers. Hue is 0-360 and Sat is 0-100.",
+        "field_hs_color_name": "Hue/Sat color",
+        "field_profile_description": "Name of a light profile to use.",
+        "field_profile_name": "Profile",
+        "field_rgb_color_description": "The color in RGB format. A list of three integers between 0 and 255 representing the values of red, green, and blue.",
+        "field_rgb_color_name": "Color",
+        "field_rgbw_color_description": "The color in RGBW format. A list of four integers between 0 and 255 representing the values of red, green, blue, and white.",
+        "field_rgbw_color_name": "RGBW-color",
+        "field_rgbww_color_description": "The color in RGBWW format. A list of five integers between 0 and 255 representing the values of red, green, blue, cold white, and warm white.",
+        "field_rgbww_color_name": "RGBWW-color",
+        "field_transition_description": "Duration it takes to get to next state.",
+        "field_transition_name": "Transition",
+        "field_white_description": "Set the light to white mode.",
+        "field_white_name": "White",
+        "field_xy_color_description": "Color in XY-format. A list of two decimal numbers between 0 and 1.",
+        "field_xy_color_name": "XY-color",
+        "section_additional_fields_name": "Additional options",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least",
+        "trigger_threshold_name": "Threshold type"
+    },
+    "conditions": {
+        "is_brightness": {
+            "description": "Tests the brightness of one or more lights.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Light brightness"
+        },
+        "is_off": {
+            "description": "Tests if one or more lights are off.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Light is off"
+        },
+        "is_on": {
+            "description": "Tests if one or more lights are on.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Light is on"
+        }
+    },
+    "device_automation": {
+        "action_type": {
+            "brightness_decrease": "Decrease {entity_name} brightness",
+            "brightness_increase": "Increase {entity_name} brightness",
+            "flash": "Flash {entity_name}",
+            "toggle": "Toggle {entity_name}",
+            "turn_off": "Turn off {entity_name}",
+            "turn_on": "Turn on {entity_name}"
+        },
+        "condition_type": {
+            "is_off": "{entity_name} is off",
+            "is_on": "{entity_name} is on"
+        },
+        "extra_fields": {
+            "brightness_pct": "Brightness",
+            "flash": "Flash",
+            "for": "Duration"
+        },
+        "trigger_type": {
+            "changed_states": "{entity_name} turned on or off",
+            "turned_off": "{entity_name} turned off",
+            "turned_on": "{entity_name} turned on"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Light",
+            "state": {
+                "off": "Off",
+                "on": "On"
+            },
+            "state_attributes": {
+                "brightness": {
+                    "name": "Brightness"
+                },
+                "color_mode": {
+                    "name": "Color mode",
+                    "state": {
+                        "brightness": "Brightness only",
+                        "color_temp": "Color temperature",
+                        "hs": "HS",
+                        "onoff": "On/Off",
+                        "rgb": "RGB",
+                        "rgbw": "RGBW",
+                        "rgbww": "RGBWW",
+                        "unknown": "Unknown",
+                        "white": "White",
+                        "xy": "XY"
+                    }
+                },
+                "color_temp_kelvin": {
+                    "name": "Color temperature (Kelvin)"
+                },
+                "effect": {
+                    "name": "Effect",
+                    "state": {
+                        "off": "Off"
+                    }
+                },
+                "effect_list": {
+                    "name": "Available effects"
+                },
+                "max_color_temp_kelvin": {
+                    "name": "Maximum color temperature (Kelvin)"
+                },
+                "min_color_temp_kelvin": {
+                    "name": "Minimum color temperature (Kelvin)"
+                },
+                "supported_color_modes": {
+                    "name": "Available color modes",
+                    "state": {
+                        "brightness": "Brightness only",
+                        "color_temp": "Color temperature",
+                        "hs": "HS",
+                        "onoff": "On/Off",
+                        "rgb": "RGB",
+                        "rgbw": "RGBW",
+                        "rgbww": "RGBWW",
+                        "unknown": "Unknown",
+                        "white": "White",
+                        "xy": "XY"
+                    }
+                }
+            }
+        }
+    },
+    "selector": {
+        "color_name": {
+            "options": {
+                "aliceblue": "Alice blue",
+                "antiquewhite": "Antique white",
+                "aqua": "Aqua",
+                "aquamarine": "Aquamarine",
+                "azure": "Azure",
+                "beige": "Beige",
+                "bisque": "Bisque",
+                "blanchedalmond": "Blanched almond",
+                "blue": "Blue",
+                "blueviolet": "Blue violet",
+                "brown": "Brown",
+                "burlywood": "Burlywood",
+                "cadetblue": "Cadet blue",
+                "chartreuse": "Chartreuse",
+                "chocolate": "Chocolate",
+                "coral": "Coral",
+                "cornflowerblue": "Cornflower blue",
+                "cornsilk": "Cornsilk",
+                "crimson": "Crimson",
+                "cyan": "Cyan",
+                "darkblue": "Dark blue",
+                "darkcyan": "Dark cyan",
+                "darkgoldenrod": "Dark goldenrod",
+                "darkgray": "Dark gray",
+                "darkgreen": "Dark green",
+                "darkgrey": "Dark grey",
+                "darkkhaki": "Dark khaki",
+                "darkmagenta": "Dark magenta",
+                "darkolivegreen": "Dark olive green",
+                "darkorange": "Dark orange",
+                "darkorchid": "Dark orchid",
+                "darkred": "Dark red",
+                "darksalmon": "Dark salmon",
+                "darkseagreen": "Dark sea green",
+                "darkslateblue": "Dark slate blue",
+                "darkslategray": "Dark slate gray",
+                "darkslategrey": "Dark slate grey",
+                "darkturquoise": "Dark turquoise",
+                "darkviolet": "Dark violet",
+                "deeppink": "Deep pink",
+                "deepskyblue": "Deep sky blue",
+                "dimgray": "Dim gray",
+                "dimgrey": "Dim grey",
+                "dodgerblue": "Dodger blue",
+                "firebrick": "Fire brick",
+                "floralwhite": "Floral white",
+                "forestgreen": "Forest green",
+                "fuchsia": "Fuchsia",
+                "gainsboro": "Gainsboro",
+                "ghostwhite": "Ghost white",
+                "gold": "Gold",
+                "goldenrod": "Goldenrod",
+                "gray": "Gray",
+                "green": "Green",
+                "greenyellow": "Green yellow",
+                "grey": "Grey",
+                "homeassistant": "Home Assistant",
+                "honeydew": "Honeydew",
+                "hotpink": "Hot pink",
+                "indianred": "Indian red",
+                "indigo": "Indigo",
+                "ivory": "Ivory",
+                "khaki": "Khaki",
+                "lavender": "Lavender",
+                "lavenderblush": "Lavender blush",
+                "lawngreen": "Lawn green",
+                "lemonchiffon": "Lemon chiffon",
+                "lightblue": "Light blue",
+                "lightcoral": "Light coral",
+                "lightcyan": "Light cyan",
+                "lightgoldenrodyellow": "Light goldenrod yellow",
+                "lightgray": "Light gray",
+                "lightgreen": "Light green",
+                "lightgrey": "Light grey",
+                "lightpink": "Light pink",
+                "lightsalmon": "Light salmon",
+                "lightseagreen": "Light sea green",
+                "lightskyblue": "Light sky blue",
+                "lightslategray": "Light slate gray",
+                "lightslategrey": "Light slate grey",
+                "lightsteelblue": "Light steel blue",
+                "lightyellow": "Light yellow",
+                "lime": "Lime",
+                "limegreen": "Lime green",
+                "linen": "Linen",
+                "magenta": "Magenta",
+                "maroon": "Maroon",
+                "mediumaquamarine": "Medium aquamarine",
+                "mediumblue": "Medium blue",
+                "mediumorchid": "Medium orchid",
+                "mediumpurple": "Medium purple",
+                "mediumseagreen": "Medium sea green",
+                "mediumslateblue": "Medium slate blue",
+                "mediumspringgreen": "Medium spring green",
+                "mediumturquoise": "Medium turquoise",
+                "mediumvioletred": "Medium violet red",
+                "midnightblue": "Midnight blue",
+                "mintcream": "Mint cream",
+                "mistyrose": "Misty rose",
+                "moccasin": "Moccasin",
+                "navajowhite": "Navajo white",
+                "navy": "Navy",
+                "navyblue": "Navy blue",
+                "oldlace": "Old lace",
+                "olive": "Olive",
+                "olivedrab": "Olive drab",
+                "orange": "Orange",
+                "orangered": "Orange red",
+                "orchid": "Orchid",
+                "palegoldenrod": "Pale goldenrod",
+                "palegreen": "Pale green",
+                "paleturquoise": "Pale turquoise",
+                "palevioletred": "Pale violet red",
+                "papayawhip": "Papaya whip",
+                "peachpuff": "Peach puff",
+                "peru": "Peru",
+                "pink": "Pink",
+                "plum": "Plum",
+                "powderblue": "Powder blue",
+                "purple": "Purple",
+                "red": "Red",
+                "rosybrown": "Rosy brown",
+                "royalblue": "Royal blue",
+                "saddlebrown": "Saddle brown",
+                "salmon": "Salmon",
+                "sandybrown": "Sandy brown",
+                "seagreen": "Sea green",
+                "seashell": "Seashell",
+                "sienna": "Sienna",
+                "silver": "Silver",
+                "skyblue": "Sky blue",
+                "slateblue": "Slate blue",
+                "slategray": "Slate gray",
+                "slategrey": "Slate grey",
+                "snow": "Snow",
+                "springgreen": "Spring green",
+                "steelblue": "Steel blue",
+                "tan": "Tan",
+                "teal": "Teal",
+                "thistle": "Thistle",
+                "tomato": "Tomato",
+                "turquoise": "Turquoise",
+                "violet": "Violet",
+                "wheat": "Wheat",
+                "white": "White",
+                "whitesmoke": "White smoke",
+                "yellow": "Yellow",
+                "yellowgreen": "Yellow green"
+            }
+        },
+        "flash": {
+            "options": {
+                "long": "Long",
+                "short": "Short"
+            }
+        },
+        "state": {
+            "options": {
+                "off": "Off",
+                "on": "On"
+            }
+        }
+    },
+    "services": {
+        "toggle": {
+            "description": "Toggles one or more lights, from on to off, or off to on, based on their current state.",
+            "fields": {
+                "brightness": {
+                    "description": "Number indicating brightness, where 0 turns the light off, 1 is the minimum brightness, and 255 is the maximum brightness.",
+                    "name": "Brightness value"
+                },
+                "brightness_pct": {
+                    "description": "Number indicating the percentage of full brightness, where 0 turns the light off, 1 is the minimum brightness, and 100 is the maximum brightness.",
+                    "name": "Brightness"
+                },
+                "color_name": {
+                    "description": "A human-readable color name.",
+                    "name": "Color name"
+                },
+                "color_temp_kelvin": {
+                    "description": "Color temperature in Kelvin.",
+                    "name": "Color temperature"
+                },
+                "effect": {
+                    "description": "Light effect.",
+                    "name": "Effect"
+                },
+                "flash": {
+                    "description": "Tell light to flash, can be either value short or long.",
+                    "name": "Flash"
+                },
+                "hs_color": {
+                    "description": "Color in hue/sat format. A list of two integers. Hue is 0-360 and Sat is 0-100.",
+                    "name": "Hue/Sat color"
+                },
+                "profile": {
+                    "description": "Name of a light profile to use.",
+                    "name": "Profile"
+                },
+                "rgb_color": {
+                    "description": "The color in RGB format. A list of three integers between 0 and 255 representing the values of red, green, and blue.",
+                    "name": "Color"
+                },
+                "rgbw_color": {
+                    "description": "The color in RGBW format. A list of four integers between 0 and 255 representing the values of red, green, blue, and white.",
+                    "name": "RGBW-color"
+                },
+                "rgbww_color": {
+                    "description": "The color in RGBWW format. A list of five integers between 0 and 255 representing the values of red, green, blue, cold white, and warm white.",
+                    "name": "RGBWW-color"
+                },
+                "transition": {
+                    "description": "Duration it takes to get to next state.",
+                    "name": "Transition"
+                },
+                "white": {
+                    "description": "Set the light to white mode.",
+                    "name": "White"
+                },
+                "xy_color": {
+                    "description": "Color in XY-format. A list of two decimal numbers between 0 and 1.",
+                    "name": "XY-color"
+                }
+            },
+            "name": "Toggle light",
+            "sections": {
+                "additional_fields": {
+                    "name": "Additional options"
+                }
+            }
+        },
+        "turn_off": {
+            "description": "Turns off one or more lights.",
+            "fields": {
+                "flash": {
+                    "description": "Tell light to flash, can be either value short or long.",
+                    "name": "Flash"
+                },
+                "transition": {
+                    "description": "Duration it takes to get to next state.",
+                    "name": "Transition"
+                }
+            },
+            "name": "Turn off light",
+            "sections": {
+                "additional_fields": {
+                    "name": "Additional options"
+                }
+            }
+        },
+        "turn_on": {
+            "description": "Turns on one or more lights and adjusts their properties, even when they are turned on already.",
+            "fields": {
+                "brightness": {
+                    "description": "Number indicating brightness, where 0 turns the light off, 1 is the minimum brightness, and 255 is the maximum brightness.",
+                    "name": "Brightness value"
+                },
+                "brightness_pct": {
+                    "description": "Number indicating the percentage of full brightness, where 0 turns the light off, 1 is the minimum brightness, and 100 is the maximum brightness.",
+                    "name": "Brightness"
+                },
+                "brightness_step": {
+                    "description": "Change brightness by an amount.",
+                    "name": "Brightness step value"
+                },
+                "brightness_step_pct": {
+                    "description": "Change brightness by a percentage.",
+                    "name": "Brightness step"
+                },
+                "color_name": {
+                    "description": "A human-readable color name.",
+                    "name": "Color name"
+                },
+                "color_temp_kelvin": {
+                    "description": "Color temperature in Kelvin.",
+                    "name": "Color temperature"
+                },
+                "effect": {
+                    "description": "Light effect.",
+                    "name": "Effect"
+                },
+                "flash": {
+                    "description": "Tell light to flash, can be either value short or long.",
+                    "name": "Flash"
+                },
+                "hs_color": {
+                    "description": "Color in hue/sat format. A list of two integers. Hue is 0-360 and Sat is 0-100.",
+                    "name": "Hue/Sat color"
+                },
+                "profile": {
+                    "description": "Name of a light profile to use.",
+                    "name": "Profile"
+                },
+                "rgb_color": {
+                    "description": "The color in RGB format. A list of three integers between 0 and 255 representing the values of red, green, and blue.",
+                    "name": "Color"
+                },
+                "rgbw_color": {
+                    "description": "The color in RGBW format. A list of four integers between 0 and 255 representing the values of red, green, blue, and white.",
+                    "name": "RGBW-color"
+                },
+                "rgbww_color": {
+                    "description": "The color in RGBWW format. A list of five integers between 0 and 255 representing the values of red, green, blue, cold white, and warm white.",
+                    "name": "RGBWW-color"
+                },
+                "transition": {
+                    "description": "Duration it takes to get to next state.",
+                    "name": "Transition"
+                },
+                "white": {
+                    "description": "Set the light to white mode.",
+                    "name": "White"
+                },
+                "xy_color": {
+                    "description": "Color in XY-format. A list of two decimal numbers between 0 and 1.",
+                    "name": "XY-color"
+                }
+            },
+            "name": "Turn on light",
+            "sections": {
+                "additional_fields": {
+                    "name": "Additional options"
+                }
+            }
+        }
+    },
+    "title": "Light",
+    "triggers": {
+        "brightness_changed": {
+            "description": "Triggers when the brightness of one or more lights changes.",
+            "fields": {
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Light brightness changed"
+        },
+        "brightness_crossed_threshold": {
+            "description": "Triggers when the brightness of one or more lights crosses a threshold.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                },
+                "threshold": {
+                    "name": "Threshold type"
+                }
+            },
+            "name": "Light brightness crossed threshold"
+        },
+        "turned_off": {
+            "description": "Triggers when one or more lights turn off.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Light turned off"
+        },
+        "turned_on": {
+            "description": "Triggers when one or more lights turn on.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Light turned on"
+        }
+    }
+}

--- a/homeassistant/components/scene/translations/en.json
+++ b/homeassistant/components/scene/translations/en.json
@@ -1,0 +1,69 @@
+{
+    "exceptions": {
+        "entity_not_dynamically_created": {
+            "message": "The scene {entity_id} is not created with action `scene.create`."
+        },
+        "entity_not_scene": {
+            "message": "{entity_id} is not a valid entity ID of a scene."
+        }
+    },
+    "services": {
+        "apply": {
+            "description": "Activates a scene with configuration.",
+            "fields": {
+                "entities": {
+                    "description": "List of entities and their target state.",
+                    "name": "Entities state"
+                },
+                "transition": {
+                    "description": "Time it takes the devices to transition into the states defined in the scene.",
+                    "name": "Transition"
+                }
+            },
+            "name": "Apply scene"
+        },
+        "create": {
+            "description": "Creates a new scene.",
+            "fields": {
+                "entities": {
+                    "description": "List of entities and their target state. If your entities are already in the target state right now, use 'Entities snapshot' instead.",
+                    "name": "Entity states"
+                },
+                "scene_id": {
+                    "description": "The entity ID of the new scene.",
+                    "name": "Scene entity ID"
+                },
+                "snapshot_entities": {
+                    "description": "List of entities to be included in the snapshot. By taking a snapshot, you record the current state of those entities. If you do not want to use the current state of all your entities for this scene, you can combine 'Entities snapshot' with 'Entity states'.",
+                    "name": "Entities snapshot"
+                }
+            },
+            "name": "Create scene"
+        },
+        "delete": {
+            "description": "Deletes a dynamically created scene.",
+            "name": "Delete scene"
+        },
+        "reload": {
+            "description": "Reloads the scenes from the YAML-configuration.",
+            "name": "Reload scenes"
+        },
+        "turn_on": {
+            "description": "Activates a scene.",
+            "fields": {
+                "transition": {
+                    "description": "Time it takes the devices to transition into the states defined in the scene.",
+                    "name": "Transition"
+                }
+            },
+            "name": "Activate scene"
+        }
+    },
+    "title": "Scene",
+    "triggers": {
+        "activated": {
+            "description": "Triggers when one or more scenes are activated.",
+            "name": "Scene activated"
+        }
+    }
+}

--- a/homeassistant/components/sensor/translations/en.json
+++ b/homeassistant/components/sensor/translations/en.json
@@ -1,0 +1,351 @@
+{
+    "device_automation": {
+        "condition_type": {
+            "is_absolute_humidity": "Current {entity_name} absolute humidity",
+            "is_apparent_power": "Current {entity_name} apparent power",
+            "is_aqi": "Current {entity_name} air quality index",
+            "is_area": "Current {entity_name} area",
+            "is_atmospheric_pressure": "Current {entity_name} atmospheric pressure",
+            "is_battery_level": "Current {entity_name} battery level",
+            "is_blood_glucose_concentration": "Current {entity_name} blood glucose concentration",
+            "is_carbon_dioxide": "Current {entity_name} carbon dioxide concentration level",
+            "is_carbon_monoxide": "Current {entity_name} carbon monoxide concentration level",
+            "is_conductivity": "Current {entity_name} conductivity",
+            "is_current": "Current {entity_name} current",
+            "is_data_rate": "Current {entity_name} data rate",
+            "is_data_size": "Current {entity_name} data size",
+            "is_distance": "Current {entity_name} distance",
+            "is_duration": "Current {entity_name} duration",
+            "is_energy": "Current {entity_name} energy",
+            "is_energy_distance": "Current {entity_name} energy per distance",
+            "is_frequency": "Current {entity_name} frequency",
+            "is_gas": "Current {entity_name} gas",
+            "is_humidity": "Current {entity_name} humidity",
+            "is_illuminance": "Current {entity_name} illuminance",
+            "is_irradiance": "Current {entity_name} irradiance",
+            "is_moisture": "Current {entity_name} moisture",
+            "is_monetary": "Current {entity_name} monetary balance",
+            "is_nitrogen_dioxide": "Current {entity_name} nitrogen dioxide concentration level",
+            "is_nitrogen_monoxide": "Current {entity_name} nitrogen monoxide concentration level",
+            "is_nitrous_oxide": "Current {entity_name} nitrous oxide concentration level",
+            "is_ozone": "Current {entity_name} ozone concentration level",
+            "is_ph": "Current {entity_name} pH level",
+            "is_pm1": "Current {entity_name} PM1 concentration level",
+            "is_pm10": "Current {entity_name} PM10 concentration level",
+            "is_pm25": "Current {entity_name} PM2.5 concentration level",
+            "is_pm4": "Current {entity_name} PM4 concentration level",
+            "is_power": "Current {entity_name} power",
+            "is_power_factor": "Current {entity_name} power factor",
+            "is_precipitation": "Current {entity_name} precipitation",
+            "is_precipitation_intensity": "Current {entity_name} precipitation intensity",
+            "is_pressure": "Current {entity_name} pressure",
+            "is_radon": "Current {entity_name} radon concentration level",
+            "is_reactive_energy": "Current {entity_name} reactive energy",
+            "is_reactive_power": "Current {entity_name} reactive power",
+            "is_signal_strength": "Current {entity_name} signal strength",
+            "is_sound_pressure": "Current {entity_name} sound pressure",
+            "is_speed": "Current {entity_name} speed",
+            "is_sulphur_dioxide": "Current {entity_name} sulphur dioxide concentration level",
+            "is_temperature": "Current {entity_name} temperature",
+            "is_temperature_delta": "Current {entity_name} temperature interval",
+            "is_value": "Current {entity_name} value",
+            "is_volatile_organic_compounds": "Current {entity_name} volatile organic compounds concentration level",
+            "is_volatile_organic_compounds_parts": "Current {entity_name} volatile organic compounds concentration level",
+            "is_voltage": "Current {entity_name} voltage",
+            "is_volume": "Current {entity_name} volume",
+            "is_volume_flow_rate": "Current {entity_name} volume flow rate",
+            "is_water": "Current {entity_name} water",
+            "is_weight": "Current {entity_name} weight",
+            "is_wind_direction": "Current {entity_name} wind direction",
+            "is_wind_speed": "Current {entity_name} wind speed"
+        },
+        "extra_fields": {
+            "above": "Above",
+            "below": "Below",
+            "for": "Duration"
+        },
+        "trigger_type": {
+            "absolute_humidity": "{entity_name} absolute humidity changes",
+            "apparent_power": "{entity_name} apparent power changes",
+            "aqi": "{entity_name} air quality index changes",
+            "area": "{entity_name} area changes",
+            "atmospheric_pressure": "{entity_name} atmospheric pressure changes",
+            "battery_level": "{entity_name} battery level changes",
+            "blood_glucose_concentration": "{entity_name} blood glucose concentration changes",
+            "carbon_dioxide": "{entity_name} carbon dioxide concentration changes",
+            "carbon_monoxide": "{entity_name} carbon monoxide concentration changes",
+            "conductivity": "{entity_name} conductivity changes",
+            "current": "{entity_name} current changes",
+            "data_rate": "{entity_name} data rate changes",
+            "data_size": "{entity_name} data size changes",
+            "distance": "{entity_name} distance changes",
+            "duration": "{entity_name} duration changes",
+            "energy": "{entity_name} energy changes",
+            "energy_distance": "{entity_name} energy per distance changes",
+            "frequency": "{entity_name} frequency changes",
+            "gas": "{entity_name} gas changes",
+            "humidity": "{entity_name} humidity changes",
+            "illuminance": "{entity_name} illuminance changes",
+            "irradiance": "{entity_name} irradiance changes",
+            "moisture": "{entity_name} moisture changes",
+            "monetary": "{entity_name} monetary balance changes",
+            "nitrogen_dioxide": "{entity_name} nitrogen dioxide concentration changes",
+            "nitrogen_monoxide": "{entity_name} nitrogen monoxide concentration changes",
+            "nitrous_oxide": "{entity_name} nitrous oxide concentration changes",
+            "ozone": "{entity_name} ozone concentration changes",
+            "ph": "{entity_name} pH level changes",
+            "pm1": "{entity_name} PM1 concentration changes",
+            "pm10": "{entity_name} PM10 concentration changes",
+            "pm25": "{entity_name} PM2.5 concentration changes",
+            "pm4": "{entity_name} PM4 concentration changes",
+            "power": "{entity_name} power changes",
+            "power_factor": "{entity_name} power factor changes",
+            "precipitation": "{entity_name} precipitation changes",
+            "precipitation_intensity": "{entity_name} precipitation intensity changes",
+            "pressure": "{entity_name} pressure changes",
+            "radon": "{entity_name} radon concentration changes",
+            "reactive_energy": "{entity_name} reactive energy changes",
+            "reactive_power": "{entity_name} reactive power changes",
+            "signal_strength": "{entity_name} signal strength changes",
+            "sound_pressure": "{entity_name} sound pressure changes",
+            "speed": "{entity_name} speed changes",
+            "sulphur_dioxide": "{entity_name} sulphur dioxide concentration changes",
+            "temperature": "{entity_name} temperature changes",
+            "temperature_delta": "{entity_name} temperature interval changes",
+            "value": "{entity_name} value changes",
+            "volatile_organic_compounds": "{entity_name} volatile organic compounds concentration changes",
+            "volatile_organic_compounds_parts": "{entity_name} volatile organic compounds concentration changes",
+            "voltage": "{entity_name} voltage changes",
+            "volume": "{entity_name} volume changes",
+            "volume_flow_rate": "{entity_name} volume flow rate changes",
+            "water": "{entity_name} water changes",
+            "weight": "{entity_name} weight changes",
+            "wind_direction": "{entity_name} wind direction changes",
+            "wind_speed": "{entity_name} wind speed changes"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Sensor",
+            "state": {
+                "off": "Off",
+                "on": "On"
+            },
+            "state_attributes": {
+                "last_reset": {
+                    "name": "Last reset"
+                },
+                "options": {
+                    "name": "Possible states"
+                },
+                "state_class": {
+                    "name": "State class",
+                    "state": {
+                        "measurement": "Measurement",
+                        "measurement_angle": "Measurement angle",
+                        "total": "Total",
+                        "total_increasing": "Total increasing"
+                    }
+                }
+            }
+        },
+        "absolute_humidity": {
+            "name": "Absolute humidity"
+        },
+        "apparent_power": {
+            "name": "Apparent power"
+        },
+        "aqi": {
+            "name": "Air quality index"
+        },
+        "area": {
+            "name": "Area"
+        },
+        "atmospheric_pressure": {
+            "name": "Atmospheric pressure"
+        },
+        "battery": {
+            "name": "Battery"
+        },
+        "blood_glucose_concentration": {
+            "name": "Blood glucose concentration"
+        },
+        "carbon_dioxide": {
+            "name": "Carbon dioxide"
+        },
+        "carbon_monoxide": {
+            "name": "Carbon monoxide"
+        },
+        "conductivity": {
+            "name": "Conductivity"
+        },
+        "current": {
+            "name": "Current"
+        },
+        "data_rate": {
+            "name": "Data rate"
+        },
+        "data_size": {
+            "name": "Data size"
+        },
+        "date": {
+            "name": "Date"
+        },
+        "distance": {
+            "name": "Distance"
+        },
+        "duration": {
+            "name": "Duration"
+        },
+        "energy": {
+            "name": "Energy"
+        },
+        "energy_distance": {
+            "name": "Energy per distance"
+        },
+        "energy_storage": {
+            "name": "Stored energy"
+        },
+        "enum": {
+            "name": "Sensor"
+        },
+        "frequency": {
+            "name": "Frequency"
+        },
+        "gas": {
+            "name": "Gas"
+        },
+        "humidity": {
+            "name": "Humidity"
+        },
+        "illuminance": {
+            "name": "Illuminance"
+        },
+        "irradiance": {
+            "name": "Irradiance"
+        },
+        "moisture": {
+            "name": "Moisture"
+        },
+        "monetary": {
+            "name": "Monetary balance"
+        },
+        "nitrogen_dioxide": {
+            "name": "Nitrogen dioxide"
+        },
+        "nitrogen_monoxide": {
+            "name": "Nitrogen monoxide"
+        },
+        "nitrous_oxide": {
+            "name": "Nitrous oxide"
+        },
+        "ozone": {
+            "name": "Ozone"
+        },
+        "ph": {
+            "name": "pH"
+        },
+        "pm1": {
+            "name": "PM1"
+        },
+        "pm10": {
+            "name": "PM10"
+        },
+        "pm25": {
+            "name": "PM2.5"
+        },
+        "pm4": {
+            "name": "PM4"
+        },
+        "power": {
+            "name": "Power"
+        },
+        "power_factor": {
+            "name": "Power factor"
+        },
+        "precipitation": {
+            "name": "Precipitation"
+        },
+        "precipitation_intensity": {
+            "name": "Precipitation intensity"
+        },
+        "pressure": {
+            "name": "Pressure"
+        },
+        "radon": {
+            "name": "Radon"
+        },
+        "reactive_energy": {
+            "name": "Reactive energy"
+        },
+        "reactive_power": {
+            "name": "Reactive power"
+        },
+        "signal_strength": {
+            "name": "Signal strength"
+        },
+        "sound_pressure": {
+            "name": "Sound pressure"
+        },
+        "speed": {
+            "name": "Speed"
+        },
+        "sulphur_dioxide": {
+            "name": "Sulphur dioxide"
+        },
+        "temperature": {
+            "name": "Temperature"
+        },
+        "temperature_delta": {
+            "name": "Temperature delta"
+        },
+        "timestamp": {
+            "name": "Timestamp"
+        },
+        "uptime": {
+            "name": "Uptime"
+        },
+        "volatile_organic_compounds": {
+            "name": "Volatile organic compounds"
+        },
+        "volatile_organic_compounds_parts": {
+            "name": "Volatile organic compounds parts"
+        },
+        "voltage": {
+            "name": "Voltage"
+        },
+        "volume": {
+            "name": "Volume"
+        },
+        "volume_flow_rate": {
+            "name": "Volume flow rate"
+        },
+        "volume_storage": {
+            "name": "Stored volume"
+        },
+        "water": {
+            "name": "Water"
+        },
+        "weight": {
+            "name": "Weight"
+        },
+        "wind_direction": {
+            "name": "Wind direction"
+        },
+        "wind_speed": {
+            "name": "Wind speed"
+        }
+    },
+    "issues": {
+        "mean_type_changed": {
+            "title": "The mean type of {statistic_id} has changed"
+        },
+        "state_class_removed": {
+            "title": "{statistic_id} no longer has a state class"
+        },
+        "units_changed": {
+            "title": "The unit of {statistic_id} has changed"
+        }
+    },
+    "title": "Sensor"
+}

--- a/homeassistant/components/siren/translations/en.json
+++ b/homeassistant/components/siren/translations/en.json
@@ -1,0 +1,103 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least"
+    },
+    "conditions": {
+        "is_off": {
+            "description": "Tests if one or more sirens are off.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Siren is off"
+        },
+        "is_on": {
+            "description": "Tests if one or more sirens are on.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Siren is on"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Siren",
+            "state": {
+                "off": "Off",
+                "on": "On"
+            },
+            "state_attributes": {
+                "available_tones": {
+                    "name": "Available tones"
+                }
+            }
+        }
+    },
+    "services": {
+        "toggle": {
+            "description": "Toggles a siren on/off.",
+            "name": "Toggle siren"
+        },
+        "turn_off": {
+            "description": "Turns off a siren.",
+            "name": "Turn off siren"
+        },
+        "turn_on": {
+            "description": "Turns on a siren.",
+            "fields": {
+                "duration": {
+                    "description": "Number of seconds the sound is played. Must be supported by the integration.",
+                    "name": "Duration"
+                },
+                "tone": {
+                    "description": "The tone to emit. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration.",
+                    "name": "Tone"
+                },
+                "volume_level": {
+                    "description": "The volume. 0 is inaudible, 1 is the maximum volume. Must be supported by the integration.",
+                    "name": "Volume"
+                }
+            },
+            "name": "Turn on siren"
+        }
+    },
+    "title": "Siren",
+    "triggers": {
+        "turned_off": {
+            "description": "Triggers when one or more sirens turn off.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Siren turned off"
+        },
+        "turned_on": {
+            "description": "Triggers when one or more sirens turn on.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Siren turned on"
+        }
+    }
+}

--- a/homeassistant/components/tuya/const.py
+++ b/homeassistant/components/tuya/const.py
@@ -976,6 +976,7 @@ class DPCode(StrEnum):
     WATER_RESET = "water_reset"  # Resetting of water usage days
     WATER_SET = "water_set"  # Water level
     WATER_TIME = "water_time"  # Water usage duration
+    WATER_TOTAL = "water_total"
     WATERSENSOR_STATE = "watersensor_state"
     WEATHER_DELAY = "weather_delay"
     WET = "wet"  # Humidification

--- a/homeassistant/components/tuya/sensor.py
+++ b/homeassistant/components/tuya/sensor.py
@@ -1093,6 +1093,12 @@ SENSORS: dict[DeviceCategory, tuple[TuyaSensorEntityDescription, ...]] = {
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         *BATTERY_SENSORS,
+        TuyaSensorEntityDescription(
+            key=DPCode.WATER_TOTAL,
+            translation_key="total_water",
+            device_class=SensorDeviceClass.WATER,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+        ),
     ),
     DeviceCategory.SGBJ: BATTERY_SENSORS,
     DeviceCategory.SJ: BATTERY_SENSORS,

--- a/homeassistant/components/tuya/strings.json
+++ b/homeassistant/components/tuya/strings.json
@@ -962,6 +962,9 @@
       "total_volatile_organic_compound": {
         "name": "Total volatile organic compound"
       },
+      "total_water": {
+        "name": "Total water"
+      },
       "total_watering_time": {
         "name": "Total watering time"
       },

--- a/homeassistant/components/vacuum/translations/en.json
+++ b/homeassistant/components/vacuum/translations/en.json
@@ -1,0 +1,254 @@
+{
+    "common": {
+        "condition_behavior_name": "Condition passes if",
+        "condition_for_name": "For at least",
+        "trigger_behavior_name": "Trigger when",
+        "trigger_for_name": "For at least"
+    },
+    "conditions": {
+        "is_cleaning": {
+            "description": "Tests if one or more vacuum cleaners are cleaning.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner is cleaning"
+        },
+        "is_docked": {
+            "description": "Tests if one or more vacuum cleaners are docked.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner is docked"
+        },
+        "is_encountering_an_error": {
+            "description": "Tests if one or more vacuum cleaners are encountering an error.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner is encountering an error"
+        },
+        "is_paused": {
+            "description": "Tests if one or more vacuum cleaners are paused.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner is paused"
+        },
+        "is_returning": {
+            "description": "Tests if one or more vacuum cleaners are returning to the dock.",
+            "fields": {
+                "behavior": {
+                    "name": "Condition passes if"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner is returning"
+        }
+    },
+    "device_automation": {
+        "action_type": {
+            "clean": "Let {entity_name} clean",
+            "dock": "Let {entity_name} return to the dock"
+        },
+        "condition_type": {
+            "is_cleaning": "{entity_name} is cleaning",
+            "is_docked": "{entity_name} is docked"
+        },
+        "extra_fields": {
+            "for": "Duration"
+        },
+        "trigger_type": {
+            "cleaning": "{entity_name} started cleaning",
+            "docked": "{entity_name} docked"
+        }
+    },
+    "entity_component": {
+        "_": {
+            "name": "Vacuum",
+            "state": {
+                "cleaning": "Cleaning",
+                "docked": "Docked",
+                "error": "Error",
+                "idle": "Idle",
+                "off": "Off",
+                "on": "On",
+                "paused": "Paused",
+                "returning": "Returning to dock"
+            }
+        }
+    },
+    "exceptions": {
+        "area_mapping_not_configured": {
+            "message": "Area mapping is not configured for `{entity_id}`. Configure the segment-to-area mapping before using this action."
+        },
+        "areas_not_mapped": {
+            "message": "The following areas are not mapped to any segments of targeted vacuums: {areas}"
+        }
+    },
+    "issues": {
+        "segments_changed": {
+            "title": "Vacuum segments have changed for {entity_id}"
+        }
+    },
+    "services": {
+        "clean_area": {
+            "description": "Tells a vacuum cleaner to clean one or more areas.",
+            "fields": {
+                "cleaning_area_id": {
+                    "description": "Areas to clean.",
+                    "name": "Areas"
+                }
+            },
+            "name": "Clean area with vacuum cleaner"
+        },
+        "clean_spot": {
+            "description": "Tells a vacuum cleaner to do a spot clean-up.",
+            "name": "Clean spot with vacuum cleaner"
+        },
+        "locate": {
+            "description": "Locates a vacuum cleaner.",
+            "name": "Locate vacuum cleaner"
+        },
+        "pause": {
+            "description": "Pauses a vacuum cleaner's current task.",
+            "name": "Pause vacuum cleaner"
+        },
+        "return_to_base": {
+            "description": "Sends a vacuum cleaner back to its dock.",
+            "name": "Return vacuum cleaner to dock"
+        },
+        "send_command": {
+            "description": "Sends a command to a vacuum cleaner.",
+            "fields": {
+                "command": {
+                    "description": "Command to execute. The commands are integration-specific.",
+                    "name": "Command"
+                },
+                "params": {
+                    "description": "Parameters for the command. The parameters are integration-specific.",
+                    "name": "Parameters"
+                }
+            },
+            "name": "Send command to vacuum cleaner"
+        },
+        "set_fan_speed": {
+            "description": "Sets the fan speed of a vacuum cleaner.",
+            "fields": {
+                "fan_speed": {
+                    "description": "Fan speed. The value depends on the integration. Some integrations have speed steps, like 'medium'. Some use a percentage, between 0 and 100.",
+                    "name": "Fan speed"
+                }
+            },
+            "name": "Set vacuum cleaner fan speed"
+        },
+        "start": {
+            "description": "Starts or resumes a vacuum cleaner's cleaning task.",
+            "name": "Start vacuum cleaner"
+        },
+        "start_pause": {
+            "description": "Starts, pauses, or resumes a vacuum cleaner's cleaning task.",
+            "name": "Start/pause vacuum cleaner"
+        },
+        "stop": {
+            "description": "Stops a vacuum cleaner's current task.",
+            "name": "Stop vacuum cleaner"
+        },
+        "toggle": {
+            "description": "Toggles a vacuum cleaner on/off.",
+            "name": "Toggle vacuum cleaner"
+        },
+        "turn_off": {
+            "description": "Turns off a vacuum cleaner.",
+            "name": "Turn off vacuum cleaner"
+        },
+        "turn_on": {
+            "description": "Turns on a vacuum cleaner.",
+            "name": "Turn on vacuum cleaner"
+        }
+    },
+    "title": "Vacuum",
+    "triggers": {
+        "errored": {
+            "description": "Triggers when one or more vacuum cleaners encounter an error.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner encountered an error"
+        },
+        "paused_cleaning": {
+            "description": "Triggers when one or more vacuum cleaners pause cleaning.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner paused cleaning"
+        },
+        "returned_to_dock": {
+            "description": "Triggers when one or more vacuum cleaners have returned to dock.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner returned to dock"
+        },
+        "started_cleaning": {
+            "description": "Triggers when one or more vacuum cleaners start cleaning.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner started cleaning"
+        },
+        "started_returning": {
+            "description": "Triggers when one or more vacuum cleaners start returning to dock.",
+            "fields": {
+                "behavior": {
+                    "name": "Trigger when"
+                },
+                "for": {
+                    "name": "For at least"
+                }
+            },
+            "name": "Vacuum cleaner started returning to dock"
+        }
+    }
+}

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -83,22 +83,6 @@ def build_resources(
     }
 
 
-def _find_translation_file(
-    integration: Integration, language: str
-) -> pathlib.Path | None:
-    """Resolve the translation source file for a language."""
-    translation_file = integration.file_path / "translations" / f"{language}.json"
-    if translation_file.is_file():
-        return translation_file
-
-    if language == LOCALE_EN:
-        strings_file = integration.file_path / "strings.json"
-        if strings_file.is_file():
-            return strings_file
-
-    return None
-
-
 async def _async_get_component_strings(
     hass: HomeAssistant,
     languages: Iterable[str],
@@ -112,14 +96,15 @@ async def _async_get_component_strings(
     loaded_translations_by_language: dict[str, dict[str, Any]] = {}
     has_files_to_load = False
     for language in languages:
-        files_to_load: dict[str, pathlib.Path] = {}
-        for domain in components:
-            if not (integration := integrations.get(domain)):
-                continue
-
-            if translation_file := _find_translation_file(integration, language):
-                files_to_load[domain] = translation_file
-
+        file_name = f"{language}.json"
+        files_to_load: dict[str, pathlib.Path] = {
+            domain: integration.file_path / "translations" / file_name
+            for domain in components
+            if (
+                (integration := integrations.get(domain))
+                and integration.has_translations
+            )
+        }
         files_to_load_by_language[language] = files_to_load
         has_files_to_load |= bool(files_to_load)
 

--- a/homeassistant/helpers/translation.py
+++ b/homeassistant/helpers/translation.py
@@ -83,6 +83,22 @@ def build_resources(
     }
 
 
+def _find_translation_file(
+    integration: Integration, language: str
+) -> pathlib.Path | None:
+    """Resolve the translation source file for a language."""
+    translation_file = integration.file_path / "translations" / f"{language}.json"
+    if translation_file.is_file():
+        return translation_file
+
+    if language == LOCALE_EN:
+        strings_file = integration.file_path / "strings.json"
+        if strings_file.is_file():
+            return strings_file
+
+    return None
+
+
 async def _async_get_component_strings(
     hass: HomeAssistant,
     languages: Iterable[str],
@@ -96,15 +112,14 @@ async def _async_get_component_strings(
     loaded_translations_by_language: dict[str, dict[str, Any]] = {}
     has_files_to_load = False
     for language in languages:
-        file_name = f"{language}.json"
-        files_to_load: dict[str, pathlib.Path] = {
-            domain: integration.file_path / "translations" / file_name
-            for domain in components
-            if (
-                (integration := integrations.get(domain))
-                and integration.has_translations
-            )
-        }
+        files_to_load: dict[str, pathlib.Path] = {}
+        for domain in components:
+            if not (integration := integrations.get(domain)):
+                continue
+
+            if translation_file := _find_translation_file(integration, language):
+                files_to_load[domain] = translation_file
+
         files_to_load_by_language[language] = files_to_load
         has_files_to_load |= bool(files_to_load)
 

--- a/tests/components/tuya/fixtures/sfkzq_kcdiut0eqeni7b8n.json
+++ b/tests/components/tuya/fixtures/sfkzq_kcdiut0eqeni7b8n.json
@@ -1,0 +1,132 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "Smart Water Valve BV05",
+  "category": "sfkzq",
+  "product_id": "kcdiut0eqeni7b8n",
+  "product_name": "Smart Water Valve BV05",
+  "online": true,
+  "sub": false,
+  "time_zone": "+01:00",
+  "active_time": "2025-11-10T18:11:10+00:00",
+  "create_time": "2025-11-10T18:11:10+00:00",
+  "update_time": "2025-11-10T18:11:10+00:00",
+  "function": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 10
+      }
+    },
+    "weather_delay": {
+      "type": "Enum",
+      "value": {
+        "range": ["cancel", "24h", "48h", "72h"]
+      }
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 86400,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status_range": {
+    "switch": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "percent_control": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 10
+      }
+    },
+    "percent_state": {
+      "type": "Integer",
+      "value": {
+        "unit": "%",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "water_once": {
+      "type": "Integer",
+      "value": {
+        "unit": "L",
+        "min": 0,
+        "max": 10000,
+        "scale": 1,
+        "step": 1
+      }
+    },
+    "water_total": {
+      "type": "Integer",
+      "value": {
+        "unit": "L",
+        "min": 0,
+        "max": 999999999,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "weather_delay": {
+      "type": "Enum",
+      "value": {
+        "range": ["cancel", "24h", "48h", "72h"]
+      }
+    },
+    "countdown": {
+      "type": "Integer",
+      "value": {
+        "unit": "s",
+        "min": 0,
+        "max": 86400,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "sensor_temperature": {
+      "type": "Integer",
+      "value": {
+        "unit": "℃",
+        "min": 0,
+        "max": 100,
+        "scale": 0,
+        "step": 1
+      }
+    }
+  },
+  "status": {
+    "switch": true,
+    "percent_control": 100,
+    "percent_state": 100,
+    "water_once": 0,
+    "water_total": 0,
+    "weather_delay": "cancel",
+    "countdown": 0,
+    "sensor_temperature": 22
+  },
+  "set_up": true,
+  "support_local": true
+}

--- a/tests/components/tuya/snapshots/test_button.ambr
+++ b/tests/components/tuya/snapshots/test_button.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_platform_setup_and_discovery[button.c9_key_common_action_restart-entry]
+# name: test_platform_setup_and_discovery[button.c9_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.c9_key_common_action_restart',
+    'entity_id': 'button.c9_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': '[%key:common::action::restart%]',
+    'object_id_base': 'Restart',
     'options': dict({
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': '[%key:common::action::restart%]',
+    'original_name': 'Restart',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,21 +36,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[button.c9_key_common_action_restart-state]
+# name: test_platform_setup_and_discovery[button.c9_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'C9 [%key:common::action::restart%]',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'C9 Restart',
     }),
     'context': <ANY>,
-    'entity_id': 'button.c9_key_common_action_restart',
+    'entity_id': 'button.c9_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_platform_setup_and_discovery[button.intercom_key_common_action_restart-entry]
+# name: test_platform_setup_and_discovery[button.intercom_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -64,7 +64,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.intercom_key_common_action_restart',
+    'entity_id': 'button.intercom_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -72,12 +72,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': '[%key:common::action::restart%]',
+    'object_id_base': 'Restart',
     'options': dict({
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': '[%key:common::action::restart%]',
+    'original_name': 'Restart',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -87,14 +87,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[button.intercom_key_common_action_restart-state]
+# name: test_platform_setup_and_discovery[button.intercom_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Intercom [%key:common::action::restart%]',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Intercom Restart',
     }),
     'context': <ANY>,
-    'entity_id': 'button.intercom_key_common_action_restart',
+    'entity_id': 'button.intercom_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -301,7 +301,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_platform_setup_and_discovery[button.security_camera_key_common_action_restart-entry]
+# name: test_platform_setup_and_discovery[button.security_camera_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -315,7 +315,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.security_camera_key_common_action_restart',
+    'entity_id': 'button.security_camera_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -323,12 +323,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': '[%key:common::action::restart%]',
+    'object_id_base': 'Restart',
     'options': dict({
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': '[%key:common::action::restart%]',
+    'original_name': 'Restart',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -338,14 +338,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[button.security_camera_key_common_action_restart-state]
+# name: test_platform_setup_and_discovery[button.security_camera_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Security Camera [%key:common::action::restart%]',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Security Camera Restart',
     }),
     'context': <ANY>,
-    'entity_id': 'button.security_camera_key_common_action_restart',
+    'entity_id': 'button.security_camera_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tuya/snapshots/test_button.ambr
+++ b/tests/components/tuya/snapshots/test_button.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_platform_setup_and_discovery[button.c9_restart-entry]
+# name: test_platform_setup_and_discovery[button.c9_key_common_action_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.c9_restart',
+    'entity_id': 'button.c9_key_common_action_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,12 +21,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Restart',
+    'object_id_base': '[%key:common::action::restart%]',
     'options': dict({
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': 'Restart',
+    'original_name': '[%key:common::action::restart%]',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -36,21 +36,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[button.c9_restart-state]
+# name: test_platform_setup_and_discovery[button.c9_key_common_action_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'C9 Restart',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'C9 [%key:common::action::restart%]',
     }),
     'context': <ANY>,
-    'entity_id': 'button.c9_restart',
+    'entity_id': 'button.c9_key_common_action_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_platform_setup_and_discovery[button.intercom_restart-entry]
+# name: test_platform_setup_and_discovery[button.intercom_key_common_action_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -64,7 +64,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.intercom_restart',
+    'entity_id': 'button.intercom_key_common_action_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -72,12 +72,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Restart',
+    'object_id_base': '[%key:common::action::restart%]',
     'options': dict({
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': 'Restart',
+    'original_name': '[%key:common::action::restart%]',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -87,14 +87,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[button.intercom_restart-state]
+# name: test_platform_setup_and_discovery[button.intercom_key_common_action_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Intercom Restart',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Intercom [%key:common::action::restart%]',
     }),
     'context': <ANY>,
-    'entity_id': 'button.intercom_restart',
+    'entity_id': 'button.intercom_key_common_action_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -301,7 +301,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_platform_setup_and_discovery[button.security_camera_restart-entry]
+# name: test_platform_setup_and_discovery[button.security_camera_key_common_action_restart-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -315,7 +315,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.security_camera_restart',
+    'entity_id': 'button.security_camera_key_common_action_restart',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -323,12 +323,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Restart',
+    'object_id_base': '[%key:common::action::restart%]',
     'options': dict({
     }),
     'original_device_class': <ButtonDeviceClass.RESTART: 'restart'>,
     'original_icon': None,
-    'original_name': 'Restart',
+    'original_name': '[%key:common::action::restart%]',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -338,14 +338,14 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_platform_setup_and_discovery[button.security_camera_restart-state]
+# name: test_platform_setup_and_discovery[button.security_camera_key_common_action_restart-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'restart',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Security Camera Restart',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Security Camera [%key:common::action::restart%]',
     }),
     'context': <ANY>,
-    'entity_id': 'button.security_camera_restart',
+    'entity_id': 'button.security_camera_key_common_action_restart',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -5858,6 +5858,37 @@
     'via_device_id': None,
   })
 # ---
+# name: test_device_registry[n8b7ineqe0tuidckqzkfs]
+  DeviceRegistryEntrySnapshot({
+    'area_id': None,
+    'config_entries': <ANY>,
+    'config_entries_subentries': <ANY>,
+    'configuration_url': None,
+    'connections': set({
+    }),
+    'disabled_by': None,
+    'entry_type': None,
+    'hw_version': None,
+    'id': <ANY>,
+    'identifiers': set({
+      tuple(
+        'tuya',
+        'n8b7ineqe0tuidckqzkfs',
+      ),
+    }),
+    'labels': set({
+    }),
+    'manufacturer': 'Tuya',
+    'model': 'Smart Water Valve BV05',
+    'model_id': 'kcdiut0eqeni7b8n',
+    'name': 'Smart Water Valve BV05',
+    'name_by_user': None,
+    'primary_config_entry': <ANY>,
+    'serial_number': None,
+    'sw_version': None,
+    'via_device_id': None,
+  })
+# ---
 # name: test_device_registry[nc4e9nlZPTuTNfYEzc]
   DeviceRegistryEntrySnapshot({
     'area_id': None,

--- a/tests/components/tuya/snapshots/test_number.ambr
+++ b/tests/components/tuya/snapshots/test_number.ambr
@@ -3149,6 +3149,67 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[number.smart_water_valve_bv05_irrigation_duration-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 86400.0,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0.0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1.0,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'number',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'number.smart_water_valve_bv05_irrigation_duration',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Irrigation duration',
+    'options': dict({
+    }),
+    'original_device_class': <NumberDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Irrigation duration',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'irrigation_duration',
+    'unique_id': 'tuya.n8b7ineqe0tuidckqzkfscountdown',
+    'unit_of_measurement': 's',
+  })
+# ---
+# name: test_platform_setup_and_discovery[number.smart_water_valve_bv05_irrigation_duration-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Smart Water Valve BV05 Irrigation duration',
+      <NumberEntityCapabilityAttribute.MAX: 'max'>: 86400.0,
+      <NumberEntityCapabilityAttribute.MIN: 'min'>: 0.0,
+      <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
+      <NumberEntityCapabilityAttribute.STEP: 'step'>: 1.0,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 's',
+    }),
+    'context': <ANY>,
+    'entity_id': 'number.smart_water_valve_bv05_irrigation_duration',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[number.smart_white_noise_machine_volume-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_select.ambr
+++ b/tests/components/tuya/snapshots/test_select.ambr
@@ -5881,6 +5881,69 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[select.smart_water_valve_bv05_weather_delay-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'cancel',
+        '24h',
+        '48h',
+        '72h',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'select.smart_water_valve_bv05_weather_delay',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Weather delay',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Weather delay',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'weather_delay',
+    'unique_id': 'tuya.n8b7ineqe0tuidckqzkfsweather_delay',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[select.smart_water_valve_bv05_weather_delay-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Smart Water Valve BV05 Weather delay',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'cancel',
+        '24h',
+        '48h',
+        '72h',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.smart_water_valve_bv05_weather_delay',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'cancel',
+  })
+# ---
 # name: test_platform_setup_and_discovery[select.socket3_power_on_behavior-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -2864,67 +2864,6 @@
     'state': '100.0',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-      'sensor.private': dict({
-        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.6tbtkuv3tal1aesfjxqwindspeed_avg',
-    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BR 7-in-1 WLAN Wetterstation Anthrazit',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.0',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit_air_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -4116,6 +4055,67 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wind speed',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Wind speed',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.6tbtkuv3tal1aesfjxqwindspeed_avg',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BR 7-in-1 WLAN Wetterstation Anthrazit Wind speed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.c30_battery-entry]
@@ -9319,64 +9319,6 @@
     'state': '32.2',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.grillhomero-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.grillhomero',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'indexed_temperature',
-    'unique_id': 'tuya.yybgnzr3ztwstemp_current_2',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.grillhomero-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Grillhőmérő',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.grillhomero',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.grillhomero_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -9484,6 +9426,64 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.grillhomero_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.grillhomero_temperature_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.grillhomero_temperature_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_temperature',
+    'unique_id': 'tuya.yybgnzr3ztwstemp_current_2',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.grillhomero_temperature_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Grillhőmérő Temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.grillhomero_temperature_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -22973,64 +22973,6 @@
     'state': 'high',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.sws_16600_wifi_sh',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.ai9swgb6tyinbwbxjxqwindspeed_avg',
-    'unit_of_measurement': 'km/h',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SWS 16600 WiFi SH',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'km/h',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.sws_16600_wifi_sh',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.0',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh_air_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -24105,6 +24047,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '20.5',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh_wind_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.sws_16600_wifi_sh_wind_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Wind speed',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': 'Wind speed',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.ai9swgb6tyinbwbxjxqwindspeed_avg',
+    'unit_of_measurement': 'km/h',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh_wind_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SWS 16600 WiFi SH Wind speed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'km/h',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.sws_16600_wifi_sh_wind_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.temperature_and_humidity_sensor_battery-entry]
@@ -26954,7 +26954,7 @@
     'state': '100.0',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester-entry]
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_conductivity-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -26970,7 +26970,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester',
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_conductivity',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -26978,7 +26978,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': None,
+    'object_id_base': 'Conductivity',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -26986,7 +26986,7 @@
     }),
     'original_device_class': <SensorDeviceClass.CONDUCTIVITY: 'conductivity'>,
     'original_icon': None,
-    'original_name': None,
+    'original_name': 'Conductivity',
     'platform': 'tuya',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -26996,71 +26996,16 @@
     'unit_of_measurement': <UnitOfConductivity.MICROSIEMENS_PER_CM: 'μS/cm'>,
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester-state]
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_conductivity-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'conductivity',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester Conductivity',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfConductivity.MICROSIEMENS_PER_CM: 'μS/cm'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': None,
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.PH: 'ph'>,
-    'original_icon': None,
-    'original_name': None,
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.frmfrbds0jixxyaljbngdph_current',
-    'unit_of_measurement': '',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'ph',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_2',
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_conductivity',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -27115,6 +27060,61 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_oxydo_reduction_potential',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_ph-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_ph',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'pH',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PH: 'ph'>,
+    'original_icon': None,
+    'original_name': 'pH',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.frmfrbds0jixxyaljbngdph_current',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_ph-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'ph',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester pH',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_ph',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -4118,67 +4118,6 @@
     'state': 'unknown',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Wind speed',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-      'sensor.private': dict({
-        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
-    'original_icon': None,
-    'original_name': 'Wind speed',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.6tbtkuv3tal1aesfjxqwindspeed_avg',
-    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BR 7-in-1 WLAN Wetterstation Anthrazit Wind speed',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit_wind_speed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.0',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.c30_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -9545,64 +9484,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.grillhomero_temperature',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.grillhomero_temperature_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.grillhomero_temperature_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Temperature',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'Temperature',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'indexed_temperature',
-    'unique_id': 'tuya.yybgnzr3ztwstemp_current_2',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.grillhomero_temperature_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Grillhőmérő Temperature',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.grillhomero_temperature_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -24226,64 +24107,6 @@
     'state': '20.5',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh_wind_speed-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.sws_16600_wifi_sh_wind_speed',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Wind speed',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 2,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
-    'original_icon': None,
-    'original_name': 'Wind speed',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.ai9swgb6tyinbwbxjxqwindspeed_avg',
-    'unit_of_measurement': 'km/h',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh_wind_speed-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SWS 16600 WiFi SH Wind speed',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'km/h',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.sws_16600_wifi_sh_wind_speed',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0.0',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.temperature_and_humidity_sensor_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -27244,64 +27067,6 @@
     'state': 'unavailable',
   })
 # ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_conductivity-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_conductivity',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Conductivity',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.CONDUCTIVITY: 'conductivity'>,
-    'original_icon': None,
-    'original_name': 'Conductivity',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.frmfrbds0jixxyaljbngdec_current',
-    'unit_of_measurement': <UnitOfConductivity.MICROSIEMENS_PER_CM: 'μS/cm'>,
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_conductivity-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'conductivity',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester Conductivity',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfConductivity.MICROSIEMENS_PER_CM: 'μS/cm'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_conductivity',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
 # name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_oxydo_reduction_potential-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -27350,61 +27115,6 @@
     }),
     'context': <ANY>,
     'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_oxydo_reduction_potential',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unavailable',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_ph-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_ph',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'pH',
-    'options': dict({
-    }),
-    'original_device_class': <SensorDeviceClass.PH: 'ph'>,
-    'original_icon': None,
-    'original_name': 'pH',
-    'platform': 'tuya',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'tuya.frmfrbds0jixxyaljbngdph_current',
-    'unit_of_measurement': '',
-  })
-# ---
-# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_ph-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'ph',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester pH',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '',
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_ph',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/tuya/snapshots/test_sensor.ambr
+++ b/tests/components/tuya/snapshots/test_sensor.ambr
@@ -2864,6 +2864,67 @@
     'state': '100.0',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.6tbtkuv3tal1aesfjxqwindspeed_avg',
+    'unit_of_measurement': <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BR 7-in-1 WLAN Wetterstation Anthrazit',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSpeed.KILOMETERS_PER_HOUR: 'km/h'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.br_7_in_1_wlan_wetterstation_anthrazit',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.br_7_in_1_wlan_wetterstation_anthrazit_air_pressure-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -9317,6 +9378,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '32.2',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.grillhomero-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.grillhomero',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'indexed_temperature',
+    'unique_id': 'tuya.yybgnzr3ztwstemp_current_2',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.grillhomero-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Grillhőmérő',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.grillhomero',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.grillhomero_battery-entry]
@@ -20612,6 +20731,64 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[sensor.smart_water_valve_bv05_total_water-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.smart_water_valve_bv05_total_water',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Total water',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Total water',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_water',
+    'unique_id': 'tuya.n8b7ineqe0tuidckqzkfswater_total',
+    'unit_of_measurement': 'L',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.smart_water_valve_bv05_total_water-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'water',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Smart Water Valve BV05 Total water',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'L',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.smart_water_valve_bv05_total_water',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
+  })
+# ---
 # name: test_platform_setup_and_discovery[sensor.smogo_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -22913,6 +23090,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'high',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.sws_16600_wifi_sh',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.WIND_SPEED: 'wind_speed'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.ai9swgb6tyinbwbxjxqwindspeed_avg',
+    'unit_of_measurement': 'km/h',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'wind_speed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SWS 16600 WiFi SH',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'km/h',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.sws_16600_wifi_sh',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0.0',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.sws_16600_wifi_sh_air_pressure-entry]
@@ -26894,6 +27129,119 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100.0',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.CONDUCTIVITY: 'conductivity'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.frmfrbds0jixxyaljbngdec_current',
+    'unit_of_measurement': <UnitOfConductivity.MICROSIEMENS_PER_CM: 'μS/cm'>,
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'conductivity',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfConductivity.MICROSIEMENS_PER_CM: 'μS/cm'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.PH: 'ph'>,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'tuya.frmfrbds0jixxyaljbngdph_current',
+    'unit_of_measurement': '',
+  })
+# ---
+# name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'ph',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'WiFi smart online 8 in 1 tester',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.wifi_smart_online_8_in_1_tester_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unavailable',
   })
 # ---
 # name: test_platform_setup_and_discovery[sensor.wifi_smart_online_8_in_1_tester_conductivity-entry]

--- a/tests/components/tuya/snapshots/test_valve.ambr
+++ b/tests/components/tuya/snapshots/test_valve.ambr
@@ -581,6 +581,59 @@
     'state': 'unavailable',
   })
 # ---
+# name: test_platform_setup_and_discovery[valve.smart_water_valve_bv05_valve-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'valve',
+    'entity_category': None,
+    'entity_id': 'valve.smart_water_valve_bv05_valve',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Valve',
+    'options': dict({
+    }),
+    'original_device_class': <ValveDeviceClass.WATER: 'water'>,
+    'original_icon': None,
+    'original_name': 'Valve',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ValveEntityFeature: 3>,
+    'translation_key': 'valve',
+    'unique_id': 'tuya.n8b7ineqe0tuidckqzkfsswitch',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[valve.smart_water_valve_bv05_valve-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'water',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Smart Water Valve BV05 Valve',
+      <ValveEntityStateAttribute.IS_CLOSED: 'is_closed'>: False,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ValveEntityFeature: 3>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'valve.smart_water_valve_bv05_valve',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'open',
+  })
+# ---
 # name: test_platform_setup_and_discovery[valve.sprinkler_cesare_valve-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([


### PR DESCRIPTION
## Proposed change

Add support for the `water_total` datapoint as a sensor for Tuya smart water timers using the `sfkzq` device category.

Some Tuya smart water valve / water timer devices expose accumulated water usage through the `water_total` status datapoint, but Home Assistant currently does not create a sensor entity for it.

This change maps `water_total` to a water sensor with `total_increasing` state class.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to issue: #156292
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr