### PR TITLE
Add security policy link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+Information on Home Assistant's security policies and guidelines can be found on the Home Assistant website:
+
+<https://www.home-assistant.io/security/>
+
+Please do not open public issues for security vulnerabilities. Report vulnerabilities using GitHub Security Advisory:
+
+<https://github.com/home-assistant/core/security/advisories/new>


### PR DESCRIPTION
## Breaking change
None.

## Proposed change
Adds a root SECURITY.md that points researchers to Home Assistant's canonical security policy and the private GitHub Security Advisory reporting flow. This keeps the repository-local policy as a thin pointer to the existing published policy and does not change the disclosure process.

## Type of change
- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #171158
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] I have followed the development checklist
- [x] I have followed the perfect PR recommendations
- [ ] The code has been formatted using Ruff (ruff format homeassistant tests)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

Validation:
- git diff --cached --check before commit
- Verified the canonical security policy page loads: https://www.home-assistant.io/security/
- Verified the repository has active GitHub Security Advisories via the GitHub API

Notes:
- Docs/community-health file only; Python tests and Ruff formatting were not applicable.