### PR TITLE
Use base EntityStateAttribute for geo_location coordinates

### DIFF
--- a/homeassistant/components/geo_location/__init__.py
+++ b/homeassistant/components/geo_location/__init__.py
@@ -7,7 +7,11 @@ from typing import Any, final, override
 from propcache.api import cached_property
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE  # noqa: F401
+from homeassistant.const import (  # noqa: F401
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    EntityStateAttribute,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
@@ -105,7 +109,7 @@ class GeolocationEvent(Entity, cached_properties=CACHED_PROPERTIES_WITH_ATTR_):
         """Return the state attributes of this external event."""
         data: dict[str, Any] = {GeolocationEntityStateAttribute.SOURCE: self.source}
         if self.latitude is not None:
-            data[GeolocationEntityStateAttribute.LATITUDE] = round(self.latitude, 5)
+            data[EntityStateAttribute.LATITUDE] = round(self.latitude, 5)
         if self.longitude is not None:
-            data[GeolocationEntityStateAttribute.LONGITUDE] = round(self.longitude, 5)
+            data[EntityStateAttribute.LONGITUDE] = round(self.longitude, 5)
         return data

--- a/homeassistant/components/geo_location/const.py
+++ b/homeassistant/components/geo_location/const.py
@@ -2,8 +2,17 @@
 
 from enum import StrEnum
 
+from homeassistant.helpers.deprecation import EnumWithDeprecatedMembers
 
-class GeolocationEntityStateAttribute(StrEnum):
+
+class GeolocationEntityStateAttribute(
+    StrEnum,
+    metaclass=EnumWithDeprecatedMembers,
+    deprecated={
+        "LATITUDE": ("EntityStateAttribute.LATITUDE", "2027.2.0"),
+        "LONGITUDE": ("EntityStateAttribute.LONGITUDE", "2027.2.0"),
+    },
+):
     """State attributes for geolocation entities."""
 
     SOURCE = "source"

--- a/homeassistant/components/geo_location/const.py
+++ b/homeassistant/components/geo_location/const.py
@@ -16,5 +16,5 @@ class GeolocationEntityStateAttribute(
     """State attributes for geolocation entities."""
 
     SOURCE = "source"
-    LATITUDE = "latitude"
-    LONGITUDE = "longitude"
+    LATITUDE = "latitude"  # Deprecated, replaced with EntityStateAttribute.LATITUDE
+    LONGITUDE = "longitude"  # Deprecated, replaced with EntityStateAttribute.LONGITUDE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633 and #176119, which introduced the base `EntityStateAttribute` enum and moved `latitude`/`longitude` onto it.

The geo_location entity writes its coordinates through `GeolocationEntityStateAttribute.LATITUDE` / `GeolocationEntityStateAttribute.LONGITUDE`. Now that `latitude`/`longitude` live on the base enum, the entity writes them through `EntityStateAttribute.LATITUDE` / `EntityStateAttribute.LONGITUDE`, and the platform-specific enum members are deprecated (via `EnumWithDeprecatedMembers`, breaking in 2027.2) in favour of the base enum. `GeolocationEntityStateAttribute.SOURCE` is unchanged.

No behaviour change: these enums are `StrEnum`s, so the resolved keys are identical.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
