### PR TITLE
Move script tool-alias logic into the script integration

### DIFF
--- a/homeassistant/components/script/llm.py
+++ b/homeassistant/components/script/llm.py
@@ -34,6 +34,14 @@ class ScriptTool(ActionTool):
         if self.name[0].isdigit():
             self.name = "_" + self.name
 
+        if entity_entry and (
+            aliases := er.async_get_entity_aliases(hass, entity_entry)
+        ):
+            alias_text = "Aliases: " + str(sorted(aliases))
+            self.description = (
+                f"{self.description}. {alias_text}" if self.description else alias_text
+            )
+
 
 @callback
 def async_get_tools(

--- a/homeassistant/helpers/llm.py
+++ b/homeassistant/helpers/llm.py
@@ -9,7 +9,6 @@ import slugify as unicode_slug
 import voluptuous as vol
 from voluptuous_openapi import UNSUPPORTED, convert
 
-from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
 from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_SERVICE,
@@ -26,7 +25,6 @@ from . import (
     area_registry as ar,
     config_validation as cv,
     device_registry as dr,
-    entity_registry as er,
     floor_registry as fr,
     intent,
     selector,
@@ -602,20 +600,6 @@ def _get_cached_action_parameters(
                 schema[key] = cv.string
 
         parameters = vol.Schema(schema)
-
-        if domain == SCRIPT_DOMAIN:
-            entity_registry = er.async_get(hass)
-            if (
-                entity_id := entity_registry.async_get_entity_id(domain, domain, action)
-            ) is not None and (
-                entity_entry := entity_registry.async_get(entity_id)
-            ) is not None:
-                aliases = er.async_get_entity_aliases(hass, entity_entry)
-                if aliases:
-                    if description:
-                        description = description + ". Aliases: " + str(sorted(aliases))
-                    else:
-                        description = "Aliases: " + str(sorted(aliases))
 
         parameters_cache.setdefault(domain, {})[action] = (description, parameters)
 

--- a/tests/components/script/test_llm.py
+++ b/tests/components/script/test_llm.py
@@ -6,7 +6,7 @@ from homeassistant.components import llm as llm_component
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.script import llm as script_llm
 from homeassistant.core import Context, HomeAssistant
-from homeassistant.helpers import llm
+from homeassistant.helpers import entity_registry as er, llm
 from homeassistant.setup import async_setup_component
 
 ENTITY_ID = "script.test_script"
@@ -92,3 +92,15 @@ async def test_script_tool_name_not_started_with_digit(hass: HomeAssistant) -> N
     async_expose_entity(hass, "conversation", "script.123456", True)
     result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
     assert "_123456" in [tool.name for tool in result.tools]
+
+
+async def test_script_tool_description_includes_aliases(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the script tool description is extended with the entity aliases."""
+    entity_registry.async_update_entity(ENTITY_ID, aliases=["barkeep", "pour a drink"])
+    result = await llm_component.async_get_tools(hass, _llm_context(), "assist")
+    tool = next(tool for tool in result.tools if tool.name == "test_script")
+    assert tool.description == (
+        "This is a test script. Aliases: ['barkeep', 'pour a drink']"
+    )

--- a/tests/helpers/test_llm.py
+++ b/tests/helpers/test_llm.py
@@ -861,15 +861,10 @@ async def test_action_tool(
     }
     assert tool.parameters.schema == schema
 
+    # The parameter cache stores the base description; ScriptTool appends aliases.
     assert hass.data[llm.ACTION_PARAMETERS_CACHE]["script"] == {
-        "test_script": (
-            "This is a test script. Aliases: ['script alias', 'script name']",
-            vol.Schema(schema),
-        ),
-        "script_with_no_fields": (
-            "This is another test script. Aliases: ['test script 2']",
-            vol.Schema({}),
-        ),
+        "test_script": ("This is a test script", vol.Schema(schema)),
+        "script_with_no_fields": ("This is another test script", vol.Schema({})),
     }
 
     # Test script with response
@@ -978,14 +973,8 @@ async def test_action_tool(
     assert tool.parameters.schema == schema
 
     assert hass.data[llm.ACTION_PARAMETERS_CACHE]["script"] == {
-        "test_script": (
-            "This is a new test script. Aliases: ['script alias', 'script name']",
-            vol.Schema(schema),
-        ),
-        "script_with_no_fields": (
-            "This is another test script. Aliases: ['test script 2']",
-            vol.Schema({}),
-        ),
+        "test_script": ("This is a new test script", vol.Schema(schema)),
+        "script_with_no_fields": ("This is another test script", vol.Schema({})),
     }
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The description of a script LLM tool is extended with the script entity's aliases (e.g. `... Aliases: ['barkeep']`). This was handled inside the generic `ActionTool` helper in `homeassistant/helpers/llm.py` — `_get_cached_action_parameters` had a `domain == script` special case that reached into the entity registry.

Move that script-specific logic to `ScriptTool` in the `script` integration, where the script entity is already resolved, and drop the special case (and its entity-registry lookup) from the shared helper. `ActionTool` and its parameter cache are now domain-agnostic.

Side effect (an improvement): the parameter cache now stores the base description, and `ScriptTool` appends the aliases each time it is built, so the aliases always reflect the current entity registry instead of whatever was cached when the description was first computed.

Behaviour of the resulting tool description is unchanged.

Note: this overlaps with #176082 (dead-code removal in `helpers/llm.py`); whichever lands first, the other will be rebased.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---
_Generated by [Claude Code](https://claude.ai/code/session_01XBeShjtSna2nRBmvLyrwy1)_