### PR TITLE
Remove unused states_entity_filter from recorder Filters

### DIFF
--- a/homeassistant/components/recorder/filters.py
+++ b/homeassistant/components/recorder/filters.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.entityfilter import CONF_ENTITY_GLOBS
 from homeassistant.helpers.json import json_dumps
 from homeassistant.helpers.typing import ConfigType
 
-from .db_schema import ENTITY_ID_IN_EVENT, OLD_ENTITY_ID_IN_EVENT, States, StatesMeta
+from .db_schema import ENTITY_ID_IN_EVENT, OLD_ENTITY_ID_IN_EVENT, StatesMeta
 
 DOMAIN = "history"
 HISTORY_FILTERS = "history_filters"
@@ -204,19 +204,6 @@ class Filters:
         # - Entity listed in entities include: include
         # - Otherwise: exclude
         return i_entities
-
-    def states_entity_filter(self) -> ColumnElement:
-        """Generate the States.entity_id filter query.
-
-        This is no longer used except by the legacy queries.
-        """
-
-        def _encoder(data: Any) -> Any:
-            """Nothing to encode for states since there is no json."""
-            return data
-
-        # The type annotation should be improved so the type ignore can be removed
-        return self._generate_filter_for_columns((States.entity_id,), _encoder)  # type: ignore[arg-type]
 
     def states_metadata_entity_filter(self) -> ColumnElement:
         """Generate the StatesMeta.entity_id filter query."""

--- a/tests/components/recorder/test_filters.py
+++ b/tests/components/recorder/test_filters.py
@@ -151,12 +151,4 @@ async def test_an_empty_filter_raises() -> None:
             " has_config before calling this method"
         ),
     ):
-        filters.states_entity_filter()
-    with pytest.raises(
-        RuntimeError,
-        match=(
-            "No filter configuration provided, check"
-            " has_config before calling this method"
-        ),
-    ):
         filters.events_entity_filter()


### PR DESCRIPTION
## Breaking change


## Proposed change

`Filters.states_entity_filter` in the recorder was documented as "no longer used except by the legacy queries", but a search of the codebase shows it has no remaining callers at all — the legacy queries no longer reference it. This removes the dead method along with its now-unused `States` import and the test case that exercised it.

The sibling `states_metadata_entity_filter` is still used (e.g. from `logbook/queries/all.py`) and is left untouched.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018wcL7U9FSCvkPeGvSY27kp)_