### PR TITLE
Fix VeSync crash on fan levels outside of defined list

### DIFF
--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -163,15 +163,15 @@ class VeSyncFanHA(VeSyncBaseEntity[VeSyncFanBase | VeSyncPurifier], FanEntity):
         """Return the currently set speed."""
 
         current_level = self.device.state.fan_level
-        if (
-            self.device.state.mode in (VS_FAN_MODE_MANUAL, VS_FAN_MODE_NORMAL)
-            and current_level is not None
-        ):
+        if self.device.state.mode in (VS_FAN_MODE_MANUAL, VS_FAN_MODE_NORMAL):
             if current_level == 0:
                 return 0
-            return ordered_list_item_to_percentage(
-                self.device.fan_levels, current_level
-            )
+            # The device can report an out-of-range level (e.g. -1) when the
+            # speed is not applicable; treat it as unknown instead of crashing.
+            if current_level in self.device.fan_levels:
+                return ordered_list_item_to_percentage(
+                    self.device.fan_levels, current_level
+                )
         return None
 
     @property

--- a/tests/components/vesync/common.py
+++ b/tests/components/vesync/common.py
@@ -134,6 +134,10 @@ def mock_devices_response(
     for fixture in DEVICE_FIXTURES[device_name]:
         detail = load_json_object_fixture(fixture[2], DOMAIN)
         if details_override:
+            assert "result" in detail.get("result", {}), (
+                f"Fixture {fixture[2]} does not have the expected "
+                "result.result payload to apply details_override"
+            )
             detail["result"]["result"].update(details_override)
         getattr(aioclient_mock, fixture[0])(
             f"https://smartapi.vesync.com{fixture[1]}",

--- a/tests/components/vesync/common.py
+++ b/tests/components/vesync/common.py
@@ -99,9 +99,15 @@ DEVICE_FIXTURES: dict[str, list[tuple[str, str, str]]] = {
 
 
 def mock_devices_response(
-    aioclient_mock: AiohttpClientMocker, device_name: str
+    aioclient_mock: AiohttpClientMocker,
+    device_name: str,
+    details_override: dict[str, Any] | None = None,
 ) -> None:
-    """Build a response for the Helpers.call_api method."""
+    """Build a response for the Helpers.call_api method.
+
+    ``details_override`` is merged into the nested ``result`` payload of the
+    device detail response, allowing tests to simulate specific device states.
+    """
     device_list = [
         device
         for device in ALL_DEVICES["result"]["list"]
@@ -126,9 +132,12 @@ def mock_devices_response(
     )
 
     for fixture in DEVICE_FIXTURES[device_name]:
+        detail = load_json_object_fixture(fixture[2], DOMAIN)
+        if details_override:
+            detail["result"]["result"].update(details_override)
         getattr(aioclient_mock, fixture[0])(
             f"https://smartapi.vesync.com{fixture[1]}",
-            json=load_json_object_fixture(fixture[2], DOMAIN),
+            json=detail,
         )
     mock_firmware(aioclient_mock)
 

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -202,13 +202,7 @@ async def test_out_of_range_fan_level(
     config_entry: MockConfigEntry,
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
-    """Test a device reporting an out-of-range fan level loads without crashing.
-
-    The CoreBreeze 432S (LPF-R432S) reports fan level -1 when the speed is not
-    applicable, which previously raised ValueError during setup and every
-    coordinator update. The entity should stay available with an unknown
-    percentage instead of crashing.
-    """
+    """Test that an out-of-range fan level produces an unknown percentage."""
 
     mock_devices_response(
         aioclient_mock, "CoreBreeze 432S", details_override={"fanSpeedLevel": -1}

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -6,8 +6,17 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.fan import ATTR_PRESET_MODE, DOMAIN as FAN_DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
+from homeassistant.components.fan import (
+    ATTR_PERCENTAGE,
+    ATTR_PRESET_MODE,
+    DOMAIN as FAN_DOMAIN,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -186,6 +195,32 @@ async def test_set_preset_mode(
         await hass.async_block_till_done()
         method_mock.assert_called_once()
         update_mock.assert_called_once()
+
+
+async def test_out_of_range_fan_level(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test a device reporting an out-of-range fan level loads without crashing.
+
+    The CoreBreeze 432S (LPF-R432S) reports fan level -1 when the speed is not
+    applicable, which previously raised ValueError during setup and every
+    coordinator update. The entity should stay available with an unknown
+    percentage instead of crashing.
+    """
+
+    mock_devices_response(
+        aioclient_mock, "CoreBreeze 432S", details_override={"fanSpeedLevel": -1}
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_PEDESTAL_FAN)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes[ATTR_PERCENTAGE] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes the error described in #174010 (re)adding support for the Levoit LPF-R432S-AEU. It maybe also fixes #174655. There is still a warning about missing eco mode which I will adress in another PR.

The fan percentage property raised ValueError when a device reported a fan level outside its fan_levels list (e.g. -1, used when the speed is not applicable). This broke entity setup and every coordinator update for affected devices such as the CoreBreeze 432S (LPF-R432S). Guard against levels that are not in fan_levels and report the speed as unknown instead of crashing.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174010
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
