### PR TITLE
Add reconfiguration support for energieleser

### DIFF
--- a/homeassistant/components/energieleser/config_flow.py
+++ b/homeassistant/components/energieleser/config_flow.py
@@ -141,6 +141,44 @@ class EnergieleserConfigFlow(ConfigFlow, domain=DOMAIN):
             },
         )
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle a reconfiguration flow initialized by the user."""
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            client = EnergieleserClient(
+                host=host, session=async_get_clientsession(self.hass)
+            )
+            try:
+                device = await client.get_device()
+            except EnergieleserConnectionError:
+                errors["base"] = "cannot_connect"
+            except EnergieleserUnknownDeviceError:
+                errors["base"] = "unknown_device_type"
+            except EnergieleserError:
+                errors["base"] = "unknown"
+            else:
+                if device.device_id != entry.data[CONF_DEVICE_ID]:
+                    errors["base"] = "another_device"
+                else:
+                    return self.async_update_reload_and_abort(
+                        entry,
+                        data_updates={CONF_HOST: host},
+                    )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_USER_SCHEMA,
+                suggested_values=entry.data | (user_input or {}),
+            ),
+            errors=errors,
+        )
+
     def _create_entry(
         self, host: str, title: str, device_id: str, sw_version: str | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/energieleser/config_flow.py
+++ b/homeassistant/components/energieleser/config_flow.py
@@ -162,13 +162,12 @@ class EnergieleserConfigFlow(ConfigFlow, domain=DOMAIN):
             except EnergieleserError:
                 errors["base"] = "unknown"
             else:
-                if device.device_id != entry.data[CONF_DEVICE_ID]:
-                    errors["base"] = "another_device"
-                else:
-                    return self.async_update_reload_and_abort(
-                        entry,
-                        data_updates={CONF_HOST: host},
-                    )
+                await self.async_set_unique_id(device.device_id)
+                self._abort_if_unique_id_mismatch(reason="wrong_device")
+                return self.async_update_reload_and_abort(
+                    entry,
+                    data_updates={CONF_HOST: host},
+                )
 
         return self.async_show_form(
             step_id="reconfigure",

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -68,7 +68,7 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: exempt

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -3,16 +3,28 @@
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser."
     },
     "error": {
+      "another_device": "The device at this IP address does not match the originally configured device.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser."
     },
     "flow_title": "{device_type} · {host}",
     "step": {
+      "reconfigure": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]"
+        },
+        "data_description": {
+          "host": "[%key:component::energieleser::config::step::user::data_description::host%]"
+        },
+        "description": "Update the IP address or hostname of your energieleser device.",
+        "title": "Reconfigure energieleser"
+      },
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]"

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -5,10 +5,10 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
-      "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser."
+      "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser.",
+      "wrong_device": "The device at this IP address does not match the originally configured device."
     },
     "error": {
-      "another_device": "The device at this IP address does not match the originally configured device.",
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "unknown": "[%key:common::config_flow::error::unknown%]",
       "unknown_device_type": "This isn't a supported energieleser product. Please check that the device is a stromleser, gasleser, wasserleser, or wärmeleser."

--- a/tests/components/energieleser/test_config_flow.py
+++ b/tests/components/energieleser/test_config_flow.py
@@ -307,3 +307,90 @@ async def test_zeroconf_flow_errors(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == expected_reason
+
+
+@pytest.mark.usefixtures("mock_setup_entry", "mock_energieleser_client")
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_stromleser_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful reconfiguration flow."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.102"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_stromleser_config_entry.data[CONF_HOST] == "192.168.1.102"
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+async def test_reconfigure_flow_another_device(
+    hass: HomeAssistant,
+    mock_stromleser_config_entry: MockConfigEntry,
+    mock_energieleser_client: AsyncMock,
+    mock_gasleser_device: GasleserDevice,
+) -> None:
+    """Test reconfiguration flow with a different device."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    # Return a different device than the configured one
+    mock_energieleser_client.get_device.return_value = mock_gasleser_device
+
+    result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.105"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "another_device"}
+
+
+@pytest.mark.usefixtures("mock_setup_entry")
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        pytest.param(
+            EnergieleserConnectionError("boom"), "cannot_connect", id="cannot_connect"
+        ),
+        pytest.param(
+            EnergieleserUnknownDeviceError("FOO_0000000001"),
+            "unknown_device_type",
+            id="unknown_device_type",
+        ),
+        pytest.param(
+            EnergieleserError("boom"),
+            "unknown",
+            id="unknown",
+        ),
+    ],
+)
+async def test_reconfigure_flow_errors(
+    hass: HomeAssistant,
+    mock_stromleser_config_entry: MockConfigEntry,
+    mock_energieleser_client: AsyncMock,
+    side_effect: Exception,
+    expected_error: str,
+) -> None:
+    """Test client errors during reconfiguration flow."""
+    mock_stromleser_config_entry.add_to_hass(hass)
+    mock_energieleser_client.get_device.side_effect = side_effect
+
+    result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.105"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}

--- a/tests/components/energieleser/test_config_flow.py
+++ b/tests/components/energieleser/test_config_flow.py
@@ -341,7 +341,7 @@ async def test_reconfigure_flow_another_device(
     """Test reconfiguration flow with a different device."""
     mock_stromleser_config_entry.add_to_hass(hass)
 
-mock_energieleser_client.get_device.return_value = mock_gasleser_device
+    mock_energieleser_client.get_device.return_value = mock_gasleser_device
 
     result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -394,7 +394,7 @@ async def test_reconfigure_flow_errors(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
 
-mock_energieleser_client.get_device.side_effect = None
+    mock_energieleser_client.get_device.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_HOST: "192.168.1.102"},

--- a/tests/components/energieleser/test_config_flow.py
+++ b/tests/components/energieleser/test_config_flow.py
@@ -341,8 +341,7 @@ async def test_reconfigure_flow_another_device(
     """Test reconfiguration flow with a different device."""
     mock_stromleser_config_entry.add_to_hass(hass)
 
-    # Return a different device than the configured one
-    mock_energieleser_client.get_device.return_value = mock_gasleser_device
+mock_energieleser_client.get_device.return_value = mock_gasleser_device
 
     result = await mock_stromleser_config_entry.start_reconfigure_flow(hass)
     assert result["type"] is FlowResultType.FORM
@@ -395,8 +394,7 @@ async def test_reconfigure_flow_errors(
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
 
-    # Recover
-    mock_energieleser_client.get_device.side_effect = None
+mock_energieleser_client.get_device.side_effect = None
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={CONF_HOST: "192.168.1.102"},

--- a/tests/components/energieleser/test_config_flow.py
+++ b/tests/components/energieleser/test_config_flow.py
@@ -352,8 +352,8 @@ async def test_reconfigure_flow_another_device(
         user_input={CONF_HOST: "192.168.1.105"},
     )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["errors"] == {"base": "another_device"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_device"
 
 
 @pytest.mark.usefixtures("mock_setup_entry")
@@ -394,3 +394,13 @@ async def test_reconfigure_flow_errors(
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": expected_error}
+
+    # Recover
+    mock_energieleser_client.get_device.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        user_input={CONF_HOST: "192.168.1.102"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds reconfiguration flow support and tests to the `energieleser` integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr