### PR TITLE
Set up network integration independently of http

### DIFF
--- a/homeassistant/components/network/manifest.json
+++ b/homeassistant/components/network/manifest.json
@@ -2,7 +2,6 @@
   "domain": "network",
   "name": "Network Configuration",
   "codeowners": ["@home-assistant/core"],
-  "dependencies": ["websocket_api"],
   "documentation": "https://www.home-assistant.io/integrations/network",
   "integration_type": "system",
   "iot_class": "local_push",

--- a/tests/components/network/test_init.py
+++ b/tests/components/network/test_init.py
@@ -608,7 +608,7 @@ async def test_async_get_source_ip_cannot_be_determined_and_no_enabled_addresses
         "homeassistant.components.network.util.ifaddr.get_adapters",
         return_value=[],
     ):
-        assert not await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}})
         await hass.async_block_till_done()
         with pytest.raises(HomeAssistantError):
             await network.async_get_source_ip(hass, MDNS_TARGET_IP)

--- a/tests/components/ssdp/test_init.py
+++ b/tests/components/ssdp/test_init.py
@@ -763,6 +763,11 @@ async def test_bind_failure_skips_adapter(
         if self.source == ("2001:db8::", 0, 0, 1):
             raise OSError
 
+    # The UPnP server needs a presentation URL, which is derived from the
+    # instance URL. In production http is set up before ssdp; set an internal
+    # URL here so get_url() succeeds without relying on http being set up.
+    hass.config.internal_url = "http://10.10.10.10:8123"
+
     SsdpListener.async_start = _async_start
     UpnpServer.async_start = _async_start
     await init_ssdp_component(hass)


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `network` integration declared `websocket_api` as a dependency solely so it could register its configuration websocket commands. Since `websocket_api` depends on `http`, this coupled `network`'s setup to `http` coming up successfully. When `http` fails to set up (for example when the server cannot bind its port), `network` failed to set up as well. The lazily created zeroconf/aiohttp DNS resolver then crashed with `KeyError: 'network'` the moment any integration created a client session, producing confusing tracebacks like the one below for unrelated integrations:

```
File "/usr/src/homeassistant/homeassistant/components/network/network.py", line 30, in async_get_loaded_network
    return hass.data[DATA_NETWORK]
KeyError: 'network'
```

`websocket_api.async_register_command` only writes handlers into `hass.data` and is safe to call whether or not `websocket_api` has been set up yet. `websocket_api` is also part of hassfest's allowed-used-components list, so importing it does not require a manifest dependency. Foundational integrations such as `homeassistant` and `logger` already register websocket commands this way without depending on `websocket_api`.

Dropping the dependency lets `network` set up on its own. An `http` setup failure now degrades gracefully — `network` still loads, so consumers of the shared client session (zeroconf resolver, etc.) keep working, and the boot ends in recovery mode with a clean chain of "Setup failed" messages instead of a `KeyError` crash.

Other integrations like `logger` or `homeassistant` don't have `websocket_api` in their dependencies and register websocket API commands as well.

The existing test `test_async_get_source_ip_cannot_be_determined_and_no_enabled_addresses` previously asserted that `network` setup *fails* in this scenario. That only happened incidentally: `http`, pulled in via the old dependency chain, calls `async_get_source_ip`, which raised when the source IP could not be determined, failing the chain. With the dependency removed, `network` setup correctly succeeds (matching the sibling `test_async_get_source_ip_no_ip_loopback` test); the assertion is updated accordingly. The test's actual intent — that `async_get_source_ip` raises `HomeAssistantError` — is unchanged.

Removing the dependency also removes an incidental transitive http setup that exactly one test relied on: ssdp/test_init.py::test_bind_failure_skips_adapter. ssdp's UPnP server calls get_url(), which needs http; ssdp declares only network and leaned on network → websocket_api → http. In production this doesn't matter (ssdp is stage 1, http is stage 0), and in the bind-failure case ssdp already degrades gracefully (skips the server, keeps the scanner). But the test set ssdp up in isolation and depended on the transitive pull.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
