### PR TITLE
Fast-revert pending HTTP config when the server cannot bind

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -59,7 +59,7 @@ from homeassistant.util.json import json_loads
 
 from .auth import async_setup_auth
 from .ban import setup_bans
-from .config import async_load_config, default_server_port
+from .config import async_get_and_load_store, async_load_config, default_server_port
 from .const import (  # noqa: F401
     CONF_BASE_URL,
     CONF_CORS_ORIGINS,
@@ -256,7 +256,24 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         """Start the server."""
         with async_start_setup(hass, integration="http", phase=SetupPhases.SETUP):
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_server)
-            await server.start()
+            try:
+                await server.start()
+            except HomeAssistantHTTPBindError:
+                # The configured host/port cannot be bound. If we are trialing a
+                # pending (unconfirmed) config it is already known to be
+                # unusable, so revert to the stable config right away instead of
+                # waiting out the auto-revert trial window. A pending config is
+                # only under trial when a revert is scheduled; on the stable
+                # config there is nothing better to try, so we stay up without
+                # an HTTP server.
+                store = await async_get_and_load_store(hass)
+                if store.revert_deadline is not None:
+                    _LOGGER.error(
+                        "Reverting pending HTTP config to stable because the "
+                        "server could not bind to port %d",
+                        server.server_port,
+                    )
+                    await store.async_revert_to_stable_now()
 
     async_when_setup_or_start(hass, "frontend", start_server)
 
@@ -361,6 +378,17 @@ async def _serve_file_with_cache_headers(
 
 async def _serve_file(path: str, request: web.Request) -> web.FileResponse:
     return web.FileResponse(path)
+
+
+class HomeAssistantHTTPBindError(HomeAssistantError):
+    """Error raised when the HTTP server cannot bind to the configured address.
+
+    ``loop.create_server()`` only resolves the host and stands up the listening
+    socket, so any error from it means the configured host/port is unusable
+    (port in use, privileged port, unavailable host, DNS failure, ...). These
+    are permanent for the current config, so a pending config that hits one can
+    be reverted immediately instead of waiting out the trial window.
+    """
 
 
 class HomeAssistantHTTP:
@@ -672,6 +700,9 @@ class HomeAssistantHTTP:
             _LOGGER.error(
                 "Failed to create HTTP server at port %d: %s", self.server_port, error
             )
+            raise HomeAssistantHTTPBindError(
+                f"Could not bind the HTTP server to port {self.server_port}: {error}"
+            ) from error
 
         _LOGGER.info("Now listening on port %d", self.server_port)
 

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -47,6 +47,7 @@ from homeassistant.helpers.http import (
 )
 from homeassistant.helpers.importlib import async_import_module
 from homeassistant.helpers.network import NoURLAvailableError, get_url
+from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.setup import (
     SetupPhases,
@@ -261,19 +262,28 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             except HomeAssistantHTTPBindError:
                 # The configured host/port cannot be bound. If we are trialing a
                 # pending (unconfirmed) config it is already known to be
-                # unusable, so revert to the stable config right away instead of
-                # waiting out the auto-revert trial window. A pending config is
-                # only under trial when a revert is scheduled; on the stable
-                # config there is nothing better to try, so we stay up without
-                # an HTTP server.
+                # unusable, so revert to the stable config instead of waiting
+                # out the auto-revert trial window. A pending config is only
+                # under trial when a revert is scheduled; on the stable config
+                # there is nothing better to try, so we stay up without an HTTP
+                # server.
                 store = await async_get_and_load_store(hass)
                 if store.revert_deadline is not None:
                     _LOGGER.error(
-                        "Reverting pending HTTP config to stable because the "
-                        "server could not bind to port %d",
+                        "Could not bind to port %d; reverting the pending HTTP "
+                        "config to stable once startup has completed",
                         server.server_port,
                     )
-                    await store.async_revert_to_stable_now()
+
+                    async def _revert_to_stable(_hass: HomeAssistant) -> None:
+                        await store.async_revert_to_stable_now()
+
+                    # Defer the revert until Core has started. Restarting during
+                    # startup deadlocks: the restart request queues behind
+                    # Supervisor's Core start job, which only finishes once Core
+                    # is fully started - which is blocked waiting on this very
+                    # request.
+                    async_at_started(hass, _revert_to_stable)
 
     async_when_setup_or_start(hass, "frontend", start_server)
 

--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -345,15 +345,29 @@ class HTTPConfigStore:
         self._revert_deadline = None
 
     async def _async_revert_to_stable(self, _now: datetime) -> None:
-        """Clear the unconfirmed pending config and restart to apply stable."""
-        self._async_cancel_revert()
+        """Revert to stable because the pending trial window expired."""
         if self._pending is None:
+            self._async_cancel_revert()
             return
         _LOGGER.warning(
             "Pending HTTP config was not confirmed within %s; reverting to the "
             "stable config and restarting",
             AUTO_REVERT_DELAY,
         )
+        await self.async_revert_to_stable_now()
+
+    async def async_revert_to_stable_now(self) -> None:
+        """Clear the unconfirmed pending config and restart to apply stable.
+
+        Unlike the scheduled revert, this happens immediately. It is used when
+        the pending config is already known to be unusable (e.g. its port could
+        not be bound), so waiting out the trial window would only delay
+        recovery.
+        """
+        await self.async_load()
+        self._async_cancel_revert()
+        if self._pending is None:
+            return
         self._pending = None
         await self._async_persist()
         # Imported here to avoid a circular import at module load time.

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -25,8 +25,12 @@ from homeassistant.components.http.config import (
     default_server_port,
 )
 from homeassistant.components.http.const import ENV_SETUP_PORT
-from homeassistant.const import HASSIO_USER_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_START,
+    EVENT_HOMEASSISTANT_STARTED,
+    HASSIO_USER_NAME,
+)
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.http import KEY_HASS
 from homeassistant.helpers.network import NoURLAvailableError
@@ -1522,15 +1526,56 @@ async def test_pending_config_reverts_immediately_on_bind_failure(
         await hass.async_start()
         await hass.async_block_till_done()
 
-    # The pending config is dropped and a restart requested right away, without
-    # waiting out AUTO_REVERT_DELAY.
+    # The pending config is dropped and a restart requested once Core has
+    # started, without waiting out AUTO_REVERT_DELAY.
     assert hass_storage["http"]["data"] == {
         "stable": HTTP_STORAGE_SCHEMA({"server_port": 9876}),
         "pending": None,
         "yaml_migration_done": True,
     }
     assert len(restart_calls) == 1
-    assert "could not bind to port 80" in caplog.text
+    assert "reverting the pending HTTP config to stable" in caplog.text
+
+
+async def test_pending_bind_failure_revert_deferred_until_started(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """The revert restart is deferred until Core has started.
+
+    Restarting during bootstrap deadlocks: the restart request queues behind
+    Supervisor's Core start job, which cannot finish until Core is fully
+    started. So the revert must not be issued until EVENT_HOMEASSISTANT_STARTED.
+    """
+    hass_storage["http"] = _stable_http_storage(
+        {"server_port": 9876}, pending={"server_port": 80}
+    )
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+
+    with patch(
+        "asyncio.BaseEventLoop.create_server",
+        side_effect=OSError(errno.EADDRINUSE, "Address already in use"),
+    ):
+        assert await async_setup_component(hass, "http", {})
+
+        # Bootstrap: the server fails to bind, but the revert must not restart
+        # yet - doing so during startup would deadlock.
+        hass.set_state(CoreState.starting)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
+        await hass.async_block_till_done()
+        assert len(restart_calls) == 0
+        assert hass_storage["http"]["data"]["pending"] == HTTP_STORAGE_SCHEMA(
+            {"server_port": 80}
+        )
+
+        # Once Core has started, the revert clears pending and restarts.
+        hass.set_state(CoreState.running)
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert len(restart_calls) == 1
+    assert hass_storage["http"]["data"]["pending"] is None
 
 
 async def test_stable_config_bind_failure_does_not_revert(

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -2,10 +2,12 @@
 
 import asyncio
 from collections.abc import Callable
+import errno
 from http import HTTPStatus
 import logging
 import os
 from pathlib import Path
+import socket
 from typing import Any
 from unittest.mock import ANY, Mock, patch
 
@@ -1475,6 +1477,81 @@ async def test_pending_config_promote_cancels_revert(
 
     assert hass_storage["http"]["data"] == {
         "stable": HTTP_STORAGE_SCHEMA({"server_port": 9999}),
+        "pending": None,
+        "yaml_migration_done": True,
+    }
+    assert len(restart_calls) == 0
+
+
+@pytest.mark.parametrize(
+    "bind_error",
+    [
+        # Port already in use (e.g. taken by another proxy): OSError, errno 98.
+        OSError(errno.EADDRINUSE, "Address already in use"),
+        # Privileged port without CAP_NET_BIND_SERVICE: PermissionError, errno 13.
+        PermissionError(errno.EACCES, "Permission denied"),
+        # Configured host is not a local address: OSError with no errno.
+        OSError("could not bind on any address out of [('10.0.0.1', 80)]"),
+        # Unresolvable host name: gaierror (an OSError subclass), negative errno.
+        socket.gaierror(socket.EAI_NONAME, "Name or service not known"),
+    ],
+    ids=["address-in-use", "permission-denied", "no-bindable-address", "bad-host"],
+)
+async def test_pending_config_reverts_immediately_on_bind_failure(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+    bind_error: OSError,
+) -> None:
+    """A pending config that cannot bind its address reverts without waiting.
+
+    Any failure to stand up the listener (not just ``EADDRINUSE``) is a
+    permanent fault for the current config, so the trial is abandoned at once.
+    """
+    hass_storage["http"] = _stable_http_storage(
+        {"server_port": 9876}, pending={"server_port": 80}
+    )
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+
+    with patch(
+        "asyncio.BaseEventLoop.create_server",
+        side_effect=bind_error,
+    ):
+        assert await async_setup_component(hass, "http", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    # The pending config is dropped and a restart requested right away, without
+    # waiting out AUTO_REVERT_DELAY.
+    assert hass_storage["http"]["data"] == {
+        "stable": HTTP_STORAGE_SCHEMA({"server_port": 9876}),
+        "pending": None,
+        "yaml_migration_done": True,
+    }
+    assert len(restart_calls) == 1
+    assert "could not bind to port 80" in caplog.text
+
+
+async def test_stable_config_bind_failure_does_not_revert(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """A bind failure on the stable config must not clear config or restart."""
+    hass_storage["http"] = _stable_http_storage({"server_port": 80})
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+
+    with patch(
+        "asyncio.BaseEventLoop.create_server",
+        side_effect=OSError(errno.EADDRINUSE, "Address already in use"),
+    ):
+        assert await async_setup_component(hass, "http", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    assert hass_storage["http"]["data"] == {
+        "stable": HTTP_STORAGE_SCHEMA({"server_port": 80}),
         "pending": None,
         "yaml_migration_done": True,
     }


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

Now that the HTTP config is UI-managed, a changed config is applied as a *pending* trial on the next start and only reverts to the last-known-good *stable* config after the five-minute `AUTO_REVERT_DELAY` window elapses without confirmation.

When the configured address simply cannot be bound (for example the user picks a port that is already taken by a proxy), the trial has *already* failed — the server is not listening — yet Home Assistant still waited out the full five minutes before restarting into the stable config. In practice this looks like a long, silent hang after an obvious error:

```
ERROR (MainThread) [homeassistant.components.http] Failed to create HTTP server at port 80: [Errno 98] error while attempting to bind on address ('::', 80, 0, 0): [errno 98] address in use
```

This PR short-circuits that wait:

- `HomeAssistantHTTP.start()` no longer swallows the bind error (it also used to misleadingly log "Now listening on port" afterwards). It now raises a dedicated `HomeAssistantHTTPBindError` from the bind call.
- When a pending config is under trial (a revert is scheduled), `start_server` catches that error and reverts to stable and restarts *immediately* instead of waiting out the window.
- The trigger is scoped to the bind itself. `loop.create_server()` only resolves the host and stands up the listening socket, so any error from it is a permanent fault for the current config. This intentionally covers more than `EADDRINUSE` (errno 98) — a privileged port without `CAP_NET_BIND_SERVICE` raises `PermissionError` (errno 13), an unavailable host yields an errno-less `OSError`, and an unresolvable host raises `socket.gaierror` — all equally permanent, none worth a five-minute wait.
- The **stable** config never fast-reverts, so a genuinely unbindable stable config cannot cause a restart crash-loop; Home Assistant stays up (without an HTTP server) as before.

The soft-failure path (config binds fine but is otherwise bad) is unchanged and still relies on the five-minute auto-revert window.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
