### PR TITLE
Fix SmartThings crash when threeAxis attribute is None

### DIFF
--- a/homeassistant/components/smartthings/sensor.py
+++ b/homeassistant/components/smartthings/sensor.py
@@ -1061,17 +1061,17 @@ CAPABILITY_TO_SENSORS: dict[
             SmartThingsSensorEntityDescription(
                 key="x_coordinate",
                 translation_key="x_coordinate",
-                value_fn=lambda value: value[0],
+                value_fn=lambda value: value[0] if value else None,
             ),
             SmartThingsSensorEntityDescription(
                 key="y_coordinate",
                 translation_key="y_coordinate",
-                value_fn=lambda value: value[1],
+                value_fn=lambda value: value[1] if value else None,
             ),
             SmartThingsSensorEntityDescription(
                 key="z_coordinate",
                 translation_key="z_coordinate",
-                value_fn=lambda value: value[2],
+                value_fn=lambda value: value[2] if value else None,
             ),
         ]
     },

--- a/tests/components/smartthings/test_sensor.py
+++ b/tests/components/smartthings/test_sensor.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 
 from . import (
+    set_attribute_value,
     setup_integration,
     snapshot_smartthings_entities,
     trigger_health_update,
@@ -61,6 +62,28 @@ async def test_state_update(
     )
 
     assert hass.states.get("sensor.theater_ac_office_granit_temperature").state == "20"
+
+
+@pytest.mark.parametrize("device_fixture", ["multipurpose_sensor"])
+async def test_three_axis_none_value(
+    hass: HomeAssistant,
+    devices: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test three axis coordinate sensors handle a None value."""
+    set_attribute_value(devices, Capability.THREE_AXIS, Attribute.THREE_AXIS, None)
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get("sensor.theater_deck_door_x_coordinate").state == (
+        STATE_UNKNOWN
+    )
+    assert hass.states.get("sensor.theater_deck_door_y_coordinate").state == (
+        STATE_UNKNOWN
+    )
+    assert hass.states.get("sensor.theater_deck_door_z_coordinate").state == (
+        STATE_UNKNOWN
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

SmartThings can report `null` for the `threeAxis` attribute of a multipurpose sensor. The X/Y/Z coordinate sensor descriptions index into the value (`value[0]`/`value[1]`/`value[2]`) without checking it is present, so the coordinate entities fail to set up with `TypeError: 'NoneType' object is not subscriptable`.

Guard the three `value_fn`s so the entities report an unknown state instead of crashing, following the same pattern as #171467 which fixed the identical problem for `None` timestamp attributes. A regression test asserts the coordinate sensors report `unknown` when `threeAxis` is `None`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176122
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

> **AI disclosure:** This change was developed with the assistance of Claude (Claude Code). The diagnosis, the guard, and the regression test were reviewed and verified locally, and I can explain every line.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
