### PR TITLE
Fix trusted proxies type when HTTP config is loaded from storage

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -207,7 +207,11 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     cors_origins = conf[CONF_CORS_ORIGINS]
     use_x_forwarded_for = conf.get(CONF_USE_X_FORWARDED_FOR, False)
     use_x_frame_options = conf[CONF_USE_X_FRAME_OPTIONS]
-    trusted_proxies = conf.get(CONF_TRUSTED_PROXIES) or []
+    # The loaded config stores trusted proxies as strings (JSON-serializable);
+    # the forwarded middleware needs IPv4Network/IPv6Network objects.
+    trusted_proxies = [
+        ip_network(proxy) for proxy in conf.get(CONF_TRUSTED_PROXIES) or []
+    ]
     is_ban_enabled = conf[CONF_IP_BAN_ENABLED]
     login_threshold = conf[CONF_LOGIN_ATTEMPTS_THRESHOLD]
     ssl_profile = conf[CONF_SSL_PROFILE]

--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from datetime import datetime, timedelta
-from ipaddress import IPv4Network, IPv6Network, ip_network
+from ipaddress import ip_network
 import logging
 import os
 from typing import Any, Final, TypedDict, cast, override
@@ -87,7 +87,7 @@ class ConfData(TypedDict, total=False):
     ssl_key: str
     cors_allowed_origins: list[str]
     use_x_forwarded_for: bool
-    trusted_proxies: list[IPv4Network | IPv6Network]
+    trusted_proxies: list[str]
     login_attempts_threshold: int
     ip_ban_enabled: bool
     ssl_profile: str

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -172,6 +172,43 @@ async def test_proxy_config(hass: HomeAssistant) -> None:
     )
 
 
+async def test_proxy_config_forwarded_request(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test a request with X-Forwarded-For from a trusted proxy is accepted.
+
+    The config store persists trusted proxies as strings; this exercises the
+    forwarded middleware with a config loaded from the store to guard against
+    passing the strings through instead of IP network objects.
+    """
+    hass_storage[DOMAIN] = {
+        "version": 2,
+        "key": DOMAIN,
+        "data": {
+            "stable": {
+                "server_port": 8123,
+                "cors_allowed_origins": ["https://cast.home-assistant.io"],
+                "use_x_forwarded_for": True,
+                "trusted_proxies": ["127.0.0.0/8"],
+                "ip_ban_enabled": True,
+                "login_attempts_threshold": -1,
+                "ssl_profile": "modern",
+                "use_x_frame_options": True,
+            },
+            "pending": None,
+            "yaml_migration_done": True,
+        },
+    }
+    assert await async_setup_component(hass, "api", {})
+    client = await hass_client()
+
+    resp = await client.get("/api/", headers={"X-Forwarded-For": "203.0.113.5"})
+
+    assert resp.status == HTTPStatus.OK
+
+
 async def test_proxy_config_only_use_xff(hass: HomeAssistant) -> None:
     """Test use_x_forwarded_for must config together with trusted_proxies."""
     assert (

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -183,24 +183,12 @@ async def test_proxy_config_forwarded_request(
     forwarded middleware with a config loaded from the store to guard against
     passing the strings through instead of IP network objects.
     """
-    hass_storage[DOMAIN] = {
-        "version": 2,
-        "key": DOMAIN,
-        "data": {
-            "stable": {
-                "server_port": 8123,
-                "cors_allowed_origins": ["https://cast.home-assistant.io"],
-                "use_x_forwarded_for": True,
-                "trusted_proxies": ["127.0.0.0/8"],
-                "ip_ban_enabled": True,
-                "login_attempts_threshold": -1,
-                "ssl_profile": "modern",
-                "use_x_frame_options": True,
-            },
-            "pending": None,
-            "yaml_migration_done": True,
-        },
-    }
+    hass_storage[DOMAIN] = _stable_http_storage(
+        {
+            "use_x_forwarded_for": True,
+            "trusted_proxies": ["127.0.0.0/8"],
+        }
+    )
     assert await async_setup_component(hass, "api", {})
     client = await hass_client()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Since #171177 the HTTP configuration is loaded through the config store, whose schema normalizes `trusted_proxies` to strings so the config is JSON-serializable for storage and the WebSocket API. However, the strings were passed straight to the forwarded middleware, which needs `IPv4Network`/`IPv6Network` objects. As a result, any request carrying an `X-Forwarded-For` header from a trusted proxy (e.g. via the NGINX proxy add-on) fails with HTTP 500:

```
TypeError: 'in <string>' requires string as left operand, not IPv4Address
```

This effectively breaks all reverse proxy setups on dev. Before #171177, the config came from the YAML schema which converted trusted proxies with `ip_network`; the removed `start_http_server_and_save_config` converted to strings only when persisting.

This PR converts the stored strings back to `ip_network` objects at the point of consumption in `async_setup`, and corrects the `ConfData` annotation to `list[str]` to reflect what the store actually holds (the incorrect annotation is why mypy did not catch this). A regression test is added which seeds the config store with trusted proxies and performs a request with an `X-Forwarded-For` header; it reproduces the `TypeError` without the fix.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175894
- This PR is related to issue: #171177
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
