### PR TITLE
Correct Evohome's validation of system identifiers

### DIFF
--- a/homeassistant/components/evohome/services.py
+++ b/homeassistant/components/evohome/services.py
@@ -101,12 +101,12 @@ def _register_zone_entity_services(hass: HomeAssistant) -> None:
     )
 
 
-def _resolve_ctl_unique_id(
+def _resolve_target_tcs(
     hass: HomeAssistant,
     call: ServiceCall,
-    tcs_id: str,
-) -> str:
-    """Resolve the target controller unique_id from an optional entity_id.
+    tcs: ControlSystem,
+) -> ControlSystem:
+    """Resolve the target controller from an optional entity_id.
 
     During the deprecation window, advise users to switch to targeting the controller.
     """
@@ -119,7 +119,7 @@ def _resolve_ctl_unique_id(
             translation_key="deprecated_controller_service",
             translation_placeholders={"service": call.service},
         )
-        return tcs_id
+        return tcs
 
     entry = er.async_get(hass).async_get(entity_id)
 
@@ -134,7 +134,7 @@ def _resolve_ctl_unique_id(
     if (
         entry.domain != CLIMATE_DOMAIN
         or entry.platform != DOMAIN
-        or entry.unique_id != tcs_id
+        or entry.unique_id != tcs.id
     ):
         raise ServiceValidationError(
             translation_domain=DOMAIN,
@@ -142,7 +142,7 @@ def _resolve_ctl_unique_id(
             translation_placeholders={"service": call.service},
         )
 
-    return tcs_id
+    return tcs
 
 
 def _register_dhw_entity_services(hass: HomeAssistant) -> None:
@@ -241,8 +241,9 @@ def setup_service_functions(
             )
 
         if call.service == EvoService.SET_SYSTEM_MODE:
-            _validate_set_system_mode_params(coordinator.tcs, call.data)
-            unique_id = _resolve_ctl_unique_id(hass, call, coordinator.tcs.id)
+            target_tcs = _resolve_target_tcs(hass, call, coordinator.tcs)
+            _validate_set_system_mode_params(target_tcs, call.data)
+            unique_id = target_tcs.id
         else:
             # this service call to be deprecated, so no need to _resolve_ctl_unique_id
             unique_id = coordinator.tcs.id

--- a/tests/components/evohome/test_services.py
+++ b/tests/components/evohome/test_services.py
@@ -492,6 +492,37 @@ async def test_set_system_mode_entity_not_found(hass: HomeAssistant) -> None:
     }
 
 
+@pytest.mark.parametrize("install", ["default"])
+@pytest.mark.usefixtures("evohome")
+async def test_set_system_mode_resolves_entity_before_validating_mode(
+    hass: HomeAssistant,
+) -> None:
+    """Test the target entity is resolved before mode data is validated.
+
+    Both the entity_id and the mode data are invalid here; entity_not_found must win,
+    proving mode validation runs against the resolved target, not a stale closure-
+    captured one that gets validated before the target is even confirmed to exist.
+    """
+
+    non_existent_entity_id = "climate.non_existent_entity"
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            EvoService.SET_SYSTEM_MODE,
+            {
+                SZ_MODE: "NotARealMode",
+                ATTR_ENTITY_ID: non_existent_entity_id,
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "entity_not_found"
+    assert exc_info.value.translation_placeholders == {
+        ATTR_ENTITY_ID: non_existent_entity_id,
+    }
+
+
 _SET_SYSTEM_MODE_VALIDATOR_PARAMS = [
     (
         {SZ_MODE: "NotARealMode"},


### PR DESCRIPTION


<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR prepares Evohome for the addition of Config Flow.

The `_validate_set_system_mode_params()` was always called against `coordinator.tcs`, separately from `_resolve_ctl_unique_id()` resolving the entity a few lines later. 

This behavior is OK today only since one controller can exist.  In this PR, we resolve the target ControlSystem first and validate against that, so validation and dispatch can't silently diverge once entity-targeting covers multiple controllers.

When config flow id added to Evohome, the intention is for the `location_idx` config parameter to be dropped and Evohome will no longer be limited to a single heating system. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
