### PR TITLE
Store recovery HTTP config with the full trusted proxy network

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -725,8 +725,11 @@ async def start_http_server_and_save_config(
     )
 
     if CONF_TRUSTED_PROXIES in conf:
+        # Store the full network (address and prefix) so the recovery config
+        # round-trips losslessly; ``network_address`` alone drops the netmask
+        # and would narrow e.g. 10.0.0.0/24 to a single host.
         conf[CONF_TRUSTED_PROXIES] = [
-            str(cast(IPv4Network | IPv6Network, ip).network_address)
+            str(cast(IPv4Network | IPv6Network, ip))
             for ip in conf[CONF_TRUSTED_PROXIES]
         ]
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -490,7 +490,7 @@ async def test_storing_config(
     config = {
         http.CONF_SERVER_PORT: unused_tcp_port_factory(),
         "use_x_forwarded_for": True,
-        "trusted_proxies": ["192.168.1.100"],
+        "trusted_proxies": ["192.168.1.100", "10.0.0.0/24"],
     }
 
     assert await async_setup_component(hass, http.DOMAIN, {http.DOMAIN: config})
@@ -501,7 +501,9 @@ async def test_storing_config(
     await hass.async_block_till_done()
 
     restored = await http.async_get_last_config(hass)
-    restored["trusted_proxies"][0] = ip_network(restored["trusted_proxies"][0])
+    restored["trusted_proxies"] = [
+        ip_network(proxy) for proxy in restored["trusted_proxies"]
+    ]
 
     assert restored == http.HTTP_SCHEMA(config)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The recovery HTTP config saved only the network address of each trusted proxy (`ip.network_address`), dropping the prefix length. A configured network like `10.0.0.0/24` was stored as `10.0.0.0` and read back as `10.0.0.0/32`, so recovery mode narrowed the trusted proxies to a single host and rejected requests from the actual reverse proxy.

This stores the full network (`str(ip)`) so the recovery config round-trips losslessly. The restored value is re-validated through `HTTP_SCHEMA` (which accepts both the bare and masked forms), so this is safe on read back. The config is written on every startup that stays up past the save delay, so an affected instance self-heals the stored value on the next boot with this fix.

This came up while testing #171177 on a setup using the NGINX proxy add-on with its commonly used trusted proxy config `172.30.33.0/24`. The recovery store had persisted it as `172.30.33.0` (later read back as `172.30.33.0/32`), which then carried the mangled value into the new config store's `stable` slot during the v1→v2 migration. Fixing the save here means the stored network is correct before an upgrade to the config store version ever migrates it.

**This fix is for `rc`/stable only and does not apply to `dev`.** On `dev` the whole recovery-save code path (`start_http_server_and_save_config` / `async_get_last_config`) was removed and replaced by the new UI-managed HTTP config store in #171177, so the offending `network_address` line no longer exists there. The store schema on `dev` already persists trusted proxies with their full prefix. No equivalent change is needed on `dev`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
