### PR TITLE
Fix ESPHome discovery overwriting user configured hostname with IP

### DIFF
--- a/homeassistant/components/esphome/config_flow.py
+++ b/homeassistant/components/esphome/config_flow.py
@@ -51,6 +51,7 @@ from homeassistant.helpers.service_info.hassio import HassioServiceInfo
 from homeassistant.helpers.service_info.mqtt import MqttServiceInfo
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.util.json import json_loads_object
+from homeassistant.util.network import is_ip_address
 
 from .const import (
     CONF_ALLOW_SERVICE_CALLS,
@@ -387,10 +388,7 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             # Don't probe to verify the mac is correct since
             # the host matches (and port matches if provided).
             raise AbortFlow("already_configured")
-        # If the entry is loaded and the device is currently connected,
-        # don't update the host. This prevents transient mDNS announcements
-        # (e.g., during WiFi mesh roaming) from overwriting a working connection.
-        if entry.state is ConfigEntryState.LOADED and entry.runtime_data.available:
+        if self._async_host_update_blocked(entry):
             raise AbortFlow("already_configured")
         configured_psk: str | None = entry.data.get(CONF_NOISE_PSK)
         await self._fetch_device_info(host, port or configured_port, configured_psk)
@@ -400,6 +398,20 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
             if port is not None:
                 updates[CONF_PORT] = port
         self._abort_unique_id_configured_with_details(updates=updates)
+
+    @callback
+    def _async_host_update_blocked(self, entry: ConfigEntry) -> bool:
+        """Return True if discovery must not update the entry host."""
+        configured_host: str | None = entry.data.get(CONF_HOST)
+        if configured_host and not is_ip_address(configured_host):
+            # Entry is configured with a hostname; never replace it
+            # with a discovered IP address.
+            return True
+        # If the entry is loaded and the device is currently connected,
+        # don't update the host. This prevents transient mDNS announcements
+        # (e.g., during WiFi mesh roaming) or stale retained MQTT discovery
+        # payloads from overwriting a working connection.
+        return entry.state is ConfigEntryState.LOADED and entry.runtime_data.available
 
     @callback
     def _abort_unique_id_configured_with_details(self, updates: dict[str, Any]) -> None:
@@ -462,9 +474,14 @@ class EsphomeFlowHandler(ConfigFlow, domain=DOMAIN):
 
         # Check if already configured
         await self.async_set_unique_id(mac_address)
-        self._abort_unique_id_configured_with_details(
-            updates={CONF_HOST: self._host, CONF_PORT: self._port}
-        )
+        updates: dict[str, Any] = {}
+        if not (
+            entry := self.hass.config_entries.async_entry_for_domain_unique_id(
+                self.handler, mac_address
+            )
+        ) or not self._async_host_update_blocked(entry):
+            updates = {CONF_HOST: self._host, CONF_PORT: self._port}
+        self._abort_unique_id_configured_with_details(updates=updates)
 
         return await self.async_step_discovery_confirm()
 

--- a/tests/components/esphome/test_config_flow.py
+++ b/tests/components/esphome/test_config_flow.py
@@ -864,12 +864,9 @@ async def test_discovery_already_configured(hass: HomeAssistant) -> None:
     )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured_updates"
-    assert result["description_placeholders"] == {
-        "title": "Mock Title",
-        "name": "unknown",
-        "mac": "11:22:33:44:55:aa",
-    }
+    assert result["reason"] == "already_configured"
+    # Entry is configured with a hostname; discovery must not replace it
+    assert entry.data[CONF_HOST] == "test8266.local"
 
 
 @pytest.mark.usefixtures("mock_zeroconf")
@@ -943,6 +940,36 @@ async def test_discovery_does_not_update_host_when_device_is_connected_dhcp(
     assert result["reason"] == "already_configured"
     # Host should NOT be updated since the device is currently connected
     assert entry.data[CONF_HOST] == "192.168.1.2"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_discovery_dhcp_does_not_update_host_configured_hostname(
+    hass: HomeAssistant, mock_client: APIClient
+) -> None:
+    """Test DHCP discovery does not update a hostname configured entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "test8266.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_DHCP},
+        data=DhcpServiceInfo(
+            ip="192.168.43.184",
+            macaddress="1122334455aa",
+            hostname="test8266",
+        ),
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    # Entry is configured with a hostname; discovery must not replace it
+    assert entry.data[CONF_HOST] == "test8266.local"
+    # The device should not have been probed since no update is possible
+    assert len(mock_client.device_info.mock_calls) == 0
 
 
 @pytest.mark.usefixtures("mock_client", "mock_setup_entry", "mock_zeroconf")
@@ -2297,6 +2324,100 @@ async def test_discovery_mqtt_initiation(hass: HomeAssistant) -> None:
 
     assert result["result"]
     assert result["result"].unique_id == "11:22:33:44:55:aa"
+
+
+@pytest.mark.usefixtures("mock_client", "mock_setup_entry", "mock_zeroconf")
+async def test_discovery_mqtt_updates_host(hass: HomeAssistant) -> None:
+    """Test MQTT discovery updates the host of an IP configured entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.43.183", CONF_PORT: 6053, CONF_PASSWORD: ""},
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    service_info = MqttServiceInfo(
+        topic="esphome/discover/test",
+        payload='{"name":"test","mac":"1122334455aa","port":6053,"ip":"192.168.43.184"}',
+        qos=0,
+        retain=False,
+        subscribed_topic="esphome/discover/#",
+        timestamp=None,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=service_info
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_updates"
+    assert entry.data[CONF_HOST] == "192.168.43.184"
+
+
+@pytest.mark.usefixtures("mock_client", "mock_setup_entry", "mock_zeroconf")
+async def test_discovery_mqtt_does_not_update_host_configured_hostname(
+    hass: HomeAssistant,
+) -> None:
+    """Test MQTT discovery does not update a hostname configured entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "test8266.local", CONF_PORT: 6053, CONF_PASSWORD: ""},
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+
+    service_info = MqttServiceInfo(
+        topic="esphome/discover/test",
+        payload='{"name":"test","mac":"1122334455aa","port":6053,"ip":"192.168.43.184"}',
+        qos=0,
+        retain=False,
+        subscribed_topic="esphome/discover/#",
+        timestamp=None,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=service_info
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_detailed"
+    # Entry is configured with a hostname; discovery must not replace it
+    assert entry.data[CONF_HOST] == "test8266.local"
+
+
+@pytest.mark.usefixtures("mock_zeroconf")
+async def test_discovery_mqtt_does_not_update_host_when_device_is_connected(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+) -> None:
+    """Test MQTT discovery does not update host when device is connected."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.2",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+        },
+        unique_id="11:22:33:44:55:aa",
+    )
+    entry.add_to_hass(hass)
+    await mock_esphome_device(mock_client=mock_client, entry=entry)
+
+    service_info = MqttServiceInfo(
+        topic="esphome/discover/test",
+        payload='{"name":"test","mac":"1122334455aa","port":6053,"ip":"192.168.1.99"}',
+        qos=0,
+        retain=False,
+        subscribed_topic="esphome/discover/#",
+        timestamp=None,
+    )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_MQTT}, data=service_info
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_detailed"
+    # Host should NOT be updated since the device is currently connected
+    assert entry.data[CONF_HOST] == "192.168.1.2"
 
 
 @pytest.mark.usefixtures("mock_setup_entry", "mock_zeroconf")


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

If a user configures an ESPHome device with a hostname, discovery would replace it with the discovered IP address. The zeroconf and dhcp flows did this whenever the device was not currently connected, and the mqtt flow did it unconditionally, so a stale retained discovery payload could overwrite the host on every restart.

Discovery now never replaces a hostname with an IP; the mqtt flow also gets the same guard as zeroconf that skips the update while the device is connected, since retained payloads can be stale. IP to IP updates from discovery still work as before, and user initiated flows can still change the host to anything.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174973
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
