### PR TITLE
Bump pyimouapi to 1.3.0

### DIFF
--- a/homeassistant/components/imou/manifest.json
+++ b/homeassistant/components/imou/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["pyimouapi==1.2.8"]
+  "requirements": ["pyimouapi==1.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2245,7 +2245,7 @@ pyialarm==2.2.0
 pyicloud==2.6.5
 
 # homeassistant.components.imou
-pyimouapi==1.2.8
+pyimouapi==1.3.0
 
 # homeassistant.components.insteon
 pyinsteon==1.6.4


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!-- N/A -->

## Proposed change
Bump `pyimouapi` from 1.2.8 to 1.3.0 for the Imou integration.

This is a standalone dependency update to unblock the follow-up sensor platform PR ([#176069](https://github.com/home-assistant/core/pull/176069)).

**Changelog:** https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api/compare/1.2.8...1.3.0
**Release:** https://pypi.org/project/pyimouapi/1.3.0/
**Diff:** https://github.com/Imou-OpenPlatform/Py-Imou-Open-Api/compare/1.2.8...1.3.0

### Upstream changes (1.2.8 → 1.3.0)

**1.2.9**
- `async_set_message_callback` on `ImouOpenApiClient`
- `ImouDeviceSummary` and `async_get_device_summaries` on `ImouDeviceManager`

**1.3.0**
- Sensor `PARAM_STATE` values normalized to `int`/`float` for numeric sensors
- Added `PARAM_STATE_VARIANT` (`numeric` | `enum`) on sensor entries
- Added `pyimouapi.sensor.normalize_sensor_state` and `apply_sensor_state`
- `ha_device.py` routes sensor updates through the new normalization helpers

No breaking API changes for existing Imou platforms (button, camera, switch). Switch/binary-sensor `PARAM_STATE` remains `bool`. Existing Imou integration tests pass without Home Assistant code changes.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: N/A (no user-facing changes in this PR)
- Link to developer documentation pull request:
- Link to frontend pull request:
- Follow-up PR: https://github.com/home-assistant/core/pull/176069

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr