### PR TITLE
Add support for `eco` mode of VeSync devices

### DIFF
--- a/homeassistant/components/vesync/const.py
+++ b/homeassistant/components/vesync/const.py
@@ -36,6 +36,7 @@ VS_FAN_MODE_TURBO = "turbo"
 VS_FAN_MODE_PET = "pet"
 VS_FAN_MODE_MANUAL = "manual"
 VS_FAN_MODE_NORMAL = "normal"
+VS_FAN_MODE_ECO = "eco"
 
 # not a full list as manual is used as speed not present
 VS_FAN_MODE_PRESET_LIST_HA = [
@@ -44,6 +45,7 @@ VS_FAN_MODE_PRESET_LIST_HA = [
     VS_FAN_MODE_TURBO,
     VS_FAN_MODE_PET,
     VS_FAN_MODE_NORMAL,
+    VS_FAN_MODE_ECO,
 ]
 NIGHT_LIGHT_LEVEL_BRIGHT = "bright"
 NIGHT_LIGHT_LEVEL_DIM = "dim"

--- a/homeassistant/components/vesync/fan.py
+++ b/homeassistant/components/vesync/fan.py
@@ -20,6 +20,7 @@ from .const import (
     VS_DEVICES,
     VS_DISCOVERY,
     VS_FAN_MODE_AUTO,
+    VS_FAN_MODE_ECO,
     VS_FAN_MODE_MANUAL,
     VS_FAN_MODE_NORMAL,
     VS_FAN_MODE_PET,
@@ -40,6 +41,7 @@ VS_TO_HA_MODE_MAP = {
     VS_FAN_MODE_PET: VS_FAN_MODE_PET,
     VS_FAN_MODE_MANUAL: VS_FAN_MODE_MANUAL,
     VS_FAN_MODE_NORMAL: VS_FAN_MODE_NORMAL,
+    VS_FAN_MODE_ECO: VS_FAN_MODE_ECO,
 }
 
 PARALLEL_UPDATES = 1
@@ -313,6 +315,8 @@ class VeSyncFanHA(VeSyncBaseEntity[VeSyncFanBase | VeSyncPurifier], FanEntity):
         elif vs_mode == VS_FAN_MODE_NORMAL:
             if hasattr(self.device, "set_normal_mode"):
                 success = await self.device.set_normal_mode()
+        elif vs_mode == VS_FAN_MODE_ECO:
+            success = await self.device.set_mode(VS_FAN_MODE_ECO)
 
         if not success:
             if self.device.last_response:

--- a/homeassistant/components/vesync/icons.json
+++ b/homeassistant/components/vesync/icons.json
@@ -7,6 +7,7 @@
             "state": {
               "advanced_sleep": "mdi:sleep",
               "auto": "mdi:fan-auto",
+              "eco": "mdi:leaf",
               "pet": "mdi:paw",
               "sleep": "mdi:sleep",
               "turbo": "mdi:weather-tornado"

--- a/homeassistant/components/vesync/strings.json
+++ b/homeassistant/components/vesync/strings.json
@@ -52,6 +52,7 @@
           "preset_mode": {
             "state": {
               "auto": "[%key:common::state::auto%]",
+              "eco": "Eco",
               "normal": "[%key:common::state::normal%]",
               "pet": "Pet",
               "sleep": "Sleep",

--- a/tests/components/vesync/fixtures/pedestal-fan-detail.json
+++ b/tests/components/vesync/fixtures/pedestal-fan-detail.json
@@ -9,7 +9,7 @@
     "code": 0,
     "result": {
       "powerSwitch": 0,
-      "workMode": "normal",
+      "workMode": "eco",
       "fanSpeedLevel": 1,
       "temperature": 717,
       "muteSwitch": 1,

--- a/tests/components/vesync/fixtures/pedestal-fan-detail.json
+++ b/tests/components/vesync/fixtures/pedestal-fan-detail.json
@@ -9,7 +9,7 @@
     "code": 0,
     "result": {
       "powerSwitch": 0,
-      "workMode": "eco",
+      "workMode": "normal",
       "fanSpeedLevel": 1,
       "temperature": 717,
       "muteSwitch": 1,

--- a/tests/components/vesync/snapshots/test_fan.ambr
+++ b/tests/components/vesync/snapshots/test_fan.ambr
@@ -925,6 +925,7 @@
       'area_id': None,
       'capabilities': dict({
         <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+          'eco',
           'normal',
           'sleep',
           'turbo',
@@ -974,6 +975,7 @@
       <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 8.333333333333334,
       <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'normal',
       <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'eco',
         'normal',
         'sleep',
         'turbo',

--- a/tests/components/vesync/snapshots/test_fan.ambr
+++ b/tests/components/vesync/snapshots/test_fan.ambr
@@ -481,113 +481,6 @@
   list([
   ])
 # ---
-# name: test_fan_state[CoreBreeze 432S][devices]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'config_entries_subentries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'vesync',
-          'corebreeze432s',
-        ),
-      }),
-      'labels': set({
-      }),
-      'manufacturer': 'VeSync',
-      'model': 'LPF-R432S-AEU',
-      'model_id': None,
-      'name': 'CoreBreeze 432S',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_fan_state[CoreBreeze 432S][entities]
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': list([
-        None,
-      ]),
-      'area_id': None,
-      'capabilities': dict({
-        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
-          'eco',
-          'normal',
-          'sleep',
-          'turbo',
-        ]),
-      }),
-      'config_entry_id': <ANY>,
-      'config_subentry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'fan',
-      'entity_category': None,
-      'entity_id': 'fan.corebreeze_432s',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'object_id_base': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': None,
-      'platform': 'vesync',
-      'previous_unique_id': None,
-      'suggested_object_id': None,
-      'supported_features': <FanEntityFeature: 59>,
-      'translation_key': 'vesync',
-      'unique_id': 'corebreeze432s',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_fan_state[CoreBreeze 432S][fan.corebreeze_432s]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'active_time': None,
-      'child_lock': False,
-      'display_status': 'off',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CoreBreeze 432S',
-      'mode': <FanModes.ECO: 'eco'>,
-      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: True,
-      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
-      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 8.333333333333334,
-      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'eco',
-      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
-        'eco',
-        'normal',
-        'sleep',
-        'turbo',
-      ]),
-      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <FanEntityFeature: 59>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'fan.corebreeze_432s',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
-# ---
 # name: test_fan_state[Dimmable Light][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -989,4 +882,111 @@
 # name: test_fan_state[Wall Switch][entities]
   list([
   ])
+# ---
+# name: test_fan_state[CoreBreeze 432S][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'corebreeze432s',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LPF-R432S-AEU',
+      'model_id': None,
+      'name': 'CoreBreeze 432S',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[CoreBreeze 432S][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': list([
+        None,
+      ]),
+      'area_id': None,
+      'capabilities': dict({
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+          'eco',
+          'normal',
+          'sleep',
+          'turbo',
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'fan',
+      'entity_category': None,
+      'entity_id': 'fan.corebreeze_432s',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'object_id_base': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': None,
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': <FanEntityFeature: 59>,
+      'translation_key': 'vesync',
+      'unique_id': 'corebreeze432s',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[CoreBreeze 432S][fan.corebreeze_432s]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'active_time': None,
+      'child_lock': False,
+      'display_status': 'off',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CoreBreeze 432S',
+      'mode': <FanModes.NORMAL: 'normal'>,
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: True,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 8,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 8.333333333333334,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'normal',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'eco',
+        'normal',
+        'sleep',
+        'turbo',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <FanEntityFeature: 59>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.corebreeze_432s',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
 # ---

--- a/tests/components/vesync/snapshots/test_fan.ambr
+++ b/tests/components/vesync/snapshots/test_fan.ambr
@@ -481,6 +481,113 @@
   list([
   ])
 # ---
+# name: test_fan_state[CoreBreeze 432S][devices]
+  list([
+    DeviceRegistryEntrySnapshot({
+      'area_id': None,
+      'config_entries': <ANY>,
+      'config_entries_subentries': <ANY>,
+      'configuration_url': None,
+      'connections': set({
+      }),
+      'disabled_by': None,
+      'entry_type': None,
+      'hw_version': None,
+      'id': <ANY>,
+      'identifiers': set({
+        tuple(
+          'vesync',
+          'corebreeze432s',
+        ),
+      }),
+      'labels': set({
+      }),
+      'manufacturer': 'VeSync',
+      'model': 'LPF-R432S-AEU',
+      'model_id': None,
+      'name': 'CoreBreeze 432S',
+      'name_by_user': None,
+      'primary_config_entry': <ANY>,
+      'serial_number': None,
+      'sw_version': None,
+      'via_device_id': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[CoreBreeze 432S][entities]
+  list([
+    EntityRegistryEntrySnapshot({
+      'aliases': list([
+        None,
+      ]),
+      'area_id': None,
+      'capabilities': dict({
+        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+          'eco',
+          'normal',
+          'sleep',
+          'turbo',
+        ]),
+      }),
+      'config_entry_id': <ANY>,
+      'config_subentry_id': <ANY>,
+      'device_class': None,
+      'device_id': <ANY>,
+      'disabled_by': None,
+      'domain': 'fan',
+      'entity_category': None,
+      'entity_id': 'fan.corebreeze_432s',
+      'has_entity_name': True,
+      'hidden_by': None,
+      'icon': None,
+      'id': <ANY>,
+      'labels': set({
+      }),
+      'name': None,
+      'object_id_base': None,
+      'options': dict({
+      }),
+      'original_device_class': None,
+      'original_icon': None,
+      'original_name': None,
+      'platform': 'vesync',
+      'previous_unique_id': None,
+      'suggested_object_id': None,
+      'supported_features': <FanEntityFeature: 59>,
+      'translation_key': 'vesync',
+      'unique_id': 'corebreeze432s',
+      'unit_of_measurement': None,
+    }),
+  ])
+# ---
+# name: test_fan_state[CoreBreeze 432S][fan.corebreeze_432s]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'active_time': None,
+      'child_lock': False,
+      'display_status': 'off',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CoreBreeze 432S',
+      'mode': <FanModes.ECO: 'eco'>,
+      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: True,
+      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: None,
+      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 8.333333333333334,
+      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'eco',
+      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
+        'eco',
+        'normal',
+        'sleep',
+        'turbo',
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <FanEntityFeature: 59>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'fan.corebreeze_432s',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_fan_state[Dimmable Light][devices]
   list([
     DeviceRegistryEntrySnapshot({
@@ -882,111 +989,4 @@
 # name: test_fan_state[Wall Switch][entities]
   list([
   ])
-# ---
-# name: test_fan_state[CoreBreeze 432S][devices]
-  list([
-    DeviceRegistryEntrySnapshot({
-      'area_id': None,
-      'config_entries': <ANY>,
-      'config_entries_subentries': <ANY>,
-      'configuration_url': None,
-      'connections': set({
-      }),
-      'disabled_by': None,
-      'entry_type': None,
-      'hw_version': None,
-      'id': <ANY>,
-      'identifiers': set({
-        tuple(
-          'vesync',
-          'corebreeze432s',
-        ),
-      }),
-      'labels': set({
-      }),
-      'manufacturer': 'VeSync',
-      'model': 'LPF-R432S-AEU',
-      'model_id': None,
-      'name': 'CoreBreeze 432S',
-      'name_by_user': None,
-      'primary_config_entry': <ANY>,
-      'serial_number': None,
-      'sw_version': None,
-      'via_device_id': None,
-    }),
-  ])
-# ---
-# name: test_fan_state[CoreBreeze 432S][entities]
-  list([
-    EntityRegistryEntrySnapshot({
-      'aliases': list([
-        None,
-      ]),
-      'area_id': None,
-      'capabilities': dict({
-        <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
-          'eco',
-          'normal',
-          'sleep',
-          'turbo',
-        ]),
-      }),
-      'config_entry_id': <ANY>,
-      'config_subentry_id': <ANY>,
-      'device_class': None,
-      'device_id': <ANY>,
-      'disabled_by': None,
-      'domain': 'fan',
-      'entity_category': None,
-      'entity_id': 'fan.corebreeze_432s',
-      'has_entity_name': True,
-      'hidden_by': None,
-      'icon': None,
-      'id': <ANY>,
-      'labels': set({
-      }),
-      'name': None,
-      'object_id_base': None,
-      'options': dict({
-      }),
-      'original_device_class': None,
-      'original_icon': None,
-      'original_name': None,
-      'platform': 'vesync',
-      'previous_unique_id': None,
-      'suggested_object_id': None,
-      'supported_features': <FanEntityFeature: 59>,
-      'translation_key': 'vesync',
-      'unique_id': 'corebreeze432s',
-      'unit_of_measurement': None,
-    }),
-  ])
-# ---
-# name: test_fan_state[CoreBreeze 432S][fan.corebreeze_432s]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      'active_time': None,
-      'child_lock': False,
-      'display_status': 'off',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'CoreBreeze 432S',
-      'mode': <FanModes.NORMAL: 'normal'>,
-      <FanEntityStateAttribute.OSCILLATING: 'oscillating'>: True,
-      <FanEntityStateAttribute.PERCENTAGE: 'percentage'>: 8,
-      <FanEntityStateAttribute.PERCENTAGE_STEP: 'percentage_step'>: 8.333333333333334,
-      <FanEntityStateAttribute.PRESET_MODE: 'preset_mode'>: 'normal',
-      <FanEntityCapabilityAttribute.PRESET_MODES: 'preset_modes'>: list([
-        'eco',
-        'normal',
-        'sleep',
-        'turbo',
-      ]),
-      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <FanEntityFeature: 59>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'fan.corebreeze_432s',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'off',
-  })
 # ---

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -9,6 +9,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.fan import (
     ATTR_PERCENTAGE,
     ATTR_PRESET_MODE,
+    ATTR_PRESET_MODES,
     DOMAIN as FAN_DOMAIN,
 )
 from homeassistant.const import (
@@ -215,6 +216,46 @@ async def test_out_of_range_fan_level(
     assert state is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.attributes[ATTR_PERCENTAGE] is None
+
+
+async def test_set_preset_mode_eco(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test the eco preset is exposed, reflected, and sets the mode via set_mode."""
+    mock_devices_response(
+        aioclient_mock, "CoreBreeze 432S", details_override={"workMode": "eco"}
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_PEDESTAL_FAN)
+    assert state is not None
+    assert "eco" in state.attributes[ATTR_PRESET_MODES]
+    assert state.attributes[ATTR_PRESET_MODE] == "eco"
+
+    with (
+        patch(
+            "pyvesync.devices.vesyncfan.VeSyncPedestalFan.set_mode",
+            new_callable=AsyncMock,
+            return_value=True,
+        ) as method_mock,
+        patch(
+            "homeassistant.components.vesync.fan.VeSyncFanHA.async_write_ha_state"
+        ) as update_mock,
+    ):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_PEDESTAL_FAN, ATTR_PRESET_MODE: "eco"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+
+    method_mock.assert_awaited_once_with("eco")
+    update_mock.assert_called_once()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -224,9 +224,7 @@ async def test_set_preset_mode_eco(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the eco preset is exposed, reflected, and sets the mode via set_mode."""
-    mock_devices_response(
-        aioclient_mock, "CoreBreeze 432S", details_override={"workMode": "eco"}
-    )
+    mock_devices_response(aioclient_mock, "CoreBreeze 432S")
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()

--- a/tests/components/vesync/test_fan.py
+++ b/tests/components/vesync/test_fan.py
@@ -224,7 +224,9 @@ async def test_set_preset_mode_eco(
     aioclient_mock: AiohttpClientMocker,
 ) -> None:
     """Test the eco preset is exposed, reflected, and sets the mode via set_mode."""
-    mock_devices_response(aioclient_mock, "CoreBreeze 432S")
+    mock_devices_response(
+        aioclient_mock, "CoreBreeze 432S", details_override={"workMode": "eco"}
+    )
 
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Levoit LPF-R432S does have the mode `eco` which this PR adds to address the warning in the logfile.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
