### PR TITLE
Add party mode image platform to music_assistant

### DIFF
--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -289,6 +289,9 @@ async def async_setup_entry(  # noqa: C901
         ):
             current_instance_id = current_party_provider.instance_id
 
+        if not current_instance_id:
+            return
+
         if party_mode_state["instance_id"] != current_instance_id:
             old_instance_id = party_mode_state["instance_id"]
             party_mode_state["instance_id"] = current_instance_id
@@ -309,8 +312,7 @@ async def async_setup_entry(  # noqa: C901
                             device.id, remove_config_entry_id=entry.entry_id
                         )
 
-            if current_instance_id:
-                add_party_mode(current_instance_id)
+            add_party_mode(current_instance_id)
 
     entry.async_on_unload(
         mass.subscribe(handle_providers_updated, EventType.PROVIDERS_UPDATED)

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -29,6 +29,7 @@ from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
     ConfigEntryError,
     ConfigEntryNotReady,
+    HomeAssistantError,
 )
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -39,7 +40,7 @@ from homeassistant.helpers.issue_registry import (
 )
 
 from .const import ATTR_CONF_EXPOSE_PLAYER_TO_HA, DOMAIN, LOGGER
-from .helpers import get_music_assistant_client
+from .helpers import get_music_assistant_client, get_party_device_id
 from .services import register_actions
 
 if TYPE_CHECKING:
@@ -49,6 +50,7 @@ if TYPE_CHECKING:
 
 PLATFORMS = [
     Platform.BUTTON,
+    Platform.IMAGE,
     Platform.MEDIA_PLAYER,
     Platform.NUMBER,
     Platform.SELECT,
@@ -73,6 +75,7 @@ class MusicAssistantEntryData:
     listen_task: asyncio.Task
     discovered_players: set[str] = field(default_factory=set)
     platform_handlers: dict[Platform, PlayerAddCallback] = field(default_factory=dict)
+    party_handlers: dict[Platform, Callable[[str], None]] = field(default_factory=dict)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -245,12 +248,73 @@ async def async_setup_entry(  # noqa: C901
     player_ids = {player.player_id for player in all_player_configs}
     dev_reg = dr.async_get(hass)
     dev_entries = dr.async_entries_for_config_entry(dev_reg, entry.entry_id)
+
+    party_provider = mass.get_provider("party")
+    party_device_id = None
+    party_instance_id = None
+    if party_provider and isinstance(party_provider.instance_id, str):
+        party_instance_id = party_provider.instance_id
+        assert mass.server_info is not None
+        party_device_id = get_party_device_id(
+            mass.server_info.server_id, party_instance_id
+        )
+
     for device in dev_entries:
         for identifier in device.identifiers:
-            if identifier[0] == DOMAIN and identifier[1] not in player_ids:
+            if (
+                identifier[0] == DOMAIN
+                and identifier[1] not in player_ids
+                and identifier[1] != party_device_id
+            ):
                 dev_reg.async_update_device(
                     device.id, remove_config_entry_id=entry.entry_id
                 )
+
+    party_mode_state = {"instance_id": party_instance_id}
+
+    def add_party_mode(instance_id: str) -> None:
+        """Handle adding Party Mode as HA device + entities."""
+        for callback in entry.runtime_data.party_handlers.values():
+            callback(instance_id)
+
+    if party_instance_id:
+        add_party_mode(party_instance_id)
+
+    def handle_providers_updated(event: MassEvent) -> None:
+        """Handle Mass Providers Updated event."""
+        current_party_provider = mass.get_provider("party")
+        current_instance_id = None
+        if current_party_provider and isinstance(
+            current_party_provider.instance_id, str
+        ):
+            current_instance_id = current_party_provider.instance_id
+
+        if party_mode_state["instance_id"] != current_instance_id:
+            old_instance_id = party_mode_state["instance_id"]
+            party_mode_state["instance_id"] = current_instance_id
+
+            if old_instance_id:
+                assert mass.server_info is not None
+                old_device_id = get_party_device_id(
+                    mass.server_info.server_id, old_instance_id
+                )
+                for device in dr.async_entries_for_config_entry(
+                    dev_reg, entry.entry_id
+                ):
+                    if any(
+                        identifier[0] == DOMAIN and identifier[1] == old_device_id
+                        for identifier in device.identifiers
+                    ):
+                        dev_reg.async_update_device(
+                            device.id, remove_config_entry_id=entry.entry_id
+                        )
+
+            if current_instance_id:
+                add_party_mode(current_instance_id)
+
+    entry.async_on_unload(
+        mass.subscribe(handle_providers_updated, EventType.PROVIDERS_UPDATED)
+    )
 
     return True
 
@@ -311,6 +375,17 @@ async def async_remove_config_entry_device(
         # this should not be possible at all, but guard it anyways
         return False
     mass = get_music_assistant_client(hass, config_entry.entry_id)
+    party_provider = mass.get_provider("party")
+    if party_provider:
+        assert mass.server_info is not None
+        if player_id == get_party_device_id(
+            mass.server_info.server_id, party_provider.instance_id
+        ):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="party_mode_active_device_removal",
+            )
+
     if mass.players.get(player_id) is None:
         # player is already removed on the server, this is an orphaned device
         return True

--- a/homeassistant/components/music_assistant/const.py
+++ b/homeassistant/components/music_assistant/const.py
@@ -1,9 +1,12 @@
 """Constants for Music Assistant Component."""
 
+from datetime import timedelta
 import logging
 
 DOMAIN = "music_assistant"
 DOMAIN_EVENT = f"{DOMAIN}_event"
+
+PARTY_URL_POLL_INTERVAL = timedelta(minutes=10)
 
 DEFAULT_NAME = "Music Assistant"
 

--- a/homeassistant/components/music_assistant/entity.py
+++ b/homeassistant/components/music_assistant/entity.py
@@ -1,6 +1,6 @@
 """Base entity model."""
 
-from typing import TYPE_CHECKING, override
+from typing import TYPE_CHECKING, Any, override
 
 from music_assistant_models.enums import EventType
 from music_assistant_models.event import MassEvent
@@ -11,6 +11,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN
+from .helpers import get_party_device_id, get_party_device_info
 
 if TYPE_CHECKING:
     from music_assistant_client import MusicAssistantClient
@@ -129,3 +130,53 @@ class MusicAssistantPlayerOptionEntity(MusicAssistantEntity):
 
     def on_player_option_update(self, player_option: PlayerOption) -> None:
         """Callback for player option updates."""
+
+
+class MusicAssistantPartyModeEntity(Entity):
+    """Base Entity for Music Assistant Party Mode."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        unique_id_suffix: str,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize MusicAssistantPartyModeEntity."""
+        super().__init__(**kwargs)
+        self.mass = mass
+        self.instance_id = instance_id
+        assert mass.server_info is not None
+        server_id = mass.server_info.server_id
+        self._attr_device_info = get_party_device_info(server_id, instance_id)
+        self._attr_unique_id = (
+            f"{get_party_device_id(server_id, instance_id)}_{unique_id_suffix}"
+        )
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await self.async_on_update()
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.PROVIDERS_UPDATED,
+            )
+        )
+        self.async_on_remove(
+            self.mass.subscribe(
+                self.__on_mass_update,
+                EventType.CORE_STATE_UPDATED,
+            )
+        )
+
+    async def __on_mass_update(self, event: MassEvent) -> None:
+        """Call when we receive an event from MusicAssistant."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    async def async_on_update(self) -> None:
+        """Handle provider updates."""

--- a/homeassistant/components/music_assistant/helpers.py
+++ b/homeassistant/components/music_assistant/helpers.py
@@ -9,6 +9,9 @@ from music_assistant_models.errors import MusicAssistantError
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.device_registry import DeviceInfo
+
+from .const import DOMAIN
 
 if TYPE_CHECKING:
     from music_assistant_client import MusicAssistantClient
@@ -62,3 +65,17 @@ async def async_resolve_mass_username(
     if username in available_usernames:
         return username
     return None
+
+
+def get_party_device_id(server_id: str, instance_id: str) -> str:
+    """Return composite device ID for Party Mode."""
+    return f"{server_id}_{instance_id}"
+
+
+def get_party_device_info(server_id: str, instance_id: str) -> DeviceInfo:
+    """Return device info for Party Mode."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, get_party_device_id(server_id, instance_id))},
+        name="Party Mode Plugin",
+        manufacturer="Music Assistant",
+    )

--- a/homeassistant/components/music_assistant/icons.json
+++ b/homeassistant/components/music_assistant/icons.json
@@ -4,6 +4,11 @@
       "favorite_now_playing": {
         "default": "mdi:heart-plus"
       }
+    },
+    "image": {
+      "party_mode_qr": {
+        "default": "mdi:qrcode"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/music_assistant/image.py
+++ b/homeassistant/components/music_assistant/image.py
@@ -1,0 +1,124 @@
+"""Music Assistant Image platform."""
+
+from datetime import datetime
+import io
+from typing import override
+
+from music_assistant_client.client import MusicAssistantClient
+from music_assistant_models.errors import MusicAssistantError
+
+from homeassistant.components.image import ImageEntity, ImageEntityDescription
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.event import async_track_time_interval
+from homeassistant.util import dt as dt_util
+
+from . import MusicAssistantConfigEntry
+from .const import LOGGER, PARTY_URL_POLL_INTERVAL
+from .entity import MusicAssistantPartyModeEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: MusicAssistantConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Music Assistant Image Entities."""
+    mass = entry.runtime_data.mass
+
+    def add_party_mode(instance_id: str) -> None:
+        """Handle add party mode."""
+        async_add_entities(
+            [
+                MusicAssistantPartyModeImage(
+                    hass,
+                    mass,
+                    instance_id,
+                    entity_description=ImageEntityDescription(
+                        key="party_mode_qr",
+                        translation_key="party_mode_qr",
+                    ),
+                )
+            ]
+        )
+
+    entry.runtime_data.party_handlers.setdefault(Platform.IMAGE, add_party_mode)
+
+
+class MusicAssistantPartyModeImage(MusicAssistantPartyModeEntity, ImageEntity):
+    """Representation of an Image entity for Party Mode QR Code."""
+
+    _attr_content_type = "image/svg+xml"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        mass: MusicAssistantClient,
+        instance_id: str,
+        entity_description: ImageEntityDescription,
+    ) -> None:
+        """Initialize."""
+        super().__init__(
+            mass=mass,
+            instance_id=instance_id,
+            unique_id_suffix=entity_description.key,
+            hass=hass,
+        )
+        self.entity_description = entity_description
+        self._current_url: str | None = None
+        self._image_bytes: bytes | None = None
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register callbacks."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            async_track_time_interval(
+                self.hass,
+                self._handle_timer,
+                PARTY_URL_POLL_INTERVAL,
+            )
+        )
+
+    async def _handle_timer(self, _now: datetime) -> None:
+        """Handle periodic update."""
+        await self.async_on_update()
+        self.async_write_ha_state()
+
+    def _generate_qr_code(self, url: str) -> bytes:
+        """Generate a QR code SVG for the party URL."""
+        import segno  # noqa: PLC0415
+
+        qr = segno.make(url)
+        buffer = io.BytesIO()
+        qr.save(buffer, kind="svg", scale=4, light="white")
+        return buffer.getvalue()
+
+    @override
+    async def async_on_update(self) -> None:
+        """Handle provider updates."""
+        try:
+            url = await self.mass.send_command("party/url")
+        except MusicAssistantError as err:
+            LOGGER.debug("Failed to fetch party URL for QR: %s", err)
+            url = None
+
+        if not url or not isinstance(url, str):
+            self._current_url = None
+            self._image_bytes = None
+            self._attr_available = False
+            return
+
+        if url != self._current_url:
+            self._current_url = url
+            self._image_bytes = await self.hass.async_add_executor_job(
+                self._generate_qr_code, url
+            )
+            self._attr_image_last_updated = dt_util.utcnow()
+        self._attr_available = True
+
+    @override
+    async def async_image(self) -> bytes | None:
+        """Return bytes of image."""
+        return self._image_bytes

--- a/homeassistant/components/music_assistant/manifest.json
+++ b/homeassistant/components/music_assistant/manifest.json
@@ -10,6 +10,6 @@
   "iot_class": "local_push",
   "loggers": ["music_assistant"],
   "quality_scale": "bronze",
-  "requirements": ["music-assistant-client==1.4.3"],
+  "requirements": ["music-assistant-client==1.4.3", "segno==1.6.6"],
   "zeroconf": ["_mass._tcp.local."]
 }

--- a/homeassistant/components/music_assistant/strings.json
+++ b/homeassistant/components/music_assistant/strings.json
@@ -54,6 +54,11 @@
         "name": "Favorite current song"
       }
     },
+    "image": {
+      "party_mode_qr": {
+        "name": "Guest QR code"
+      }
+    },
     "media_player": {
       "media_player": {
         "state_attributes": {
@@ -262,6 +267,9 @@
   "exceptions": {
     "invalid_username": {
       "message": "The username {username} does not exist. Available usernames are {available_usernames}."
+    },
+    "party_mode_active_device_removal": {
+      "message": "Cannot delete active Party Mode device. Disable the Party Mode provider in Music Assistant settings instead."
     }
   },
   "issues": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2980,6 +2980,9 @@ screenlogicpy==0.10.2
 # homeassistant.components.backup
 securetar==2026.4.1
 
+# homeassistant.components.music_assistant
+segno==1.6.6
+
 # homeassistant.components.sendgrid
 sendgrid==6.8.2
 

--- a/tests/components/music_assistant/common.py
+++ b/tests/components/music_assistant/common.py
@@ -81,6 +81,7 @@ async def setup_integration_from_fixtures(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
+    music_assistant_client.send_command.reset_mock()
     return config_entry
 
 

--- a/tests/components/music_assistant/conftest.py
+++ b/tests/components/music_assistant/conftest.py
@@ -9,6 +9,8 @@ from music_assistant_client.player_queues import PlayerQueues
 from music_assistant_client.players import Players
 from music_assistant_models.api import ServerInfoMessage
 from music_assistant_models.config_entries import PlayerConfig
+from music_assistant_models.enums import ProviderType
+from music_assistant_models.provider import ProviderInstance
 import pytest
 
 from homeassistant.components.music_assistant.config_flow import CONF_URL
@@ -84,7 +86,36 @@ async def music_assistant_client_fixture() -> AsyncGenerator[MagicMock]:
                 for player in client.players
             ]
 
-        client.config.get_player_configs = get_player_configs
+        client.config.get_player_configs = AsyncMock(side_effect=get_player_configs)
+
+        async def get_providers() -> list[ProviderInstance]:
+            """Mock get providers."""
+            return [
+                ProviderInstance(
+                    type=ProviderType.PLUGIN,
+                    domain="party",
+                    name="Party Mode",
+                    instance_id="party_instance",
+                    supported_features=set(),
+                    available=True,
+                )
+            ]
+
+        client.get_providers = AsyncMock(side_effect=get_providers)
+
+        def get_provider(domain: str) -> ProviderInstance | None:
+            if domain == "party":
+                return ProviderInstance(
+                    type=ProviderType.PLUGIN,
+                    domain="party",
+                    name="Party Mode Plugin",
+                    instance_id="party_instance",
+                    supported_features=set(),
+                    available=True,
+                )
+            return None
+
+        client.get_provider = MagicMock(side_effect=get_provider)
 
         yield client
 

--- a/tests/components/music_assistant/snapshots/test_image.ambr
+++ b/tests/components/music_assistant/snapshots/test_image.ambr
@@ -1,0 +1,53 @@
+# serializer version: 1
+# name: test_image_entities[image.party_mode_plugin_guest_qr_code-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'image',
+    'entity_category': None,
+    'entity_id': 'image.party_mode_plugin_guest_qr_code',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Guest QR code',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Guest QR code',
+    'platform': 'music_assistant',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'party_mode_qr',
+    'unique_id': '1234_party_instance_party_mode_qr',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_image_entities[image.party_mode_plugin_guest_qr_code-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ImageEntityStateAttribute.ACCESS_TOKEN: 'access_token'>: '1',
+      <EntityStateAttribute.ENTITY_PICTURE: 'entity_picture'>: '/api/image_proxy/image.party_mode_plugin_guest_qr_code?token=1',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Party Mode Plugin Guest QR code',
+    }),
+    'context': <ANY>,
+    'entity_id': 'image.party_mode_plugin_guest_qr_code',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2024-01-01T12:00:00+00:00',
+  })
+# ---

--- a/tests/components/music_assistant/test_image.py
+++ b/tests/components/music_assistant/test_image.py
@@ -171,9 +171,10 @@ async def test_party_mode_provider_lifecycle(
         hass, music_assistant_client, EventType.PROVIDERS_UPDATED
     )
 
-    # Device should have config entry association removed
+    # Device should NOT have config entry association removed yet
     device = device_registry.async_get_device({(DOMAIN, "1234_party_instance")})
-    assert device is None or not device.config_entries
+    assert device is not None
+    assert device.config_entries
 
     # 3. Simulate provider replacement with a new instance ID
     music_assistant_client.get_provider.return_value = ProviderInstance(
@@ -188,6 +189,10 @@ async def test_party_mode_provider_lifecycle(
     await trigger_subscription_callback(
         hass, music_assistant_client, EventType.PROVIDERS_UPDATED
     )
+
+    # Now the old device should have config entry association removed
+    device = device_registry.async_get_device({(DOMAIN, "1234_party_instance")})
+    assert device is None or not device.config_entries
 
     # Verify the new device registry entry is created
     new_device = device_registry.async_get_device({(DOMAIN, "1234_new_party_instance")})

--- a/tests/components/music_assistant/test_image.py
+++ b/tests/components/music_assistant/test_image.py
@@ -1,0 +1,237 @@
+"""Test Music Assistant image entities."""
+
+from collections.abc import Generator
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from music_assistant_models.enums import EventType
+from music_assistant_models.errors import MusicAssistantError
+from music_assistant_models.provider import ProviderInstance, ProviderType
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.music_assistant import async_remove_config_entry_device
+from homeassistant.components.music_assistant.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+import homeassistant.util.dt as dt_util
+
+from .common import (
+    setup_integration_from_fixtures,
+    snapshot_music_assistant_entities,
+    trigger_subscription_callback,
+)
+
+from tests.common import async_fire_time_changed
+
+
+@pytest.fixture(autouse=True)
+def mock_getrandbits() -> Generator[None]:
+    """Mock image access token which normally is randomized."""
+    with patch(
+        "homeassistant.components.image.SystemRandom.getrandbits",
+        return_value=1,
+    ):
+        yield
+
+
+async def test_image_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    music_assistant_client: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test image entities."""
+    freezer.move_to("2024-01-01T12:00:00+00:00")
+    music_assistant_client.send_command.return_value = "http://mock-party-url"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    snapshot_music_assistant_entities(hass, entity_registry, snapshot, Platform.IMAGE)
+
+
+async def test_image_url_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test image updates when URL changes."""
+    music_assistant_client.send_command.return_value = "http://mock-party-url-1"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    last_updated = state.state
+    assert last_updated is not None
+
+    music_assistant_client.send_command.return_value = "http://mock-party-url-2"
+
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state != last_updated
+
+
+async def test_two_entries_same_party_instance(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that two entries with the same party instance ID get different entity unique IDs."""
+    music_assistant_client.send_command.return_value = "http://mock-party-url"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    # Setup second entry with a different server ID
+    music_assistant_client.server_info.server_id = "second_server_id"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    entities = er.async_entries_for_device(
+        entity_registry,
+        next(
+            d.id
+            for d in hass.data["device_registry"].devices.values()
+            if d.identifiers == {("music_assistant", "second_server_id_party_instance")}
+        ),
+    )
+    # The entities should be created, verifying that they did not fail due to duplicate unique IDs
+    assert len(entities) > 0
+    # Also verify the first entry's entities still exist
+    first_entities = er.async_entries_for_device(
+        entity_registry,
+        next(
+            d.id
+            for d in hass.data["device_registry"].devices.values()
+            if d.identifiers == {("music_assistant", "1234_party_instance")}
+        ),
+    )
+    assert len(first_entities) > 0
+
+
+async def test_image_url_fetch_failure_and_recovery(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test image updates when URL fetch fails or returns falsy, and recovers."""
+    # Start with a valid URL
+    music_assistant_client.send_command.return_value = "http://mock-party-url-1"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    # Mock MusicAssistantError
+    music_assistant_client.send_command.side_effect = MusicAssistantError("Error")
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=1))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+
+    # Recover
+    music_assistant_client.send_command.side_effect = None
+    music_assistant_client.send_command.return_value = "http://mock-party-url-2"
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=2))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    # Return None
+    music_assistant_client.send_command.return_value = None
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(hours=3))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_party_mode_provider_lifecycle(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the provider lifecycle of Party Mode (removal and replacement)."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    # 1. Verify initial setup registers the device
+    device = device_registry.async_get_device({(DOMAIN, "1234_party_instance")})
+    assert device is not None
+
+    # 2. Simulate provider removal (get_provider returns None)
+    music_assistant_client.get_provider.side_effect = None
+    music_assistant_client.get_provider.return_value = None
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PROVIDERS_UPDATED
+    )
+
+    # Device should have config entry association removed
+    device = device_registry.async_get_device({(DOMAIN, "1234_party_instance")})
+    assert device is None or not device.config_entries
+
+    # 3. Simulate provider replacement with a new instance ID
+    music_assistant_client.get_provider.return_value = ProviderInstance(
+        type=ProviderType.PLUGIN,
+        domain="party",
+        name="New Party Mode Plugin",
+        instance_id="new_party_instance",
+        supported_features=set(),
+        available=True,
+    )
+    # Trigger callback which will add the new party mode device
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PROVIDERS_UPDATED
+    )
+
+    # Verify the new device registry entry is created
+    new_device = device_registry.async_get_device({(DOMAIN, "1234_new_party_instance")})
+    assert new_device is not None
+
+    # 4. Verify we cannot remove the active party device
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await async_remove_config_entry_device(hass, config_entry, new_device)
+    assert excinfo.value.translation_domain == DOMAIN
+    assert excinfo.value.translation_key == "party_mode_active_device_removal"
+
+
+async def test_party_mode_core_state_update(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that QR code updates when a CORE_STATE_UPDATED event is received."""
+    # Start with initial valid URL
+    music_assistant_client.send_command.return_value = "http://mock-party-url-1"
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    state = hass.states.get("image.party_mode_plugin_guest_qr_code")
+    assert state
+    assert state.state != STATE_UNAVAILABLE
+
+    entity = hass.data["entity_components"]["image"].get_entity(
+        "image.party_mode_plugin_guest_qr_code"
+    )
+    assert entity is not None
+
+    # Fetch initial image bytes
+    bytes_1 = await entity.async_image()
+    assert bytes_1 is not None
+
+    # Simulate URL change on the server
+    music_assistant_client.send_command.return_value = "http://mock-party-url-2"
+
+    # Trigger CORE_STATE_UPDATED callback
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.CORE_STATE_UPDATED
+    )
+
+    # Fetch updated image bytes
+    bytes_2 = await entity.async_image()
+    assert bytes_2 is not None
+    assert bytes_1 != bytes_2


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Music Assistant has [Party Mode](https://www.music-assistant.io/plugins/party/#for-guests) which allows guests to add songs to the queue.

This PR adds a new Party Mode Plugin device to the Music Assistant integration if the user has the plugin enabled on Music Assistant. All of the party mode configuration variables are synced to Home Assistant, and are updatable from there.

Notably, this PR adds a guest QR code based on the guest URL that is set in Music Assistant allowing users to display it on dashboards for guests to scan.

Introduce Party Mode Image platform and core configurations for the Music Assistant integration. This is the first PR in a chain of PRs splitting the party mode implementation into separate platforms (Image, Sensor, Number, Select, Switch, Text).

This is the first PR in a stack. Will re-target the other PRs to dev after preceding PRs are merged.

1. home-assistant/core#176148 <-
2. cnorick/core#1
3. cnorick/core#2
4. cnorick/core#3
5. cnorick/core#4
6. cnorick/core#5


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46791
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
