### PR TITLE
Restore optimistic template switches with empty UI state

### DIFF
--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -27,11 +27,7 @@ _SENTINEL = object()
 
 
 def _is_missing_template(value: Any) -> bool:
-    """Return True if a state template is unset or effectively empty.
-
-    UI config entries may store an empty string for optional template fields.
-    Treat those the same as a missing template so optimistic restore works.
-    """
+    """Return True if a state template is unset or empty/whitespace only."""
     if value is None:
         return True
     if isinstance(value, Template):

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -177,9 +177,7 @@ class AbstractTemplateEntity(Entity):
         if not isinstance(template, Template):
             return None
 
-        # Only suppress empty state templates used for optimistic mode.
-        # Other options (for example availability) may intentionally use an
-        # empty template and must keep their previous render behavior.
+        # Empty availability templates must still render (false -> unavailable).
         if self._is_optimistic_state_option(option) and _is_missing_template(template):
             return None
 

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -174,7 +174,13 @@ class AbstractTemplateEntity(Entity):
     ) -> Template | None:
         """Add a template."""
         template = self._config.get(option)
-        if not isinstance(template, Template) or _is_missing_template(template):
+        if not isinstance(template, Template):
+            return None
+
+        # Only suppress empty state templates used for optimistic mode.
+        # Other options (for example availability) may intentionally use an
+        # empty template and must keep their previous render behavior.
+        if self._is_optimistic_state_option(option) and _is_missing_template(template):
             return None
 
         if add_if_static or (not template.is_static):
@@ -186,6 +192,16 @@ class AbstractTemplateEntity(Entity):
                 none_on_template_error,
             )
         return template
+
+    def _is_optimistic_state_option(self, option: str) -> bool:
+        """Return True if option drives optimistic state for this entity."""
+        if not self._optimistic_entity:
+            return False
+        if option == self._state_option:
+            return True
+        return bool(
+            self._extra_optimistic_options and option in self._extra_optimistic_options
+        )
 
     def add_script(
         self,

--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -26,6 +26,21 @@ from .const import CONF_ATTRIBUTES, CONF_DEFAULT_ENTITY_ID, CONF_PICTURE
 _SENTINEL = object()
 
 
+def _is_missing_template(value: Any) -> bool:
+    """Return True if a state template is unset or effectively empty.
+
+    UI config entries may store an empty string for optional template fields.
+    Treat those the same as a missing template so optimistic restore works.
+    """
+    if value is None:
+        return True
+    if isinstance(value, Template):
+        return not value.template.strip()
+    if isinstance(value, str):
+        return not value.strip()
+    return False
+
+
 @dataclass
 class EntityTemplate:
     """Information class for properly handling template results."""
@@ -70,10 +85,12 @@ class AbstractTemplateEntity(Entity):
             optimistic = config.get(CONF_OPTIMISTIC)
 
             if self._state_option is not None:
-                assumed_optimistic = config.get(self._state_option) is None
+                assumed_optimistic = _is_missing_template(
+                    config.get(self._state_option)
+                )
                 if self._extra_optimistic_options:
                     assumed_optimistic = assumed_optimistic and all(
-                        config.get(option) is None
+                        _is_missing_template(config.get(option))
                         for option in self._extra_optimistic_options
                     )
 
@@ -160,18 +177,19 @@ class AbstractTemplateEntity(Entity):
         add_if_static: bool = True,
     ) -> Template | None:
         """Add a template."""
-        if (template := self._config.get(option)) and isinstance(template, Template):
-            if add_if_static or (not template.is_static):
-                self._templates[option] = EntityTemplate(
-                    attribute,
-                    template,
-                    validator,
-                    on_update,
-                    none_on_template_error,
-                )
-            return template
+        template = self._config.get(option)
+        if not isinstance(template, Template) or _is_missing_template(template):
+            return None
 
-        return None
+        if add_if_static or (not template.is_static):
+            self._templates[option] = EntityTemplate(
+                attribute,
+                template,
+                validator,
+                on_update,
+                none_on_template_error,
+            )
+        return template
 
     def add_script(
         self,

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -597,6 +597,92 @@ async def test_restore_state(
     assert state.state == test_state
 
 
+@pytest.mark.parametrize("test_state", [STATE_ON, STATE_OFF])
+async def test_config_entry_optimistic_restore_with_empty_value_template(
+    hass: HomeAssistant, test_state: str
+) -> None:
+    """UI empty value_template should keep optimistic mode and restore state.
+
+    Config entries created from the UI may store an empty string for the optional
+    state field. That must not disable optimistic mode or block restore.
+    """
+    mock_restore_cache(hass, (State("switch.my_template", test_state),))
+    hass.set_state(CoreState.starting)
+    mock_component(hass, "recorder")
+
+    entry = MockConfigEntry(
+        data={},
+        domain=template.DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": SWITCH_DOMAIN,
+            "value_template": "",
+            "turn_on": [],
+            "turn_off": [],
+        },
+        title="My template",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.my_template")
+    assert state is not None
+    assert state.state == test_state
+    assert state.attributes.get("assumed_state") is True
+
+
+async def test_config_entry_optimistic_turn_on_with_empty_value_template(
+    hass: HomeAssistant,
+) -> None:
+    """UI empty value_template should still allow optimistic turn on/off."""
+    entry = MockConfigEntry(
+        data={},
+        domain=template.DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": SWITCH_DOMAIN,
+            "value_template": "",
+            "turn_on": [],
+            "turn_off": [],
+        },
+        title="My template",
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("switch.my_template")
+    assert state is not None
+    assert state.attributes.get("assumed_state") is True
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: "switch.my_template"},
+        blocking=True,
+    )
+
+    state = hass.states.get("switch.my_template")
+    assert state is not None
+    assert state.state == STATE_ON
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "switch.my_template"},
+        blocking=True,
+    )
+
+    state = hass.states.get("switch.my_template")
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
 @pytest.mark.parametrize(
     ("count", "attribute_template"),
     [(1, "{{ is_state('switch.test_state', 'on') }}")],

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -598,8 +598,9 @@ async def test_restore_state(
 
 
 @pytest.mark.parametrize("test_state", [STATE_ON, STATE_OFF])
+@pytest.mark.parametrize("value_template", ["", "   "])
 async def test_config_entry_optimistic_restore_with_empty_value_template(
-    hass: HomeAssistant, test_state: str
+    hass: HomeAssistant, test_state: str, value_template: str
 ) -> None:
     """UI empty value_template should keep optimistic mode and restore state."""
     mock_restore_cache(hass, (State("switch.my_template", test_state),))
@@ -612,7 +613,7 @@ async def test_config_entry_optimistic_restore_with_empty_value_template(
         options={
             "name": "My template",
             "template_type": SWITCH_DOMAIN,
-            "value_template": "",
+            "value_template": value_template,
             "turn_on": [],
             "turn_off": [],
         },

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -601,11 +601,7 @@ async def test_restore_state(
 async def test_config_entry_optimistic_restore_with_empty_value_template(
     hass: HomeAssistant, test_state: str
 ) -> None:
-    """UI empty value_template should keep optimistic mode and restore state.
-
-    Config entries created from the UI may store an empty string for the optional
-    state field. That must not disable optimistic mode or block restore.
-    """
+    """UI empty value_template should keep optimistic mode and restore state."""
     mock_restore_cache(hass, (State("switch.my_template", test_state),))
     hass.set_state(CoreState.starting)
     mock_component(hass, "recorder")
@@ -635,7 +631,7 @@ async def test_config_entry_optimistic_restore_with_empty_value_template(
     assert state.attributes.get("assumed_state") is True
 
 
-async def test_config_entry_optimistic_turn_on_with_empty_value_template(
+async def test_config_entry_optimistic_turn_on_off_with_empty_value_template(
     hass: HomeAssistant,
 ) -> None:
     """UI empty value_template should still allow optimistic turn on/off."""

--- a/tests/components/template/test_switch.py
+++ b/tests/components/template/test_switch.py
@@ -680,6 +680,28 @@ async def test_config_entry_optimistic_turn_on_off_with_empty_value_template(
 
 
 @pytest.mark.parametrize(
+    "style",
+    [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER],
+)
+async def test_empty_availability_template_keeps_entity_unavailable(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+) -> None:
+    """Empty availability templates should still render false and hide the entity."""
+    await setup_entity(
+        hass,
+        TEST_SWITCH,
+        style,
+        1,
+        {"availability": ""},
+        extra_config=SWITCH_ACTIONS,
+        state_template="{{ true }}",
+    )
+    await async_trigger(hass, TEST_STATE_ENTITY_ID)
+    assert hass.states.get(TEST_SWITCH.entity_id).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
     ("count", "attribute_template"),
     [(1, "{{ is_state('switch.test_state', 'on') }}")],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Template switches created in the UI can end up with an empty `value_template` when the optional state field is left blank. That empty string was treated as a real state template, so the switch was no longer optimistic. Turn on/off did not update the entity state, and the last state was not restored after a restart.

Empty or whitespace-only state templates are now treated as missing for optimistic state options only. The switch stays in optimistic mode, tracks no empty state template, and restores its previous on/off value after restart. Availability and other non-state templates keep their previous empty-string render behavior.

Fixes #173706

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173706
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr