### PR TITLE
Raise `HomeAssistantError` when retries are exhausted in STMP legacy notify action

### DIFF
--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -320,6 +320,8 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
                 mail.sendmail(self._sender, recipients, msg.as_string())
                 break
             except SMTPServerDisconnected as e:
+                with suppress(SMTPException):
+                    mail.quit()
                 if attempt == self.tries - 1:
                     _LOGGER.debug("Full exception:", exc_info=True)
                     raise HomeAssistantError(
@@ -330,11 +332,10 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
                     "SMTPServerDisconnected sending mail: retrying connection",
                     exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
                 )
-                with suppress(SMTPException):
-                    mail.quit()
-
                 mail = self.connect()
             except SMTPException as e:
+                with suppress(SMTPException):
+                    mail.quit()
                 if attempt == self.tries - 1:
                     _LOGGER.debug("Full exception:", exc_info=True)
                     raise HomeAssistantError(
@@ -345,8 +346,6 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
                     "SMTPException sending mail: retrying connection",
                     exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
                 )
-                with suppress(SMTPException):
-                    mail.quit()
                 mail = self.connect()
         with suppress(SMTPException):
             mail.quit()

--- a/homeassistant/components/smtp/notify.py
+++ b/homeassistant/components/smtp/notify.py
@@ -315,19 +315,32 @@ class MailNotificationService(SmtpClient, BaseNotificationService):
     def _send_email(self, msg: MIMEMultipart | MIMEText, recipients: list[str]) -> None:
         """Send the message."""
         mail = self.connect()
-        for _ in range(self.tries):
+        for attempt in range(self.tries):
             try:
                 mail.sendmail(self._sender, recipients, msg.as_string())
                 break
-            except SMTPServerDisconnected:
+            except SMTPServerDisconnected as e:
+                if attempt == self.tries - 1:
+                    _LOGGER.debug("Full exception:", exc_info=True)
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="send_mail_connection_error",
+                    ) from e
                 _LOGGER.warning(
                     "SMTPServerDisconnected sending mail: retrying connection",
                     exc_info=_LOGGER.isEnabledFor(logging.DEBUG),
                 )
                 with suppress(SMTPException):
                     mail.quit()
+
                 mail = self.connect()
-            except SMTPException:
+            except SMTPException as e:
+                if attempt == self.tries - 1:
+                    _LOGGER.debug("Full exception:", exc_info=True)
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="send_mail_connection_error",
+                    ) from e
                 _LOGGER.warning(
                     "SMTPException sending mail: retrying connection",
                     exc_info=_LOGGER.isEnabledFor(logging.DEBUG),

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -393,3 +393,4 @@ async def test_legacy_notify_exception(
         )
 
     assert e.value.translation_key == "send_mail_connection_error"
+    assert smtp.sendmail.call_count == 2

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -4,6 +4,7 @@ from pathlib import Path
 import re
 from smtplib import (
     SMTPAuthenticationError,
+    SMTPException,
     SMTPHeloError,
     SMTPSenderRefused,
     SMTPServerDisconnected,
@@ -16,6 +17,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.notify import (
     ATTR_MESSAGE,
+    ATTR_TARGET,
     DOMAIN as NOTIFY_DOMAIN,
     SERVICE_SEND_MESSAGE,
 )
@@ -360,3 +362,34 @@ async def test_notify_retry_on_disconnect_with_broken_quit(
     )
 
     assert smtp.sendmail.call_count == 2
+
+
+@pytest.mark.parametrize("exception", [SMTPServerDisconnected, SMTPException])
+async def test_legacy_notify_exception(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    smtp: MagicMock,
+    exception: Exception,
+) -> None:
+    """Test legacy notify action raises when retries are exhausted."""
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    smtp.sendmail.side_effect = exception
+
+    with pytest.raises(HomeAssistantError) as e:
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            "home_assistant",
+            {
+                ATTR_TARGET: ["recipient@example.com"],
+                ATTR_MESSAGE: "Hello World",
+            },
+            blocking=True,
+        )
+
+    assert e.value.translation_key == "send_mail_connection_error"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to discussion here: https://github.com/home-assistant/core/pull/175781#issuecomment-4897530368

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
