### PR TITLE
Seed filter sensor from current source state on startup

### DIFF
--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -392,12 +392,19 @@ class SensorFilter(SensorEntity):
 
         @callback
         def _async_hass_started(hass: HomeAssistant) -> None:
-            """Delay source entity tracking."""
+            """Delay source entity tracking and seed the current source state.
+
+            History replay only covers recorded samples. If the source already
+            has a steady value at startup (including 0) and does not change
+            again, state_changed never fires and the filter would stay unknown.
+            """
             self.async_on_remove(
                 async_track_state_change_event(
                     self.hass, [self._entity], self._update_filter_sensor_state_event
                 )
             )
+            if (source_state := self.hass.states.get(self._entity)) is not None:
+                self._update_filter_sensor_state(source_state)
 
         self.async_on_remove(async_at_started(self.hass, _async_hass_started))
 

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -392,12 +392,7 @@ class SensorFilter(SensorEntity):
 
         @callback
         def _async_hass_started(hass: HomeAssistant) -> None:
-            """Delay source entity tracking and seed the current source state.
-
-            History replay only covers recorded samples. If the source already
-            has a steady value at startup (including 0) and does not change
-            again, state_changed never fires and the filter would stay unknown.
-            """
+            """Track source changes and seed any steady state already present."""
             self.async_on_remove(
                 async_track_state_change_event(
                     self.hass, [self._entity], self._update_filter_sensor_state_event

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -589,3 +589,85 @@ async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
 
     assert hass.states.get("sensor.test") is None
     assert hass.states.get("sensor.filtered_realistic_humidity")
+
+
+async def test_seed_current_zero_state_on_start(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Filter should adopt a source value of 0 already present at startup.
+
+    Without seeding the current source state, the filter stays unknown until the
+    source changes again. A steady zero is a valid reading and must not be skipped.
+    """
+    hass.states.async_set("sensor.test_monitored", "0")
+    await hass.async_block_till_done()
+
+    config = {
+        "sensor": {
+            "platform": "filter",
+            "name": "test",
+            "entity_id": "sensor.test_monitored",
+            "filters": [
+                {"filter": "lowpass", "time_constant": 10, "precision": 2},
+            ],
+        }
+    }
+
+    with (
+        patch(
+            "homeassistant.components.recorder.history.state_changes_during_period",
+            return_value={},
+        ),
+        patch(
+            "homeassistant.components.recorder.history.get_last_state_changes",
+            return_value={},
+        ),
+        assert_setup_component(1, "sensor"),
+    ):
+        assert await async_setup_component(hass, "sensor", config)
+        await hass.async_block_till_done()
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.state == "0.0"
+
+
+async def test_seed_current_nonzero_state_on_start(
+    recorder_mock: Recorder, hass: HomeAssistant
+) -> None:
+    """Filter should also seed non-zero current source values at startup."""
+    hass.states.async_set("sensor.test_monitored", "12.5")
+    await hass.async_block_till_done()
+
+    config = {
+        "sensor": {
+            "platform": "filter",
+            "name": "test",
+            "entity_id": "sensor.test_monitored",
+            "filters": [
+                {"filter": "lowpass", "time_constant": 10, "precision": 1},
+            ],
+        }
+    }
+
+    with (
+        patch(
+            "homeassistant.components.recorder.history.state_changes_during_period",
+            return_value={},
+        ),
+        patch(
+            "homeassistant.components.recorder.history.get_last_state_changes",
+            return_value={},
+        ),
+        assert_setup_component(1, "sensor"),
+    ):
+        assert await async_setup_component(hass, "sensor", config)
+        await hass.async_block_till_done()
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test")
+    assert state is not None
+    assert state.state == "12.5"

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -591,15 +591,22 @@ async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:
     assert hass.states.get("sensor.filtered_realistic_humidity")
 
 
-async def test_seed_current_zero_state_on_start(
-    recorder_mock: Recorder, hass: HomeAssistant
+@pytest.mark.parametrize(
+    ("source_state", "precision", "expected_state"),
+    [
+        ("0", 2, "0.0"),
+        ("12.5", 1, "12.5"),
+    ],
+)
+async def test_seed_current_source_state_on_start(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    source_state: str,
+    precision: int,
+    expected_state: str,
 ) -> None:
-    """Filter should adopt a source value of 0 already present at startup.
-
-    Without seeding the current source state, the filter stays unknown until the
-    source changes again. A steady zero is a valid reading and must not be skipped.
-    """
-    hass.states.async_set("sensor.test_monitored", "0")
+    """Filter should seed the current source state at startup."""
+    hass.states.async_set("sensor.test_monitored", source_state)
     await hass.async_block_till_done()
 
     config = {
@@ -608,7 +615,7 @@ async def test_seed_current_zero_state_on_start(
             "name": "test",
             "entity_id": "sensor.test_monitored",
             "filters": [
-                {"filter": "lowpass", "time_constant": 10, "precision": 2},
+                {"filter": "lowpass", "time_constant": 10, "precision": precision},
             ],
         }
     }
@@ -631,43 +638,4 @@ async def test_seed_current_zero_state_on_start(
 
     state = hass.states.get("sensor.test")
     assert state is not None
-    assert state.state == "0.0"
-
-
-async def test_seed_current_nonzero_state_on_start(
-    recorder_mock: Recorder, hass: HomeAssistant
-) -> None:
-    """Filter should also seed non-zero current source values at startup."""
-    hass.states.async_set("sensor.test_monitored", "12.5")
-    await hass.async_block_till_done()
-
-    config = {
-        "sensor": {
-            "platform": "filter",
-            "name": "test",
-            "entity_id": "sensor.test_monitored",
-            "filters": [
-                {"filter": "lowpass", "time_constant": 10, "precision": 1},
-            ],
-        }
-    }
-
-    with (
-        patch(
-            "homeassistant.components.recorder.history.state_changes_during_period",
-            return_value={},
-        ),
-        patch(
-            "homeassistant.components.recorder.history.get_last_state_changes",
-            return_value={},
-        ),
-        assert_setup_component(1, "sensor"),
-    ):
-        assert await async_setup_component(hass, "sensor", config)
-        await hass.async_block_till_done()
-        await hass.async_start()
-        await hass.async_block_till_done()
-
-    state = hass.states.get("sensor.test")
-    assert state is not None
-    assert state.state == "12.5"
+    assert state.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
After a restart, filter sensors only subscribed to future `state_changed` events. If the source already had a steady value, including `0`, and there were no history samples to replay, the filter stayed `unknown` until the source changed again.

The filter now seeds from the current source state when Home Assistant starts, so a valid zero or other steady reading is applied immediately.

Fixes #159080

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159080
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr