### PR TITLE
Remove unused hass.data[DOMAIN] from discord

### DIFF
--- a/homeassistant/components/discord/__init__.py
+++ b/homeassistant/components/discord/__init__.py
@@ -37,8 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     finally:
         await discord_bot.close()
 
-    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data
-
     hass.async_create_task(
         discovery.async_load_platform(
             hass, Platform.NOTIFY, DOMAIN, dict(entry.data), hass.data[DATA_HASS_CONFIG]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes the legacy `hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry.data` store from `discord`'s `async_setup_entry`, per the `entry.runtime_data` migration task (#176085, part of home-assistant/epics#43).

Nothing ever reads `hass.data[DOMAIN]` in `discord`: the notify platform receives its configuration via `discovery_info` (`dict(entry.data)` is passed through `discovery.async_load_platform`), and no other module or test consumes the stored value. (`hass.data[DATA_HASS_CONFIG]`, set in `async_setup`, is a different key and out of scope for this rule.) There is therefore no runtime data to move to `entry.runtime_data`; removing the dead store completes the migration for this integration (the `DOMAIN` import stays — it is still used by `CONFIG_SCHEMA` and the discovery call).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #176085
- This PR is related to issue: home-assistant/epics#43
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
