### PR TITLE
Apply AGENTS.md code quality rules to samsungtv integration

### DIFF
--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -114,7 +114,6 @@ async def _async_update_ssdp_locations(
 
 async def async_setup_entry(hass: HomeAssistant, entry: SamsungTVConfigEntry) -> bool:
     """Set up the Samsung TV platform."""
-    # Initialize bridge
     if entry.data.get(CONF_METHOD) == METHOD_ENCRYPTED_WEBSOCKET:
         if not entry.data.get(CONF_TOKEN) or not entry.data.get(CONF_SESSION_ID):
             raise ConfigEntryAuthFailed(
@@ -130,7 +129,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: SamsungTVConfigEntry) ->
 
     bridge.register_reauth_callback(_access_denied)
 
-    # Ensure updates get saved against the config_entry
     @callback
     def _update_config_entry(updates: Mapping[str, Any]) -> None:
         """Update config entry with the new token."""

--- a/homeassistant/components/samsungtv/__init__.py
+++ b/homeassistant/components/samsungtv/__init__.py
@@ -62,7 +62,7 @@ class DebouncedEntryReloader:
         self.hass = hass
         self.entry = entry
         self.token = self.entry.data.get(CONF_TOKEN)
-        self._debounced_reload: Debouncer[Coroutine[Any, Any, None]] = Debouncer(
+        self._debounced_reload: Debouncer[Coroutine[None, None, None]] = Debouncer(
             hass,
             LOGGER,
             cooldown=ENTRY_RELOAD_COOLDOWN,

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -502,11 +502,11 @@ class SamsungTVWSBridge(
         self._rest_api: SamsungTVAsyncRest | None = None
         self._device_info: dict[str, Any] | None = None
 
-    def _get_device_spec(self, key: str) -> Any | None:
+    def _get_device_spec(self, key: str) -> str | None:
         """Check if a flag exists in latest device info."""
         if not ((info := self._device_info) and (device := info.get("device"))):
             return None
-        return device.get(key)
+        return cast(str | None, device.get(key))
 
     @override
     async def async_is_on(self) -> bool:

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -658,7 +658,9 @@ class SamsungTVWSBridge(
             except (WebSocketException, AsyncioTimeoutError, OSError) as err:
                 LOGGER.debug("Failed to get remote for %s: %s", self.host, repr(err))
                 self._remote = None
-            else:
+
+            # All exception handlers set self._remote to None above
+            if self._remote is not None:
                 LOGGER.debug("Created SamsungTVWSBridge for %s", self.host)
                 if self._device_info is None:
                     await self.async_device_info()

--- a/homeassistant/components/samsungtv/bridge.py
+++ b/homeassistant/components/samsungtv/bridge.py
@@ -103,7 +103,6 @@ async def async_get_device_info(
     host: str,
 ) -> tuple[str, int | None, str | None, dict[str, Any] | None]:
     """Fetch the port, method, and device info."""
-    # Try the websocket ssl and non-ssl ports
     for port in WEBSOCKET_PORTS:
         bridge = SamsungTVBridge.get_bridge(hass, METHOD_WEBSOCKET, host, port)
         if info := await bridge.async_device_info():
@@ -112,7 +111,6 @@ async def async_get_device_info(
                 port,
                 info,
             )
-            # Check the encrypted port if the model requires encryption
             if model_requires_encryption(info.get("device", {}).get("modelName")):
                 encrypted_bridge = SamsungTVEncryptedBridge(
                     hass, METHOD_ENCRYPTED_WEBSOCKET, host, ENCRYPTED_WEBSOCKET_PORT
@@ -127,13 +125,11 @@ async def async_get_device_info(
                     )
             return RESULT_SUCCESS, port, METHOD_WEBSOCKET, info
 
-    # Try legacy port
     bridge = SamsungTVBridge.get_bridge(hass, METHOD_LEGACY, host, LEGACY_PORT)
     result = await bridge.async_try_connect()
     if result in SUCCESSFUL_RESULTS:
         return result, LEGACY_PORT, METHOD_LEGACY, await bridge.async_device_info()
 
-    # Failed to get info
     return result, None, None, None
 
 
@@ -366,7 +362,6 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
     def _send_key(self, key: str) -> None:
         """Send a key using legacy protocol."""
         try:
-            # recreate connection if connection was dead
             retry_count = 1
             for _ in range(retry_count + 1):
                 try:
@@ -401,7 +396,6 @@ class SamsungTVLegacyBridge(SamsungTVBridge):
         """Close remote object."""
         try:
             if self._remote is not None:
-                # Close the current remote connection
                 self._remote.close()
             self._remote = None
         except OSError:
@@ -437,7 +431,6 @@ class SamsungTVWSBaseBridge[
     async def _async_send_commands(self, commands: list[_CommandT]) -> None:
         """Send the commands using websocket protocol."""
         try:
-            # recreate connection if connection was dead
             retry_count = 1
             for _ in range(retry_count + 1):
                 try:
@@ -458,7 +451,6 @@ class SamsungTVWSBaseBridge[
     async def _async_get_remote(self) -> _RemoteT | None:
         """Create or return a remote control instance."""
         if (remote := self._remote) and remote.is_alive():
-            # If we have one then try to use it
             return remote
 
         async with self._remote_lock:
@@ -475,7 +467,6 @@ class SamsungTVWSBaseBridge[
         """Close remote object."""
         try:
             if self._remote is not None:
-                # Close the current remote connection
                 await self._remote.close()
             self._remote = None
         except OSError as err:
@@ -670,7 +661,6 @@ class SamsungTVWSBridge(
             else:
                 LOGGER.debug("Created SamsungTVWSBridge for %s", self.host)
                 if self._device_info is None:
-                    # Initialise device info on first connect
                     await self.async_device_info()
                 if self.token != self._remote.token:
                     LOGGER.warning(

--- a/homeassistant/components/samsungtv/config_flow.py
+++ b/homeassistant/components/samsungtv/config_flow.py
@@ -346,7 +346,7 @@ class SamsungTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if (
-                (pin := user_input.get(CONF_PIN))
+                (pin := user_input[CONF_PIN])
                 and (token := await self._authenticator.try_pin(pin))
                 and (session_id := await self._authenticator.get_session_id_and_close())
             ):
@@ -632,7 +632,7 @@ class SamsungTVConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             if (
-                (pin := user_input.get(CONF_PIN))
+                (pin := user_input[CONF_PIN])
                 and (token := await self._authenticator.try_pin(pin))
                 and (session_id := await self._authenticator.get_session_id_and_close())
             ):

--- a/homeassistant/components/samsungtv/coordinator.py
+++ b/homeassistant/components/samsungtv/coordinator.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from datetime import timedelta
-from typing import Any, override
+from typing import override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -38,7 +38,7 @@ class SamsungTVDataUpdateCoordinator(DataUpdateCoordinator[None]):
 
         self.bridge = bridge
         self.is_on: bool | None = None
-        self.async_extra_update: Callable[[], Coroutine[Any, Any, None]] | None = None
+        self.async_extra_update: Callable[[], Coroutine[None, None, None]] | None = None
 
     @override
     async def _async_update_data(self) -> None:

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -58,7 +58,6 @@ SUPPORT_SAMSUNGTV = (
 # Max delay waiting for app_list to return, as some TVs simply ignore the request
 APP_LIST_DELAY = 3
 
-# Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
 

--- a/homeassistant/components/samsungtv/media_player.py
+++ b/homeassistant/components/samsungtv/media_player.py
@@ -164,7 +164,7 @@ class SamsungTVDevice(SamsungTVEntity, MediaPlayerEntity):
                 await self._dmr_device.async_unsubscribe_services()
             return
 
-        startup_tasks: list[asyncio.Task[Any]] = []
+        startup_tasks: list[asyncio.Task[None]] = []
 
         if not self._app_list_event.is_set():
             startup_tasks.append(create_eager_task(self._async_startup_app_list()))

--- a/homeassistant/components/samsungtv/remote.py
+++ b/homeassistant/components/samsungtv/remote.py
@@ -11,7 +11,6 @@ from .const import LOGGER
 from .coordinator import SamsungTVConfigEntry
 from .entity import SamsungTVEntity
 
-# Coordinator is used to centralize the data updates
 PARALLEL_UPDATES = 0
 
 

--- a/tests/components/samsungtv/__init__.py
+++ b/tests/components/samsungtv/__init__.py
@@ -1,7 +1,6 @@
 """Tests for the samsungtv component."""
 
 from collections.abc import Mapping
-from typing import Any
 
 from homeassistant.components.samsungtv.const import DOMAIN, METHOD_LEGACY
 from homeassistant.config_entries import ConfigEntry
@@ -12,7 +11,7 @@ from tests.common import MockConfigEntry
 
 
 async def setup_samsungtv_entry(
-    hass: HomeAssistant, data: Mapping[str, Any]
+    hass: HomeAssistant, data: Mapping[str, str | int]
 ) -> ConfigEntry:
     """Set up mock Samsung TV from config entry data."""
     entry = MockConfigEntry(

--- a/tests/components/samsungtv/conftest.py
+++ b/tests/components/samsungtv/conftest.py
@@ -235,16 +235,16 @@ def remote_websocket_fixture() -> Generator[Mock]:
         remote_websocket.ws_event_callback = ws_event_callback
 
     async def _send_commands(commands: list[SamsungTVCommand]):
-        if (
-            len(commands) == 1
-            and isinstance(commands[0], ChannelEmitCommand)
-            and commands[0].params["event"] == "ed.installedApp.get"
-            and remote_websocket.app_list_data is not None
-        ):
-            remote_websocket.raise_mock_ws_event_callback(
-                ED_INSTALLED_APP_EVENT,
-                remote_websocket.app_list_data,
-            )
+        if remote_websocket.app_list_data is None:
+            return
+        if not (len(commands) == 1 and isinstance(commands[0], ChannelEmitCommand)):
+            return
+        if commands[0].params["event"] != "ed.installedApp.get":
+            return
+        remote_websocket.raise_mock_ws_event_callback(
+            ED_INSTALLED_APP_EVENT,
+            remote_websocket.app_list_data,
+        )
 
     def _mock_ws_event_callback(event: str, response: Any):
         if remote_websocket.ws_event_callback:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adapts the samsungtv integration code to the rules defined in the project's AGENTS.md file. The integration was written before these rules existed and had never been audited against them.

The 5 commits are organized by rule, each addressing a specific AGENTS.md guideline:

1. Avoid branching in tests — Replace compound condition with guard clauses in _send_commands mock
2. Prefer concrete types over Any — 5 type annotations narrowed (Coroutine, Task, Mapping, return type)
3. No comments that restate the code — Remove 13 redundant comments across 4 files
4. Direct key access when validation guarantees the key — 2 occurrences of .get() → [] in config flow
5. Small try-clauses — Move unrelated initialization logic out of the else block in bridge.py

With this PR, no remaining code in the samsungtv integration violates the AGENTS.md rules that were identified during the audit.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

None.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
