### PR TITLE
Sonos - avoid blocking call to get uid

### DIFF
--- a/homeassistant/components/sonos/__init__.py
+++ b/homeassistant/components/sonos/__init__.py
@@ -497,8 +497,21 @@ class SonosDiscoveryManager:
             )
             if not known_speaker:
                 try:
+                    uid = await self.hass.async_add_executor_job(getattr, soco, "uid")
+                except HTTPError as err:
+                    await self._process_http_connection_error(err, ip_addr)
+                    continue
+                except (
+                    OSError,
+                    SoCoException,
+                    Timeout,
+                    TimeoutError,
+                ) as ex:
+                    _LOGGER.warning("Could not get Sonos uid from %s: %s", ip_addr, ex)
+                    continue
+                try:
                     await self._async_handle_discovery_message(
-                        soco.uid,
+                        uid,
                         ip_addr,
                         "manual zone scan",
                     )
@@ -515,7 +528,7 @@ class SonosDiscoveryManager:
                     # Only send the message if the ping was successful.
                     async_dispatcher_send(
                         self.hass,
-                        f"{SONOS_SPEAKER_ACTIVITY}-{soco.uid}",
+                        f"{SONOS_SPEAKER_ACTIVITY}-{known_speaker.uid}",
                         "manual zone scan",
                     )
                 except SonosUpdateError:

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from http import HTTPStatus
+from itertools import chain, repeat
 import logging
 from unittest.mock import Mock, PropertyMock, patch
 
@@ -313,14 +314,6 @@ async def test_async_poll_manual_hosts_uid_oserror(
     soco_1 = soco_factory.cache_mock(_MockSoCoUidError(), "10.10.10.1", "Living Room")
     soco_factory.cache_mock(MockSoCo(), "10.10.10.2", "Bedroom")
     uid = soco_1.uid
-    uid_call_count = 0
-
-    def _uid_side_effect() -> str:
-        nonlocal uid_call_count
-        uid_call_count += 1
-        if uid_call_count == 1:
-            return uid
-        raise OSError("uid unavailable")
 
     with (
         caplog.at_level(logging.WARNING),
@@ -329,7 +322,7 @@ async def test_async_poll_manual_hosts_uid_oserror(
             "uid",
             new_callable=PropertyMock,
             create=True,
-            side_effect=_uid_side_effect,
+            side_effect=chain([uid], repeat(OSError("uid unavailable"))),
         ),
     ):
         await _setup_hass(hass)
@@ -354,21 +347,13 @@ async def test_async_poll_manual_hosts_uid_http_error(
     soco_1 = soco_factory.cache_mock(_MockSoCoUidError(), "10.10.10.1", "Living Room")
     soco_factory.cache_mock(MockSoCo(), "10.10.10.2", "Bedroom")
     uid = soco_1.uid
-    uid_call_count = 0
-
-    def _uid_side_effect() -> str:
-        nonlocal uid_call_count
-        uid_call_count += 1
-        if uid_call_count == 1:
-            return uid
-        raise http_error
 
     with patch.object(
         type(soco_1),
         "uid",
         new_callable=PropertyMock,
         create=True,
-        side_effect=_uid_side_effect,
+        side_effect=chain([uid], repeat(http_error)),
     ):
         await _setup_hass(hass)
 

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -252,6 +252,15 @@ class _MockSoCoVisibleZones(MockSoCo):
         return self.vz_return
 
 
+class _MockSoCoUidError(MockSoCo):
+    """Mock SoCo used for uid property error tests."""
+
+    @property
+    def visible_zones(self):
+        """Return no additional zones without touching uid lookup."""
+        return set()
+
+
 async def _setup_hass(hass: HomeAssistant):
     await async_setup_component(
         hass,
@@ -290,6 +299,88 @@ async def test_async_poll_manual_hosts_1(
             f"Could not get visible Sonos devices from {soco_2.ip_address}"
             not in caplog.text
         )
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def test_async_poll_manual_hosts_uid_oserror(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    entity_registry: er.EntityRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test uid lookup OSError skips host and logs warning."""
+    soco_1 = soco_factory.cache_mock(_MockSoCoUidError(), "10.10.10.1", "Living Room")
+    soco_factory.cache_mock(MockSoCo(), "10.10.10.2", "Bedroom")
+    uid = soco_1.uid
+    uid_call_count = 0
+
+    def _uid_side_effect() -> str:
+        nonlocal uid_call_count
+        uid_call_count += 1
+        if uid_call_count == 1:
+            return uid
+        raise OSError("uid unavailable")
+
+    with (
+        caplog.at_level(logging.WARNING),
+        patch.object(
+            type(soco_1),
+            "uid",
+            new_callable=PropertyMock,
+            create=True,
+            side_effect=_uid_side_effect,
+        ),
+    ):
+        await _setup_hass(hass)
+
+    assert "media_player.bedroom" in entity_registry.entities
+    assert "media_player.living_room" not in entity_registry.entities
+    assert f"Could not get Sonos uid from {soco_1.ip_address}" in caplog.text
+
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+
+async def test_async_poll_manual_hosts_uid_http_error(
+    hass: HomeAssistant,
+    soco_factory: SoCoMockFactory,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test uid lookup HTTPError skips host and creates UPnP issue."""
+    resp = Response()
+    resp.status_code = HTTPStatus.FORBIDDEN
+    http_error = HTTPError(response=resp)
+
+    soco_1 = soco_factory.cache_mock(_MockSoCoUidError(), "10.10.10.1", "Living Room")
+    soco_factory.cache_mock(MockSoCo(), "10.10.10.2", "Bedroom")
+    uid = soco_1.uid
+    uid_call_count = 0
+
+    def _uid_side_effect() -> str:
+        nonlocal uid_call_count
+        uid_call_count += 1
+        if uid_call_count == 1:
+            return uid
+        raise http_error
+
+    with patch.object(
+        type(soco_1),
+        "uid",
+        new_callable=PropertyMock,
+        create=True,
+        side_effect=_uid_side_effect,
+    ):
+        await _setup_hass(hass)
+
+    assert "media_player.bedroom" in entity_registry.entities
+    assert "media_player.living_room" not in entity_registry.entities
+
+    issue_registry = ir.async_get(hass)
+    issue = issue_registry.async_get_issue(
+        sonos.DOMAIN, f"{UPNP_ISSUE_ID}_{soco_1.ip_address}"
+    )
+    assert issue is not None
+    assert issue.translation_placeholders.get("device_ip") == soco_1.ip_address
 
     await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/sonos/test_init.py
+++ b/tests/components/sonos/test_init.py
@@ -339,7 +339,7 @@ async def test_async_poll_manual_hosts_uid_http_error(
     soco_factory: SoCoMockFactory,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test uid lookup HTTPError skips host and creates UPnP issue."""
+    """Test uid lookup HTTPError skips host."""
     resp = Response()
     resp.status_code = HTTPStatus.FORBIDDEN
     http_error = HTTPError(response=resp)
@@ -359,13 +359,6 @@ async def test_async_poll_manual_hosts_uid_http_error(
 
     assert "media_player.bedroom" in entity_registry.entities
     assert "media_player.living_room" not in entity_registry.entities
-
-    issue_registry = ir.async_get(hass)
-    issue = issue_registry.async_get_issue(
-        sonos.DOMAIN, f"{UPNP_ISSUE_ID}_{soco_1.ip_address}"
-    )
-    assert issue is not None
-    assert issue.translation_placeholders.get("device_ip") == soco_1.ip_address
 
     await hass.async_block_till_done(wait_background_tasks=True)
 


### PR DESCRIPTION
## Proposed change

Avoid blocking call in setup that will trigger a runtime error.

I was unable to reproduce the sequence / timing that led to the issue. However, accessing soco.uid when it is not initialized leads to a blocking call.  Access this via an executor.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175800
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
