### PR TITLE
Migrate ddwrt from DeviceScanner to ScannerEntity and add config flow

### DIFF
--- a/homeassistant/components/ddwrt/__init__.py
+++ b/homeassistant/components/ddwrt/__init__.py
@@ -1,1 +1,22 @@
-"""The ddwrt component."""
+"""The DD-WRT integration."""
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .coordinator import DdWrtConfigEntry, DdWrtDataUpdateCoordinator
+
+PLATFORMS = [Platform.DEVICE_TRACKER]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: DdWrtConfigEntry) -> bool:
+    """Set up DD-WRT from a config entry."""
+    coordinator = DdWrtDataUpdateCoordinator(hass, entry)
+    await coordinator.async_config_entry_first_refresh()
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: DdWrtConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/ddwrt/config_flow.py
+++ b/homeassistant/components/ddwrt/config_flow.py
@@ -1,0 +1,91 @@
+"""Config flow for the DD-WRT integration."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.helpers import config_validation as cv
+
+from .const import (
+    CONF_WIRELESS_ONLY,
+    DEFAULT_NAME,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DEFAULT_WIRELESS_ONLY,
+    DOMAIN,
+)
+from .router import DdWrtConnectionError, DdWrtRouter
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): cv.string,
+        vol.Required(CONF_USERNAME): cv.string,
+        vol.Required(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_SSL, default=DEFAULT_SSL): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=DEFAULT_VERIFY_SSL): cv.boolean,
+        vol.Optional(CONF_WIRELESS_ONLY, default=DEFAULT_WIRELESS_ONLY): cv.boolean,
+    }
+)
+
+
+def _validate_connection(data: dict[str, Any]) -> None:
+    """Validate that we can connect to the DD-WRT router."""
+    router = DdWrtRouter(
+        data[CONF_HOST],
+        data[CONF_USERNAME],
+        data[CONF_PASSWORD],
+        use_ssl=data[CONF_SSL],
+        verify_ssl=data[CONF_VERIFY_SSL],
+        wireless_only=data[CONF_WIRELESS_ONLY],
+    )
+    router.get_clients()
+
+
+class DdWrtConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for DD-WRT."""
+
+    VERSION = 1
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
+            try:
+                await self.hass.async_add_executor_job(_validate_connection, user_input)
+            except DdWrtConnectionError:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(
+                    title=f"{DEFAULT_NAME} ({user_input[CONF_HOST]})",
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
+        """Import existing configuration from configuration.yaml."""
+        self._async_abort_entries_match({CONF_HOST: import_data[CONF_HOST]})
+        try:
+            await self.hass.async_add_executor_job(_validate_connection, import_data)
+        except DdWrtConnectionError:
+            return self.async_abort(reason="cannot_connect")
+
+        return self.async_create_entry(
+            title=f"{DEFAULT_NAME} ({import_data[CONF_HOST]})",
+            data=import_data,
+        )

--- a/homeassistant/components/ddwrt/config_flow.py
+++ b/homeassistant/components/ddwrt/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for the DD-WRT integration."""
 
-from typing import Any
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -54,6 +54,7 @@ class DdWrtConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:

--- a/homeassistant/components/ddwrt/config_flow.py
+++ b/homeassistant/components/ddwrt/config_flow.py
@@ -22,7 +22,7 @@ from .const import (
     DEFAULT_WIRELESS_ONLY,
     DOMAIN,
 )
-from .router import DdWrtConnectionError, DdWrtRouter
+from .router import DdWrtAuthError, DdWrtConnectionError, DdWrtRouter
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -64,6 +64,8 @@ class DdWrtConfigFlow(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             try:
                 await self.hass.async_add_executor_job(_validate_connection, user_input)
+            except DdWrtAuthError:
+                errors["base"] = "invalid_auth"
             except DdWrtConnectionError:
                 errors["base"] = "cannot_connect"
             else:

--- a/homeassistant/components/ddwrt/const.py
+++ b/homeassistant/components/ddwrt/const.py
@@ -1,0 +1,11 @@
+"""Constants for the DD-WRT integration."""
+
+DOMAIN = "ddwrt"
+
+DEFAULT_NAME = "DD-WRT"
+
+CONF_WIRELESS_ONLY = "wireless_only"
+
+DEFAULT_SSL = False
+DEFAULT_VERIFY_SSL = True
+DEFAULT_WIRELESS_ONLY = True

--- a/homeassistant/components/ddwrt/coordinator.py
+++ b/homeassistant/components/ddwrt/coordinator.py
@@ -1,0 +1,58 @@
+"""DataUpdateCoordinator for DD-WRT."""
+
+from datetime import timedelta
+import logging
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import CONF_WIRELESS_ONLY, DOMAIN
+from .router import DdWrtClients, DdWrtConnectionError, DdWrtRouter
+
+_LOGGER = logging.getLogger(__name__)
+
+UPDATE_INTERVAL = timedelta(seconds=30)
+
+type DdWrtConfigEntry = ConfigEntry[DdWrtDataUpdateCoordinator]
+
+
+class DdWrtDataUpdateCoordinator(DataUpdateCoordinator[DdWrtClients]):
+    """Class to manage fetching data from a DD-WRT router."""
+
+    config_entry: DdWrtConfigEntry
+
+    def __init__(self, hass: HomeAssistant, config_entry: DdWrtConfigEntry) -> None:
+        """Initialize the coordinator from a config entry."""
+        self.host = config_entry.data[CONF_HOST]
+        self.router = DdWrtRouter(
+            self.host,
+            config_entry.data[CONF_USERNAME],
+            config_entry.data[CONF_PASSWORD],
+            use_ssl=config_entry.data[CONF_SSL],
+            verify_ssl=config_entry.data[CONF_VERIFY_SSL],
+            wireless_only=config_entry.data[CONF_WIRELESS_ONLY],
+        )
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN} - {self.host}",
+            update_interval=UPDATE_INTERVAL,
+        )
+
+    async def _async_update_data(self) -> DdWrtClients:
+        """Fetch the connected clients from the DD-WRT router."""
+        try:
+            return await self.hass.async_add_executor_job(self.router.get_clients)
+        except DdWrtConnectionError as err:
+            raise UpdateFailed(
+                f"Failed to fetch data from DD-WRT router {self.host}"
+            ) from err

--- a/homeassistant/components/ddwrt/coordinator.py
+++ b/homeassistant/components/ddwrt/coordinator.py
@@ -2,6 +2,7 @@
 
 from datetime import timedelta
 import logging
+from typing import override
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -48,6 +49,7 @@ class DdWrtDataUpdateCoordinator(DataUpdateCoordinator[DdWrtClients]):
             update_interval=UPDATE_INTERVAL,
         )
 
+    @override
     async def _async_update_data(self) -> DdWrtClients:
         """Fetch the connected clients from the DD-WRT router."""
         try:

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -80,6 +80,8 @@ async def async_setup_scanner(
         )
         return False
 
+    ir.async_delete_issue(hass, DOMAIN, "yaml_import_cannot_connect")
+
     ir.async_create_issue(
         hass,
         HOMEASSISTANT_DOMAIN,

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -1,5 +1,7 @@
 """Support for DD-WRT routers as a device tracker."""
 
+from typing import override
+
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
@@ -131,16 +133,19 @@ class DdWrtScannerEntity(CoordinatorEntity[DdWrtDataUpdateCoordinator], ScannerE
         self._attr_name = device.get("hostname") or mac
 
     @property
+    @override
     def is_connected(self) -> bool:
         """Return true if the device is currently connected to the router."""
         return self._mac in self.coordinator.data
 
     @property
+    @override
     def mac_address(self) -> str:
         """Return the MAC address of the device."""
         return self._mac
 
     @property
+    @override
     def ip_address(self) -> str | None:
         """Return the IP address of the device."""
         if device := self.coordinator.data.get(self._mac):
@@ -148,6 +153,7 @@ class DdWrtScannerEntity(CoordinatorEntity[DdWrtDataUpdateCoordinator], ScannerE
         return None
 
     @property
+    @override
     def hostname(self) -> str | None:
         """Return the hostname of the device."""
         if device := self.coordinator.data.get(self._mac):

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -1,18 +1,13 @@
-"""Support for DD-WRT routers."""
+"""Support for DD-WRT routers as a device tracker."""
 
-from http import HTTPStatus
-import logging
-import re
-from typing import override
-
-import requests
 import voluptuous as vol
 
 from homeassistant.components.device_tracker import (
-    DOMAIN as DEVICE_TRACKER_DOMAIN,
     PLATFORM_SCHEMA as DEVICE_TRACKER_PLATFORM_SCHEMA,
-    DeviceScanner,
+    AsyncSeeCallback,
+    ScannerEntity,
 )
+from homeassistant.config_entries import SOURCE_IMPORT
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -20,19 +15,22 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
-from homeassistant.helpers.typing import ConfigType
+from homeassistant.core import DOMAIN as HOMEASSISTANT_DOMAIN, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv, issue_registry as ir
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-_LOGGER = logging.getLogger(__name__)
-
-_DDWRT_DATA_REGEX = re.compile(r"\{(\w+)::([^\}]*)\}")
-_MAC_REGEX = re.compile(r"(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})")
-
-DEFAULT_SSL = False
-DEFAULT_VERIFY_SSL = True
-CONF_WIRELESS_ONLY = "wireless_only"
-DEFAULT_WIRELESS_ONLY = True
+from .const import (
+    CONF_WIRELESS_ONLY,
+    DEFAULT_NAME,
+    DEFAULT_SSL,
+    DEFAULT_VERIFY_SSL,
+    DEFAULT_WIRELESS_ONLY,
+    DOMAIN,
+)
+from .coordinator import DdWrtConfigEntry, DdWrtDataUpdateCoordinator
 
 PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
     {
@@ -46,126 +44,112 @@ PLATFORM_SCHEMA = DEVICE_TRACKER_PLATFORM_SCHEMA.extend(
 )
 
 
-def get_scanner(hass: HomeAssistant, config: ConfigType) -> DdWrtDeviceScanner | None:
-    """Validate the configuration and return a DD-WRT scanner."""
-    try:
-        return DdWrtDeviceScanner(config[DEVICE_TRACKER_DOMAIN])
-    except ConnectionError:
+async def async_setup_scanner(
+    hass: HomeAssistant,
+    config: ConfigType,
+    _async_see: AsyncSeeCallback,
+    _discovery_info: DiscoveryInfoType | None = None,
+) -> bool:
+    """Set up the legacy DD-WRT device tracker by importing YAML config."""
+    import_data = {
+        CONF_HOST: config[CONF_HOST],
+        CONF_USERNAME: config[CONF_USERNAME],
+        CONF_PASSWORD: config[CONF_PASSWORD],
+        CONF_SSL: config[CONF_SSL],
+        CONF_VERIFY_SSL: config[CONF_VERIFY_SSL],
+        CONF_WIRELESS_ONLY: config[CONF_WIRELESS_ONLY],
+    }
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_IMPORT},
+        data=import_data,
+    )
+
+    if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "yaml_import_cannot_connect",
+            is_fixable=False,
+            issue_domain=DOMAIN,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="yaml_import_cannot_connect",
+            translation_placeholders={"host": config[CONF_HOST]},
+        )
+        return False
+
+    ir.async_create_issue(
+        hass,
+        HOMEASSISTANT_DOMAIN,
+        f"deprecated_yaml_{DOMAIN}",
+        is_fixable=False,
+        issue_domain=DOMAIN,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="deprecated_yaml",
+        translation_placeholders={
+            "domain": DOMAIN,
+            "integration_title": DEFAULT_NAME,
+        },
+    )
+
+    return True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: DdWrtConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up device tracker entities for a DD-WRT config entry."""
+    coordinator = config_entry.runtime_data
+    tracked: set[str] = set()
+
+    @callback
+    def _async_update_devices() -> None:
+        """Add entities for newly discovered devices."""
+        new_entities = [
+            DdWrtScannerEntity(coordinator, mac)
+            for mac in coordinator.data
+            if mac not in tracked
+        ]
+        if new_entities:
+            tracked.update(entity.mac_address for entity in new_entities)
+            async_add_entities(new_entities)
+
+    config_entry.async_on_unload(coordinator.async_add_listener(_async_update_devices))
+    _async_update_devices()
+
+
+class DdWrtScannerEntity(CoordinatorEntity[DdWrtDataUpdateCoordinator], ScannerEntity):
+    """Representation of a device connected to a DD-WRT router."""
+
+    def __init__(self, coordinator: DdWrtDataUpdateCoordinator, mac: str) -> None:
+        """Initialize the tracked device."""
+        super().__init__(coordinator)
+        self._mac = mac
+        device = coordinator.data.get(mac) or {}
+        self._attr_name = device.get("hostname") or mac
+
+    @property
+    def is_connected(self) -> bool:
+        """Return true if the device is currently connected to the router."""
+        return self._mac in self.coordinator.data
+
+    @property
+    def mac_address(self) -> str:
+        """Return the MAC address of the device."""
+        return self._mac
+
+    @property
+    def ip_address(self) -> str | None:
+        """Return the IP address of the device."""
+        if device := self.coordinator.data.get(self._mac):
+            return device.get("ip")
         return None
 
-
-class DdWrtDeviceScanner(DeviceScanner):
-    """Class which queries a wireless router running DD-WRT firmware."""
-
-    def __init__(self, config):
-        """Initialize the DD-WRT scanner."""
-        self.protocol = "https" if config[CONF_SSL] else "http"
-        self.verify_ssl = config[CONF_VERIFY_SSL]
-        self.host = config[CONF_HOST]
-        self.username = config[CONF_USERNAME]
-        self.password = config[CONF_PASSWORD]
-        self.wireless_only = config[CONF_WIRELESS_ONLY]
-
-        self.last_results = {}
-        self.mac2name = {}
-
-        # Test the router is accessible
-        url = f"{self.protocol}://{self.host}/Status_Wireless.live.asp"
-        if not self.get_ddwrt_data(url):
-            raise ConnectionError("Cannot connect to DD-Wrt router")
-
-    @override
-    def scan_devices(self):
-        """Scan for new devices and return a list with found device IDs."""
-        self._update_info()
-
-        return self.last_results
-
-    @override
-    def get_device_name(self, device):
-        """Return the name of the given device or None if we don't know."""
-        # If not initialised and not already scanned and not found.
-        if device not in self.mac2name:
-            url = f"{self.protocol}://{self.host}/Status_Lan.live.asp"
-
-            if not (data := self.get_ddwrt_data(url)):
-                return None
-
-            if not (dhcp_leases := data.get("dhcp_leases")):
-                return None
-
-            # Remove leading and trailing quotes and spaces
-            cleaned_str = dhcp_leases.replace('"', "").replace("'", "").replace(" ", "")
-            elements = cleaned_str.split(",")
-            num_clients = int(len(elements) / 5)
-            self.mac2name = {}
-            for idx in range(num_clients):
-                # The data is a single array
-                # every 5 elements represents one host, the MAC
-                # is the third element and the name is the first.
-                mac_index = (idx * 5) + 2
-                if mac_index < len(elements):
-                    mac = elements[mac_index]
-                    self.mac2name[mac] = elements[idx * 5]
-
-        return self.mac2name.get(device)
-
-    def _update_info(self):
-        """Ensure the information from the DD-WRT router is up to date.
-
-        Return boolean if scanning successful.
-        """
-        _LOGGER.debug("Checking ARP")
-
-        endpoint = "Wireless" if self.wireless_only else "Lan"
-        url = f"{self.protocol}://{self.host}/Status_{endpoint}.live.asp"
-
-        if not (data := self.get_ddwrt_data(url)):
-            return False
-
-        self.last_results = []
-
-        if self.wireless_only:
-            active_clients = data.get("active_wireless")
-        else:
-            active_clients = data.get("arp_table")
-        if not active_clients:
-            return False
-
-        # The DD-WRT UI uses its own data format and then
-        # regex's out values so this is done here too
-        # Remove leading and trailing single quotes.
-        clean_str = active_clients.strip().strip("'")
-        elements = clean_str.split("','")
-
-        self.last_results.extend(item for item in elements if _MAC_REGEX.match(item))
-
-        return True
-
-    def get_ddwrt_data(self, url):
-        """Retrieve data from DD-WRT and return parsed result."""
-        try:
-            response = requests.get(
-                url,
-                auth=(self.username, self.password),
-                timeout=4,
-                verify=self.verify_ssl,
-            )
-        except requests.exceptions.Timeout:
-            _LOGGER.exception("Connection to the router timed out")
-            return None
-        if response.status_code == HTTPStatus.OK:
-            return _parse_ddwrt_response(response.text)
-        if response.status_code == HTTPStatus.UNAUTHORIZED:
-            # Authentication error
-            _LOGGER.exception(
-                "Failed to authenticate, check your username and password"
-            )
-            return None
-        _LOGGER.error("Invalid response from DD-WRT: %s", response)
+    @property
+    def hostname(self) -> str | None:
+        """Return the hostname of the device."""
+        if device := self.coordinator.data.get(self._mac):
+            return device.get("hostname")
         return None
-
-
-def _parse_ddwrt_response(data_str):
-    """Parse the DD-WRT data format."""
-    return dict(_DDWRT_DATA_REGEX.findall(data_str))

--- a/homeassistant/components/ddwrt/device_tracker.py
+++ b/homeassistant/components/ddwrt/device_tracker.py
@@ -67,11 +67,13 @@ async def async_setup_scanner(
         data=import_data,
     )
 
+    issue_id = f"yaml_import_cannot_connect_{config[CONF_HOST]}"
+
     if result["type"] is FlowResultType.ABORT and result["reason"] == "cannot_connect":
         ir.async_create_issue(
             hass,
             DOMAIN,
-            "yaml_import_cannot_connect",
+            issue_id,
             is_fixable=False,
             issue_domain=DOMAIN,
             severity=ir.IssueSeverity.ERROR,
@@ -80,7 +82,7 @@ async def async_setup_scanner(
         )
         return False
 
-    ir.async_delete_issue(hass, DOMAIN, "yaml_import_cannot_connect")
+    ir.async_delete_issue(hass, DOMAIN, issue_id)
 
     ir.async_create_issue(
         hass,

--- a/homeassistant/components/ddwrt/manifest.json
+++ b/homeassistant/components/ddwrt/manifest.json
@@ -2,7 +2,9 @@
   "domain": "ddwrt",
   "name": "DD-WRT",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ddwrt",
+  "integration_type": "device",
   "iot_class": "local_polling",
   "quality_scale": "legacy"
 }

--- a/homeassistant/components/ddwrt/manifest.json
+++ b/homeassistant/components/ddwrt/manifest.json
@@ -4,7 +4,7 @@
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ddwrt",
-  "integration_type": "device",
+  "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "legacy"
 }

--- a/homeassistant/components/ddwrt/router.py
+++ b/homeassistant/components/ddwrt/router.py
@@ -45,13 +45,20 @@ class DdWrtRouter:
         """Return the connected clients keyed by MAC address.
 
         Also serves as the connectivity/credentials check: it raises
-        DdWrtConnectionError when the router cannot be reached or the
-        credentials are rejected.
+        DdWrtConnectionError when the router cannot be reached, the
+        credentials are rejected, or the response is not a valid DD-WRT
+        status page (for example a login or proxy page returned with a
+        200 status).
         """
         endpoint = "Wireless" if self._wireless_only else "Lan"
         status = self._get_data(f"Status_{endpoint}.live.asp")
         field = "active_wireless" if self._wireless_only else "arp_table"
-        macs = self._extract_macs(status.get(field))
+        if field not in status:
+            raise DdWrtConnectionError(
+                f"Unexpected response from DD-WRT router at {self._host}, "
+                f"missing '{field}' field"
+            )
+        macs = self._extract_macs(status[field])
         leases = self._get_leases()
         return {mac: leases.get(mac, {"hostname": None, "ip": None}) for mac in macs}
 

--- a/homeassistant/components/ddwrt/router.py
+++ b/homeassistant/components/ddwrt/router.py
@@ -50,21 +50,25 @@ class DdWrtRouter:
         status page (for example a login or proxy page returned with a
         200 status).
         """
-        endpoint = "Wireless" if self._wireless_only else "Lan"
-        status = self._get_data(f"Status_{endpoint}.live.asp")
-        field = "active_wireless" if self._wireless_only else "arp_table"
-        if field not in status:
+        lan = self._get_data("Status_Lan.live.asp")
+        if self._wireless_only:
+            active = self._get_data("Status_Wireless.live.asp")
+            field = "active_wireless"
+        else:
+            active = lan
+            field = "arp_table"
+        if field not in active:
             raise DdWrtConnectionError(
                 f"Unexpected response from DD-WRT router at {self._host}, "
                 f"missing '{field}' field"
             )
-        macs = self._extract_macs(status[field])
-        leases = self._get_leases()
+        macs = self._extract_macs(active[field])
+        leases = self._parse_leases(lan)
         return {mac: leases.get(mac, {"hostname": None, "ip": None}) for mac in macs}
 
-    def _get_leases(self) -> DdWrtClients:
-        """Return the DHCP leases keyed by MAC address."""
-        data = self._get_data("Status_Lan.live.asp")
+    @staticmethod
+    def _parse_leases(data: dict[str, str]) -> DdWrtClients:
+        """Parse the DHCP leases from a Status_Lan response."""
         if not (raw := data.get("dhcp_leases")):
             return {}
         cleaned = raw.replace('"', "").replace("'", "").replace(" ", "")

--- a/homeassistant/components/ddwrt/router.py
+++ b/homeassistant/components/ddwrt/router.py
@@ -17,7 +17,11 @@ type DdWrtClients = dict[str, dict[str, str | None]]
 
 
 class DdWrtConnectionError(Exception):
-    """Raised when the router is unreachable or rejects the credentials."""
+    """Raised when the router cannot be reached or returns an invalid response."""
+
+
+class DdWrtAuthError(DdWrtConnectionError):
+    """Raised when the router rejects the provided credentials."""
 
 
 class DdWrtRouter:
@@ -107,7 +111,7 @@ class DdWrtRouter:
             ) from err
 
         if response.status_code == HTTPStatus.UNAUTHORIZED:
-            raise DdWrtConnectionError(
+            raise DdWrtAuthError(
                 "Authentication failed, check your username and password"
             )
         if response.status_code != HTTPStatus.OK:

--- a/homeassistant/components/ddwrt/router.py
+++ b/homeassistant/components/ddwrt/router.py
@@ -1,0 +1,106 @@
+"""Client for querying a wireless router running DD-WRT firmware."""
+
+from http import HTTPStatus
+import logging
+import re
+
+import requests
+
+_LOGGER = logging.getLogger(__name__)
+
+_DDWRT_DATA_REGEX = re.compile(r"\{(\w+)::([^\}]*)\}")
+_MAC_REGEX = re.compile(r"(([0-9A-Fa-f]{1,2}\:){5}[0-9A-Fa-f]{1,2})")
+
+_HTTP_TIMEOUT = 4
+
+type DdWrtClients = dict[str, dict[str, str | None]]
+
+
+class DdWrtConnectionError(Exception):
+    """Raised when the router is unreachable or rejects the credentials."""
+
+
+class DdWrtRouter:
+    """Query a wireless router running DD-WRT firmware over HTTP."""
+
+    def __init__(
+        self,
+        host: str,
+        username: str,
+        password: str,
+        *,
+        use_ssl: bool,
+        verify_ssl: bool,
+        wireless_only: bool,
+    ) -> None:
+        """Initialize the DD-WRT router client."""
+        self._protocol = "https" if use_ssl else "http"
+        self._host = host
+        self._username = username
+        self._password = password
+        self._verify_ssl = verify_ssl
+        self._wireless_only = wireless_only
+
+    def get_clients(self) -> DdWrtClients:
+        """Return the connected clients keyed by MAC address.
+
+        Also serves as the connectivity/credentials check: it raises
+        DdWrtConnectionError when the router cannot be reached or the
+        credentials are rejected.
+        """
+        endpoint = "Wireless" if self._wireless_only else "Lan"
+        status = self._get_data(f"Status_{endpoint}.live.asp")
+        field = "active_wireless" if self._wireless_only else "arp_table"
+        macs = self._extract_macs(status.get(field))
+        leases = self._get_leases()
+        return {mac: leases.get(mac, {"hostname": None, "ip": None}) for mac in macs}
+
+    def _get_leases(self) -> DdWrtClients:
+        """Return the DHCP leases keyed by MAC address."""
+        data = self._get_data("Status_Lan.live.asp")
+        if not (raw := data.get("dhcp_leases")):
+            return {}
+        cleaned = raw.replace('"', "").replace("'", "").replace(" ", "")
+        elements = cleaned.split(",")
+        leases: DdWrtClients = {}
+        for idx in range(len(elements) // 5):
+            base = idx * 5
+            mac = elements[base + 2]
+            leases[mac] = {
+                "hostname": elements[base] or None,
+                "ip": elements[base + 1] or None,
+            }
+        return leases
+
+    @staticmethod
+    def _extract_macs(raw: str | None) -> list[str]:
+        """Extract the MAC addresses from a DD-WRT list field."""
+        if not raw:
+            return []
+        cleaned = raw.strip().strip("'")
+        return [item for item in cleaned.split("','") if _MAC_REGEX.match(item)]
+
+    def _get_data(self, path: str) -> dict[str, str]:
+        """Retrieve and parse a DD-WRT live status endpoint."""
+        url = f"{self._protocol}://{self._host}/{path}"
+        try:
+            response = requests.get(
+                url,
+                auth=(self._username, self._password),
+                timeout=_HTTP_TIMEOUT,
+                verify=self._verify_ssl,
+            )
+        except requests.exceptions.RequestException as err:
+            raise DdWrtConnectionError(
+                f"Error connecting to DD-WRT router at {self._host}"
+            ) from err
+
+        if response.status_code == HTTPStatus.UNAUTHORIZED:
+            raise DdWrtConnectionError(
+                "Authentication failed, check your username and password"
+            )
+        if response.status_code != HTTPStatus.OK:
+            raise DdWrtConnectionError(
+                f"Unexpected response from DD-WRT router: {response.status_code}"
+            )
+        return dict(_DDWRT_DATA_REGEX.findall(response.text))

--- a/homeassistant/components/ddwrt/strings.json
+++ b/homeassistant/components/ddwrt/strings.json
@@ -10,9 +10,9 @@
       "user": {
         "data": {
           "host": "[%key:common::config_flow::data::host%]",
-          "username": "[%key:common::config_flow::data::username%]",
           "password": "[%key:common::config_flow::data::password%]",
           "ssl": "[%key:common::config_flow::data::ssl%]",
+          "username": "[%key:common::config_flow::data::username%]",
           "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
           "wireless_only": "Track wireless clients only"
         },

--- a/homeassistant/components/ddwrt/strings.json
+++ b/homeassistant/components/ddwrt/strings.json
@@ -24,7 +24,7 @@
   },
   "issues": {
     "yaml_import_cannot_connect": {
-      "description": "The YAML configuration for DD-WRT at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, update your `configuration.yaml` if needed, and restart Home Assistant.",
+      "description": "The YAML configuration for the DD-WRT router at `{host}` could not be imported because Home Assistant could not connect to it. Device tracking for this router is currently unavailable.\n\nTo fix this:\n\n1. Confirm that `{host}` is reachable and the router is online.\n2. Verify the username and password in your `configuration.yaml` are correct.\n3. Restart Home Assistant.\n\nAfter a successful restart, the router is imported automatically and this issue is removed.",
       "title": "YAML configuration import failed: cannot connect"
     }
   }

--- a/homeassistant/components/ddwrt/strings.json
+++ b/homeassistant/components/ddwrt/strings.json
@@ -1,0 +1,31 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "host": "[%key:common::config_flow::data::host%]",
+          "username": "[%key:common::config_flow::data::username%]",
+          "password": "[%key:common::config_flow::data::password%]",
+          "ssl": "[%key:common::config_flow::data::ssl%]",
+          "verify_ssl": "[%key:common::config_flow::data::verify_ssl%]",
+          "wireless_only": "Track wireless clients only"
+        },
+        "data_description": {
+          "wireless_only": "When enabled, only clients connected over Wi-Fi are tracked. When disabled, all clients in the router's ARP table are tracked."
+        }
+      }
+    }
+  },
+  "issues": {
+    "yaml_import_cannot_connect": {
+      "description": "The YAML configuration for DD-WRT at `{host}` could not be imported because the connection failed.\n\nPlease check that `{host}` is reachable, update your `configuration.yaml` if needed, and restart Home Assistant.",
+      "title": "YAML configuration import failed: cannot connect"
+    }
+  }
+}

--- a/homeassistant/components/ddwrt/strings.json
+++ b/homeassistant/components/ddwrt/strings.json
@@ -4,7 +4,8 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "error": {
-      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]"
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
       "user": {

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -148,6 +148,7 @@ FLOWS = {
         "daikin",
         "data_grand_lyon",
         "datadog",
+        "ddwrt",
         "deako",
         "deconz",
         "decora_wifi",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1261,8 +1261,8 @@
     },
     "ddwrt": {
       "name": "DD-WRT",
-      "integration_type": "hub",
-      "config_flow": false,
+      "integration_type": "device",
+      "config_flow": true,
       "iot_class": "local_polling"
     },
     "deako": {

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -1261,7 +1261,7 @@
     },
     "ddwrt": {
       "name": "DD-WRT",
-      "integration_type": "device",
+      "integration_type": "hub",
       "config_flow": true,
       "iot_class": "local_polling"
     },

--- a/tests/components/ddwrt/__init__.py
+++ b/tests/components/ddwrt/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the DD-WRT integration."""

--- a/tests/components/ddwrt/conftest.py
+++ b/tests/components/ddwrt/conftest.py
@@ -1,0 +1,66 @@
+"""Fixtures for DD-WRT integration tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.ddwrt.const import CONF_WIRELESS_ONLY, DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_USERNAME,
+    CONF_VERIFY_SSL,
+)
+
+from tests.common import MockConfigEntry
+
+MOCK_HOST = "192.168.1.1"
+MOCK_USERNAME = "admin"
+MOCK_PASSWORD = "password"
+
+MOCK_CONFIG = {
+    CONF_HOST: MOCK_HOST,
+    CONF_USERNAME: MOCK_USERNAME,
+    CONF_PASSWORD: MOCK_PASSWORD,
+    CONF_SSL: False,
+    CONF_VERIFY_SSL: True,
+    CONF_WIRELESS_ONLY: True,
+}
+
+MOCK_CLIENTS = {
+    "AA:BB:CC:DD:EE:FF": {"hostname": "my-phone", "ip": "192.168.1.100"},
+    "11:22:33:44:55:66": {"hostname": "my-laptop", "ip": "192.168.1.101"},
+}
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Override async_setup_entry."""
+    with patch(
+        "homeassistant.components.ddwrt.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        yield mock_setup_entry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN, data=MOCK_CONFIG, title=f"DD-WRT ({MOCK_HOST})"
+    )
+
+
+@pytest.fixture
+def mock_router() -> Generator[MagicMock]:
+    """Mock DdWrtRouter to return known clients."""
+    with (
+        patch("homeassistant.components.ddwrt.coordinator.DdWrtRouter") as mock,
+        patch("homeassistant.components.ddwrt.config_flow.DdWrtRouter", new=mock),
+    ):
+        instance = MagicMock()
+        instance.get_clients.return_value = MOCK_CLIENTS
+        mock.return_value = instance
+        yield mock

--- a/tests/components/ddwrt/test_config_flow.py
+++ b/tests/components/ddwrt/test_config_flow.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 from homeassistant.components.ddwrt.const import DOMAIN
-from homeassistant.components.ddwrt.router import DdWrtConnectionError
+from homeassistant.components.ddwrt.router import DdWrtAuthError, DdWrtConnectionError
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -54,6 +54,22 @@ async def test_user_flow_cannot_connect(
         result["flow_id"], user_input=MOCK_CONFIG
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_invalid_auth(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_router: MagicMock
+) -> None:
+    """Test the user flow reports invalid auth distinctly from cannot connect."""
+    mock_router.return_value.get_clients.side_effect = DdWrtAuthError("bad creds")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
 
 
 async def test_user_flow_already_configured(

--- a/tests/components/ddwrt/test_config_flow.py
+++ b/tests/components/ddwrt/test_config_flow.py
@@ -1,0 +1,119 @@
+"""Tests for the DD-WRT config flow."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.ddwrt.const import DOMAIN
+from homeassistant.components.ddwrt.router import DdWrtConnectionError
+from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_USER
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import MOCK_CONFIG, MOCK_HOST
+
+from tests.common import MockConfigEntry
+
+
+async def test_user_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_router: MagicMock
+) -> None:
+    """Test a successful user config flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"DD-WRT ({MOCK_HOST})"
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_user_flow_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_router: MagicMock
+) -> None:
+    """Test the user flow surfaces a connection error and then recovers."""
+    mock_router.return_value.get_clients.side_effect = DdWrtConnectionError("fail")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+    mock_router.return_value.get_clients.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_router: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the user flow aborts when the host is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow_success(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_router: MagicMock
+) -> None:
+    """Test a successful import flow."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == f"DD-WRT ({MOCK_HOST})"
+    assert result["data"] == MOCK_CONFIG
+
+
+async def test_import_flow_already_configured(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+    mock_router: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the import flow aborts when the host is already configured."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_import_flow_cannot_connect(
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, mock_router: MagicMock
+) -> None:
+    """Test the import flow aborts on a connection error."""
+    mock_router.return_value.get_clients.side_effect = DdWrtConnectionError("fail")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_IMPORT}, data=MOCK_CONFIG
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"

--- a/tests/components/ddwrt/test_device_tracker.py
+++ b/tests/components/ddwrt/test_device_tracker.py
@@ -1,0 +1,95 @@
+"""Tests for the DD-WRT device tracker."""
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.ddwrt.const import DOMAIN
+from homeassistant.components.ddwrt.router import DdWrtConnectionError
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntryState
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.setup import async_setup_component
+
+from .conftest import MOCK_CONFIG
+
+from tests.common import MockConfigEntry
+
+
+async def test_entities_created(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_router: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test device tracker entities are created from coordinator data."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entries = [
+        entry
+        for entry in entity_registry.entities.values()
+        if entry.domain == "device_tracker" and entry.platform == DOMAIN
+    ]
+    assert len(entries) == 2
+
+    entity_ids = {entry.entity_id for entry in entries}
+    assert any(
+        entity_id.startswith("device_tracker.my_phone") for entity_id in entity_ids
+    )
+    assert any(
+        entity_id.startswith("device_tracker.my_laptop") for entity_id in entity_ids
+    )
+
+
+async def test_setup_entry_update_failed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_router: MagicMock,
+) -> None:
+    """Test the config entry retries setup when the router cannot be reached."""
+    mock_router.return_value.get_clients.side_effect = DdWrtConnectionError("fail")
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_legacy_platform_imports_config_entry(
+    hass: HomeAssistant, mock_router: MagicMock
+) -> None:
+    """Test the legacy device tracker platform imports a config entry."""
+    assert await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": [{"platform": DOMAIN, **MOCK_CONFIG}]},
+    )
+    await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data == MOCK_CONFIG
+    assert entries[0].source == SOURCE_IMPORT
+
+
+async def test_legacy_platform_creates_issue_on_cannot_connect(
+    hass: HomeAssistant,
+    mock_router: MagicMock,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test the legacy platform creates a repair issue when it cannot connect."""
+    mock_router.return_value.get_clients.side_effect = DdWrtConnectionError("fail")
+
+    assert await async_setup_component(
+        hass,
+        "device_tracker",
+        {"device_tracker": [{"platform": DOMAIN, **MOCK_CONFIG}]},
+    )
+    await hass.async_block_till_done()
+
+    issue = issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect")
+    assert issue is not None
+    assert issue.translation_key == "yaml_import_cannot_connect"
+    assert issue.translation_placeholders == {"host": MOCK_CONFIG["host"]}

--- a/tests/components/ddwrt/test_device_tracker.py
+++ b/tests/components/ddwrt/test_device_tracker.py
@@ -9,9 +9,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.setup import async_setup_component
 
-from .conftest import MOCK_CONFIG
+from .conftest import MOCK_CLIENTS, MOCK_CONFIG
 
 from tests.common import MockConfigEntry
+
+_MAC_LAPTOP = "11:22:33:44:55:66"
 
 
 async def test_entities_created(
@@ -40,6 +42,70 @@ async def test_entities_created(
     assert any(
         entity_id.startswith("device_tracker.my_laptop") for entity_id in entity_ids
     )
+
+
+async def test_new_client_added_after_setup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_router: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a client discovered after setup gets a new entity."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    def _ddwrt_entities() -> list[str]:
+        return [
+            entry.entity_id
+            for entry in entity_registry.entities.values()
+            if entry.platform == DOMAIN
+        ]
+
+    assert len(_ddwrt_entities()) == 2
+
+    mock_router.return_value.get_clients.return_value = {
+        **MOCK_CLIENTS,
+        "99:88:77:66:55:44": {"hostname": "my-tablet", "ip": "192.168.1.102"},
+    }
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    assert len(_ddwrt_entities()) == 3
+
+
+async def test_device_disconnect_and_reconnect(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_router: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test an entity flips to not_home when a device disappears and back on return."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_registry.async_update_entity("device_tracker.my_phone", disabled_by=None)
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.my_phone").state == "home"
+
+    mock_router.return_value.get_clients.return_value = {
+        _MAC_LAPTOP: MOCK_CLIENTS[_MAC_LAPTOP]
+    }
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.my_phone").state == "not_home"
+
+    mock_router.return_value.get_clients.return_value = MOCK_CLIENTS
+    await mock_config_entry.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("device_tracker.my_phone").state == "home"
 
 
 async def test_setup_entry_update_failed(

--- a/tests/components/ddwrt/test_device_tracker.py
+++ b/tests/components/ddwrt/test_device_tracker.py
@@ -155,7 +155,9 @@ async def test_legacy_platform_creates_issue_on_cannot_connect(
     )
     await hass.async_block_till_done()
 
-    issue = issue_registry.async_get_issue(DOMAIN, "yaml_import_cannot_connect")
+    issue = issue_registry.async_get_issue(
+        DOMAIN, f"yaml_import_cannot_connect_{MOCK_CONFIG['host']}"
+    )
     assert issue is not None
     assert issue.translation_key == "yaml_import_cannot_connect"
     assert issue.translation_placeholders == {"host": MOCK_CONFIG["host"]}

--- a/tests/components/ddwrt/test_router.py
+++ b/tests/components/ddwrt/test_router.py
@@ -1,0 +1,115 @@
+"""Tests for the DD-WRT router client."""
+
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from homeassistant.components.ddwrt.router import DdWrtConnectionError, DdWrtRouter
+
+_MAC_PHONE = "AA:BB:CC:DD:EE:FF"
+_MAC_LAPTOP = "11:22:33:44:55:66"
+
+_WIRELESS_RESPONSE = (
+    "{active_wireless::"
+    "'AA:BB:CC:DD:EE:FF','eth1','5','54M',"
+    "'11:22:33:44:55:66','eth1','2','54M'}"
+)
+_LAN_RESPONSE = (
+    "{arp_table::"
+    "'my-phone','192.168.1.100','AA:BB:CC:DD:EE:FF','5',"
+    "'my-laptop','192.168.1.101','11:22:33:44:55:66','3'}"
+    "{dhcp_leases::"
+    "'my-phone','192.168.1.100','AA:BB:CC:DD:EE:FF','86400','1',"
+    "'my-laptop','192.168.1.101','11:22:33:44:55:66','86400','2'}"
+)
+
+
+def _mock_response(status_code: HTTPStatus, text: str) -> MagicMock:
+    """Build a mocked requests response."""
+    response = MagicMock()
+    response.status_code = status_code
+    response.text = text
+    return response
+
+
+def _make_router(*, wireless_only: bool = True) -> DdWrtRouter:
+    """Build a router client for tests."""
+    return DdWrtRouter(
+        "192.168.1.1",
+        "admin",
+        "password",
+        use_ssl=False,
+        verify_ssl=True,
+        wireless_only=wireless_only,
+    )
+
+
+@patch("homeassistant.components.ddwrt.router.requests.get")
+def test_get_clients_wireless_only(mock_get: MagicMock) -> None:
+    """Test that wireless clients are parsed and enriched with lease data."""
+
+    def _side_effect(url: str, **kwargs: object) -> MagicMock:
+        text = _WIRELESS_RESPONSE if "Wireless" in url else _LAN_RESPONSE
+        return _mock_response(HTTPStatus.OK, text)
+
+    mock_get.side_effect = _side_effect
+
+    clients = _make_router().get_clients()
+
+    assert clients == {
+        _MAC_PHONE: {"hostname": "my-phone", "ip": "192.168.1.100"},
+        _MAC_LAPTOP: {"hostname": "my-laptop", "ip": "192.168.1.101"},
+    }
+
+
+@patch("homeassistant.components.ddwrt.router.requests.get")
+def test_get_clients_lan_mode(mock_get: MagicMock) -> None:
+    """Test that all ARP-table clients are tracked when not wireless-only."""
+    mock_get.return_value = _mock_response(HTTPStatus.OK, _LAN_RESPONSE)
+
+    clients = _make_router(wireless_only=False).get_clients()
+
+    assert set(clients) == {_MAC_PHONE, _MAC_LAPTOP}
+    assert clients[_MAC_PHONE] == {"hostname": "my-phone", "ip": "192.168.1.100"}
+
+
+@patch("homeassistant.components.ddwrt.router.requests.get")
+def test_get_clients_without_leases(mock_get: MagicMock) -> None:
+    """Test clients without a matching DHCP lease get null hostname and ip."""
+
+    def _side_effect(url: str, **kwargs: object) -> MagicMock:
+        text = _WIRELESS_RESPONSE if "Wireless" in url else "{dhcp_leases::}"
+        return _mock_response(HTTPStatus.OK, text)
+
+    mock_get.side_effect = _side_effect
+
+    clients = _make_router().get_clients()
+
+    assert clients == {
+        _MAC_PHONE: {"hostname": None, "ip": None},
+        _MAC_LAPTOP: {"hostname": None, "ip": None},
+    }
+
+
+@patch("homeassistant.components.ddwrt.router.requests.get")
+def test_timeout_raises(mock_get: MagicMock) -> None:
+    """Test a request timeout is translated to a connection error."""
+    mock_get.side_effect = requests.exceptions.Timeout
+
+    with pytest.raises(DdWrtConnectionError):
+        _make_router().get_clients()
+
+
+@pytest.mark.parametrize(
+    "status_code",
+    [HTTPStatus.UNAUTHORIZED, HTTPStatus.INTERNAL_SERVER_ERROR],
+)
+@patch("homeassistant.components.ddwrt.router.requests.get")
+def test_bad_status_raises(mock_get: MagicMock, status_code: HTTPStatus) -> None:
+    """Test non-OK status codes are translated to a connection error."""
+    mock_get.return_value = _mock_response(status_code, "")
+
+    with pytest.raises(DdWrtConnectionError):
+        _make_router().get_clients()

--- a/tests/components/ddwrt/test_router.py
+++ b/tests/components/ddwrt/test_router.py
@@ -94,6 +94,19 @@ def test_get_clients_without_leases(mock_get: MagicMock) -> None:
 
 
 @patch("homeassistant.components.ddwrt.router.requests.get")
+def test_malformed_200_raises(mock_get: MagicMock) -> None:
+    """Test a 200 response without the expected field raises an error.
+
+    A login or proxy page returned with a 200 status must not be treated
+    as an empty client list, otherwise validation would falsely succeed.
+    """
+    mock_get.return_value = _mock_response(HTTPStatus.OK, "<html>Login</html>")
+
+    with pytest.raises(DdWrtConnectionError):
+        _make_router().get_clients()
+
+
+@patch("homeassistant.components.ddwrt.router.requests.get")
 def test_timeout_raises(mock_get: MagicMock) -> None:
     """Test a request timeout is translated to a connection error."""
     mock_get.side_effect = requests.exceptions.Timeout

--- a/tests/components/ddwrt/test_router.py
+++ b/tests/components/ddwrt/test_router.py
@@ -109,7 +109,7 @@ def test_malformed_200_raises(mock_get: MagicMock) -> None:
 @patch("homeassistant.components.ddwrt.router.requests.get")
 def test_timeout_raises(mock_get: MagicMock) -> None:
     """Test a request timeout is translated to a connection error."""
-    mock_get.side_effect = requests.exceptions.Timeout
+    mock_get.side_effect = requests.exceptions.Timeout()
 
     with pytest.raises(DdWrtConnectionError):
         _make_router().get_clients()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is not a breaking change. Existing YAML configuration continues to work and is automatically imported into a config entry, after which a repair issue guides users to remove the YAML.

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the DD-WRT device tracker off the deprecated synchronous `DeviceScanner`/`get_scanner` pattern onto the modern async `ScannerEntity` pattern, as tracked by the epic #50326. This mirrors the approach of the merged `unifi_direct` migration (#171991).

Changes:
- Add a config flow with a UI setup step and automatic YAML to UI import (`async_step_import`), plus a deprecation repair issue for existing `configuration.yaml` users and a `yaml_import_cannot_connect` issue when an import fails to connect.
- Add a `DataUpdateCoordinator` that polls the router on an interval.
- Extract the router HTTP/parsing logic out of the old scanner into a dedicated `DdWrtRouter` client that raises a single `DdWrtConnectionError`.
- Rewrite `device_tracker.py` around `ScannerEntity` + `CoordinatorEntity`, creating one entity per detected device (MAC) exposing `is_connected`, `mac_address`, `ip_address`, and `hostname`.
- Update the manifest (`config_flow: true`, `integration_type: device`) and regenerate the derived files with hassfest.
- Add tests for the config flow, the coordinator/entities, and the router parsing (mocked HTTP responses; 98% coverage).

Note: `ip`/`hostname` are read from the router's DHCP leases table using the same group layout the previous code relied on. This was validated against mocked responses rather than physical DD-WRT hardware, so confirmation from a reviewer with a real device is welcome.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #143027
- This PR is related to issue: #50326
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
