### PR TITLE
Use core radon device class for Airthings BLE

### DIFF
--- a/homeassistant/components/airthings_ble/const.py
+++ b/homeassistant/components/airthings_ble/const.py
@@ -5,9 +5,6 @@ from airthings_ble import AirthingsDeviceType
 DOMAIN = "airthings_ble"
 MFCT_ID = 820
 
-VOLUME_BECQUEREL = "Bq/m³"
-VOLUME_PICOCURIE = "pCi/L"
-
 DEVICE_MODEL = "device_model"
 
 DEFAULT_SCAN_INTERVAL = 300

--- a/homeassistant/components/airthings_ble/coordinator.py
+++ b/homeassistant/components/airthings_ble/coordinator.py
@@ -14,7 +14,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
-from homeassistant.util.unit_system import METRIC_SYSTEM
 
 from .const import (
     DEFAULT_SCAN_INTERVAL,
@@ -36,9 +35,7 @@ class AirthingsBLEDataUpdateCoordinator(DataUpdateCoordinator[AirthingsDevice]):
 
     def __init__(self, hass: HomeAssistant, entry: AirthingsBLEConfigEntry) -> None:
         """Initialize the coordinator."""
-        self.airthings = AirthingsBluetoothDeviceData(
-            _LOGGER, hass.config.units is METRIC_SYSTEM
-        )
+        self.airthings = AirthingsBluetoothDeviceData(_LOGGER, True)
 
         device_model = entry.data.get(DEVICE_MODEL)
         interval = DEVICE_SPECIFIC_SCAN_INTERVAL.get(

--- a/homeassistant/components/airthings_ble/sensor.py
+++ b/homeassistant/components/airthings_ble/sensor.py
@@ -1,7 +1,6 @@
 """Support for airthings ble sensors."""
 
 from collections.abc import Callable
-import dataclasses
 from dataclasses import dataclass
 import logging
 from typing import override
@@ -19,6 +18,7 @@ from homeassistant.const import (
     EntityCategory,
     Platform,
     UnitOfPressure,
+    UnitOfRadiationConcentration,
     UnitOfRatio,
     UnitOfSoundPressure,
     UnitOfTemperature,
@@ -33,9 +33,8 @@ from homeassistant.helpers.entity_registry import (
 )
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util.unit_system import METRIC_SYSTEM
 
-from .const import DOMAIN, VOLUME_BECQUEREL, VOLUME_PICOCURIE
+from .const import DOMAIN
 from .coordinator import AirthingsBLEConfigEntry, AirthingsBLEDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -65,14 +64,20 @@ SENSORS_MAPPING_TEMPLATE: dict[str, AirthingsBLESensorEntityDescription] = {
     "radon_1day_avg": AirthingsBLESensorEntityDescription(
         key="radon_1day_avg",
         translation_key="radon_1day_avg",
-        native_unit_of_measurement=VOLUME_BECQUEREL,
+        device_class=SensorDeviceClass.RADON,
+        native_unit_of_measurement=(
+            UnitOfRadiationConcentration.BECQUEREL_PER_CUBIC_METER
+        ),
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     "radon_longterm_avg": AirthingsBLESensorEntityDescription(
         key="radon_longterm_avg",
         translation_key="radon_longterm_avg",
-        native_unit_of_measurement=VOLUME_BECQUEREL,
+        device_class=SensorDeviceClass.RADON,
+        native_unit_of_measurement=(
+            UnitOfRadiationConcentration.BECQUEREL_PER_CUBIC_METER
+        ),
         suggested_display_precision=0,
         state_class=SensorStateClass.MEASUREMENT,
     ),
@@ -210,26 +215,12 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the Airthings BLE sensors."""
-    is_metric = hass.config.units is METRIC_SYSTEM
-
     coordinator = entry.runtime_data
-
-    # we need to change some units
-    sensors_mapping = SENSORS_MAPPING_TEMPLATE.copy()
-    if not is_metric:
-        for key, val in sensors_mapping.items():
-            if val.native_unit_of_measurement is not VOLUME_BECQUEREL:
-                continue
-            sensors_mapping[key] = dataclasses.replace(
-                val,
-                native_unit_of_measurement=VOLUME_PICOCURIE,
-                suggested_display_precision=1,
-            )
 
     entities = []
     _LOGGER.debug("got sensors: %s", coordinator.data.sensors)
     for sensor_type, sensor_value in coordinator.data.sensors.items():
-        if sensor_type not in sensors_mapping:
+        if sensor_type not in SENSORS_MAPPING_TEMPLATE:
             _LOGGER.debug(
                 "Unknown sensor type detected: %s, %s",
                 sensor_type,
@@ -238,7 +229,11 @@ async def async_setup_entry(
             continue
         async_migrate(hass, coordinator.data.address, sensor_type)
         entities.append(
-            AirthingsSensor(coordinator, coordinator.data, sensors_mapping[sensor_type])
+            AirthingsSensor(
+                coordinator,
+                coordinator.data,
+                SENSORS_MAPPING_TEMPLATE[sensor_type],
+            )
         )
 
     async_add_entities(entities)

--- a/tests/components/airthings_ble/test_sensor.py
+++ b/tests/components/airthings_ble/test_sensor.py
@@ -14,9 +14,15 @@ from homeassistant.components.airthings_ble.const import (
     DEVICE_SPECIFIC_SCAN_INTERVAL,
     DOMAIN,
 )
-from homeassistant.const import STATE_UNKNOWN, Platform
+from homeassistant.components.airthings_ble.coordinator import (
+    AirthingsBLEDataUpdateCoordinator,
+)
+from homeassistant.components.airthings_ble.sensor import SENSORS_MAPPING_TEMPLATE
+from homeassistant.components.sensor import SensorDeviceClass
+from homeassistant.const import STATE_UNKNOWN, Platform, UnitOfRadiationConcentration
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from . import (
     CO2_V1,
@@ -290,6 +296,32 @@ async def test_translation_keys_wave_enhance(
 
     expected_name = f"Airthings Wave Enhance (123456) {expected_sensor_name}"
     assert state.attributes.get("friendly_name") == expected_name
+
+
+def test_radon_uses_core_device_class(
+    hass: HomeAssistant,
+) -> None:
+    """Test that BLE radon sensors expose core radon metadata."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+
+    coordinator = AirthingsBLEDataUpdateCoordinator(
+        hass,
+        MockConfigEntry(domain=DOMAIN, unique_id=WAVE_SERVICE_INFO.address, data={}),
+    )
+
+    for key in ("radon_1day_avg", "radon_longterm_avg"):
+        description = SENSORS_MAPPING_TEMPLATE[key]
+        assert description.device_class == SensorDeviceClass.RADON
+        assert (
+            description.native_unit_of_measurement
+            == UnitOfRadiationConcentration.BECQUEREL_PER_CUBIC_METER
+        )
+
+    assert coordinator.airthings.is_metric is True
+    assert (
+        SENSORS_MAPPING_TEMPLATE["radon_1day_avg"].native_unit_of_measurement
+        != UnitOfRadiationConcentration.PICOCURIES_PER_LITER
+    )
 
 
 async def test_disabled_connectivity_mode_corentium_home_2(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR updates the `airthings_ble` integration to use Home Assistant's core radon unit support added in #175135.

Instead of having the BLE integration and the upstream BLE library convert radon values based on Home Assistant's unit system, the integration now:

- exposes radon average sensors in their native unit, `Bq/m³`
- marks those sensors as `SensorDeviceClass.RADON`
- relies on Home Assistant core to convert/display `pCi/L` when needed

This aligns `airthings_ble` with the already-merged `airthings` cloud integration change and removes the custom radon unit handling from the BLE path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #113912
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:
- Related core support: #175135
- Related cloud follow-up: #166087
- Local verification run for this PR:
  - `./.venv/bin/python -m pytest -q tests/components/airthings_ble/test_sensor.py`
  - `./.venv/bin/python -m ruff check homeassistant/components/airthings_ble/coordinator.py homeassistant/components/airthings_ble/const.py homeassistant/components/airthings_ble/sensor.py tests/components/airthings_ble/test_sensor.py`
  - `./.venv/bin/python -m ruff format --check homeassistant/components/airthings_ble/coordinator.py homeassistant/components/airthings_ble/const.py homeassistant/components/airthings_ble/sensor.py tests/components/airthings_ble/test_sensor.py`

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
