### PR TITLE
Skip global ESPHome update lock when dashboard has a build queue

### DIFF
--- a/homeassistant/components/esphome/coordinator.py
+++ b/homeassistant/components/esphome/coordinator.py
@@ -14,6 +14,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 MIN_VERSION_SUPPORTS_UPDATE = AwesomeVersion("2023.1.0")
+MIN_VERSION_SUPPORTS_BUILD_QUEUE = AwesomeVersion("2026.6.0")
 REFRESH_INTERVAL = timedelta(minutes=5)
 
 
@@ -34,6 +35,7 @@ class ESPHomeDashboardCoordinator(DataUpdateCoordinator[dict[str, ConfiguredDevi
         self.url = url
         self.api = ESPHomeDashboardAPI(url, async_get_clientsession(hass))
         self.supports_update: bool | None = None
+        self.supports_build_queue = False
 
     @override
     async def _async_update_data(self) -> dict[str, ConfiguredDevice]:
@@ -41,13 +43,14 @@ class ESPHomeDashboardCoordinator(DataUpdateCoordinator[dict[str, ConfiguredDevi
         devices = await self.api.get_devices()
         configured_devices = devices["configured"]
 
-        if (
-            self.supports_update is None
-            and configured_devices
-            and (current_version := configured_devices[0].get("current_version"))
+        if configured_devices and (
+            current_version := configured_devices[0].get("current_version")
         ):
-            self.supports_update = (
-                AwesomeVersion(current_version) > MIN_VERSION_SUPPORTS_UPDATE
-            )
+            version = AwesomeVersion(current_version)
+            if self.supports_update is None:
+                self.supports_update = version > MIN_VERSION_SUPPORTS_UPDATE
+            # The dashboard has its own build queue since 2026.6.0
+            # and can accept multiple compile requests at once
+            self.supports_build_queue = version >= MIN_VERSION_SUPPORTS_BUILD_QUEUE
 
         return {dev["name"]: dev for dev in configured_devices}

--- a/homeassistant/components/esphome/update.py
+++ b/homeassistant/components/esphome/update.py
@@ -233,21 +233,27 @@ class ESPHomeDashboardUpdateEntity(
 
         # Ensure only one OTA per device at a time
         async with self._install_lock:
-            # Ensure only one compile at a time for ALL devices
-            async with self.hass.data.setdefault(KEY_UPDATE_LOCK, asyncio.Lock()):
-                coordinator = self.coordinator
-                api = coordinator.api
-                device = coordinator.data.get(self._device_info.name)
-                assert device is not None
-                configuration = device["configuration"]
-                if not await api.compile(configuration):
-                    raise HomeAssistantError(
-                        translation_domain=DOMAIN,
-                        translation_key="error_compiling",
-                        translation_placeholders={
-                            "configuration": configuration,
-                        },
-                    )
+            coordinator = self.coordinator
+            api = coordinator.api
+            device = coordinator.data.get(self._device_info.name)
+            assert device is not None
+            configuration = device["configuration"]
+            if coordinator.supports_build_queue:
+                # The dashboard has its own build queue
+                # and can handle concurrent compile requests
+                compiled = await api.compile(configuration)
+            else:
+                # Ensure only one compile at a time for ALL devices
+                async with self.hass.data.setdefault(KEY_UPDATE_LOCK, asyncio.Lock()):
+                    compiled = await api.compile(configuration)
+            if not compiled:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="error_compiling",
+                    translation_placeholders={
+                        "configuration": configuration,
+                    },
+                )
 
             # If the device uses deep sleep, there's a small chance it goes
             # to sleep right after the dashboard connects but before the OTA

--- a/tests/components/esphome/test_update.py
+++ b/tests/components/esphome/test_update.py
@@ -10,6 +10,7 @@ from awesomeversion.exceptions import AwesomeVersionCompareException
 import pytest
 
 from homeassistant.components.esphome.dashboard import async_get_dashboard
+from homeassistant.components.esphome.update import KEY_UPDATE_LOCK
 from homeassistant.components.homeassistant import (
     DOMAIN as HOMEASSISTANT_DOMAIN,
     SERVICE_UPDATE_ENTITY,
@@ -809,6 +810,98 @@ async def test_attempt_to_update_twice(
 
         with pytest.raises(HomeAssistantError, match="OTA"):
             await update_task
+
+
+async def test_update_dashboard_with_build_queue_skips_global_lock(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test the global compile lock is skipped when the dashboard has a build queue."""
+    mock_dashboard["configured"] = [
+        {
+            "name": "test",
+            "current_version": "2026.6.0",
+            "configuration": "test.yaml",
+        }
+    ]
+    await async_get_dashboard(hass).async_refresh()
+    await mock_esphome_device(mock_client=mock_client)
+    await hass.async_block_till_done()
+
+    # Hold the global compile lock; the install must not need it
+    lock = hass.data.setdefault(KEY_UPDATE_LOCK, asyncio.Lock())
+    await lock.acquire()
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
+            return_value=True,
+        ) as mock_compile,
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.upload",
+            return_value=True,
+        ),
+    ):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: "update.test_firmware"},
+            blocking=True,
+        )
+    lock.release()
+
+    assert len(mock_compile.mock_calls) == 1
+    assert mock_compile.mock_calls[0][1][0] == "test.yaml"
+
+
+async def test_update_dashboard_without_build_queue_waits_for_global_lock(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test the global compile lock still serializes installs on older dashboards."""
+    mock_dashboard["configured"] = [
+        {
+            "name": "test",
+            "current_version": "2026.5.0",
+            "configuration": "test.yaml",
+        }
+    ]
+    await async_get_dashboard(hass).async_refresh()
+    await mock_esphome_device(mock_client=mock_client)
+    await hass.async_block_till_done()
+
+    lock = hass.data.setdefault(KEY_UPDATE_LOCK, asyncio.Lock())
+    await lock.acquire()
+    with (
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.compile",
+            return_value=True,
+        ) as mock_compile,
+        patch(
+            "homeassistant.components.esphome.coordinator.ESPHomeDashboardAPI.upload",
+            return_value=True,
+        ),
+    ):
+        update_task = hass.async_create_task(
+            hass.services.async_call(
+                UPDATE_DOMAIN,
+                SERVICE_INSTALL,
+                {ATTR_ENTITY_ID: "update.test_firmware"},
+                blocking=True,
+            )
+        )
+        for _ in range(5):
+            await asyncio.sleep(0)
+        # The compile must be blocked on the global lock
+        assert len(mock_compile.mock_calls) == 0
+        lock.release()
+        await update_task
+
+    assert len(mock_compile.mock_calls) == 1
+    assert mock_compile.mock_calls[0][1][0] == "test.yaml"
 
 
 async def test_update_deep_sleep_already_online(


### PR DESCRIPTION


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The dashboard update entities hold a global lock so only one compile is ever sent to the dashboard at a time. Since 2026.6.0 the dashboard has its own build queue and can accept concurrent compile requests, so the global lock defeats remote build pools with multiple servers; only one server ever gets work. Skip the global lock when the dashboard reports 2026.6.0 or later, detected from the configured device current_version the same way supports_update is. The per device OTA lock is unchanged, and older dashboards keep the old serialized behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/esphome/device-builder/issues/1934
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
