### PR TITLE
Add binary sensor platform to Fronius with backup mode

### DIFF
--- a/homeassistant/components/fronius/__init__.py
+++ b/homeassistant/components/fronius/__init__.py
@@ -35,7 +35,7 @@ from .coordinator import (
 )
 
 _LOGGER: Final = logging.getLogger(__name__)
-PLATFORMS: Final = [Platform.SENSOR]
+PLATFORMS: Final = [Platform.BINARY_SENSOR, Platform.SENSOR]
 
 type FroniusConfigEntry = ConfigEntry[FroniusSolarNet]
 

--- a/homeassistant/components/fronius/binary_sensor.py
+++ b/homeassistant/components/fronius/binary_sensor.py
@@ -1,0 +1,85 @@
+"""Support for Fronius binary sensors."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, override
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory, Platform
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .entity import FroniusEntity, FroniusEntityDescription
+
+if TYPE_CHECKING:
+    from . import FroniusConfigEntry
+    from .coordinator import FroniusPowerFlowUpdateCoordinator
+
+
+PARALLEL_UPDATES = 0
+
+
+@dataclass(frozen=True)
+class FroniusBinarySensorEntityDescription(
+    FroniusEntityDescription, BinarySensorEntityDescription
+):
+    """Describes Fronius binary sensor entity."""
+
+
+POWER_FLOW_BINARY_SENSOR_DESCRIPTIONS: list[FroniusBinarySensorEntityDescription] = [
+    FroniusBinarySensorEntityDescription(
+        key="backup_mode",
+    ),
+    FroniusBinarySensorEntityDescription(
+        key="battery_standby",
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: FroniusConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Fronius binary sensor entities based on a config entry."""
+    solar_net = config_entry.runtime_data
+    if solar_net.power_flow_coordinator is not None:
+        solar_net.power_flow_coordinator.add_entities_for_seen_keys(
+            async_add_entities, Platform.BINARY_SENSOR, PowerFlowBinarySensor
+        )
+
+
+class PowerFlowBinarySensor(FroniusEntity, BinarySensorEntity):
+    """Defines a Fronius power flow binary sensor entity."""
+
+    entity_description: FroniusBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: FroniusPowerFlowUpdateCoordinator,
+        description: FroniusBinarySensorEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius power flow binary sensor."""
+        super().__init__(coordinator, description, solar_net_id)
+        self._attr_is_on = self._device_data()[self.response_key]["value"]
+        # SolarNet device is already created in FroniusSolarNet._create_solar_net_device
+        self._attr_device_info = coordinator.solar_net.system_device_info
+        self._attr_unique_id = (
+            f"{coordinator.solar_net.solar_net_device_id}-power_flow-{description.key}"
+        )
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        try:
+            self._attr_is_on = self._device_data()[self.response_key]["value"]
+        except KeyError:
+            # KeyError: raised when omitted in response, e.g. when backup power
+            # is deactivated after the entity was created
+            self._attr_is_on = None
+        self.async_write_ha_state()

--- a/homeassistant/components/fronius/coordinator.py
+++ b/homeassistant/components/fronius/coordinator.py
@@ -1,15 +1,18 @@
 """DataUpdateCoordinators for the Fronius integration."""
 
 from abc import ABC, abstractmethod
+from collections.abc import Mapping, Sequence
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any, override
 
 from pyfronius import BadStatusError, FroniusError
 
+from homeassistant.const import Platform
 from homeassistant.core import callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+from .binary_sensor import POWER_FLOW_BINARY_SENSOR_DESCRIPTIONS
 from .const import (
     DOMAIN,
     SOLAR_NET_ID_POWER_FLOW,
@@ -17,6 +20,7 @@ from .const import (
     FroniusDeviceInfo,
     SolarNetId,
 )
+from .entity import FroniusEntity, FroniusEntityDescription
 from .sensor import (
     INVERTER_ENTITY_DESCRIPTIONS,
     LOGGER_ENTITY_DESCRIPTIONS,
@@ -24,12 +28,10 @@ from .sensor import (
     OHMPILOT_ENTITY_DESCRIPTIONS,
     POWER_FLOW_ENTITY_DESCRIPTIONS,
     STORAGE_ENTITY_DESCRIPTIONS,
-    FroniusSensorEntityDescription,
 )
 
 if TYPE_CHECKING:
     from . import FroniusSolarNet
-    from .sensor import _FroniusSensorEntity
 
 
 class FroniusCoordinatorBase(
@@ -39,7 +41,7 @@ class FroniusCoordinatorBase(
 
     default_interval: timedelta
     error_interval: timedelta
-    valid_descriptions: list[FroniusSensorEntityDescription]
+    valid_descriptions: Mapping[Platform, Sequence[FroniusEntityDescription]]
 
     MAX_FAILED_UPDATES = 3
 
@@ -49,7 +51,7 @@ class FroniusCoordinatorBase(
         self.solar_net = solar_net
         # unregistered_descriptors are used to create entities in platform module
         self.unregistered_descriptors: dict[
-            SolarNetId, list[FroniusSensorEntityDescription]
+            SolarNetId, dict[Platform, list[FroniusEntityDescription]]
         ] = {}
         super().__init__(*args, update_interval=self.default_interval, **kwargs)
 
@@ -80,15 +82,17 @@ class FroniusCoordinatorBase(
             for solar_net_id in data:
                 if solar_net_id not in self.unregistered_descriptors:
                     # id seen for the first time
-                    self.unregistered_descriptors[solar_net_id] = (
-                        self.valid_descriptions.copy()
-                    )
+                    self.unregistered_descriptors[solar_net_id] = {
+                        platform: list(descriptions)
+                        for platform, descriptions in self.valid_descriptions.items()
+                    }
             return data
 
     @callback
-    def add_entities_for_seen_keys[_FroniusEntityT: _FroniusSensorEntity](
+    def add_entities_for_seen_keys[_FroniusEntityT: FroniusEntity](
         self,
         async_add_entities: AddEntitiesCallback,
+        platform: Platform,
         entity_constructor: type[_FroniusEntityT],
     ) -> None:
         """Add entities for received keys and registers listener for future seen keys.
@@ -102,7 +106,9 @@ class FroniusCoordinatorBase(
             new_entities: list[_FroniusEntityT] = []
             for solar_net_id, device_data in self.data.items():
                 remaining_unregistered_descriptors = []
-                for description in self.unregistered_descriptors[solar_net_id]:
+                for description in self.unregistered_descriptors[solar_net_id][
+                    platform
+                ]:
                     key = description.response_key or description.key
                     if key not in device_data:
                         remaining_unregistered_descriptors.append(description)
@@ -117,7 +123,7 @@ class FroniusCoordinatorBase(
                             solar_net_id=solar_net_id,
                         )
                     )
-                self.unregistered_descriptors[solar_net_id] = (
+                self.unregistered_descriptors[solar_net_id][platform] = (
                     remaining_unregistered_descriptors
                 )
             async_add_entities(new_entities)
@@ -133,7 +139,7 @@ class FroniusInverterUpdateCoordinator(FroniusCoordinatorBase):
 
     default_interval = timedelta(minutes=1)
     error_interval = timedelta(minutes=10)
-    valid_descriptions = INVERTER_ENTITY_DESCRIPTIONS
+    valid_descriptions = {Platform.SENSOR: INVERTER_ENTITY_DESCRIPTIONS}
 
     SILENT_RETRIES = 3
 
@@ -170,7 +176,7 @@ class FroniusLoggerUpdateCoordinator(FroniusCoordinatorBase):
 
     default_interval = timedelta(hours=1)
     error_interval = timedelta(hours=1)
-    valid_descriptions = LOGGER_ENTITY_DESCRIPTIONS
+    valid_descriptions = {Platform.SENSOR: LOGGER_ENTITY_DESCRIPTIONS}
 
     @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -184,7 +190,7 @@ class FroniusMeterUpdateCoordinator(FroniusCoordinatorBase):
 
     default_interval = timedelta(minutes=1)
     error_interval = timedelta(minutes=10)
-    valid_descriptions = METER_ENTITY_DESCRIPTIONS
+    valid_descriptions = {Platform.SENSOR: METER_ENTITY_DESCRIPTIONS}
 
     @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -198,7 +204,7 @@ class FroniusOhmpilotUpdateCoordinator(FroniusCoordinatorBase):
 
     default_interval = timedelta(minutes=1)
     error_interval = timedelta(minutes=10)
-    valid_descriptions = OHMPILOT_ENTITY_DESCRIPTIONS
+    valid_descriptions = {Platform.SENSOR: OHMPILOT_ENTITY_DESCRIPTIONS}
 
     @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -212,7 +218,10 @@ class FroniusPowerFlowUpdateCoordinator(FroniusCoordinatorBase):
 
     default_interval = timedelta(seconds=10)
     error_interval = timedelta(minutes=3)
-    valid_descriptions = POWER_FLOW_ENTITY_DESCRIPTIONS
+    valid_descriptions = {
+        Platform.SENSOR: POWER_FLOW_ENTITY_DESCRIPTIONS,
+        Platform.BINARY_SENSOR: POWER_FLOW_BINARY_SENSOR_DESCRIPTIONS,
+    }
 
     @override
     async def _update_method(self) -> dict[SolarNetId, Any]:
@@ -226,7 +235,7 @@ class FroniusStorageUpdateCoordinator(FroniusCoordinatorBase):
 
     default_interval = timedelta(minutes=1)
     error_interval = timedelta(minutes=10)
-    valid_descriptions = STORAGE_ENTITY_DESCRIPTIONS
+    valid_descriptions = {Platform.SENSOR: STORAGE_ENTITY_DESCRIPTIONS}
 
     @override
     async def _update_method(self) -> dict[SolarNetId, Any]:

--- a/homeassistant/components/fronius/entity.py
+++ b/homeassistant/components/fronius/entity.py
@@ -1,0 +1,42 @@
+"""Base entity for the Fronius integration."""
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+if TYPE_CHECKING:
+    from .coordinator import FroniusCoordinatorBase
+
+
+@dataclass(frozen=True)
+class FroniusEntityDescription(EntityDescription):
+    """Base class for Fronius entity descriptions."""
+
+    response_key: str | None = None
+
+
+class FroniusEntity(CoordinatorEntity["FroniusCoordinatorBase"]):
+    """Defines a Fronius coordinator entity."""
+
+    entity_description: FroniusEntityDescription
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: FroniusCoordinatorBase,
+        description: FroniusEntityDescription,
+        solar_net_id: str,
+    ) -> None:
+        """Set up an individual Fronius coordinator entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self.response_key = description.response_key or description.key
+        self.solar_net_id = solar_net_id
+        self._attr_translation_key = description.translation_key or description.key
+
+    def _device_data(self) -> dict[str, Any]:
+        """Extract information for SolarNet device from coordinator data."""
+        return self.coordinator.data[self.solar_net_id]

--- a/homeassistant/components/fronius/icons.json
+++ b/homeassistant/components/fronius/icons.json
@@ -1,5 +1,13 @@
 {
   "entity": {
+    "binary_sensor": {
+      "backup_mode": {
+        "default": "mdi:home-battery"
+      },
+      "battery_standby": {
+        "default": "mdi:power-standby"
+      }
+    },
     "sensor": {
       "cash_factor": {
         "default": "mdi:cash-plus"

--- a/homeassistant/components/fronius/sensor.py
+++ b/homeassistant/components/fronius/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     PERCENTAGE,
     EntityCategory,
+    Platform,
     UnitOfApparentPower,
     UnitOfElectricCurrent,
     UnitOfElectricPotential,
@@ -27,7 +28,6 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     DOMAIN,
@@ -40,6 +40,7 @@ from .const import (
     get_meter_location_description,
     get_ohmpilot_state_message,
 )
+from .entity import FroniusEntity, FroniusEntityDescription
 
 if TYPE_CHECKING:
     from . import FroniusConfigEntry
@@ -69,33 +70,35 @@ async def async_setup_entry(
 
     for inverter_coordinator in solar_net.inverter_coordinators:
         inverter_coordinator.add_entities_for_seen_keys(
-            async_add_entities, InverterSensor
+            async_add_entities, Platform.SENSOR, InverterSensor
         )
     if solar_net.logger_coordinator is not None:
         solar_net.logger_coordinator.add_entities_for_seen_keys(
-            async_add_entities, LoggerSensor
+            async_add_entities, Platform.SENSOR, LoggerSensor
         )
     if solar_net.meter_coordinator is not None:
         solar_net.meter_coordinator.add_entities_for_seen_keys(
-            async_add_entities, MeterSensor
+            async_add_entities, Platform.SENSOR, MeterSensor
         )
     if solar_net.ohmpilot_coordinator is not None:
         solar_net.ohmpilot_coordinator.add_entities_for_seen_keys(
-            async_add_entities, OhmpilotSensor
+            async_add_entities, Platform.SENSOR, OhmpilotSensor
         )
     if solar_net.power_flow_coordinator is not None:
         solar_net.power_flow_coordinator.add_entities_for_seen_keys(
-            async_add_entities, PowerFlowSensor
+            async_add_entities, Platform.SENSOR, PowerFlowSensor
         )
     if solar_net.storage_coordinator is not None:
         solar_net.storage_coordinator.add_entities_for_seen_keys(
-            async_add_entities, StorageSensor
+            async_add_entities, Platform.SENSOR, StorageSensor
         )
 
     @callback
     def async_add_new_entities(coordinator: FroniusInverterUpdateCoordinator) -> None:
         """Add newly found inverter entities."""
-        coordinator.add_entities_for_seen_keys(async_add_entities, InverterSensor)
+        coordinator.add_entities_for_seen_keys(
+            async_add_entities, Platform.SENSOR, InverterSensor
+        )
 
     config_entry.async_on_unload(
         async_dispatcher_connect(
@@ -107,14 +110,13 @@ async def async_setup_entry(
 
 
 @dataclass(frozen=True)
-class FroniusSensorEntityDescription(SensorEntityDescription):
+class FroniusSensorEntityDescription(FroniusEntityDescription, SensorEntityDescription):
     """Describes Fronius sensor entity."""
 
     default_value: StateType | None = None
     # Gen24 devices may report 0 for total energy while doing firmware updates.
     # Handling such values shall mitigate spikes in delta calculations.
     invalid_when_falsy: bool = False
-    response_key: str | None = None
     value_fn: Callable[[StateType], StateType] | None = None
 
 
@@ -746,12 +748,10 @@ STORAGE_ENTITY_DESCRIPTIONS: list[FroniusSensorEntityDescription] = [
 ]
 
 
-class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEntity):
-    """Defines a Fronius coordinator entity."""
+class _FroniusSensorEntity(FroniusEntity, SensorEntity):
+    """Defines a Fronius coordinator sensor entity."""
 
     entity_description: FroniusSensorEntityDescription
-
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -760,16 +760,8 @@ class _FroniusSensorEntity(CoordinatorEntity["FroniusCoordinatorBase"], SensorEn
         solar_net_id: str,
     ) -> None:
         """Set up an individual Fronius meter sensor."""
-        super().__init__(coordinator)
-        self.entity_description = description
-        self.response_key = description.response_key or description.key
-        self.solar_net_id = solar_net_id
+        super().__init__(coordinator, description, solar_net_id)
         self._attr_native_value = self._get_entity_value()
-        self._attr_translation_key = description.translation_key or description.key
-
-    def _device_data(self) -> dict[str, Any]:
-        """Extract information for SolarNet device from coordinator data."""
-        return self.coordinator.data[self.solar_net_id]
 
     def _get_entity_value(self) -> Any:
         """Extract entity value from coordinator.

--- a/homeassistant/components/fronius/strings.json
+++ b/homeassistant/components/fronius/strings.json
@@ -36,6 +36,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "backup_mode": {
+        "name": "Backup mode"
+      },
+      "battery_standby": {
+        "name": "Battery standby"
+      }
+    },
     "sensor": {
       "capacity_designed": {
         "name": "Designed capacity"

--- a/tests/components/fronius/snapshots/test_binary_sensor.ambr
+++ b/tests/components/fronius/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,201 @@
+# serializer version: 1
+# name: test_binary_sensors[gen24][binary_sensor.solarnet_backup_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.solarnet_backup_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Backup mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Backup mode',
+    'platform': 'fronius',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'backup_mode',
+    'unique_id': 'solar_net_123.4567890-power_flow-backup_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[gen24][binary_sensor.solarnet_backup_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarNet Backup mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.solarnet_backup_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[gen24][binary_sensor.solarnet_battery_standby-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.solarnet_battery_standby',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery standby',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Battery standby',
+    'platform': 'fronius',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_standby',
+    'unique_id': 'solar_net_123.4567890-power_flow-battery_standby',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[gen24][binary_sensor.solarnet_battery_standby-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarNet Battery standby',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.solarnet_battery_standby',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_binary_sensors[gen24_storage][binary_sensor.solarnet_backup_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.solarnet_backup_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Backup mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Backup mode',
+    'platform': 'fronius',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'backup_mode',
+    'unique_id': 'solar_net_12345678-power_flow-backup_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[gen24_storage][binary_sensor.solarnet_backup_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarNet Backup mode',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.solarnet_backup_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_binary_sensors[gen24_storage][binary_sensor.solarnet_battery_standby-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.solarnet_battery_standby',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery standby',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Battery standby',
+    'platform': 'fronius',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'battery_standby',
+    'unique_id': 'solar_net_12345678-power_flow-battery_standby',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensors[gen24_storage][binary_sensor.solarnet_battery_standby-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'SolarNet Battery standby',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.solarnet_battery_standby',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/fronius/test_binary_sensor.py
+++ b/tests/components/fronius/test_binary_sensor.py
@@ -1,0 +1,54 @@
+"""Tests for the Fronius binary sensor platform."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import MOCK_UID, mock_responses, setup_fronius_integration
+
+from tests.common import snapshot_platform
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    ("fixture_set", "unique_id"),
+    [
+        pytest.param("gen24", MOCK_UID, id="gen24"),
+        pytest.param("gen24_storage", "12345678", id="gen24_storage"),
+    ],
+)
+async def test_binary_sensors(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    fixture_set: str,
+    unique_id: str,
+) -> None:
+    """Test Fronius power flow binary sensors for Gen24 devices."""
+    mock_responses(aioclient_mock, fixture_set=fixture_set)
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.BINARY_SENSOR]):
+        config_entry = await setup_fronius_integration(
+            hass, is_logger=False, unique_id=unique_id
+        )
+
+    await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+async def test_no_binary_sensors_without_backup_keys(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test that no binary sensors are created when the API omits the keys."""
+    # The Symo power flow response has neither BackupMode nor BatteryStandby.
+    mock_responses(aioclient_mock, fixture_set="symo")
+    await setup_fronius_integration(hass, is_logger=True)
+
+    assert not hass.states.async_all(domain_filter=BINARY_SENSOR_DOMAIN)

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -1,5 +1,7 @@
 """Tests for the Fronius sensor platform."""
 
+from unittest.mock import patch
+
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -10,6 +12,7 @@ from homeassistant.components.fronius.coordinator import (
     FroniusPowerFlowUpdateCoordinator,
 )
 from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -269,7 +272,8 @@ async def test_gen24(
         assert state.state == str(expected_state)
 
     mock_responses(aioclient_mock, fixture_set="gen24")
-    config_entry = await setup_fronius_integration(hass, is_logger=False)
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        config_entry = await setup_fronius_integration(hass, is_logger=False)
 
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 59
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
@@ -309,9 +313,10 @@ async def test_gen24_storage(
         assert state.state == str(expected_state)
 
     mock_responses(aioclient_mock, fixture_set="gen24_storage")
-    config_entry = await setup_fronius_integration(
-        hass, is_logger=False, unique_id="12345678"
-    )
+    with patch("homeassistant.components.fronius.PLATFORMS", [Platform.SENSOR]):
+        config_entry = await setup_fronius_integration(
+            hass, is_logger=False, unique_id="12345678"
+        )
 
     assert len(hass.states.async_all(domain_filter=SENSOR_DOMAIN)) == 73
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)


### PR DESCRIPTION
## Breaking change


## Proposed change

Adds a `binary_sensor` platform to the Fronius integration exposing two flags from the `GetPowerFlowRealtimeData` `Site` scope that previously had no entity:

- **Backup mode** (`backup_mode`) — `on` when a Gen24/Tauro/Verto inverter is actively supplying backup/island power (grid outage). No device class, enabled by default.
- **Battery standby** (`battery_standby`) — `on` when the battery is in standby. Marked as a diagnostic entity.

Both are read from the existing `FroniusPowerFlowUpdateCoordinator`. `PyFronius==0.8.2` (already pinned) already parses these into the power-flow data as `backup_mode`/`battery_standby`, so **no dependency bump is required**. As with the other Fronius entities, they are only created when the key is present in the API response, so non-Gen24 devices don't get them.

### Notable changes

- **Coordinator is now platform-aware.** `valid_descriptions`/`unregistered_descriptors` were keyed to a single platform; they are now keyed by `Platform` so the power-flow coordinator can feed both `sensor` and `binary_sensor`. `add_entities_for_seen_keys` takes a `platform` argument.
- **New `entity.py`** with a shared `FroniusEntityDescription` (carries `response_key`) and `FroniusEntity` base holding the common entity boilerplate; `sensor.py` now inherits from it.

This is a modern re-do of the abandoned #126973, incorporating its review feedback: a real `BinarySensorEntity` (not a boolean sensor), a platform-aware coordinator, `has_entity_name` + `translation_key` (no legacy `name=`), and snapshot + key-absence tests.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46745
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
