### PR TITLE
Clamp monthly utility meter resets for short months

### DIFF
--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -170,7 +170,11 @@ def _month_aware_reset_scheduler(
                 microsecond=0,
             )
         )
-        if candidate > current:
+        if (
+            candidate > current
+            if candidate.tzinfo is None
+            else candidate.astimezone(UTC) > current.astimezone(UTC)
+        ):
             yield candidate
             current = candidate
 

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -3,7 +3,7 @@
 import calendar
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from decimal import Decimal, DecimalException, InvalidOperation
 import logging
 import math
@@ -108,6 +108,22 @@ _MONTH_PERIOD_STEPS = {
 }
 
 
+def _normalize_like_cronsim(candidate: datetime) -> datetime:
+    """Match CronSim DST handling for month-based reset times.
+
+    Reset fold so ambiguous fall-back times use the first occurrence, and
+    advance minute-by-minute through spring-forward gaps so imaginary wall
+    times (for example 03:30 in Europe/Riga) become the first valid minute.
+    """
+    if candidate.tzinfo is None:
+        return candidate
+
+    result = candidate.replace(fold=0)
+    while result != result.astimezone(UTC).astimezone(result.tzinfo):
+        result += timedelta(minutes=1)
+    return result
+
+
 def _month_aware_reset_scheduler(
     start: datetime,
     *,
@@ -143,14 +159,16 @@ def _month_aware_reset_scheduler(
     while True:
         last_day = calendar.monthrange(year, month)[1]
         target_day = min(day, last_day)
-        candidate = current.replace(
-            year=year,
-            month=month,
-            day=target_day,
-            hour=hour,
-            minute=minute,
-            second=0,
-            microsecond=0,
+        candidate = _normalize_like_cronsim(
+            current.replace(
+                year=year,
+                month=month,
+                day=target_day,
+                hour=hour,
+                minute=minute,
+                second=0,
+                microsecond=0,
+            )
         )
         if candidate > current:
             yield candidate

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -121,14 +121,24 @@ def _month_aware_reset_scheduler(
     Cron day-of-month values such as 29 skip February in non-leap years.
     Clamp the intended day to the last day of each target month so monthly
     meters with large offsets still reset every month.
+
+    Multi-month periods stay aligned to January, matching the previous cron
+    patterns (`*/2`, `*/3`, and `1/12`).
     """
     month_step = _MONTH_PERIOD_STEPS[period]
-    # YEARLY always resets in January (month 1), matching the cron pattern.
-    fixed_month = 1 if period == YEARLY else None
 
     current = start
     year = current.year
-    month = fixed_month if fixed_month is not None else current.month
+    month = current.month
+
+    # Align to the calendar cycle that starts in January.
+    # monthly: every month; bimonthly: 1,3,5,...; quarterly: 1,4,7,10; yearly: 1
+    remainder = (month - 1) % month_step
+    if remainder:
+        month = month - remainder + month_step
+        while month > 12:
+            month -= 12
+            year += 1
 
     while True:
         last_day = calendar.monthrange(year, month)[1]
@@ -146,14 +156,10 @@ def _month_aware_reset_scheduler(
             yield candidate
             current = candidate
 
-        if fixed_month is not None:
+        month += month_step
+        while month > 12:
+            month -= 12
             year += 1
-            month = fixed_month
-        else:
-            month += month_step
-            while month > 12:
-                month -= 12
-                year += 1
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -480,26 +486,22 @@ class UtilityMeterSensor(RestoreSensor):
             dt_util.get_default_time_zone()
         )  # we need timezone for DST purposes (see issue #102984)
 
+        scheduler: Iterator[datetime] | None
         # Month-based periods need day-of-month clamping so offsets near the
         # end of the month still reset in short months such as February.
         if self._period in _MONTH_PERIOD_STEPS:
-            self.scheduler = _month_aware_reset_scheduler(
+            scheduler = _month_aware_reset_scheduler(
                 start,
                 day=self._meter_offset.days + 1,
                 hour=self._meter_offset.seconds // 3600,
                 minute=self._meter_offset.seconds % 3600 // 60,
                 period=self._period,
             )
-            return
-
-        self.scheduler = (
-            CronSim(
-                self._cron_pattern,
-                start,
-            )
-            if self._cron_pattern
-            else None
-        )
+        elif self._cron_pattern:
+            scheduler = CronSim(self._cron_pattern, start)
+        else:
+            scheduler = None
+        self.scheduler = scheduler
 
     def start(self, attributes: Mapping[str, Any]) -> None:
         """Initialize unit and state upon source initial update."""

--- a/homeassistant/components/utility_meter/sensor.py
+++ b/homeassistant/components/utility_meter/sensor.py
@@ -1,6 +1,7 @@
 """Utility meter from sensors providing raw data."""
 
-from collections.abc import Mapping
+import calendar
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from decimal import Decimal, DecimalException, InvalidOperation
@@ -98,6 +99,62 @@ PERIOD2CRON = {
     QUARTERLY: "{minute} {hour} {day} */3 *",
     YEARLY: "{minute} {hour} {day} 1/12 *",
 }
+
+_MONTH_PERIOD_STEPS = {
+    MONTHLY: 1,
+    BIMONTHLY: 2,
+    QUARTERLY: 3,
+    YEARLY: 12,
+}
+
+
+def _month_aware_reset_scheduler(
+    start: datetime,
+    *,
+    day: int,
+    hour: int,
+    minute: int,
+    period: str,
+) -> Iterator[datetime]:
+    """Yield reset times for month-based periods with day clamping.
+
+    Cron day-of-month values such as 29 skip February in non-leap years.
+    Clamp the intended day to the last day of each target month so monthly
+    meters with large offsets still reset every month.
+    """
+    month_step = _MONTH_PERIOD_STEPS[period]
+    # YEARLY always resets in January (month 1), matching the cron pattern.
+    fixed_month = 1 if period == YEARLY else None
+
+    current = start
+    year = current.year
+    month = fixed_month if fixed_month is not None else current.month
+
+    while True:
+        last_day = calendar.monthrange(year, month)[1]
+        target_day = min(day, last_day)
+        candidate = current.replace(
+            year=year,
+            month=month,
+            day=target_day,
+            hour=hour,
+            minute=minute,
+            second=0,
+            microsecond=0,
+        )
+        if candidate > current:
+            yield candidate
+            current = candidate
+
+        if fixed_month is not None:
+            year += 1
+            month = fixed_month
+        else:
+            month += month_step
+            while month > 12:
+                month -= 12
+                year += 1
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -396,6 +453,7 @@ class UtilityMeterSensor(RestoreSensor):
         self._input_device_class = None
         self._attr_native_unit_of_measurement = None
         self._period = meter_type
+        self._meter_offset = meter_offset
         if meter_type is not None:
             # For backwards compatibility reasons we convert
             # the period and offset into a cron pattern
@@ -418,13 +476,26 @@ class UtilityMeterSensor(RestoreSensor):
         self._config_scheduler()
 
     def _config_scheduler(self, start_time: datetime | None = None) -> None:
+        start = start_time or dt_util.now(
+            dt_util.get_default_time_zone()
+        )  # we need timezone for DST purposes (see issue #102984)
+
+        # Month-based periods need day-of-month clamping so offsets near the
+        # end of the month still reset in short months such as February.
+        if self._period in _MONTH_PERIOD_STEPS:
+            self.scheduler = _month_aware_reset_scheduler(
+                start,
+                day=self._meter_offset.days + 1,
+                hour=self._meter_offset.seconds // 3600,
+                minute=self._meter_offset.seconds % 3600 // 60,
+                period=self._period,
+            )
+            return
+
         self.scheduler = (
             CronSim(
                 self._cron_pattern,
-                start_time
-                or dt_util.now(
-                    dt_util.get_default_time_zone()
-                ),  # we need timezone for DST purposes (see issue #102984)
+                start,
             )
             if self._cron_pattern
             else None

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1,6 +1,7 @@
 """The tests for the utility_meter sensor platform."""
 
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 
 from freezegun import freeze_time
 import pytest
@@ -2217,6 +2218,38 @@ def test_month_aware_reset_scheduler_period_alignment(
     )
     for expected_reset in expected:
         assert next(scheduler) == datetime.fromisoformat(expected_reset)
+
+
+def test_month_aware_reset_scheduler_dst_gap() -> None:
+    """Spring-forward gaps should advance like CronSim instead of shifting by an hour."""
+    tz = ZoneInfo("Europe/Riga")
+    # 2021-03-28 jumps 03:00 -> 04:00; 03:30 is imaginary.
+    # CronSim yields 04:00, not the 04:30 that naive replace would become.
+    scheduler = _month_aware_reset_scheduler(
+        datetime(2021, 3, 1, 0, 0, tzinfo=tz),
+        day=28,
+        hour=3,
+        minute=30,
+        period=MONTHLY,
+    )
+    assert next(scheduler) == datetime(2021, 3, 28, 4, 0, tzinfo=tz)
+    assert next(scheduler) == datetime(2021, 4, 28, 3, 30, tzinfo=tz)
+
+
+def test_month_aware_reset_scheduler_dst_fold() -> None:
+    """Ambiguous fall-back times should use fold 0 like CronSim."""
+    tz = ZoneInfo("Europe/Riga")
+    # Start in fold 1 must not select the second 03:30 occurrence.
+    scheduler = _month_aware_reset_scheduler(
+        datetime(2021, 10, 30, 12, 0, tzinfo=tz, fold=1),
+        day=31,
+        hour=3,
+        minute=30,
+        period=MONTHLY,
+    )
+    reset = next(scheduler)
+    assert reset == datetime(2021, 10, 31, 3, 30, tzinfo=tz, fold=0)
+    assert reset.fold == 0
 
 
 async def test_monthly_offset_resets_in_february(hass: HomeAssistant) -> None:

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -2253,27 +2253,71 @@ def test_month_aware_reset_scheduler_dst_fold() -> None:
 
 
 async def test_monthly_offset_resets_in_february(hass: HomeAssistant) -> None:
-    """Monthly meter with offset 28 (day 29) should still reset in February."""
-    # YAML rejects offset >= 28 days; config entry path allows 28.
-    # Exercise the sensor class directly for the UI offset case.
-    sensor = UtilityMeterSensor(
-        hass,
-        cron_pattern=None,
-        delta_values=False,
-        meter_offset=timedelta(days=28),
-        meter_type="monthly",
-        name="energy_bill",
-        net_consumption=False,
-        parent_meter="test",
-        periodically_resetting=True,
-        source_entity="sensor.energy",
-        tariff_entity=None,
-        tariff=None,
-        unique_id="test_energy_bill",
-        sensor_always_available=False,
-    )
-    sensor.hass = hass
-    sensor.entity_id = "sensor.energy_bill"
-    sensor._config_scheduler(dt_util.parse_datetime("2026-02-05T12:00:00+00:00"))
-    next_reset = next(sensor.scheduler)
-    assert next_reset.isoformat() == "2026-02-28T00:00:00+00:00"
+    """Config-entry monthly meter with offset 28 still resets in February."""
+    # YAML rejects offset >= 28 days; the UI/config-entry path allows 28 (day 29).
+    # Day 29 does not exist in non-leap February, so the scheduled reset must
+    # clamp to Feb 28 and fire through the normal timer path.
+    now = dt_util.parse_datetime("2026-02-27T23:59:00.000000+00:00")
+    with freeze_time(now):
+        config_entry = MockConfigEntry(
+            data={},
+            domain=DOMAIN,
+            options={
+                "cycle": "monthly",
+                "delta_values": False,
+                "name": "Energy bill",
+                "net_consumption": False,
+                "offset": 28,
+                "periodically_resetting": True,
+                "source": "sensor.energy",
+                "tariffs": [],
+            },
+            title="Energy bill",
+        )
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("sensor.energy_bill")
+        assert state is not None
+        assert state.attributes.get("next_reset") == "2026-02-28T00:00:00+00:00"
+
+        async_fire_time_changed(hass, now)
+        hass.states.async_set(
+            "sensor.energy",
+            1,
+            {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR},
+        )
+        await hass.async_block_till_done()
+
+    now += timedelta(seconds=30)
+    with freeze_time(now):
+        async_fire_time_changed(hass, now)
+        hass.states.async_set(
+            "sensor.energy",
+            3,
+            {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR},
+            force_update=True,
+        )
+        await hass.async_block_till_done()
+
+    now += timedelta(seconds=30)
+    with freeze_time(now):
+        async_fire_time_changed(hass, now)
+        await hass.async_block_till_done()
+        hass.states.async_set(
+            "sensor.energy",
+            6,
+            {ATTR_UNIT_OF_MEASUREMENT: UnitOfEnergy.KILO_WATT_HOUR},
+            force_update=True,
+        )
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.energy_bill")
+    assert state is not None
+    assert state.attributes.get("last_period") == "2"
+    assert state.attributes.get("last_reset") == dt_util.as_utc(now).isoformat()
+    assert state.state == "3"

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -1,6 +1,6 @@
 """The tests for the utility_meter sensor platform."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 
 from freezegun import freeze_time
 import pytest
@@ -17,14 +17,16 @@ from homeassistant.components.sensor import (
 from homeassistant.components.utility_meter import DEFAULT_OFFSET
 from homeassistant.components.utility_meter.const import (
     ATTR_VALUE,
+    BIMONTHLY,
     DAILY,
     DOMAIN,
     HOURLY,
+    MONTHLY,
     QUARTER_HOURLY,
+    QUARTERLY,
     SERVICE_CALIBRATE_METER,
     SERVICE_RESET,
 )
-from homeassistant.components.utility_meter.const import MONTHLY
 from homeassistant.components.utility_meter.sensor import (
     ATTR_LAST_RESET,
     ATTR_STATUS,
@@ -2159,14 +2161,59 @@ async def test_device_id(
 )
 def test_month_aware_reset_scheduler(start: str, day: int, expected: list[str]) -> None:
     """Monthly resets should clamp day-of-month to the length of each month."""
-    from datetime import datetime
-
     scheduler = _month_aware_reset_scheduler(
         datetime.fromisoformat(start),
         day=day,
         hour=0,
         minute=0,
         period=MONTHLY,
+    )
+    for expected_reset in expected:
+        assert next(scheduler) == datetime.fromisoformat(expected_reset)
+
+
+@pytest.mark.parametrize(
+    ("period", "start", "expected"),
+    [
+        (
+            QUARTERLY,
+            "2017-03-31T23:59:00+00:00",
+            [
+                "2017-04-01T00:00:00+00:00",
+                "2017-07-01T00:00:00+00:00",
+                "2017-10-01T00:00:00+00:00",
+                "2018-01-01T00:00:00+00:00",
+            ],
+        ),
+        (
+            BIMONTHLY,
+            "2017-12-31T23:59:00+00:00",
+            [
+                "2018-01-01T00:00:00+00:00",
+                "2018-03-01T00:00:00+00:00",
+                "2018-05-01T00:00:00+00:00",
+            ],
+        ),
+        (
+            BIMONTHLY,
+            "2018-01-01T23:59:00+00:00",
+            [
+                "2018-03-01T00:00:00+00:00",
+                "2018-05-01T00:00:00+00:00",
+            ],
+        ),
+    ],
+)
+def test_month_aware_reset_scheduler_period_alignment(
+    period: str, start: str, expected: list[str]
+) -> None:
+    """Multi-month schedules should stay aligned to January like cron did."""
+    scheduler = _month_aware_reset_scheduler(
+        datetime.fromisoformat(start),
+        day=1,
+        hour=0,
+        minute=0,
+        period=period,
     )
     for expected_reset in expected:
         assert next(scheduler) == datetime.fromisoformat(expected_reset)

--- a/tests/components/utility_meter/test_sensor.py
+++ b/tests/components/utility_meter/test_sensor.py
@@ -24,12 +24,14 @@ from homeassistant.components.utility_meter.const import (
     SERVICE_CALIBRATE_METER,
     SERVICE_RESET,
 )
+from homeassistant.components.utility_meter.const import MONTHLY
 from homeassistant.components.utility_meter.sensor import (
     ATTR_LAST_RESET,
     ATTR_STATUS,
     COLLECTING,
     PAUSED,
     UtilityMeterSensor,
+    _month_aware_reset_scheduler,
 )
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
@@ -2118,3 +2120,80 @@ async def test_device_id(
     utility_meter_no_tariffs_entity = entity_registry.async_get("sensor.energy")
     assert utility_meter_no_tariffs_entity is not None
     assert utility_meter_no_tariffs_entity.device_id == source_entity.device_id
+
+
+@pytest.mark.parametrize(
+    ("start", "day", "expected"),
+    [
+        (
+            # Non-leap February with day 29 should clamp to Feb 28
+            "2026-02-05T12:00:00+00:00",
+            29,
+            [
+                "2026-02-28T00:00:00+00:00",
+                "2026-03-29T00:00:00+00:00",
+                "2026-04-29T00:00:00+00:00",
+            ],
+        ),
+        (
+            # Leap year February keeps day 29
+            "2024-02-05T12:00:00+00:00",
+            29,
+            [
+                "2024-02-29T00:00:00+00:00",
+                "2024-03-29T00:00:00+00:00",
+            ],
+        ),
+        (
+            # Day 31 clamps to last day of short months
+            "2026-01-05T00:00:00+00:00",
+            31,
+            [
+                "2026-01-31T00:00:00+00:00",
+                "2026-02-28T00:00:00+00:00",
+                "2026-03-31T00:00:00+00:00",
+                "2026-04-30T00:00:00+00:00",
+            ],
+        ),
+    ],
+)
+def test_month_aware_reset_scheduler(start: str, day: int, expected: list[str]) -> None:
+    """Monthly resets should clamp day-of-month to the length of each month."""
+    from datetime import datetime
+
+    scheduler = _month_aware_reset_scheduler(
+        datetime.fromisoformat(start),
+        day=day,
+        hour=0,
+        minute=0,
+        period=MONTHLY,
+    )
+    for expected_reset in expected:
+        assert next(scheduler) == datetime.fromisoformat(expected_reset)
+
+
+async def test_monthly_offset_resets_in_february(hass: HomeAssistant) -> None:
+    """Monthly meter with offset 28 (day 29) should still reset in February."""
+    # YAML rejects offset >= 28 days; config entry path allows 28.
+    # Exercise the sensor class directly for the UI offset case.
+    sensor = UtilityMeterSensor(
+        hass,
+        cron_pattern=None,
+        delta_values=False,
+        meter_offset=timedelta(days=28),
+        meter_type="monthly",
+        name="energy_bill",
+        net_consumption=False,
+        parent_meter="test",
+        periodically_resetting=True,
+        source_entity="sensor.energy",
+        tariff_entity=None,
+        tariff=None,
+        unique_id="test_energy_bill",
+        sensor_always_available=False,
+    )
+    sensor.hass = hass
+    sensor.entity_id = "sensor.energy_bill"
+    sensor._config_scheduler(dt_util.parse_datetime("2026-02-05T12:00:00+00:00"))
+    next_reset = next(sensor.scheduler)
+    assert next_reset.isoformat() == "2026-02-28T00:00:00+00:00"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Monthly utility meters with a large offset (for example offset 28, which becomes day 29) used a cron expression that has no match in February. Cron then jumped to March 29, so February never reset and usage kept accumulating into March.

Month-based periods now compute the next reset with day-of-month clamping: if the configured day does not exist in a month, the meter resets on that month's last day. Multi-month periods (`bimonthly`, `quarterly`, `yearly`) stay aligned to January so they keep the same cycle as the previous cron patterns. DST gaps and folds are normalized the same way CronSim did.

Fixes #165244

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165244
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr