### PR TITLE
Fix rest_command digest auth with templated hosts

### DIFF
--- a/homeassistant/components/rest_command/__init__.py
+++ b/homeassistant/components/rest_command/__init__.py
@@ -117,12 +117,12 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         skip_url_encoding = command_config[CONF_SKIP_URL_ENCODING]
 
         auth = None
-        digest_middleware = None
+        digest_auth: tuple[str, str] | None = None
         if CONF_USERNAME in command_config:
             username = command_config[CONF_USERNAME]
             password = command_config.get(CONF_PASSWORD, "")
             if command_config.get(CONF_AUTHENTICATION) == HTTP_DIGEST_AUTHENTICATION:
-                digest_middleware = aiohttp.DigestAuthMiddleware(username, password)
+                digest_auth = (username, password)
             else:
                 auth = aiohttp.BasicAuth(username, password=password)
 
@@ -177,8 +177,10 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 # Add authentication
                 if auth is not None:
                     request_kwargs["auth"] = auth
-                elif digest_middleware is not None:
-                    request_kwargs["middlewares"] = (digest_middleware,)
+                elif digest_auth is not None:
+                    request_kwargs["middlewares"] = (
+                        aiohttp.DigestAuthMiddleware(*digest_auth),
+                    )
 
                 async with getattr(websession, method)(
                     URL(request_url, encoded=skip_url_encoding),

--- a/tests/components/rest_command/test_init.py
+++ b/tests/components/rest_command/test_init.py
@@ -126,10 +126,10 @@ async def test_rest_command_auth(
     assert len(aioclient_mock.mock_calls) == 1
 
 
+@pytest.mark.usefixtures("aioclient_mock")
 async def test_rest_command_digest_auth(
     hass: HomeAssistant,
     setup_component: ComponentSetup,
-    aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Call a rest command with HTTP digest authentication."""
     config = {
@@ -144,11 +144,9 @@ async def test_rest_command_digest_auth(
 
     await setup_component(config)
 
-    # Mock the digest auth behavior - the request will be called
-    # with DigestAuthMiddleware
     with patch("aiohttp.ClientSession.get") as mock_get:
 
-        async def async_iter_chunks(self, chunk_size):
+        async def async_iter_chunks(self, chunk_size: int):
             yield b"success"
 
         mock_response = type(
@@ -167,13 +165,14 @@ async def test_rest_command_digest_auth(
         mock_get.return_value.__aenter__.return_value = mock_response
 
         await hass.services.async_call(DOMAIN, "digest_auth_test", {}, blocking=True)
+        await hass.services.async_call(DOMAIN, "digest_auth_test", {}, blocking=True)
 
-        # Verify that the request was made with DigestAuthMiddleware
-        assert mock_get.called
-        call_kwargs = mock_get.call_args[1]
-        assert "middlewares" in call_kwargs
-        assert len(call_kwargs["middlewares"]) == 1
-        assert isinstance(call_kwargs["middlewares"][0], aiohttp.DigestAuthMiddleware)
+        assert len(mock_get.call_args_list) == 2
+        first_middleware = mock_get.call_args_list[0].kwargs["middlewares"][0]
+        second_middleware = mock_get.call_args_list[1].kwargs["middlewares"][0]
+        assert isinstance(first_middleware, aiohttp.DigestAuthMiddleware)
+        assert isinstance(second_middleware, aiohttp.DigestAuthMiddleware)
+        assert first_middleware is not second_middleware
 
 
 async def test_rest_command_form_data(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Create a fresh `aiohttp.DigestAuthMiddleware` for each `rest_command` service call instead of reusing one middleware instance for the lifetime of the configured command.

`aiohttp` digest middleware keeps the authentication state, including origin and challenge data. Reusing the same instance can cause templated digest-auth REST commands targeting multiple hosts to return 401 after the first origin is pinned. This keeps the existing shared aiohttp session, but avoids sharing digest middleware state across calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175435
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
