### PR TITLE
Keep a stored HomeKit Thermostat choice when a pairing looks new

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -215,7 +215,8 @@ def _async_resolve_climate_type(
         # one, so every path that sets a type defers persistence until
         # the accessory exists.
         return cast(str, climate_type)
-    if aid_storage.get_accessory_type(entity_id) == TYPE_HEATER_COOLER:
+    stored_type = aid_storage.get_accessory_type(entity_id)
+    if stored_type == TYPE_HEATER_COOLER:
         if not climate_controls_target_humidity(state):
             conf[CONF_TYPE] = TYPE_HEATER_COOLER
             return None
@@ -224,7 +225,14 @@ def _async_resolve_climate_type(
         aid_storage.async_set_accessory_type(entity_id, None)
     if not climate_supports_heater_cooler(state):
         return None
-    if allow_auto and not aid_storage.entity_is_allocated(entity_id):
+    if (
+        stored_type is None
+        and allow_auto
+        and not aid_storage.entity_is_allocated(entity_id)
+    ):
+        # A stored Thermostat choice survives even when the entity looks
+        # new again, like an accessory mode pairing reset, so Automatic
+        # keeps the accessory the entity already uses.
         conf[CONF_TYPE] = TYPE_HEATER_COOLER
         return TYPE_HEATER_COOLER
     return None

--- a/tests/components/homekit/test_accessory_type.py
+++ b/tests/components/homekit/test_accessory_type.py
@@ -21,6 +21,8 @@ from homeassistant.components.homekit.const import (
     HOMEKIT_MODE_BRIDGE,
     PERSIST_LOCK_DATA,
 )
+from homeassistant.components.homekit.type_heater_coolers import HeaterCooler
+from homeassistant.components.homekit.type_thermostats import Thermostat
 from homeassistant.components.homekit.util import get_aid_storage_filename_for_entry_id
 from homeassistant.const import ATTR_SUPPORTED_FEATURES, CONF_NAME, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
@@ -144,7 +146,7 @@ async def test_existing_entity_stays_thermostat(
 
     accessories = list(homekit.bridge.accessories.values())
     assert len(accessories) == 1
-    assert type(accessories[0]).__name__ == "Thermostat"
+    assert isinstance(accessories[0], Thermostat)
     await _async_stop_bridge(homekit)
 
 
@@ -163,7 +165,7 @@ async def test_new_entity_routes_to_heater_cooler(
 
     accessories = list(homekit.bridge.accessories.values())
     assert len(accessories) == 1
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
 
@@ -215,7 +217,7 @@ async def test_failed_accessory_creation_is_not_recorded(
     # the automatic choice
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
 
@@ -232,14 +234,14 @@ async def test_heater_cooler_choice_survives_restart(
 
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
     # The entity now has an aid allocation, so only the stored choice
     # keeps it on the HeaterCooler after a restart.
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
 
@@ -256,7 +258,7 @@ async def test_gained_humidity_setpoint_drops_stored_choice(
 
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
     # The entity gains a humidity setpoint, which the HeaterCooler cannot
@@ -268,7 +270,7 @@ async def test_gained_humidity_setpoint_drops_stored_choice(
     )
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "Thermostat"
+    assert isinstance(accessories[0], Thermostat)
     assert homekit.aid_storage is not None
     assert homekit.aid_storage.get_accessory_type(ENTITY_ID) is None
     await _async_stop_bridge(homekit)
@@ -288,7 +290,7 @@ async def test_automatic_keeps_explicit_choice(
     # A new entity picks the HeaterCooler and the choice is stored
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
     # An explicit Thermostat overrides and updates the stored routing
@@ -296,14 +298,14 @@ async def test_automatic_keeps_explicit_choice(
         hass, entry, {ENTITY_ID: {CONF_TYPE: "thermostat"}}
     )
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "Thermostat"
+    assert isinstance(accessories[0], Thermostat)
     await _async_stop_bridge(homekit)
 
     # Back on automatic the entity keeps the Thermostat instead of
     # flipping back to the HeaterCooler
     homekit = await _async_start_bridge(hass, entry)
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "Thermostat"
+    assert isinstance(accessories[0], Thermostat)
     await _async_stop_bridge(homekit)
 
 
@@ -322,7 +324,7 @@ async def test_accessory_mode_existing_pairing_stays_thermostat(
         hass, entry, homekit_mode=HOMEKIT_MODE_ACCESSORY, existing_pairing=True
     )
 
-    assert type(homekit.driver.accessory).__name__ == "Thermostat"
+    assert isinstance(homekit.driver.accessory, Thermostat)
     await _async_stop_bridge(homekit)
 
 
@@ -344,7 +346,7 @@ async def test_stored_thermostat_survives_pairing_reset(
         {ENTITY_ID: {CONF_TYPE: "thermostat"}},
         homekit_mode=HOMEKIT_MODE_ACCESSORY,
     )
-    assert type(homekit.driver.accessory).__name__ == "Thermostat"
+    assert isinstance(homekit.driver.accessory, Thermostat)
     await _async_stop_bridge(homekit)
 
     # A pairing reset makes the entry look brand new, but Automatic still
@@ -352,7 +354,7 @@ async def test_stored_thermostat_survives_pairing_reset(
     homekit = await _async_start_bridge(
         hass, entry, homekit_mode=HOMEKIT_MODE_ACCESSORY
     )
-    assert type(homekit.driver.accessory).__name__ == "Thermostat"
+    assert isinstance(homekit.driver.accessory, Thermostat)
     await _async_stop_bridge(homekit)
 
 
@@ -371,7 +373,7 @@ async def test_accessory_mode_new_pairing_routes_heater_cooler(
         hass, entry, homekit_mode=HOMEKIT_MODE_ACCESSORY
     )
 
-    assert type(homekit.driver.accessory).__name__ == "HeaterCooler"
+    assert isinstance(homekit.driver.accessory, HeaterCooler)
     await _async_stop_bridge(homekit)
 
 
@@ -400,7 +402,7 @@ async def test_explicit_heater_cooler_wins_over_humidity_safeguard(
     )
 
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "HeaterCooler"
+    assert isinstance(accessories[0], HeaterCooler)
     await _async_stop_bridge(homekit)
 
 
@@ -425,5 +427,5 @@ async def test_explicit_type_wins_for_existing_entity(
     )
 
     accessories = list(homekit.bridge.accessories.values())
-    assert type(accessories[0]).__name__ == "Thermostat"
+    assert isinstance(accessories[0], Thermostat)
     await _async_stop_bridge(homekit)

--- a/tests/components/homekit/test_accessory_type.py
+++ b/tests/components/homekit/test_accessory_type.py
@@ -327,6 +327,36 @@ async def test_accessory_mode_existing_pairing_stays_thermostat(
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf", "hk_driver")
+async def test_stored_thermostat_survives_pairing_reset(
+    hass: HomeAssistant,
+) -> None:
+    """Test a stored Thermostat choice is kept when the entity looks new."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entry.add_to_hass(hass)
+    hass.states.async_set(ENTITY_ID, HVACMode.COOL, CAPABLE_ATTRS)
+
+    # An explicit Thermostat choice is stored with the accessory
+    homekit = await _async_start_bridge(
+        hass,
+        entry,
+        {ENTITY_ID: {CONF_TYPE: "thermostat"}},
+        homekit_mode=HOMEKIT_MODE_ACCESSORY,
+    )
+    assert type(homekit.driver.accessory).__name__ == "Thermostat"
+    await _async_stop_bridge(homekit)
+
+    # A pairing reset makes the entry look brand new, but Automatic still
+    # keeps the stored Thermostat instead of flipping to the HeaterCooler
+    homekit = await _async_start_bridge(
+        hass, entry, homekit_mode=HOMEKIT_MODE_ACCESSORY
+    )
+    assert type(homekit.driver.accessory).__name__ == "Thermostat"
+    await _async_stop_bridge(homekit)
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf", "hk_driver")
 async def test_accessory_mode_new_pairing_routes_heater_cooler(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1,5 +1,7 @@
 """Test the HomeKit config flow."""
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -1739,9 +1741,21 @@ async def test_options_flow_cameras_step_with_whole_domain_included(
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
-@pytest.mark.parametrize("homekit_mode", ["bridge", "accessory"])
+@pytest.mark.parametrize(
+    "homekit_attrs",
+    [
+        pytest.param(
+            lambda acc: {"bridge": Mock(accessories={2: acc})},
+            id="bridge",
+        ),
+        pytest.param(
+            lambda acc: {"bridge": None, "driver": Mock(accessory=acc)},
+            id="accessory",
+        ),
+    ],
+)
 async def test_options_flow_climate_step_shows_current_accessory(
-    hass: HomeAssistant, homekit_mode: str
+    hass: HomeAssistant, homekit_attrs: Callable[[Any], dict[str, Any]]
 ) -> None:
     """Test the climate labels show the accessory the entity uses now."""
     config_entry = _mock_config_entry_with_options_populated()
@@ -1753,11 +1767,7 @@ async def test_options_flow_climate_step_shows_current_accessory(
     # A loaded entry exposes the bridged accessories through its runtime
     # data; accessory mode reads the single accessory from the driver
     thermostat = type("Thermostat", (), {"entity_id": "climate.new"})()
-    if homekit_mode == "bridge":
-        homekit = Mock(bridge=Mock(accessories={2: thermostat}))
-    else:
-        homekit = Mock(bridge=None, driver=Mock(accessory=thermostat))
-    config_entry.runtime_data = Mock(homekit=homekit)
+    config_entry.runtime_data = Mock(homekit=Mock(**homekit_attrs(thermostat)))
 
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     result = await hass.config_entries.options.async_configure(

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1,13 +1,13 @@
 """Test the HomeKit config flow."""
 
-from collections.abc import Callable
 from typing import Any
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 import voluptuous as vol
 
 from homeassistant import config_entries
+from homeassistant.components.homekit.accessories import HomeDriver
 from homeassistant.components.homekit.const import (
     CONF_FILTER,
     DOMAIN,
@@ -1742,65 +1742,82 @@ async def test_options_flow_cameras_step_with_whole_domain_included(
 
 
 @pytest.mark.parametrize(
-    "homekit_attrs",
+    ("mode_options", "init_input", "entities_step", "entities_input"),
     [
         pytest.param(
-            lambda acc: {"bridge": Mock(accessories={2: acc})},
+            {},
+            {"domains": ["climate"], "include_exclude_mode": "include"},
+            "include",
+            {"entities": ["climate.new"]},
             id="bridge",
         ),
         pytest.param(
-            lambda acc: {"bridge": None, "driver": Mock(accessory=acc)},
+            {"mode": "accessory"},
+            {
+                "domains": ["climate"],
+                "include_exclude_mode": "include",
+                "mode": "accessory",
+            },
+            "accessory",
+            {"entities": "climate.new"},
             id="accessory",
         ),
     ],
 )
+@patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+@pytest.mark.usefixtures("mock_async_zeroconf")
 async def test_options_flow_climate_step_shows_current_accessory(
-    hass: HomeAssistant, homekit_attrs: Callable[[Any], dict[str, Any]]
+    port_mock: MagicMock,
+    hass: HomeAssistant,
+    hk_driver: HomeDriver,
+    mode_options: dict[str, str],
+    init_input: dict[str, Any],
+    entities_step: str,
+    entities_input: dict[str, Any],
 ) -> None:
     """Test the climate labels show the accessory the entity uses now."""
-    config_entry = _mock_config_entry_with_options_populated()
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "mock_name", CONF_PORT: 12345},
+        options={
+            **mode_options,
+            "filter": {
+                "include_domains": [],
+                "include_entities": ["climate.new"],
+                "exclude_domains": [],
+                "exclude_entities": [],
+            },
+        },
+    )
     config_entry.add_to_hass(hass)
 
+    # A basic climate entity bridges as a Thermostat
     hass.states.async_set("climate.new", "off")
     await hass.async_block_till_done()
 
-    # A loaded entry exposes the bridged accessories through its runtime
-    # data; accessory mode reads the single accessory from the driver
-    thermostat = type("Thermostat", (), {"entity_id": "climate.new"})()
-    config_entry.runtime_data = Mock(homekit=Mock(**homekit_attrs(thermostat)))
+    with (
+        patch(f"{PATH_HOMEKIT}.HomeDriver", return_value=hk_driver),
+        patch("pyhap.util.get_local_address", return_value="10.10.10.10"),
+    ):
+        hk_driver.async_start = AsyncMock()
+        hk_driver.async_stop = AsyncMock()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
 
-    result = await hass.config_entries.options.async_init(config_entry.entry_id)
-    result = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={
-            "domains": ["climate"],
-            "include_exclude_mode": "include",
-        },
-    )
-    result2 = await hass.config_entries.options.async_configure(
-        result["flow_id"],
-        user_input={"entities": ["climate.new"]},
-    )
-    assert result2["step_id"] == "climate"
-    assert [str(key) for key in result2["data_schema"].schema] == [
-        "new (climate.new) [Thermostat]"
-    ]
-
-    # The annotated label still round trips to the entity id
-    result2 = await hass.config_entries.options.async_configure(
-        result2["flow_id"],
-        user_input={"new (climate.new) [Thermostat]": "heater_cooler"},
-    )
-    assert result2["step_id"] == "bridged_device_triggers"
-    with patch("homeassistant.components.homekit.async_setup_entry", return_value=True):
-        result3 = await hass.config_entries.options.async_configure(
-            result2["flow_id"],
-            user_input={},
+        result = await hass.config_entries.options.async_init(config_entry.entry_id)
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input=init_input
         )
-    assert result3["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.options["entity_config"]["climate.new"]["type"] == (
-        "heater_cooler"
-    )
+        assert result["step_id"] == entities_step
+        result2 = await hass.config_entries.options.async_configure(
+            result["flow_id"], user_input=entities_input
+        )
+        assert result2["step_id"] == "climate"
+        assert [str(key) for key in result2["data_schema"].schema] == [
+            "new (climate.new) [Thermostat]"
+        ]
+        hass.config_entries.options.async_abort(result2["flow_id"])
+        await hass.config_entries.async_unload(config_entry.entry_id)
 
 
 async def test_options_flow_climate_step_with_whole_domain_included(

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -1742,13 +1742,20 @@ async def test_options_flow_cameras_step_with_whole_domain_included(
 
 
 @pytest.mark.parametrize(
-    ("mode_options", "init_input", "entities_step", "entities_input"),
+    (
+        "mode_options",
+        "init_input",
+        "entities_step",
+        "entities_input",
+        "extra_submits",
+    ),
     [
         pytest.param(
             {},
             {"domains": ["climate"], "include_exclude_mode": "include"},
             "include",
             {"entities": ["climate.new"]},
+            [{}],
             id="bridge",
         ),
         pytest.param(
@@ -1760,6 +1767,7 @@ async def test_options_flow_cameras_step_with_whole_domain_included(
             },
             "accessory",
             {"entities": "climate.new"},
+            [],
             id="accessory",
         ),
     ],
@@ -1774,6 +1782,7 @@ async def test_options_flow_climate_step_shows_current_accessory(
     init_input: dict[str, Any],
     entities_step: str,
     entities_input: dict[str, Any],
+    extra_submits: list[dict[str, Any]],
 ) -> None:
     """Test the climate labels show the accessory the entity uses now."""
     config_entry = MockConfigEntry(
@@ -1816,7 +1825,21 @@ async def test_options_flow_climate_step_shows_current_accessory(
         assert [str(key) for key in result2["data_schema"].schema] == [
             "new (climate.new) [Thermostat]"
         ]
-        hass.config_entries.options.async_abort(result2["flow_id"])
+
+        # The annotated label still round trips to the entity id
+        result3 = await hass.config_entries.options.async_configure(
+            result2["flow_id"],
+            user_input={"new (climate.new) [Thermostat]": "heater_cooler"},
+        )
+        for submit_input in extra_submits:
+            result3 = await hass.config_entries.options.async_configure(
+                result3["flow_id"], user_input=submit_input
+            )
+        assert result3["type"] is FlowResultType.CREATE_ENTRY
+        await hass.async_block_till_done()
+        assert config_entry.options["entity_config"]["climate.new"]["type"] == (
+            "heater_cooler"
+        )
         await hass.config_entries.async_unload(config_entry.entry_id)
 
 


### PR DESCRIPTION

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow up to #148231 from review comments that landed after the merge. A stored Thermostat choice now suppresses the automatic HeaterCooler pick, so an accessory mode pairing reset that makes the entry look brand new keeps the accessory the user chose; a config flow test also loses its conditional logic by parameterizing the mock shape.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #148231
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
