### PR TITLE
Add translation keys for Liebherr API error handling

### DIFF
--- a/homeassistant/components/liebherr/__init__.py
+++ b/homeassistant/components/liebherr/__init__.py
@@ -24,6 +24,7 @@ from .coordinator import LiebherrConfigEntry, LiebherrCoordinator, LiebherrData
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
+    Platform.COVER,
     Platform.LIGHT,
     Platform.NUMBER,
     Platform.SELECT,

--- a/homeassistant/components/liebherr/__init__.py
+++ b/homeassistant/components/liebherr/__init__.py
@@ -24,7 +24,6 @@ from .coordinator import LiebherrConfigEntry, LiebherrCoordinator, LiebherrData
 _LOGGER = logging.getLogger(__name__)
 
 PLATFORMS: list[Platform] = [
-    Platform.COVER,
     Platform.LIGHT,
     Platform.NUMBER,
     Platform.SELECT,
@@ -45,11 +44,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: LiebherrConfigEntry) -> 
     try:
         devices = await client.get_devices()
     except LiebherrAuthenticationError as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
-        raise ConfigEntryAuthFailed("Invalid API key") from err
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="invalid_api_key",
+        ) from err
     except LiebherrConnectionError as err:
-        # pylint: disable-next=home-assistant-exception-not-translated
-        raise ConfigEntryNotReady(f"Failed to connect to Liebherr API: {err}") from err
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from err
 
     # Create a coordinator for each device (may be empty if no devices)
     data = LiebherrData(client=client)

--- a/homeassistant/components/liebherr/coordinator.py
+++ b/homeassistant/components/liebherr/coordinator.py
@@ -60,12 +60,15 @@ class LiebherrCoordinator(DataUpdateCoordinator[DeviceState]):
         try:
             await self.client.get_device(self.device_id)
         except LiebherrAuthenticationError as err:
-            # pylint: disable-next=home-assistant-exception-not-translated
-            raise ConfigEntryAuthFailed("Invalid API key") from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="invalid_api_key",
+            ) from err
         except LiebherrConnectionError as err:
-            # pylint: disable-next=home-assistant-exception-not-translated
             raise ConfigEntryNotReady(
-                f"Failed to connect to device {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="device_connection_error",
+                translation_placeholders={"device_id": self.device_id},
             ) from err
 
     @override
@@ -74,15 +77,19 @@ class LiebherrCoordinator(DataUpdateCoordinator[DeviceState]):
         try:
             return await self.client.get_device_state(self.device_id)
         except LiebherrAuthenticationError as err:
-            # pylint: disable-next=home-assistant-exception-not-translated
-            raise ConfigEntryAuthFailed("API key is no longer valid") from err
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_expired",
+            ) from err
         except LiebherrTimeoutError as err:
-            # pylint: disable-next=home-assistant-exception-not-translated
             raise UpdateFailed(
-                f"Timeout communicating with device {self.device_id}"
+                translation_domain=DOMAIN,
+                translation_key="device_timeout_error",
+                translation_placeholders={"device_id": self.device_id},
             ) from err
         except LiebherrConnectionError as err:
-            # pylint: disable-next=home-assistant-exception-not-translated
             raise UpdateFailed(
-                f"Error communicating with device {self.device_id}"
+                translation_domain=DOMAIN,
+                translation_key="device_communication_error",
+                translation_placeholders={"device_id": self.device_id},
             ) from err

--- a/homeassistant/components/liebherr/strings.json
+++ b/homeassistant/components/liebherr/strings.json
@@ -217,11 +217,29 @@
     }
   },
   "exceptions": {
+    "auth_expired": {
+      "message": "API key is no longer valid"
+    },
+    "cannot_connect": {
+      "message": "Failed to connect to the Liebherr API"
+    },
     "close_auto_door_error": {
       "message": "An error occurred while closing the door"
     },
     "communication_error": {
       "message": "An error occurred while communicating with the device"
+    },
+    "device_communication_error": {
+      "message": "Error communicating with device {device_id}"
+    },
+    "device_connection_error": {
+      "message": "Failed to connect to device {device_id}"
+    },
+    "device_timeout_error": {
+      "message": "Timeout communicating with device {device_id}"
+    },
+    "invalid_api_key": {
+      "message": "Invalid API key"
     },
     "open_auto_door_error": {
       "message": "An error occurred while opening the door"


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add translation keys for Liebherr API error handling
Fix https://github.com/home-assistant/core/issues/171494


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #171494
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
