### PR TITLE
Validate bsblan schedule service target devices

### DIFF
--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -165,9 +165,27 @@ def _resolve_config_entry(
     return entry, device_entry
 
 
+def _device_name(device_entry: dr.DeviceEntry) -> str:
+    """Return the best available display name for a device."""
+    return device_entry.name_by_user or device_entry.name or device_entry.id
+
+
+def _ensure_water_heater_device(device_entry: dr.DeviceEntry) -> None:
+    """Validate the service targets the water heater sub-device."""
+    for domain, identifier in device_entry.identifiers:
+        if domain == DOMAIN and identifier.endswith("-water-heater"):
+            return
+    raise ServiceValidationError(
+        translation_domain=DOMAIN,
+        translation_key="not_a_water_heater_device",
+        translation_placeholders={"device_name": _device_name(device_entry)},
+    )
+
+
 async def set_hot_water_schedule(service_call: ServiceCall) -> None:
     """Set hot water heating schedule."""
-    entry, _ = _resolve_config_entry(service_call)
+    entry, device_entry = _resolve_config_entry(service_call)
+    _ensure_water_heater_device(device_entry)
     client = entry.runtime_data.client
 
     days = _build_weekly_schedule_days(service_call)

--- a/homeassistant/components/bsblan/services.yaml
+++ b/homeassistant/components/bsblan/services.yaml
@@ -6,6 +6,8 @@ sync_time:
       selector:
         device:
           integration: bsblan
+          entity:
+            - domain: button
 
 set_hot_water_schedule:
   fields:
@@ -15,6 +17,8 @@ set_hot_water_schedule:
       selector:
         device:
           integration: bsblan
+          entity:
+            - domain: water_heater
     monday_slots:
       selector:
         object:

--- a/homeassistant/components/bsblan/strings.json
+++ b/homeassistant/components/bsblan/strings.json
@@ -127,6 +127,9 @@
     "no_config_entry_for_device": {
       "message": "No configuration entry found for device: {device_id}"
     },
+    "not_a_water_heater_device": {
+      "message": "The selected device ({device_name}) is not a water heater. Please select the water heater sub-device."
+    },
     "set_data_error": {
       "message": "An error occurred while sending the data to the BSB-LAN device"
     },

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -9,7 +9,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.bsblan.const import DOMAIN, water_heater_identifier
+from homeassistant.components.bsblan.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -51,7 +51,7 @@ def water_heater_device_entry(
 ) -> dr.DeviceEntry:
     """Get the water heater sub-device entry for testing."""
     device = device_registry.async_get_device(
-        identifiers={(DOMAIN, water_heater_identifier(TEST_DEVICE_MAC))}
+        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-water-heater")}
     )
     assert device is not None
     return device

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -9,7 +9,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
 
-from homeassistant.components.bsblan.const import DOMAIN
+from homeassistant.components.bsblan.const import DOMAIN, water_heater_identifier
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
@@ -40,6 +40,19 @@ def device_entry(
 ) -> dr.DeviceEntry:
     """Get the device entry for testing."""
     device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    assert device is not None
+    return device
+
+
+@pytest.fixture
+def water_heater_device_entry(
+    device_registry: dr.DeviceRegistry,
+    setup_integration: None,
+) -> dr.DeviceEntry:
+    """Get the water heater sub-device entry for testing."""
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, water_heater_identifier(TEST_DEVICE_MAC))}
+    )
     assert device is not None
     return device
 
@@ -119,13 +132,13 @@ def device_entry(
 async def test_set_hot_water_schedule(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
     service_data: dict[str, Any],
     expected_schedules: dict[str, DaySchedule],
 ) -> None:
     """Test setting hot water schedule with various configurations."""
     # Call the service with device_id and slot fields
-    service_call_data = {"device_id": device_entry.id}
+    service_call_data = {"device_id": water_heater_device_entry.id}
     service_call_data.update(service_data)
 
     await hass.services.async_call(
@@ -216,7 +229,7 @@ async def test_no_config_entry_for_device(
 async def test_config_entry_not_loaded(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test error when config entry is not loaded."""
     await hass.config_entries.async_unload(mock_config_entry.entry_id)
@@ -226,7 +239,7 @@ async def test_config_entry_not_loaded(
             DOMAIN,
             "set_hot_water_schedule",
             {
-                "device_id": device_entry.id,
+                "device_id": water_heater_device_entry.id,
                 "monday_slots": [
                     {"start_time": time(6, 0), "end_time": time(8, 0)},
                 ],
@@ -241,12 +254,34 @@ async def test_config_entry_not_loaded(
 async def test_api_error(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test error when BSB-LAN API call fails."""
     mock_bsblan.set_hot_water_schedule.side_effect = BSBLANError("API Error")
 
     with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            DOMAIN,
+            "set_hot_water_schedule",
+            {
+                "device_id": water_heater_device_entry.id,
+                "monday_slots": [
+                    {"start_time": time(6, 0), "end_time": time(8, 0)},
+                ],
+            },
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "set_schedule_failed"
+
+
+@pytest.mark.usefixtures("setup_integration")
+async def test_set_hot_water_schedule_rejects_main_device(
+    hass: HomeAssistant,
+    device_entry: dr.DeviceEntry,
+) -> None:
+    """Test that picking the main device for hot water schedule is rejected."""
+    with pytest.raises(ServiceValidationError) as exc_info:
         await hass.services.async_call(
             DOMAIN,
             "set_hot_water_schedule",
@@ -259,7 +294,7 @@ async def test_api_error(
             blocking=True,
         )
 
-    assert exc_info.value.translation_key == "set_schedule_failed"
+    assert exc_info.value.translation_key == "not_a_water_heater_device"
 
 
 @pytest.mark.usefixtures("setup_integration")
@@ -276,7 +311,7 @@ async def test_api_error(
 )
 async def test_time_validation_errors(
     hass: HomeAssistant,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
     start_time: time | str,
     end_time: time | str,
     expected_error: str,
@@ -287,7 +322,7 @@ async def test_time_validation_errors(
             DOMAIN,
             "set_hot_water_schedule",
             {
-                "device_id": device_entry.id,
+                "device_id": water_heater_device_entry.id,
                 "monday_slots": [
                     {"start_time": start_time, "end_time": end_time},
                 ],
@@ -302,7 +337,7 @@ async def test_time_validation_errors(
 async def test_unprovided_days_are_none(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test that unprovided days are sent as None to BSB-LAN API."""
     # Only provide Monday and Tuesday, leave other days unprovided
@@ -310,7 +345,7 @@ async def test_unprovided_days_are_none(
         DOMAIN,
         "set_hot_water_schedule",
         {
-            "device_id": device_entry.id,
+            "device_id": water_heater_device_entry.id,
             "monday_slots": [
                 {"start_time": time(6, 0), "end_time": time(8, 0)},
             ],
@@ -346,7 +381,7 @@ async def test_unprovided_days_are_none(
 async def test_string_time_formats(
     hass: HomeAssistant,
     mock_bsblan: MagicMock,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with string time formats."""
     # Test with string time formats
@@ -354,7 +389,7 @@ async def test_string_time_formats(
         DOMAIN,
         "set_hot_water_schedule",
         {
-            "device_id": device_entry.id,
+            "device_id": water_heater_device_entry.id,
             "monday_slots": [
                 {"start_time": "06:00:00", "end_time": "08:00:00"},  # With seconds
             ],
@@ -382,7 +417,7 @@ async def test_string_time_formats(
 @pytest.mark.usefixtures("setup_integration")
 async def test_non_standard_time_types(
     hass: HomeAssistant,
-    device_entry: dr.DeviceEntry,
+    water_heater_device_entry: dr.DeviceEntry,
 ) -> None:
     """Test service with non-standard time types raises error."""
     # Test with integer time values - schema validation will reject these
@@ -391,7 +426,7 @@ async def test_non_standard_time_types(
             DOMAIN,
             "set_hot_water_schedule",
             {
-                "device_id": device_entry.id,
+                "device_id": water_heater_device_entry.id,
                 "monday_slots": [
                     {"start_time": 600, "end_time": 800},
                 ],


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request enhances the validation and usability of the `set_hot_water_schedule` service for the `bsblan` integration. It ensures that only the water heater sub-device can be targeted by this service, provides clearer error messages, and updates the service schema and tests accordingly.

In the next pull request we'll add heating circuit support so this is why we need to validate the device.

**Validation and Error Handling Improvements:**

- Added `_ensure_water_heater_device` in `services.py` to validate that the selected device is a water heater sub-device, raising a `ServiceValidationError` with a helpful message if not.
- Added a new translation string `not_a_water_heater_device` to provide a user-friendly error message when an invalid device is selected.

**Service Schema Updates:**

- Updated `services.yaml` to restrict the `set_hot_water_schedule` service to only accept `water_heater` domain devices, preventing accidental selection of the main device.
- Updated the `sync_time` service selector to explicitly allow only `button` domain entities.

**Test Suite Updates:**

- Added a new fixture `water_heater_device_entry` and updated all relevant tests to use the water heater sub-device, ensuring tests reflect the new validation logic. [[1]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582R47-R59) [[2]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L122-R141) [[3]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L219-R232) [[4]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L229-R242) [[5]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L244-R257) [[6]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582R278-R299) [[7]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L279-R314) [[8]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L290-R325) [[9]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L305-R348) [[10]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L349-R392) [[11]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L385-R420) [[12]](diffhunk://#diff-61a319961c667ac8e7c0ff3e7a42920926de2ddf2d6e509c5a44744834a2a582L394-R429)
- Added a dedicated test to verify that attempting to use the main device for hot water scheduling is correctly rejected with the appropriate error.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
