### PR TITLE
Raise ConfigEntryNotReady when Tuya setup hits a network error

### DIFF
--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -81,7 +81,7 @@ class DeviceListener(SharingDeviceListener):
         # Get all devices from Tuya, makes blocking web calls
         try:
             manager.update_device_cache()
-        except requests.exceptions.RequestException as exc:
+        except requests.exceptions.ConnectionError as exc:
             msg = "Unable to connect to Tuya"
             raise ConfigEntryNotReady(msg) from exc
         except Exception as exc:

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 from typing import Any
 
+import requests
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_device_handlers.devices import register_tuya_quirks
 from tuya_sharing import (
@@ -14,7 +15,7 @@ from tuya_sharing import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_send, dispatcher_send
 
@@ -80,6 +81,9 @@ class DeviceListener(SharingDeviceListener):
         # Get all devices from Tuya, makes blocking web calls
         try:
             manager.update_device_cache()
+        except requests.exceptions.RequestException as exc:
+            msg = "Unable to connect to Tuya"
+            raise ConfigEntryNotReady(msg) from exc
         except Exception as exc:
             # While in general, we should avoid catching broad exceptions,
             # we have no other way of detecting this case.

--- a/tests/components/tuya/test_init.py
+++ b/tests/components/tuya/test_init.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from syrupy.assertion import SnapshotAssertion
 from tuya_device_handlers import TUYA_QUIRKS_REGISTRY
 from tuya_sharing import CustomerDevice, Manager
@@ -15,6 +16,7 @@ from homeassistant.components.tuya.const import (
     DOMAIN,
 )
 from homeassistant.components.tuya.diagnostics import _REDACTED_DPCODES
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -369,3 +371,18 @@ async def test_fixtures_valid(hass: HomeAssistant) -> None:
                         f"Please mark `data['status']['{key}']` as `**REDACTED**`"
                         f" in {device_code}.json"
                     )
+
+
+async def test_network_error_retries_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a network error during setup results in a setup retry."""
+    manager = create_manager()
+    manager.update_device_cache.side_effect = requests.exceptions.ConnectionError(
+        "Failed to resolve 'apigw.tuyaeu.com'"
+    )
+
+    await initialize_entry(hass, manager, mock_config_entry, [])
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Tuya setup errors from `manager.update_device_cache()` propagated as unhandled exceptions: only the `sign invalid` case was mapped (to `ConfigEntryAuthFailed`), so starting Home Assistant while the network/DNS was down left the Tuya config entry permanently failed until a manual reload or restart (see the reproduction steps in the issue). 

This maps `requests` transport errors to `ConfigEntryNotReady`, so Home Assistant retries setup automatically and the integration recovers on its own once connectivity returns. The `sign invalid` reauth path is unchanged (the new branch only catches `requests.exceptions.RequestException` and runs first).

Regression test: a `ConnectionError` from `update_device_cache` puts the entry in `SETUP_RETRY`; it fails on the unpatched code (unhandled exception → permanent `SETUP_ERROR`).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #175643
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
