### PR TITLE
Fix honeywell hvac_action showing Idle when EquipmentOutputStatus is unreported

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -300,6 +300,12 @@ class HoneywellUSThermostat(ClimateEntity):
         """Return the current running hvac operation if supported."""
         if self.hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
+        # Some thermostat models never report equipment run status to the
+        # cloud API (raw EquipmentOutputStatus is None, not 0). Treating
+        # that the same as a genuine "off" report shows a misleading
+        # "Idle" while the system may actually be heating or cooling.
+        if self._device.raw_ui_data.get("EquipmentOutputStatus") is None:
+            return None
         return HW_MODE_TO_HA_HVAC_ACTION.get(self._device.equipment_output_status)
 
     @property

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -147,10 +147,21 @@ async def test_dynamic_attributes(
     assert attributes["current_humidity"] == 50
 
 
-async def test_hvac_action_unreported_equipment_status(
-    hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
+@pytest.mark.parametrize(
+    ("equipment_output_status", "expected_action"),
+    [
+        pytest.param(None, None, id="unreported"),
+        pytest.param(0, HVACAction.IDLE, id="reported_idle"),
+    ],
+)
+async def test_hvac_action_equipment_status(
+    hass: HomeAssistant,
+    device: MagicMock,
+    config_entry: MagicMock,
+    equipment_output_status: int | None,
+    expected_action: HVACAction | None,
 ) -> None:
-    """Test hvac_action is unknown when the device never reports EquipmentOutputStatus.
+    """Test hvac_action reflects the raw EquipmentOutputStatus value.
 
     Some thermostat models never send EquipmentOutputStatus to the cloud API
     (it stays None, not 0). hvac_action should be unknown in that case rather
@@ -160,7 +171,7 @@ async def test_hvac_action_unreported_equipment_status(
 
     entity_id = f"climate.{device.name}"
     device.system_mode = "cool"
-    device.raw_ui_data["EquipmentOutputStatus"] = None
+    device.raw_ui_data["EquipmentOutputStatus"] = equipment_output_status
 
     async_fire_time_changed(
         hass,
@@ -170,28 +181,7 @@ async def test_hvac_action_unreported_equipment_status(
 
     state = hass.states.get(entity_id)
     assert state.state == HVACMode.COOL
-    assert ATTR_HVAC_ACTION not in state.attributes
-
-
-async def test_hvac_action_reported_idle(
-    hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
-) -> None:
-    """Test hvac_action stays idle when the device explicitly reports 0."""
-    await init_integration(hass, config_entry)
-
-    entity_id = f"climate.{device.name}"
-    device.system_mode = "cool"
-    device.raw_ui_data["EquipmentOutputStatus"] = 0
-
-    async_fire_time_changed(
-        hass,
-        utcnow() + SCAN_INTERVAL,
-    )
-    await hass.async_block_till_done()
-
-    state = hass.states.get(entity_id)
-    assert state.state == HVACMode.COOL
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
+    assert state.attributes.get(ATTR_HVAC_ACTION) == expected_action
 
 
 async def test_mode_service_calls(

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -12,6 +12,7 @@ from syrupy.filters import props
 
 from homeassistant.components.climate import (
     ATTR_FAN_MODE,
+    ATTR_HVAC_ACTION,
     ATTR_HVAC_MODE,
     ATTR_PRESET_MODE,
     ATTR_TARGET_TEMP_HIGH,
@@ -26,6 +27,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_PRESET_MODE,
     SERVICE_SET_TEMPERATURE,
+    HVACAction,
     HVACMode,
 )
 from homeassistant.components.honeywell.climate import (
@@ -143,6 +145,53 @@ async def test_dynamic_attributes(
     attributes = state.attributes
     assert attributes["current_temperature"] == 61
     assert attributes["current_humidity"] == 50
+
+
+async def test_hvac_action_unreported_equipment_status(
+    hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
+) -> None:
+    """Test hvac_action is unknown when the device never reports EquipmentOutputStatus.
+
+    Some thermostat models never send EquipmentOutputStatus to the cloud API
+    (it stays None, not 0). hvac_action should be unknown in that case rather
+    than falsely reporting idle while the system may be heating or cooling.
+    """
+    await init_integration(hass, config_entry)
+
+    entity_id = f"climate.{device.name}"
+    device.system_mode = "cool"
+    device.raw_ui_data["EquipmentOutputStatus"] = None
+
+    async_fire_time_changed(
+        hass,
+        utcnow() + SCAN_INTERVAL,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == HVACMode.COOL
+    assert ATTR_HVAC_ACTION not in state.attributes
+
+
+async def test_hvac_action_reported_idle(
+    hass: HomeAssistant, device: MagicMock, config_entry: MagicMock
+) -> None:
+    """Test hvac_action stays idle when the device explicitly reports 0."""
+    await init_integration(hass, config_entry)
+
+    entity_id = f"climate.{device.name}"
+    device.system_mode = "cool"
+    device.raw_ui_data["EquipmentOutputStatus"] = 0
+
+    async_fire_time_changed(
+        hass,
+        utcnow() + SCAN_INTERVAL,
+    )
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state.state == HVACMode.COOL
+    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.IDLE
 
 
 async def test_mode_service_calls(


### PR DESCRIPTION
## Proposed change

Fixes #176038.

Some Honeywell TCC thermostat models never report equipment run status to the cloud API at all: the raw `EquipmentOutputStatus` field is `None` (not `0`). `aiosomecomfort`'s `Device.equipment_output_status` property collapses both `None` (never reported) and `0` (genuinely idle) into `"off"`, so `climate.py` maps both cases to `HVACAction.IDLE`. For affected models this means the thermostat card shows "Idle" even while the system is actively heating or cooling — confirmed on my own device via diagnostics (`EquipmentOutputStatus: null`, `hasFan: false`) and 7 days of recorder history showing `idle` through an unambiguous 2-hour cooling run.

This checks the raw `EquipmentOutputStatus` value directly (already an established pattern in this file, e.g. `min_temp`/`max_temp`/`_is_hold`) and returns `None` (unknown) when it's genuinely never been reported, rather than falling through to the collapsed `"off"` value. Models that do report `0` are unaffected and keep returning `HVACAction.IDLE` as before.

Related history: #68740, #72118 — closed after polling improvements, but the misleading "Idle" for null-reporting models was never addressed.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #176038
- Added `test_hvac_action_unreported_equipment_status` (asserts `hvac_action` is absent from state attributes when `EquipmentOutputStatus` is `None`) and `test_hvac_action_reported_idle` (regression guard confirming `EquipmentOutputStatus: 0` still maps to `HVACAction.IDLE` as before).
- Verified locally against the full `tests/components/honeywell/` suite (climate, config_flow, init) using `pytest-homeassistant-custom-component`: 36/37 pass, including both new tests. The one non-passing test (`test_static_attributes`, a syrupy snapshot comparison) fails identically against unmodified `dev` in the same harness, confirming it's a local snapshot-discovery artifact of my ad-hoc test environment and not a regression from this change.
- `ruff check` and `ruff format --diff` pass clean on `climate.py` against Home Assistant's own `pyproject.toml` lint config.

Opening as a draft since I'd like a codeowner's read on the approach (particularly whether returning `None` vs. some other unknown-signaling value is the right call here) before it's considered ready to merge.
