### PR TITLE
Fix flaky remote_calendar coordinator refresh test

### DIFF
--- a/tests/components/remote_calendar/test_calendar.py
+++ b/tests/components/remote_calendar/test_calendar.py
@@ -573,7 +573,7 @@ async def test_coordinator_refresh_updates_upcoming_event_state(
     assert state
     assert state.attributes.get("start_time") == "2026-05-18 06:40:00"
 
-    # Serve the updated calendar and advance the clock to the next update interval.
+    # Advance clock to trigger the next update interval
     route.return_value = Response(status_code=200, text=updated_calendar)
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
     await hass.async_block_till_done()

--- a/tests/components/remote_calendar/test_calendar.py
+++ b/tests/components/remote_calendar/test_calendar.py
@@ -574,8 +574,6 @@ async def test_coordinator_refresh_updates_upcoming_event_state(
     assert state.attributes.get("start_time") == "2026-05-18 06:40:00"
 
     # Serve the updated calendar and advance the clock to the next update interval.
-    # The response is switched after setup so the test does not depend on how many
-    # times the calendar is fetched during startup (see issue #148315).
     route.return_value = Response(status_code=200, text=updated_calendar)
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
     await hass.async_block_till_done()

--- a/tests/components/remote_calendar/test_calendar.py
+++ b/tests/components/remote_calendar/test_calendar.py
@@ -565,13 +565,7 @@ async def test_coordinator_refresh_updates_upcoming_event_state(
         """
     )
     route = respx.get(CALENDER_URL).mock(
-        side_effect=[
-            Response(status_code=200, text=original_calendar),
-            # We currently update the calendar twice on startup, tracked
-            # in issue #148315
-            Response(status_code=200, text=original_calendar),
-            Response(status_code=200, text=updated_calendar),
-        ]
+        return_value=Response(status_code=200, text=original_calendar)
     )
     await setup_integration(hass, config_entry)
 
@@ -579,11 +573,13 @@ async def test_coordinator_refresh_updates_upcoming_event_state(
     assert state
     assert state.attributes.get("start_time") == "2026-05-18 06:40:00"
 
-    # Advance clock to trigger the next update interval
+    # Serve the updated calendar and advance the clock to the next update interval.
+    # The response is switched after setup so the test does not depend on how many
+    # times the calendar is fetched during startup (see issue #148315).
+    route.return_value = Response(status_code=200, text=updated_calendar)
     async_fire_time_changed(hass, dt_util.utcnow() + timedelta(days=1))
     await hass.async_block_till_done()
 
     state = hass.states.get(TEST_ENTITY)
     assert state
     assert state.attributes.get("start_time") == "2026-05-19 08:00:00"
-    assert route.call_count == 3


### PR DESCRIPTION
## Breaking change

## Proposed change

`test_coordinator_refresh_updates_upcoming_event_state` in `tests/components/remote_calendar/test_calendar.py` is flaky.

The test mocked exactly three HTTP responses via `side_effect`, assuming the calendar is fetched **exactly twice** during startup (the double-fetch behavior tracked in #148315):

```python
side_effect=[
    Response(..., text=original_calendar),   # startup fetch #1
    Response(..., text=original_calendar),   # startup fetch #2 (issue #148315)
    Response(..., text=updated_calendar),    # day-advance refresh
]
```

That second startup fetch comes from `async_add_entities([entity], True)`, which triggers a *debounced* `async_request_refresh()`. It is nondeterministic: when startup only fetches once, the day-advance refresh consumes the second `original_calendar` response instead of reaching `updated_calendar`, so the state never updates and the assertion fails:

```
FAILED tests/components/remote_calendar/test_calendar.py::test_coordinator_refresh_updates_upcoming_event_state
  - AssertionError: assert '2026-05-18 06:40:00' == '2026-05-19 08:00:00'
```

Observed in CI: https://github.com/home-assistant/core/actions/runs/29008637667/job/86087116634#step:9:1

The fix switches the mocked response *after* setup completes rather than relying on positional list ordering, making the test independent of how many times the calendar is fetched during startup. The state transition (original → updated) still proves the refresh fetched new data, so the now-fragile `route.call_count == 3` assertion was dropped.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X81swZ7cng7Z5WaueN99kV

---
_Generated by [Claude Code](https://claude.ai/code/session_01X81swZ7cng7Z5WaueN99kV)_