### PR TITLE
Refactor Evohome's storage tests to unit-test TokenManager directly

### DIFF
--- a/tests/components/evohome/test_storage.py
+++ b/tests/components/evohome/test_storage.py
@@ -1,23 +1,29 @@
-"""The tests for evohome storage load & save."""
+"""Tests for evohome token/session storage load & save."""
 
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any, Final, TypedDict
+from unittest.mock import MagicMock, patch
 
-from evohomeasync.auth import SZ_SESSION_ID, SZ_SESSION_ID_EXPIRES
+from evohomeasync.auth import (
+    SZ_SESSION_ID,
+    SZ_SESSION_ID_EXPIRES,
+    AbstractSessionManager,
+)
 from evohomeasync2.auth import (
     SZ_ACCESS_TOKEN,
     SZ_ACCESS_TOKEN_EXPIRES,
     SZ_REFRESH_TOKEN,
+    AbstractTokenManager,
 )
 import pytest
 
 from homeassistant.components.evohome.const import DOMAIN, STORAGE_KEY, STORAGE_VER
-from homeassistant.components.evohome.storage import _TokenStoreT
+from homeassistant.components.evohome.storage import TokenManager, _TokenStoreT
 from homeassistant.const import CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from .conftest import setup_evohome
 from .const import ACCESS_TOKEN, REFRESH_TOKEN, SESSION_ID, USERNAME
 
 
@@ -32,22 +38,26 @@ def dt_pair(dt_dtm: datetime) -> tuple[datetime, str]:
 
 
 ACCESS_TOKEN_EXP_DTM, ACCESS_TOKEN_EXP_STR = dt_pair(dt_util.now() + timedelta(hours=1))
-_, SESSION_ID_EXP_STR = dt_pair(dt_util.now() + timedelta(minutes=15))
+SESSION_ID_EXP_DTM, SESSION_ID_EXP_STR = dt_pair(dt_util.now() - timedelta(hours=1))
+
+USERNAME_DIFF: Final = f"not_{USERNAME}"
+USERNAME_SAME: Final = USERNAME
 
 _TEST_STORAGE_BASE: Final[_TokenStoreT] = {
-    CONF_USERNAME: USERNAME,
+    CONF_USERNAME: USERNAME_SAME,
     SZ_REFRESH_TOKEN: REFRESH_TOKEN,
     SZ_ACCESS_TOKEN: ACCESS_TOKEN,
     SZ_ACCESS_TOKEN_EXPIRES: ACCESS_TOKEN_EXP_STR,
 }
 
-TEST_STORAGE_DATA: Final[dict[str, _TokenStoreT]] = {
+TEST_STORAGE_DATA: Final[dict[str, _TokenStoreT]] = {  # type: ignore[assignment]
     "sans_session_id": _TEST_STORAGE_BASE,
-    "with_session_id": _TEST_STORAGE_BASE
+    "with_session_id": _TEST_STORAGE_BASE | {SZ_SESSION_ID: SESSION_ID},
+    "past_session_id": _TEST_STORAGE_BASE
     | {
         SZ_SESSION_ID: SESSION_ID,
         SZ_SESSION_ID_EXPIRES: SESSION_ID_EXP_STR,
-    },  # pyright: ignore[reportAssignmentType]
+    },
 }
 
 TEST_STORAGE_NULL: Final[dict[str, _EmptyStoreT | None]] = {
@@ -55,124 +65,179 @@ TEST_STORAGE_NULL: Final[dict[str, _EmptyStoreT | None]] = {
     "store_was_reset": {},
 }
 
-DOMAIN_STORAGE_ROOT: Final = {
+DOMAIN_STORAGE_BASE: Final = {
     "version": STORAGE_VER,
     "minor_version": 1,
     "key": STORAGE_KEY,
 }
 
+# Expected session_id in storage after setup, keyed by TEST_STORAGE_DATA entry.
+# A missing or expired cached session is replaced; a valid cached session is kept.
+EXPECTED_SESSION_ID: Final[dict[str, str]] = {
+    "sans_session_id": f"new_{SESSION_ID}",
+    "with_session_id": SESSION_ID,
+    "past_session_id": f"new_{SESSION_ID}",
+}
 
-@pytest.mark.parametrize("install", ["minimal"])
+
+async def _mock_fetch_access_token(self: AbstractTokenManager) -> None:
+    """Set new access-token attrs without making HTTP requests."""
+    self._access_token = f"new_{ACCESS_TOKEN}"
+    self._access_token_expires = dt_util.now() + timedelta(seconds=1800)
+    self._refresh_token = f"new_{REFRESH_TOKEN}"
+
+
+async def _mock_fetch_session_id(self: AbstractSessionManager) -> None:
+    """Set new session-id attrs without making HTTP requests."""
+    self._session_id = f"new_{SESSION_ID}"
+    self._session_id_expires = dt_util.now() + timedelta(minutes=15)
+    self._user_info = {}  # type: ignore[reportAttributeAccessIssue]
+
+
+@contextmanager
+def _mock_token_requests():
+    with (
+        patch.object(
+            AbstractTokenManager, "fetch_access_token", _mock_fetch_access_token
+        ),
+        patch.object(
+            AbstractSessionManager, "fetch_session_id", _mock_fetch_session_id
+        ),
+    ):
+        yield
+
+
+def _make_token_manager(hass: HomeAssistant, username: str = USERNAME) -> TokenManager:
+    return TokenManager(hass, username, "password", MagicMock())
+
+
+async def _exercise(tm: TokenManager) -> None:
+    """Drive the same token/session checks the integration runs at startup."""
+    with _mock_token_requests():
+        await tm.get_access_token()
+        await tm.get_session_id()
+
+
 @pytest.mark.parametrize("idx", TEST_STORAGE_NULL)
 async def test_auth_tokens_null(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    config: dict[str, str],
     idx: str,
-    install: str,
 ) -> None:
     """Test credentials manager when cache is empty."""
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": TEST_STORAGE_NULL[idx]}
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_NULL[idx]}
-
-    async for _ in setup_evohome(hass, config, install=install):
-        pass
+    await _exercise(_make_token_manager(hass))
 
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
     # Confirm the expected tokens were cached to storage...
-    assert data[CONF_USERNAME] == USERNAME
+    assert data[CONF_USERNAME] == USERNAME_SAME
     assert data[SZ_REFRESH_TOKEN] == f"new_{REFRESH_TOKEN}"
     assert data[SZ_ACCESS_TOKEN] == f"new_{ACCESS_TOKEN}"
+    assert (
+        dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES], raise_on_error=True)
+        > dt_util.now()
+    )
 
-    assert (expires := data.get(SZ_ACCESS_TOKEN_EXPIRES)) is not None
-    assert dt_util.parse_datetime(expires, raise_on_error=True) > dt_util.now()
+    # Confirm the expected session id was cached to storage...
+    assert data.get(SZ_SESSION_ID) == f"new_{SESSION_ID}"
+    assert (session_expires := data.get(SZ_SESSION_ID_EXPIRES)) is not None
+    assert dt_util.parse_datetime(session_expires, raise_on_error=True) > dt_util.now()
 
 
-@pytest.mark.parametrize("install", ["minimal"])
 @pytest.mark.parametrize("idx", TEST_STORAGE_DATA)
 async def test_auth_tokens_same(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    config: dict[str, str],
     idx: str,
-    install: str,
 ) -> None:
     """Test credentials manager when cache contains valid data for this user."""
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": TEST_STORAGE_DATA[idx]}
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_DATA[idx]}
-
-    async for _ in setup_evohome(hass, config, install=install):
-        pass
+    await _exercise(_make_token_manager(hass))
 
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
     # Confirm the expected tokens were cached to storage...
-    assert data[CONF_USERNAME] == USERNAME
+    assert data[CONF_USERNAME] == USERNAME_SAME
     assert data[SZ_REFRESH_TOKEN] == REFRESH_TOKEN
     assert data[SZ_ACCESS_TOKEN] == ACCESS_TOKEN
+    assert dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES]) == ACCESS_TOKEN_EXP_DTM
 
-    assert (expires := data[SZ_ACCESS_TOKEN_EXPIRES]) is not None
-    assert dt_util.parse_datetime(expires, raise_on_error=True) == ACCESS_TOKEN_EXP_DTM
+    # Confirm the expected session id was cached to storage...
+    assert data.get(SZ_SESSION_ID) == EXPECTED_SESSION_ID[idx]
 
 
-@pytest.mark.parametrize("install", ["minimal"])
 @pytest.mark.parametrize("idx", TEST_STORAGE_DATA)
 async def test_auth_tokens_past(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    config: dict[str, str],
     idx: str,
-    install: str,
 ) -> None:
     """Test credentials manager when cache contains expired data for this user."""
-
-    # Make this access token have expired in the past...
     _, dt_str = dt_pair(dt_util.now() - timedelta(hours=1))
 
     test_data = TEST_STORAGE_DATA[idx].copy()  # shallow copy is OK here
     test_data[SZ_ACCESS_TOKEN_EXPIRES] = dt_str
 
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": test_data}
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": test_data}
 
-    async for _ in setup_evohome(hass, config, install=install):
-        pass
+    await _exercise(_make_token_manager(hass))
 
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
     # Confirm the expected tokens were cached to storage...
-    assert data[CONF_USERNAME] == USERNAME
+    assert data[CONF_USERNAME] == USERNAME_SAME
     assert data[SZ_REFRESH_TOKEN] == f"new_{REFRESH_TOKEN}"
     assert data[SZ_ACCESS_TOKEN] == f"new_{ACCESS_TOKEN}"
+    assert (
+        dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES], raise_on_error=True)
+        > dt_util.now()
+    )
 
-    assert (expires := data[SZ_ACCESS_TOKEN_EXPIRES]) is not None
-    assert dt_util.parse_datetime(expires, raise_on_error=True) > dt_util.now()
+    # Confirm the expected session id was cached to storage...
+    assert data.get(SZ_SESSION_ID) == EXPECTED_SESSION_ID[idx]
 
 
-@pytest.mark.parametrize("install", ["minimal"])
 @pytest.mark.parametrize("idx", TEST_STORAGE_DATA)
 async def test_auth_tokens_diff(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],
-    config: dict[str, str],
     idx: str,
-    install: str,
 ) -> None:
     """Test credentials manager when cache contains data for a different user."""
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": TEST_STORAGE_DATA[idx]}
 
-    # Make this access token be for a different user...
-    hass_storage[DOMAIN] = DOMAIN_STORAGE_ROOT | {"data": TEST_STORAGE_DATA[idx]}
-    config[CONF_USERNAME] = f"new_{USERNAME}"
-
-    async for _ in setup_evohome(hass, config, install=install):
-        pass
+    await _exercise(_make_token_manager(hass, USERNAME_DIFF))
 
     data: _TokenStoreT = hass_storage[DOMAIN]["data"]
 
     # Confirm the expected tokens were cached to storage...
-    assert data[CONF_USERNAME] == f"new_{USERNAME}"
+    assert data[CONF_USERNAME] == USERNAME_DIFF
     assert data[SZ_REFRESH_TOKEN] == f"new_{REFRESH_TOKEN}"
     assert data[SZ_ACCESS_TOKEN] == f"new_{ACCESS_TOKEN}"
+    assert (
+        dt_util.parse_datetime(data[SZ_ACCESS_TOKEN_EXPIRES], raise_on_error=True)
+        > dt_util.now()
+    )
 
-    assert (expires := data[SZ_ACCESS_TOKEN_EXPIRES]) is not None
-    assert dt_util.parse_datetime(expires, raise_on_error=True) > dt_util.now()
+    # Confirm the expected session id was cached to storage...
+    assert data.get(SZ_SESSION_ID) == f"new_{SESSION_ID}"
+    assert (session_expires := data.get(SZ_SESSION_ID_EXPIRES)) is not None
+    assert dt_util.parse_datetime(session_expires, raise_on_error=True) > dt_util.now()
+
+
+async def test_session_id_loads_store(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test that get_session_id loads the store when called before get_access_token."""
+    hass_storage[DOMAIN] = DOMAIN_STORAGE_BASE | {"data": None}
+
+    tm = _make_token_manager(hass)
+    with _mock_token_requests():
+        await tm.get_session_id()
+
+    data: dict[str, Any] = hass_storage[DOMAIN]["data"]
+    assert data[SZ_SESSION_ID] == f"new_{SESSION_ID}"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR prepares Evohome for the addition of Config Flow.

It exercises `TokenManager` directly (both `get_access_token()` and `get_session_id()` instead of going through a full integration setup (an unnecessary overhead).

This test is now much faster than before, and coverage of `test_storage.py` is extended to 100%.

This PR adds helpers, such as the `_mock_fetch_access_token()` function and the `_mock_token_requests()` context manager, than will be used by tests of config flow in future.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
