### PR TITLE
Add latitude/longitude to base EntityStateAttribute enum

### DIFF
--- a/homeassistant/components/anthropic/config_flow.py
+++ b/homeassistant/components/anthropic/config_flow.py
@@ -9,7 +9,7 @@ import anthropic
 import voluptuous as vol
 from voluptuous_openapi import convert
 
-from homeassistant.components.zone import ENTITY_ID_HOME, ZoneEntityStateAttribute
+from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntryState,
@@ -18,7 +18,13 @@ from homeassistant.config_entries import (
     ConfigSubentryFlow,
     SubentryFlowResult,
 )
-from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_NAME, CONF_PROMPT
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LLM_HASS_API,
+    CONF_NAME,
+    CONF_PROMPT,
+    EntityStateAttribute,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, llm
 from homeassistant.helpers.selector import (
@@ -562,8 +568,8 @@ class ConversationSubentryFlowHandler(ConfigSubentryFlow):
                     {
                         "role": "user",
                         "content": "Where are the following coordinates located: "
-                        f"({zone_home.attributes[ZoneEntityStateAttribute.LATITUDE]},"
-                        f" {zone_home.attributes[ZoneEntityStateAttribute.LONGITUDE]})?",
+                        f"({zone_home.attributes[EntityStateAttribute.LATITUDE]},"
+                        f" {zone_home.attributes[EntityStateAttribute.LONGITUDE]})?",
                     }
                 ],
                 max_tokens=cast(int, DEFAULT[CONF_MAX_TOKENS]),

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -14,7 +14,7 @@ import voluptuous as vol
 
 from homeassistant import util
 from homeassistant.components import zone
-from homeassistant.components.zone import ENTITY_ID_HOME, ZoneEntityStateAttribute
+from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.config import (
     async_log_schema_error,
     config_per_platform,
@@ -32,6 +32,7 @@ from homeassistant.const import (
     EVENT_HOMEASSISTANT_STOP,
     STATE_HOME,
     STATE_NOT_HOME,
+    EntityStateAttribute,
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -509,8 +510,8 @@ def async_setup_scanner_platform(
             zone_home = hass.states.get(ENTITY_ID_HOME)
             if zone_home is not None:
                 kwargs["gps"] = [
-                    zone_home.attributes[ZoneEntityStateAttribute.LATITUDE],
-                    zone_home.attributes[ZoneEntityStateAttribute.LONGITUDE],
+                    zone_home.attributes[EntityStateAttribute.LATITUDE],
+                    zone_home.attributes[EntityStateAttribute.LONGITUDE],
                 ]
                 kwargs["gps_accuracy"] = 0
 

--- a/homeassistant/components/open_meteo/coordinator.py
+++ b/homeassistant/components/open_meteo/coordinator.py
@@ -13,9 +13,8 @@ from open_meteo import (
     WindSpeedUnit,
 )
 
-from homeassistant.components.zone import ZoneEntityStateAttribute
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_ZONE
+from homeassistant.const import CONF_ZONE, EntityStateAttribute
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -50,8 +49,8 @@ class OpenMeteoDataUpdateCoordinator(DataUpdateCoordinator[Forecast]):
 
         try:
             return await self.open_meteo.forecast(
-                latitude=zone.attributes[ZoneEntityStateAttribute.LATITUDE],
-                longitude=zone.attributes[ZoneEntityStateAttribute.LONGITUDE],
+                latitude=zone.attributes[EntityStateAttribute.LATITUDE],
+                longitude=zone.attributes[EntityStateAttribute.LONGITUDE],
                 current_weather=True,
                 daily=[
                     DailyParameters.PRECIPITATION_SUM,

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -9,7 +9,7 @@ import openai
 import voluptuous as vol
 from voluptuous_openapi import convert
 
-from homeassistant.components.zone import ENTITY_ID_HOME, ZoneEntityStateAttribute
+from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     ConfigEntry,
@@ -19,7 +19,13 @@ from homeassistant.config_entries import (
     ConfigSubentryFlow,
     SubentryFlowResult,
 )
-from homeassistant.const import CONF_API_KEY, CONF_LLM_HASS_API, CONF_NAME, CONF_PROMPT
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_LLM_HASS_API,
+    CONF_NAME,
+    CONF_PROMPT,
+    EntityStateAttribute,
+)
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import llm
 from homeassistant.helpers.httpx_client import get_async_client
@@ -647,8 +653,8 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
                     {
                         "role": "system",
                         "content": "Where are the following coordinates located: "
-                        f"({zone_home.attributes[ZoneEntityStateAttribute.LATITUDE]},"
-                        f" {zone_home.attributes[ZoneEntityStateAttribute.LONGITUDE]})?",
+                        f"({zone_home.attributes[EntityStateAttribute.LATITUDE]},"
+                        f" {zone_home.attributes[EntityStateAttribute.LONGITUDE]})?",
                     }
                 ],
                 text={

--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -31,6 +31,7 @@ from homeassistant.const import (  # noqa: F401
     STATE_HOME,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import (
     Event,
@@ -601,9 +602,9 @@ class Person(
         }
 
         if self._latitude is not None:
-            data[PersonEntityStateAttribute.LATITUDE] = self._latitude
+            data[EntityStateAttribute.LATITUDE] = self._latitude
         if self._longitude is not None:
-            data[PersonEntityStateAttribute.LONGITUDE] = self._longitude
+            data[EntityStateAttribute.LONGITUDE] = self._longitude
         if self._gps_accuracy is not None:
             data[PersonEntityStateAttribute.GPS_ACCURACY] = self._gps_accuracy
         if self._source is not None:

--- a/homeassistant/components/person/const.py
+++ b/homeassistant/components/person/const.py
@@ -12,8 +12,6 @@ class PersonEntityStateAttribute(StrEnum):
     ID = "id"
     DEVICE_TRACKERS = "device_trackers"
     IN_ZONES = "in_zones"
-    LATITUDE = "latitude"
-    LONGITUDE = "longitude"
     GPS_ACCURACY = "gps_accuracy"
     SOURCE = "source"
     USER_ID = "user_id"

--- a/homeassistant/components/zone/__init__.py
+++ b/homeassistant/components/zone/__init__.py
@@ -24,6 +24,7 @@ from homeassistant.const import (  # noqa: F401
     EVENT_CORE_CONFIG_UPDATE,
     SERVICE_RELOAD,
     STATE_UNAVAILABLE,
+    EntityStateAttribute,
 )
 from homeassistant.core import (
     Event,
@@ -149,8 +150,8 @@ def async_in_zones(
                 zone_dist := distance(
                     latitude,
                     longitude,
-                    zone_attrs[ZoneEntityStateAttribute.LATITUDE],
-                    zone_attrs[ZoneEntityStateAttribute.LONGITUDE],
+                    zone_attrs[EntityStateAttribute.LATITUDE],
+                    zone_attrs[EntityStateAttribute.LONGITUDE],
                 )
             )
             is None
@@ -208,8 +209,8 @@ def async_get_enclosing_zones(hass: HomeAssistant, zone_entity_id: str) -> list[
     ):
         return []
     input_attrs = input_zone.attributes
-    input_latitude: float = input_attrs[ZoneEntityStateAttribute.LATITUDE]
-    input_longitude: float = input_attrs[ZoneEntityStateAttribute.LONGITUDE]
+    input_latitude: float = input_attrs[EntityStateAttribute.LATITUDE]
+    input_longitude: float = input_attrs[EntityStateAttribute.LONGITUDE]
     input_radius: float = input_attrs[ZoneEntityStateAttribute.RADIUS]
 
     zones: list[tuple[str, float, float]] = []
@@ -231,8 +232,8 @@ def async_get_enclosing_zones(hass: HomeAssistant, zone_entity_id: str) -> list[
             zone_dist := distance(
                 input_latitude,
                 input_longitude,
-                zone_attrs[ZoneEntityStateAttribute.LATITUDE],
-                zone_attrs[ZoneEntityStateAttribute.LONGITUDE],
+                zone_attrs[EntityStateAttribute.LATITUDE],
+                zone_attrs[EntityStateAttribute.LONGITUDE],
             )
         ) is None:
             continue
@@ -291,8 +292,8 @@ def in_zone(zone: State, latitude: float, longitude: float, radius: float = 0) -
     zone_dist = distance(
         latitude,
         longitude,
-        zone.attributes[ZoneEntityStateAttribute.LATITUDE],
-        zone.attributes[ZoneEntityStateAttribute.LONGITUDE],
+        zone.attributes[EntityStateAttribute.LATITUDE],
+        zone.attributes[EntityStateAttribute.LONGITUDE],
     )
 
     if zone_dist is None or zone.attributes[ZoneEntityStateAttribute.RADIUS] is None:
@@ -520,8 +521,8 @@ class Zone(collection.CollectionEntity):
     def _generate_attrs(self) -> None:
         """Generate new attrs based on config."""
         self._attr_extra_state_attributes = {
-            ZoneEntityStateAttribute.LATITUDE: self._config[CONF_LATITUDE],
-            ZoneEntityStateAttribute.LONGITUDE: self._config[CONF_LONGITUDE],
+            EntityStateAttribute.LATITUDE: self._config[CONF_LATITUDE],
+            EntityStateAttribute.LONGITUDE: self._config[CONF_LONGITUDE],
             ZoneEntityStateAttribute.RADIUS: self._config[CONF_RADIUS],
             ZoneEntityStateAttribute.PASSIVE: self._config[CONF_PASSIVE],
             ZoneEntityStateAttribute.PERSONS: sorted(self._persons_in_zone),

--- a/homeassistant/components/zone/const.py
+++ b/homeassistant/components/zone/const.py
@@ -10,8 +10,6 @@ HOME_ZONE = "home"
 class ZoneEntityStateAttribute(StrEnum):
     """State attributes for zone entities."""
 
-    LATITUDE = "latitude"
-    LONGITUDE = "longitude"
     RADIUS = "radius"
     PASSIVE = "passive"
     PERSONS = "persons"

--- a/homeassistant/const.py
+++ b/homeassistant/const.py
@@ -474,6 +474,8 @@ class EntityStateAttribute(StrEnum):
     ENTITY_PICTURE = "entity_picture"
     FRIENDLY_NAME = "friendly_name"
     ICON = "icon"
+    LATITUDE = "latitude"
+    LONGITUDE = "longitude"
     RESTORED = "restored"
     SUPPORTED_FEATURES = "supported_features"
     UNIT_OF_MEASUREMENT = "unit_of_measurement"

--- a/homeassistant/helpers/location.py
+++ b/homeassistant/helpers/location.py
@@ -3,7 +3,7 @@
 from collections.abc import Iterable
 import logging
 
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE
+from homeassistant.const import EntityStateAttribute
 from homeassistant.core import HomeAssistant, State
 from homeassistant.util import location as location_util
 
@@ -17,8 +17,12 @@ def has_location(state: State) -> bool:
     """
     return (
         isinstance(state, State)
-        and isinstance(state.attributes.get(ATTR_LATITUDE), (float, int))
-        and isinstance(state.attributes.get(ATTR_LONGITUDE), (float, int))
+        and isinstance(
+            state.attributes.get(EntityStateAttribute.LATITUDE), (float, int)
+        )
+        and isinstance(
+            state.attributes.get(EntityStateAttribute.LONGITUDE), (float, int)
+        )
     )
 
 
@@ -36,8 +40,8 @@ def closest(latitude: float, longitude: float, states: Iterable[State]) -> State
         with_location,
         key=lambda state: (
             location_util.distance(
-                state.attributes.get(ATTR_LATITUDE),
-                state.attributes.get(ATTR_LONGITUDE),
+                state.attributes.get(EntityStateAttribute.LATITUDE),
+                state.attributes.get(EntityStateAttribute.LONGITUDE),
                 latitude,
                 longitude,
             )
@@ -124,4 +128,7 @@ def resolve_zone(hass: HomeAssistant, zone_name: str) -> str | None:
 def _get_location_from_attributes(entity_state: State) -> str:
     """Get the lat/long string from an entities attributes."""
     attr = entity_state.attributes
-    return f"{attr.get(ATTR_LATITUDE)},{attr.get(ATTR_LONGITUDE)}"
+    return (
+        f"{attr.get(EntityStateAttribute.LATITUDE)},"
+        f"{attr.get(EntityStateAttribute.LONGITUDE)}"
+    )

--- a/homeassistant/helpers/template/extensions/state.py
+++ b/homeassistant/helpers/template/extensions/state.py
@@ -6,11 +6,10 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
     ATTR_PERSONS,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
     UnitOfLength,
 )
 from homeassistant.core import State, valid_entity_id
@@ -228,8 +227,8 @@ class StateExtension(BaseTemplateExtension):
                 )
                 return None
 
-            latitude = point_state.attributes[ATTR_LATITUDE]
-            longitude = point_state.attributes[ATTR_LONGITUDE]
+            latitude = point_state.attributes[EntityStateAttribute.LATITUDE]
+            longitude = point_state.attributes[EntityStateAttribute.LONGITUDE]
 
             entities = args[1]
 
@@ -308,8 +307,8 @@ class StateExtension(BaseTemplateExtension):
                     )
                     return None
 
-                latitude = point_state.attributes[ATTR_LATITUDE]
-                longitude = point_state.attributes[ATTR_LONGITUDE]
+                latitude = point_state.attributes[EntityStateAttribute.LATITUDE]
+                longitude = point_state.attributes[EntityStateAttribute.LONGITUDE]
 
             locations.append((latitude, longitude))
 

--- a/tests/components/kitchen_sink/snapshots/test_device_tracker.ambr
+++ b/tests/components/kitchen_sink/snapshots/test_device_tracker.ambr
@@ -41,8 +41,8 @@
         <ZoneEntityStateAttribute.EDITABLE: 'editable'>: True,
         <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test home',
         <EntityStateAttribute.ICON: 'icon'>: 'mdi:home',
-        <ZoneEntityStateAttribute.LATITUDE: 'latitude'>: 32.87336,
-        <ZoneEntityStateAttribute.LONGITUDE: 'longitude'>: -117.22743,
+        <EntityStateAttribute.LATITUDE: 'latitude'>: 32.87336,
+        <EntityStateAttribute.LONGITUDE: 'longitude'>: -117.22743,
         <ZoneEntityStateAttribute.PASSIVE: 'passive'>: False,
         <ZoneEntityStateAttribute.PERSONS: 'persons'>: list([
         ]),


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633, which introduced the base `EntityStateAttribute` enum.

`latitude` and `longitude` are generic, cross-domain state attributes (they already live in `homeassistant.const` as `ATTR_LATITUDE` / `ATTR_LONGITUDE`), so this adds them to the base `EntityStateAttribute` enum and routes the reads in `homeassistant/helpers` through the enum:

- `helpers/location.py`: `has_location`, `closest` and `_get_location_from_attributes`
- `helpers/template/extensions/state.py`: the `closest` and `distance` template functions

The `person` and `zone` platform enums added their own `LATITUDE` / `LONGITUDE` members *after* the 2026.7 release branch was cut, so they are still unreleased. Their now-redundant members are removed and their usages repointed to `EntityStateAttribute.LATITUDE` / `EntityStateAttribute.LONGITUDE` (in `zone`, `person`, `open_meteo`, `openai_conversation`, `anthropic` and `device_tracker` legacy).

The `geo_location` and `device_tracker` (`TrackerEntityStateAttribute`) platform members are intentionally left untouched: they already shipped in 2026.7, so they are public API and would need a deprecation path rather than a straight removal.

No behaviour change: these are `StrEnum`s, so the resolved keys are identical.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
