### PR TITLE
Include ConnectError in Ollama config flow

### DIFF
--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -118,7 +118,7 @@ class OllamaConfigFlow(ConfigFlow, domain=DOMAIN):
                     str(err),
                 )
                 errors["base"] = "unknown"
-        except TimeoutError, httpx.ConnectError, ConnectionError:
+        except TimeoutError, ConnectionError:
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")
@@ -278,7 +278,7 @@ class OllamaSubentryFlowHandler(ConfigSubentryFlow):
                 downloaded_models: set[str] = {
                     model_info["model"] for model_info in response.get("models", [])
                 }
-            except TimeoutError, httpx.ConnectError, httpx.HTTPError, ConnectionError:
+            except TimeoutError, httpx.HTTPError, ConnectionError:
                 _LOGGER.exception("Failed to get models from Ollama server")
                 return self.async_abort(reason="cannot_connect")
 

--- a/homeassistant/components/ollama/config_flow.py
+++ b/homeassistant/components/ollama/config_flow.py
@@ -118,7 +118,7 @@ class OllamaConfigFlow(ConfigFlow, domain=DOMAIN):
                     str(err),
                 )
                 errors["base"] = "unknown"
-        except TimeoutError, httpx.ConnectError:
+        except TimeoutError, httpx.ConnectError, ConnectionError:
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")
@@ -278,7 +278,7 @@ class OllamaSubentryFlowHandler(ConfigSubentryFlow):
                 downloaded_models: set[str] = {
                     model_info["model"] for model_info in response.get("models", [])
                 }
-            except TimeoutError, httpx.ConnectError, httpx.HTTPError:
+            except TimeoutError, httpx.ConnectError, httpx.HTTPError, ConnectionError:
                 _LOGGER.exception("Failed to get models from Ollama server")
                 return self.async_abort(reason="cannot_connect")
 

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -438,6 +438,7 @@ async def test_reauth_flow_errors(hass: HomeAssistant, side_effect, error) -> No
     ("side_effect", "error"),
     [
         (ConnectError(message=""), "cannot_connect"),
+        (ConnectionError("Failed to connect to Ollama"), "cannot_connect"),
         (RuntimeError(), "unknown"),
     ],
 )
@@ -513,15 +514,23 @@ async def test_form_invalid_url(hass: HomeAssistant) -> None:
     assert result2["errors"] == {"base": "invalid_url"}
 
 
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        ConnectError("Connection failed"),
+        ConnectionError("Failed to connect to Ollama"),
+    ],
+)
 async def test_subentry_connection_error(
     hass: HomeAssistant,
     mock_init_component,
     mock_config_entry: MockConfigEntry,
+    side_effect: Exception,
 ) -> None:
     """Test subentry creation when connection to Ollama server fails."""
     with patch(
         "ollama.AsyncClient.list",
-        side_effect=ConnectError("Connection failed"),
+        side_effect=side_effect,
     ):
         new_flow = await hass.config_entries.subentries.async_init(
             (mock_config_entry.entry_id, "conversation"),

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -517,6 +517,7 @@ async def test_form_invalid_url(hass: HomeAssistant) -> None:
 @pytest.mark.parametrize(
     "side_effect",
     [
+        TimeoutError(),
         ConnectError("Connection failed"),
         ConnectionError("Failed to connect to Ollama"),
     ],

--- a/tests/components/ollama/test_config_flow.py
+++ b/tests/components/ollama/test_config_flow.py
@@ -3,7 +3,7 @@
 import asyncio
 from unittest.mock import ANY, AsyncMock, patch
 
-from httpx import ConnectError
+from httpx import HTTPError
 from ollama import ResponseError
 import pytest
 
@@ -378,7 +378,8 @@ async def test_reauth_flow_success(
     ("side_effect", "error"),
     [
         (ResponseError(error="Unauthorized", status_code=401), "invalid_auth"),
-        (ConnectError(message="Connection failed"), "cannot_connect"),
+        (ConnectionError("Connection failed"), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
     ],
 )
 async def test_reauth_flow_errors(hass: HomeAssistant, side_effect, error) -> None:
@@ -437,8 +438,8 @@ async def test_reauth_flow_errors(hass: HomeAssistant, side_effect, error) -> No
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [
-        (ConnectError(message=""), "cannot_connect"),
         (ConnectionError("Failed to connect to Ollama"), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
         (RuntimeError(), "unknown"),
     ],
 )
@@ -463,7 +464,8 @@ async def test_form_errors(hass: HomeAssistant, side_effect, error) -> None:
 @pytest.mark.parametrize(
     ("side_effect", "error"),
     [
-        (ConnectError(message=""), "cannot_connect"),
+        (ConnectionError(), "cannot_connect"),
+        (TimeoutError(), "cannot_connect"),
         (RuntimeError(), "unknown"),
     ],
 )
@@ -518,8 +520,8 @@ async def test_form_invalid_url(hass: HomeAssistant) -> None:
     "side_effect",
     [
         TimeoutError(),
-        ConnectError("Connection failed"),
         ConnectionError("Failed to connect to Ollama"),
+        HTTPError("HTTP error"),
     ],
 )
 async def test_subentry_connection_error(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Uses correct error message for `ConnectionError` in the `ollama` integration. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175432
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
