### PR TITLE
Migrate cppm_tracker to config flow and ScannerEntity

### DIFF
--- a/homeassistant/components/cppm_tracker/__init__.py
+++ b/homeassistant/components/cppm_tracker/__init__.py
@@ -1,1 +1,22 @@
-"""Add support for ClearPass Policy Manager."""
+"""The Aruba ClearPass (cppm_tracker) integration."""
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import CppmConfigEntry, CppmDataUpdateCoordinator
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: CppmConfigEntry) -> bool:
+    """Set up cppm_tracker from a config entry."""
+    coordinator = CppmDataUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: CppmConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/cppm_tracker/config_flow.py
+++ b/homeassistant/components/cppm_tracker/config_flow.py
@@ -1,0 +1,89 @@
+"""Config flow for the Aruba ClearPass (cppm_tracker) integration."""
+
+import json
+from typing import Any, override
+
+from clearpasspy import ClearPass
+import requests
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_API_KEY, CONF_CLIENT_ID, CONF_HOST
+
+from .const import DOMAIN, GRANT_TYPE
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): str,
+        vol.Required(CONF_CLIENT_ID): str,
+        vol.Required(CONF_API_KEY): str,
+    }
+)
+
+
+def validate_connection(data: dict[str, Any]) -> None:
+    """Validate that we can authenticate against ClearPass."""
+    credentials = {
+        "server": data[CONF_HOST],
+        "grant_type": GRANT_TYPE,
+        "secret": data[CONF_API_KEY],
+        "client": data[CONF_CLIENT_ID],
+    }
+    try:
+        cppm = ClearPass(credentials)
+    except KeyError as err:
+        # clearpasspy reads the access token straight out of the response, so
+        # rejected credentials surface as a missing key.
+        raise InvalidAuth from err
+    except (requests.exceptions.RequestException, json.JSONDecodeError) as err:
+        raise CannotConnect from err
+    if cppm.access_token is None:
+        raise InvalidAuth
+
+
+class CppmConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Aruba ClearPass."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            try:
+                await self.hass.async_add_executor_job(validate_connection, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            else:
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST], data=user_input
+                )
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import a configuration from configuration.yaml."""
+        self._async_abort_entries_match({CONF_HOST: import_data[CONF_HOST]})
+
+        try:
+            await self.hass.async_add_executor_job(validate_connection, import_data)
+        except CannotConnect, InvalidAuth:
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(title=import_data[CONF_HOST], data=import_data)
+
+
+class CannotConnect(Exception):
+    """Error to indicate we cannot connect to ClearPass."""
+
+
+class InvalidAuth(Exception):
+    """Error to indicate the credentials are invalid."""

--- a/homeassistant/components/cppm_tracker/const.py
+++ b/homeassistant/components/cppm_tracker/const.py
@@ -1,0 +1,5 @@
+"""Constants for the Aruba ClearPass (cppm_tracker) integration."""
+
+DOMAIN = "cppm_tracker"
+
+GRANT_TYPE = "client_credentials"

--- a/homeassistant/components/cppm_tracker/coordinator.py
+++ b/homeassistant/components/cppm_tracker/coordinator.py
@@ -1,0 +1,89 @@
+"""DataUpdateCoordinator for the Aruba ClearPass (cppm_tracker) integration."""
+
+from datetime import timedelta
+import json
+import logging
+from typing import override
+
+from clearpasspy import ClearPass
+import requests
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_API_KEY, CONF_CLIENT_ID, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, GRANT_TYPE
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(seconds=120)
+
+ENDPOINT_LIMIT = 100
+
+
+type CppmConfigEntry = ConfigEntry[CppmDataUpdateCoordinator]
+
+
+class CppmDataUpdateCoordinator(DataUpdateCoordinator[set[str]]):
+    """Fetch the online endpoints from an Aruba ClearPass server."""
+
+    config_entry: CppmConfigEntry
+
+    def __init__(self, hass: HomeAssistant, config_entry: CppmConfigEntry) -> None:
+        """Initialize the coordinator from a config entry."""
+        self.host: str = config_entry.data[CONF_HOST]
+        self._credentials = {
+            "server": self.host,
+            "grant_type": GRANT_TYPE,
+            "secret": config_entry.data[CONF_API_KEY],
+            "client": config_entry.data[CONF_CLIENT_ID],
+        }
+        self._cppm: ClearPass | None = None
+
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} - {self.host}",
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    @override
+    async def _async_update_data(self) -> set[str]:
+        """Return the MAC addresses that are currently online."""
+        return await self.hass.async_add_executor_job(self._update)
+
+    def _update(self) -> set[str]:
+        """Query ClearPass for the endpoints that are online right now."""
+        cppm = self._connect()
+        try:
+            endpoints = cppm.get_endpoints(ENDPOINT_LIMIT)["_embedded"]["items"]
+            return {
+                item["mac_address"]
+                for item in endpoints
+                if cppm.online_status(item["mac_address"])
+            }
+        except (KeyError, TypeError, UnboundLocalError) as err:
+            # clearpasspy swallows request failures and then reads an unset
+            # local, so a dropped connection surfaces as one of these.
+            raise UpdateFailed(f"Error querying ClearPass at {self.host}") from err
+
+    def _connect(self) -> ClearPass:
+        """Return an authenticated client, logging in once and caching it."""
+        if self._cppm is not None:
+            return self._cppm
+        try:
+            cppm = ClearPass(self._credentials)
+        except (
+            KeyError,
+            requests.exceptions.RequestException,
+            json.JSONDecodeError,
+        ) as err:
+            # ClearPass authenticates in its constructor; a rejected token
+            # reads as a missing key, a bad host as a request error.
+            raise UpdateFailed(f"Error connecting to ClearPass at {self.host}") from err
+        if cppm.access_token is None:
+            raise UpdateFailed(f"Error connecting to ClearPass at {self.host}")
+        self._cppm = cppm
+        return cppm

--- a/homeassistant/components/cppm_tracker/device_tracker.py
+++ b/homeassistant/components/cppm_tracker/device_tracker.py
@@ -1,25 +1,25 @@
-"""Support for ClearPass Policy Manager."""
+"""Support for Aruba ClearPass Policy Manager."""
 
-from datetime import timedelta
-import logging
 from typing import override
 
-from clearpasspy import ClearPass
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    AsyncSeeCallback,
+    ScannerEntity,
 )
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import CONF_API_KEY, CONF_CLIENT_ID, CONF_HOST
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-SCAN_INTERVAL = timedelta(seconds=120)
-
-GRANT_TYPE = "client_credentials"
+from .const import DOMAIN
+from .coordinator import CppmConfigEntry, CppmDataUpdateCoordinator
 
 PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {
@@ -29,57 +29,89 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     }
 )
 
-_LOGGER = logging.getLogger(__name__)
 
-
-def get_scanner(hass: HomeAssistant, config: ConfigType) -> CPPMDeviceScanner | None:
-    """Initialize Scanner."""
-
-    config = config[DEVICE_TRACKER_DOMAIN]
-
-    data = {
-        "server": config[CONF_HOST],
-        "grant_type": GRANT_TYPE,
-        "secret": config[CONF_API_KEY],
-        "client": config[CONF_CLIENT_ID],
+async def async_setup_scanner(
+    hass: HomeAssistant,
+    config: ConfigType,
+    async_see: AsyncSeeCallback,
+    discovery_info: DiscoveryInfoType | None = None,
+) -> bool:
+    """Import the legacy YAML device tracker into a config entry."""
+    import_data = {
+        CONF_HOST: config[CONF_HOST],
+        CONF_CLIENT_ID: config[CONF_CLIENT_ID],
+        CONF_API_KEY: config[CONF_API_KEY],
     }
-    cppm = ClearPass(data)
-    if cppm.access_token is None:
-        return None
-    _LOGGER.debug("Successfully received Access Token")
-    return CPPMDeviceScanner(cppm)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=import_data
+    )
 
-
-class CPPMDeviceScanner(DeviceScanner):
-    """Initialize class."""
-
-    def __init__(self, cppm):
-        """Initialize class."""
-        self._cppm = cppm
-        self.results = None
-
-    @override
-    def scan_devices(self):
-        """Initialize scanner."""
-        self.get_cppm_data()
-        return [device["mac"] for device in self.results]
-
-    @override
-    def get_device_name(self, device):
-        """Retrieve device name."""
-        return next(
-            (result["name"] for result in self.results if result["mac"] == device), None
+    if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "yaml_import_cannot_connect",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="yaml_import_cannot_connect",
+            translation_placeholders={"host": config[CONF_HOST]},
         )
+        return False
 
-    def get_cppm_data(self):
-        """Retrieve data from Aruba Clearpass and return parsed result."""
-        endpoints = self._cppm.get_endpoints(100)["_embedded"]["items"]
-        devices = []
-        for item in endpoints:
-            if self._cppm.online_status(item["mac_address"]):
-                device = {"mac": item["mac_address"], "name": item["mac_address"]}
-                devices.append(device)
-            else:
-                continue
-        _LOGGER.debug("Devices: %s", devices)
-        self.results = devices
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": "Aruba ClearPass",
+        },
+    )
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: CppmConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the device tracker for a ClearPass config entry."""
+    coordinator = config_entry.runtime_data
+    tracked: set[str] = set()
+
+    @callback
+    def _async_add_new_devices() -> None:
+        new_macs = [mac for mac in coordinator.data if mac not in tracked]
+        tracked.update(new_macs)
+        if new_macs:
+            async_add_entities(CppmScannerEntity(coordinator, mac) for mac in new_macs)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_async_add_new_devices))
+    _async_add_new_devices()
+
+
+class CppmScannerEntity(CoordinatorEntity[CppmDataUpdateCoordinator], ScannerEntity):
+    """Representation of an endpoint tracked by Aruba ClearPass."""
+
+    def __init__(self, coordinator: CppmDataUpdateCoordinator, mac: str) -> None:
+        """Initialize the tracked device."""
+        super().__init__(coordinator)
+        self._mac = mac
+        self._attr_name = mac
+
+    @property
+    @override
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
+
+    @property
+    @override
+    def is_connected(self) -> bool:
+        """Return whether the device is online."""
+        return self._mac in self.coordinator.data

--- a/homeassistant/components/cppm_tracker/manifest.json
+++ b/homeassistant/components/cppm_tracker/manifest.json
@@ -2,8 +2,11 @@
   "domain": "cppm_tracker",
   "name": "Aruba ClearPass",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/cppm_tracker",
+  "integration_type": "hub",
   "iot_class": "local_polling",
+  "loggers": ["clearpasspy"],
   "quality_scale": "legacy",
   "requirements": ["clearpasspy==1.0.2"]
 }

--- a/homeassistant/components/cppm_tracker/strings.json
+++ b/homeassistant/components/cppm_tracker/strings.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "client_id": "Client ID",
+          "api_key": "[%key:common::config_flow::data::api_key%]"
+        },
+        "data_description": {
+          "host": "The hostname or IP address of your ClearPass server.",
+          "client_id": "The OAuth2 client ID configured in ClearPass.",
+          "api_key": "The client secret for the OAuth2 client."
+        }
+      }
+    }
+  },
+  "issues": {
+    "yaml_import_cannot_connect": {
+      "title": "YAML import failed: cannot connect",
+      "description": "The YAML configuration for Aruba ClearPass at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, update your `configuration.yaml` if needed, and restart Home Assistant."
+    }
+  }
+}

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -141,6 +141,7 @@ FLOWS = {
         "control4",
         "cookidoo",
         "coolmaster",
+        "cppm_tracker",
         "cpuspeed",
         "crownstone",
         "cync",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -554,7 +554,7 @@
         },
         "cppm_tracker": {
           "integration_type": "hub",
-          "config_flow": false,
+          "config_flow": true,
           "iot_class": "local_polling",
           "name": "Aruba ClearPass"
         }

--- a/tests/components/cppm_tracker/__init__.py
+++ b/tests/components/cppm_tracker/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Aruba ClearPass (cppm_tracker) integration."""

--- a/tests/components/cppm_tracker/conftest.py
+++ b/tests/components/cppm_tracker/conftest.py
@@ -1,0 +1,63 @@
+"""Fixtures for the Aruba ClearPass (cppm_tracker) integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.cppm_tracker.const import DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_CLIENT_ID, CONF_HOST
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "clearpass.example.com"
+
+MOCK_CONFIG = {
+    CONF_HOST: MOCK_HOST,
+    CONF_CLIENT_ID: "client",
+    CONF_API_KEY: "secret",
+}
+
+MAC_PHONE = "AA:BB:CC:DD:EE:FF"
+MAC_LAPTOP = "11:22:33:44:55:66"
+MAC_OFFLINE = "99:88:77:66:55:44"
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.cppm_tracker.async_setup_entry", return_value=True
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(domain=DOMAIN, data=MOCK_CONFIG, title=MOCK_HOST)
+
+
+@pytest.fixture
+def mock_clearpass() -> Generator[MagicMock]:
+    """Mock the ClearPass client with the raw ClearPass API responses."""
+    with (
+        patch(
+            "homeassistant.components.cppm_tracker.coordinator.ClearPass",
+            autospec=True,
+        ) as mock,
+        patch("homeassistant.components.cppm_tracker.config_flow.ClearPass", new=mock),
+    ):
+        instance = mock.return_value
+        instance.access_token = "token"
+        instance.get_endpoints.return_value = {
+            "_embedded": {
+                "items": [
+                    {"mac_address": MAC_PHONE},
+                    {"mac_address": MAC_LAPTOP},
+                    {"mac_address": MAC_OFFLINE},
+                ]
+            }
+        }
+        instance.online_status.side_effect = lambda mac: mac != MAC_OFFLINE
+        yield mock

--- a/tests/components/cppm_tracker/test_config_flow.py
+++ b/tests/components/cppm_tracker/test_config_flow.py
@@ -1,0 +1,177 @@
+"""Tests for the Aruba ClearPass (cppm_tracker) config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import requests
+
+from homeassistant.components.cppm_tracker.const import DOMAIN
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.const import CONF_API_KEY, CONF_CLIENT_ID, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import MOCK_CONFIG, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+USER_INPUT = {
+    CONF_HOST: MOCK_HOST,
+    CONF_CLIENT_ID: "client",
+    CONF_API_KEY: "secret",
+}
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_clearpass: MagicMock
+) -> None:
+    """Test the user flow creates an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_HOST
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_clearpass: MagicMock
+) -> None:
+    """Test the user flow recovers after a connection error."""
+    mock_clearpass.side_effect = requests.exceptions.ConnectionError
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_clearpass.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "access_token"),
+    [
+        pytest.param(KeyError("access_token"), "token", id="rejected"),
+        pytest.param(None, None, id="no_token"),
+    ],
+)
+async def test_user_flow_invalid_auth(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_clearpass: MagicMock,
+    side_effect: Exception | None,
+    access_token: str | None,
+) -> None:
+    """Test the user flow reports invalid credentials and then recovers."""
+    mock_clearpass.side_effect = side_effect
+    mock_clearpass.return_value.access_token = access_token
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    mock_clearpass.side_effect = None
+    mock_clearpass.return_value.access_token = "token"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=USER_INPUT
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_clearpass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the user flow aborts when the host is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_clearpass: MagicMock
+) -> None:
+    """Test importing a YAML configuration."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == MOCK_HOST
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_clearpass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the import flow aborts when the host is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "access_token"),
+    [
+        pytest.param(requests.exceptions.ConnectionError, "token", id="cannot_connect"),
+        pytest.param(KeyError("access_token"), "token", id="invalid_auth"),
+    ],
+)
+async def test_import_flow_aborts_on_error(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_clearpass: MagicMock,
+    side_effect: Exception,
+    access_token: str | None,
+) -> None:
+    """Test the import flow aborts when ClearPass rejects the configuration."""
+    mock_clearpass.side_effect = side_effect
+    mock_clearpass.return_value.access_token = access_token
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/cppm_tracker/test_device_tracker.py
+++ b/tests/components/cppm_tracker/test_device_tracker.py
@@ -1,0 +1,110 @@
+"""Tests for the Aruba ClearPass (cppm_tracker) device tracker."""
+
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+import requests
+
+from homeassistant.components.cppm_tracker.const import DOMAIN
+from homeassistant.components.cppm_tracker.coordinator import UPDATE_INTERVAL
+from homeassistant.config_entries import SOURCE_IMPORT
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_CLIENT_ID,
+    CONF_HOST,
+    STATE_HOME,
+    STATE_NOT_HOME,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from .conftest import MAC_LAPTOP, MAC_OFFLINE, MAC_PHONE, MOCK_CONFIG, MOCK_HOST
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+YAML_CONFIG = {
+    "device_tracker": [
+        {
+            "platform": DOMAIN,
+            CONF_HOST: MOCK_HOST,
+            CONF_CLIENT_ID: "client",
+            CONF_API_KEY: "secret",
+        }
+    ]
+}
+
+
+async def test_only_online_endpoints_are_tracked(
+    hass: HomeAssistant,
+    mock_clearpass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that only endpoints reported online become tracked entities."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
+    )
+
+    assert {e.unique_id for e in entries} == {MAC_PHONE, MAC_LAPTOP}
+    assert MAC_OFFLINE not in {e.unique_id for e in entries}
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_device_marked_away_when_offline(
+    hass: HomeAssistant,
+    mock_clearpass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a tracked device flips to away once ClearPass reports it offline."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id("device_tracker", DOMAIN, MAC_PHONE)
+    assert hass.states.get(entity_id).state == STATE_HOME
+
+    mock_clearpass.return_value.online_status.side_effect = lambda mac: False
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == STATE_NOT_HOME
+
+
+async def test_setup_scanner_imports_yaml(
+    hass: HomeAssistant, mock_clearpass: MagicMock
+) -> None:
+    """Test the legacy YAML platform imports itself into a config entry."""
+    assert await async_setup_component(hass, "device_tracker", YAML_CONFIG)
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].source == SOURCE_IMPORT
+    assert entries[0].data == MOCK_CONFIG
+
+
+async def test_setup_scanner_creates_issue_on_cannot_connect(
+    hass: HomeAssistant,
+    mock_clearpass: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test a repair issue is raised when the YAML import cannot connect."""
+    mock_clearpass.side_effect = requests.exceptions.ConnectionError
+
+    assert await async_setup_component(hass, "device_tracker", YAML_CONFIG)
+    await hass.async_block_till_done()
+
+    assert not hass.config_entries.async_entries(DOMAIN)
+    issue = issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect")
+    assert issue is not None
+    assert issue.translation_placeholders == {"host": MOCK_HOST}

--- a/tests/components/cppm_tracker/test_init.py
+++ b/tests/components/cppm_tracker/test_init.py
@@ -1,0 +1,85 @@
+"""Tests for the Aruba ClearPass (cppm_tracker) integration setup."""
+
+from unittest.mock import MagicMock
+
+from freezegun.api import FrozenDateTimeFactory
+import pytest
+import requests
+
+from homeassistant.components.cppm_tracker.coordinator import UPDATE_INTERVAL
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "access_token"),
+    [
+        pytest.param(requests.exceptions.ConnectionError, "token", id="cannot_connect"),
+        pytest.param(KeyError("access_token"), "token", id="rejected"),
+        pytest.param(None, None, id="no_token"),
+    ],
+)
+async def test_setup_retry_on_login_failure(
+    hass: HomeAssistant,
+    mock_clearpass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    side_effect: Exception | None,
+    access_token: str | None,
+) -> None:
+    """Test the config entry retries setup when login fails."""
+    mock_clearpass.side_effect = side_effect
+    mock_clearpass.return_value.access_token = access_token
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_retry_on_query_error(
+    hass: HomeAssistant, mock_clearpass: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the config entry retries setup when the endpoint query fails."""
+    mock_clearpass.return_value.get_endpoints.side_effect = KeyError
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_client_authenticates_once(
+    hass: HomeAssistant,
+    mock_clearpass: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the ClearPass client logs in once and is reused across updates."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    freezer.tick(UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_clearpass.call_count == 1
+    assert mock_clearpass.return_value.get_endpoints.call_count == 2
+
+
+async def test_unload_entry(
+    hass: HomeAssistant, mock_clearpass: MagicMock, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test the config entry unloads cleanly."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED


### PR DESCRIPTION
## Proposed change

Moves `cppm_tracker` off the legacy `DeviceScanner` API (#50326) onto a config entry with a coordinator and `ScannerEntity`. YAML still imports, with the usual deprecation notice. Follows the unifi_direct migration (#171991).

`clearpasspy` has no typed exceptions, so error mapping is best-effort. It also logs in once and reuses the client like before, which keeps the old quirk: dead until restart once the token expires. Happy to reset on failure or re-auth each cycle if you'd rather.

ClearPass only returns MACs, so entities are keyed and named by MAC like before.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143026
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
