### PR TITLE
Update energieleser to gold quality scale 

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -195,6 +195,7 @@ homeassistant.components.elgato.*
 homeassistant.components.elkm1.*
 homeassistant.components.emulated_hue.*
 homeassistant.components.energenie_power_sockets.*
+homeassistant.components.energieleser.*
 homeassistant.components.energy.*
 homeassistant.components.energyid.*
 homeassistant.components.energyzero.*

--- a/homeassistant/components/energieleser/config_flow.py
+++ b/homeassistant/components/energieleser/config_flow.py
@@ -141,6 +141,44 @@ class EnergieleserConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfiguration flow initialized by the user."""
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            client = EnergieleserClient(
+                host=host, session=async_get_clientsession(self.hass)
+            )
+            try:
+                device = await client.get_device()
+            except EnergieleserConnectionError:
+                errors["base"] = "cannot_connect"
+            except EnergieleserUnknownDeviceError:
+                errors["base"] = "unknown_device_type"
+            except EnergieleserError:
+                errors["base"] = "unknown"
+            else:
+                if device.device_id != entry.data[CONF_DEVICE_ID]:
+                    errors["base"] = "another_device"
+                else:
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates={CONF_HOST: host},
+                    )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_USER_SCHEMA,
+                suggested_values=entry.data | (user_input or {}),
+            ),
+            errors=errors,
+        )
+
     def _create_entry(
         self, host: str, title: str, device_id: str, sw_version: str | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/energieleser/coordinator.py
+++ b/homeassistant/components/energieleser/coordinator.py
@@ -9,11 +9,13 @@ from energieleser import (
     EnergieleserDevice,
     EnergieleserError,
     EnergieleserUnknownDeviceError,
+    StromleserOneDevice,
 )
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER
@@ -77,4 +79,24 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
                     "error": str(err),
                 },
             ) from err
+
+        if isinstance(device, StromleserOneDevice):
+            issue_id = f"pin_locked_{self.config_entry.entry_id}"
+            if getattr(device, "pin_locked", False):
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    issue_id,
+                    is_fixable=False,
+                    is_persistent=False,
+                    learn_more_url="https://docs.energieleser.de/en/docs/stromleser-one/installation/preparation#unlock-meter-in-extended-mode",
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="meter_locked",
+                    translation_placeholders={
+                        "device_name": self.config_entry.title,
+                    },
+                )
+            else:
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+
         return device

--- a/homeassistant/components/energieleser/coordinator.py
+++ b/homeassistant/components/energieleser/coordinator.py
@@ -52,14 +52,29 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
             device = await self.client.get_device()
         except EnergieleserUnknownDeviceError as err:
             raise UpdateFailed(
-                f"Unknown or unsupported device type for {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="unknown_device",
+                translation_placeholders={
+                    "device_id": self.device_id,
+                    "error": str(err),
+                },
             ) from err
         except EnergieleserConnectionError as err:
             raise UpdateFailed(
-                f"Cannot connect to energieleser device {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="connection_error",
+                translation_placeholders={
+                    "device_id": self.device_id,
+                    "error": str(err),
+                },
             ) from err
         except EnergieleserError as err:
             raise UpdateFailed(
-                f"Error communicating with energieleser device {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={
+                    "device_id": self.device_id,
+                    "error": str(err),
+                },
             ) from err
         return device

--- a/homeassistant/components/energieleser/coordinator.py
+++ b/homeassistant/components/energieleser/coordinator.py
@@ -82,7 +82,7 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
 
         if isinstance(device, StromleserOneDevice):
             issue_id = f"pin_locked_{self.config_entry.entry_id}"
-            if getattr(device, "pin_locked", False):
+            if device.pin_locked:
                 ir.async_create_issue(
                     self.hass,
                     DOMAIN,

--- a/homeassistant/components/energieleser/diagnostics.py
+++ b/homeassistant/components/energieleser/diagnostics.py
@@ -1,0 +1,28 @@
+"""Diagnostics support for energieleser."""
+
+import dataclasses
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .coordinator import EnergieleserConfigEntry
+
+TO_REDACT = {CONF_HOST}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: EnergieleserConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+
+    device_data = coordinator.data
+
+    device_data_dict = dataclasses.asdict(device_data)
+
+    return {
+        "info": async_redact_data(entry.data, TO_REDACT),
+        "data": device_data_dict,
+    }

--- a/homeassistant/components/energieleser/manifest.json
+++ b/homeassistant/components/energieleser/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/energieleser",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "quality_scale": "silver",
+  "quality_scale": "gold",
   "requirements": ["energieleser==0.1.4"],
   "zeroconf": [
     {

--- a/homeassistant/components/energieleser/manifest.json
+++ b/homeassistant/components/energieleser/manifest.json
@@ -7,7 +7,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "gold",
-  "requirements": ["energieleser==0.1.4"],
+  "requirements": ["energieleser==0.1.5"],
   "zeroconf": [
     {
       "type": "_stromleser._tcp.local."

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -49,16 +49,16 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: done
   discovery: done
-  docs-data-update: todo
-  docs-examples: todo
-  docs-known-limitations: todo
-  docs-supported-devices: todo
-  docs-supported-functions: todo
-  docs-troubleshooting: todo
-  docs-use-cases: todo
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices: done
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
   dynamic-devices:
     status: exempt
     comment: Each device is a separate config entry; the integration does not add devices on the fly to an existing entry.
@@ -66,10 +66,12 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: todo
-  icon-translations: todo
-  reconfiguration-flow: todo
-  repair-issues: todo
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: done
+  repair-issues:
+    status: exempt
+    comment: This integration doesn't have any cases where raising an issue is needed.
   stale-devices:
     status: exempt
     comment: One device per config entry; the device is removed when the entry is removed.

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -67,7 +67,9 @@ rules:
   entity-disabled-by-default: done
   entity-translations: done
   exception-translations: done
-  icon-translations: done
+  icon-translations:
+    status: exempt
+    comment: Entities rely on device-class and default icons; no custom icon translations are needed.
   reconfiguration-flow: done
   repair-issues: done
   stale-devices:

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -69,9 +69,7 @@ rules:
   exception-translations: done
   icon-translations: done
   reconfiguration-flow: done
-  repair-issues:
-    status: exempt
-    comment: This integration doesn't have any cases where raising an issue is needed.
+  repair-issues: done
   stale-devices:
     status: exempt
     comment: One device per config entry; the device is removed when the entry is removed.

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -103,5 +103,11 @@
     "unknown_device": {
       "message": "Unknown or unsupported device type for {device_id}: {error}"
     }
+  },
+  "issues": {
+    "meter_locked": {
+      "description": "The electricity meter {device_name} is not providing high-resolution data. You need to unlock the meter by entering the PIN provided by your electricity company. See the linked instructions for more details.",
+      "title": "Meter PIN Required"
+    }
   }
 }

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -3,16 +3,28 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser."
     },
     "error": {
+      "another_device": "The device at this IP address does not match the originally configured device.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser."
     },
     "flow_title": "{device_type} · {host}",
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::energieleser::config::step::user::data_description::host%]"
+        },
+        "description": "Update the IP address or hostname of your energieleser device.",
+        "title": "Reconfigure energieleser"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"
@@ -79,6 +91,17 @@
       "water_today_consumption": {
         "name": "Water today"
       }
+    }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "Error communicating with energieleser device {device_id}: {error}"
+    },
+    "connection_error": {
+      "message": "Cannot connect to energieleser device {device_id}: {error}"
+    },
+    "unknown_device": {
+      "message": "Unknown or unsupported device type for {device_id}: {error}"
     }
   }
 }

--- a/mypy.ini
+++ b/mypy.ini
@@ -1707,6 +1707,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.energieleser.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.energy.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -919,7 +919,7 @@ emoji==2.8.0
 emulated-roku==0.3.0
 
 # homeassistant.components.energieleser
-energieleser==0.1.4
+energieleser==0.1.5
 
 # homeassistant.components.huisbaasje
 energyflip-client==0.2.2

--- a/tests/components/energieleser/conftest.py
+++ b/tests/components/energieleser/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for energieleser integration tests."""
 
 from collections.abc import Generator
+from dataclasses import replace
 from unittest.mock import AsyncMock, patch
 
 from energieleser import (
@@ -76,6 +77,14 @@ WASSERLESER_API_RESPONSE: dict = {
 def mock_stromleser_device() -> StromleserOneDevice:
     """Return a parsed stromleser device built from the API fixture."""
     return StromleserOneDevice.from_payload(STROMLESER_API_RESPONSE)
+
+
+@pytest.fixture
+def mock_locked_stromleser_device(
+    mock_stromleser_device: StromleserOneDevice,
+) -> StromleserOneDevice:
+    """Return a stromleser device with PIN locked."""
+    return replace(mock_stromleser_device, pin_locked=True)
 
 
 @pytest.fixture

--- a/tests/components/energieleser/snapshots/test_diagnostics.ambr
+++ b/tests/components/energieleser/snapshots/test_diagnostics.ambr
@@ -20,6 +20,7 @@
       'energy_import_tariff_2': None,
       'energy_import_tariff_3': None,
       'energy_import_tariff_4': None,
+      'pin_locked': False,
       'power_absolute': None,
       'power_active': dict({
         'unit': 'W',

--- a/tests/components/energieleser/snapshots/test_diagnostics.ambr
+++ b/tests/components/energieleser/snapshots/test_diagnostics.ambr
@@ -1,0 +1,50 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'data': dict({
+      'device_id': 'STROM_ONE_8529546829',
+      'device_type': 'stromleser',
+      'energy_export': dict({
+        'unit': 'Wh',
+        'value': 26561.0,
+      }),
+      'energy_export_tariff_1': None,
+      'energy_export_tariff_2': None,
+      'energy_export_tariff_3': None,
+      'energy_export_tariff_4': None,
+      'energy_import': dict({
+        'unit': 'Wh',
+        'value': 12345.0,
+      }),
+      'energy_import_tariff_1': None,
+      'energy_import_tariff_2': None,
+      'energy_import_tariff_3': None,
+      'energy_import_tariff_4': None,
+      'power_absolute': None,
+      'power_active': dict({
+        'unit': 'W',
+        'value': 8.16,
+      }),
+      'power_export': None,
+      'power_import': None,
+      'power_l1': dict({
+        'unit': 'W',
+        'value': 0.0,
+      }),
+      'power_l2': dict({
+        'unit': 'W',
+        'value': 0.0,
+      }),
+      'power_l3': dict({
+        'unit': 'W',
+        'value': 8.16,
+      }),
+      'signal_strength_dbm': -51.0,
+      'timestamp': 1776178480,
+    }),
+    'info': dict({
+      'device_id': 'STROM_ONE_8529546829',
+      'host': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/energieleser/test_config_flow.py
+++ b/tests/components/energieleser/test_config_flow.py
@@ -307,3 +307,90 @@ async def test_zeroconf_flow_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_energieleser_client")
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_stromleser_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful reconfiguration flow."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.102"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_stromleser_config_entry.data[CONF_HOST] == "192.168.1.102"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_another_device(
+    hass: HomeAssistant,
+    mock_stromleser_config_entry: MockConfigEntry,
+    mock_energieleser_client: AsyncMock,
+    mock_gasleser_device: GasleserDevice,
+) -> None:
+    """Test reconfiguration flow with a different device."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    # Return a different device than the configured one
+    mock_energieleser_client.get_device.return_value = mock_gasleser_device
+
+    result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.105"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "another_device"}
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        pytest.param(
+            EnergieleserConnectionError("boom"), "cannot_connect", id="cannot_connect"
+        ),
+        pytest.param(
+            EnergieleserUnknownDeviceError("FOO_0000000001"),
+            "unknown_device_type",
+            id="unknown_device_type",
+        ),
+        pytest.param(
+            EnergieleserError("boom"),
+            "unknown",
+            id="unknown",
+        ),
+    ],
+)
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_stromleser_config_entry: MockConfigEntry,
+    mock_energieleser_client: AsyncMock,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test client errors during reconfiguration flow."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+    mock_energieleser_client.get_device.side_effect = side_effect
+
+    result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.105"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}

--- a/tests/components/energieleser/test_diagnostics.py
+++ b/tests/components/energieleser/test_diagnostics.py
@@ -1,0 +1,30 @@
+"""Test energieleser diagnostics."""
+
+from unittest.mock import AsyncMock
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_energieleser_client: AsyncMock,
+    mock_stromleser_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_stromleser_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(
+        hass, hass_client, mock_stromleser_config_entry
+    )
+
+    assert result == snapshot

--- a/tests/components/energieleser/test_init.py
+++ b/tests/components/energieleser/test_init.py
@@ -6,6 +6,7 @@ from energieleser import (
     EnergieleserConnectionError,
     EnergieleserError,
     EnergieleserUnknownDeviceError,
+    StromleserOneDevice,
 )
 import pytest
 
@@ -13,7 +14,7 @@ from homeassistant.components.energieleser.const import CONF_SW_VERSION, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from .conftest import STROMLESER_DEVICE_ID, STROMLESER_SW_VERSION
 
@@ -89,3 +90,39 @@ async def test_device_exposes_discovery_sw_version(
     )
     assert device is not None
     assert device.sw_version == STROMLESER_SW_VERSION
+
+
+async def test_meter_locked_repair_issue(
+    hass: HomeAssistant,
+    mock_energieleser_client: AsyncMock,
+    mock_stromleser_device: StromleserOneDevice,
+    mock_locked_stromleser_device: StromleserOneDevice,
+    mock_stromleser_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test repair issue is created when meter is locked and deleted when unlocked."""
+    mock_energieleser_client.get_device.return_value = mock_locked_stromleser_device
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_stromleser_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"pin_locked_{mock_stromleser_config_entry.entry_id}"
+    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+    assert issue.translation_key == "meter_locked"
+    assert (
+        issue.learn_more_url
+        == "https://docs.energieleser.de/en/docs/stromleser-one/installation/preparation#unlock-meter-in-extended-mode"
+    )
+    assert issue.translation_placeholders == {
+        "device_name": mock_stromleser_config_entry.title,
+    }
+
+    # Simulate meter unlocking on next update
+    mock_energieleser_client.get_device.return_value = mock_stromleser_device
+    coordinator = mock_stromleser_config_entry.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Raises the `energieleser` integration from **Silver** to **Gold** on the
Integration Quality Scale. 
Added: 
- Reconfigure flow
- Diagnostics
- Exception translations
- Repair issue
- Strict Typing


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/46756
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
