### PR TITLE
move slow coordinator schedule off the polling interval

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -271,7 +271,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
     # startup; they are also refreshed after a schedule is written via the
     # services. Don't fail if DHW is not available so the integration still
     # works on devices without hot water support.
-    entry.async_create_task(
+    entry.async_create_background_task(
         hass,
         slow_coordinator.async_refresh_slow_data(),
         name=f"{DOMAIN}_slow_data_fetch_{entry.entry_id}",

--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -257,10 +257,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
     # Perform first refresh of fast coordinator (required for entities)
     await fast_coordinator.async_config_entry_first_refresh()
 
-    # Refresh slow coordinator - don't fail if DHW is not available
-    # This allows the integration to work even if the device doesn't support DHW
-    await slow_coordinator.async_refresh()
-
     entry.runtime_data = BSBLanData(
         client=bsblan,
         fast_coordinator=fast_coordinator,
@@ -269,6 +265,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
         info=info,
         static=static_per_circuit,
         available_circuits=circuits,
+    )
+
+    # Fetch DHW config and schedule in the background so they don't block
+    # startup; they are also refreshed after a schedule is written via the
+    # services. Don't fail if DHW is not available so the integration still
+    # works on devices without hot water support.
+    entry.async_create_task(
+        hass,
+        slow_coordinator.async_refresh_slow_data(),
+        name=f"{DOMAIN}_slow_data_fetch_{entry.entry_id}",
     )
 
     # Register main device before forwarding platforms, so sub-devices

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -280,7 +280,13 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
                 self.config_entry.data[CONF_HOST],
             )
             return None
-        except BSBLANError, AttributeError:
+        except BSBLANError:
+            LOGGER.debug(
+                "DHW schedule not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
+            return None
+        except AttributeError:
             self._dhw_schedule_supported = False
             LOGGER.debug(
                 "DHW schedule is not supported by device at %s",

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -222,9 +222,6 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
                 )
                 dhw_config = None
 
-            # Read the schedule from the latest data after the device await so a
-            # concurrent schedule-write refresh is not clobbered with a stale
-            # pre-await snapshot.
             previous = self.data
             dhw_schedule = previous.dhw_schedule if previous else None
 

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the BSB-LAN integration."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 from typing import TYPE_CHECKING, override
@@ -180,6 +181,10 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             name=f"{DOMAIN}_slow_{config_entry.data[CONF_HOST]}",
             update_interval=SCAN_INTERVAL_SLOW,
         )
+        # Serialize interval polls and off-interval refreshes so a
+        # schedule-write refresh completing during a poll's device await
+        # cannot be overwritten with the poll's stale pre-await snapshot.
+        self._refresh_lock = asyncio.Lock()
 
     @override
     async def _async_update_data(self) -> BSBLanSlowData:
@@ -190,34 +195,40 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         serial-bus traffic on every interval, so it is carried over from the
         previous update.
         """
-        previous = self.data
-        try:
-            # Client is already initialized in async_setup_entry
-            # Use include filtering to only fetch parameters we actually use
-            dhw_config = await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
-        except (BSBLANConnectionError, BSBLANAuthError) as err:
-            # If config update fails, keep existing data
-            LOGGER.debug(
-                "Failed to fetch DHW config from %s: %s",
-                self.config_entry.data[CONF_HOST],
-                err,
-            )
-            if previous:
-                return previous
-            # First fetch failed, return empty data
-            return BSBLanSlowData()
-        except BSBLANError, AttributeError:
-            # Device does not support DHW functionality
-            LOGGER.debug(
-                "DHW (Domestic Hot Water) not available on device at %s",
-                self.config_entry.data[CONF_HOST],
-            )
-            dhw_config = None
+        async with self._refresh_lock:
+            try:
+                # Client is already initialized in async_setup_entry
+                # Use include filtering to only fetch parameters we actually use
+                dhw_config = await self.client.hot_water_config(
+                    include=DHW_CONFIG_INCLUDE
+                )
+            except (BSBLANConnectionError, BSBLANAuthError) as err:
+                # If config update fails, keep existing data
+                LOGGER.debug(
+                    "Failed to fetch DHW config from %s: %s",
+                    self.config_entry.data[CONF_HOST],
+                    err,
+                )
+                if self.data:
+                    return self.data
+                # First fetch failed, return empty data
+                return BSBLanSlowData()
+            except BSBLANError, AttributeError:
+                # Device does not support DHW functionality
+                LOGGER.debug(
+                    "DHW (Domestic Hot Water) not available on device at %s",
+                    self.config_entry.data[CONF_HOST],
+                )
+                dhw_config = None
 
-        return BSBLanSlowData(
-            dhw_config=dhw_config,
-            dhw_schedule=previous.dhw_schedule if previous else None,
-        )
+            # Read the schedule from the latest data after the device await so a
+            # concurrent schedule-write refresh is not clobbered with a stale
+            # pre-await snapshot.
+            previous = self.data
+            return BSBLanSlowData(
+                dhw_config=dhw_config,
+                dhw_schedule=previous.dhw_schedule if previous else None,
+            )
 
     async def async_refresh_slow_data(self) -> None:
         """Fetch DHW config and schedule off the polling interval.
@@ -227,16 +238,17 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         traffic on every interval. Values that fail to fetch keep their
         previous value.
         """
-        dhw_config = await self._async_fetch_dhw_config()
-        dhw_schedule = await self._async_fetch_dhw_schedule()
+        async with self._refresh_lock:
+            dhw_config = await self._async_fetch_dhw_config()
+            dhw_schedule = await self._async_fetch_dhw_schedule()
 
-        previous = self.data or BSBLanSlowData()
-        self.async_set_updated_data(
-            BSBLanSlowData(
-                dhw_config=dhw_config or previous.dhw_config,
-                dhw_schedule=dhw_schedule or previous.dhw_schedule,
+            previous = self.data or BSBLanSlowData()
+            self.async_set_updated_data(
+                BSBLanSlowData(
+                    dhw_config=dhw_config or previous.dhw_config,
+                    dhw_schedule=dhw_schedule or previous.dhw_schedule,
+                )
             )
-        )
 
     async def _async_fetch_dhw_config(self) -> HotWaterConfig | None:
         """Fetch the DHW config, returning None if unavailable."""

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -185,6 +185,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         # schedule-write refresh completing during a poll's device await
         # cannot be overwritten with the poll's stale pre-await snapshot.
         self._refresh_lock = asyncio.Lock()
+        self._dhw_schedule_supported = True
 
     @override
     async def _async_update_data(self) -> BSBLanSlowData:
@@ -231,7 +232,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             # startup fetch failed (e.g. a transient connection error) no
             # schedule is cached yet, so retry here until the first success.
             # Once cached, subsequent polls carry it forward without re-fetching.
-            if dhw_schedule is None:
+            if dhw_schedule is None and self._dhw_schedule_supported:
                 dhw_schedule = await self._async_fetch_dhw_schedule()
 
             return BSBLanSlowData(
@@ -242,11 +243,10 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
     async def async_refresh_slow_data(self) -> None:
         """Fetch DHW config and schedule off the polling interval.
 
-        Runs on startup (in the background) and after a schedule is written. The
-        schedule is not polled on every interval to avoid extra serial-bus
-        traffic, so it is refreshed here instead. The config is refreshed too
-        for immediacy, though it is also fetched by the interval poll. Values
-        that fail to fetch keep their previous value.
+        Runs on startup (in the background) and after a schedule is written, so
+        these rarely changing values neither block startup nor add serial-bus
+        traffic on every interval. Values that fail to fetch keep their
+        previous value.
         """
         async with self._refresh_lock:
             dhw_config = await self._async_fetch_dhw_config()
@@ -273,11 +273,20 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
 
     async def _async_fetch_dhw_schedule(self) -> HotWaterSchedule | None:
         """Fetch the DHW schedule, returning None if unavailable."""
+        if not self._dhw_schedule_supported:
+            return None
         try:
             return await self.client.hot_water_schedule()
-        except BSBLANError, AttributeError, TimeoutError:
+        except BSBLANConnectionError, BSBLANAuthError, TimeoutError:
             LOGGER.debug(
                 "DHW schedule not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
+            return None
+        except BSBLANError, AttributeError:
+            self._dhw_schedule_supported = False
+            LOGGER.debug(
+                "DHW schedule is not supported by device at %s",
                 self.config_entry.data[CONF_HOST],
             )
             return None

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -225,18 +225,28 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             # concurrent schedule-write refresh is not clobbered with a stale
             # pre-await snapshot.
             previous = self.data
+            dhw_schedule = previous.dhw_schedule if previous else None
+
+            # The schedule is otherwise fetched only off the interval. If the
+            # startup fetch failed (e.g. a transient connection error) no
+            # schedule is cached yet, so retry here until the first success.
+            # Once cached, subsequent polls carry it forward without re-fetching.
+            if dhw_schedule is None:
+                dhw_schedule = await self._async_fetch_dhw_schedule()
+
             return BSBLanSlowData(
                 dhw_config=dhw_config,
-                dhw_schedule=previous.dhw_schedule if previous else None,
+                dhw_schedule=dhw_schedule,
             )
 
     async def async_refresh_slow_data(self) -> None:
         """Fetch DHW config and schedule off the polling interval.
 
-        Runs on startup (in the background) and after a schedule is written, so
-        these rarely changing values neither block startup nor add serial-bus
-        traffic on every interval. Values that fail to fetch keep their
-        previous value.
+        Runs on startup (in the background) and after a schedule is written. The
+        schedule is not polled on every interval to avoid extra serial-bus
+        traffic, so it is refreshed here instead. The config is refreshed too
+        for immediacy, though it is also fetched by the interval poll. Values
+        that fail to fetch keep their previous value.
         """
         async with self._refresh_lock:
             dhw_config = await self._async_fetch_dhw_config()
@@ -254,7 +264,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         """Fetch the DHW config, returning None if unavailable."""
         try:
             return await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
-        except BSBLANError, AttributeError:
+        except BSBLANError, AttributeError, TimeoutError:
             LOGGER.debug(
                 "DHW config not available on device at %s",
                 self.config_entry.data[CONF_HOST],
@@ -265,7 +275,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         """Fetch the DHW schedule, returning None if unavailable."""
         try:
             return await self.client.hot_water_schedule()
-        except BSBLANError, AttributeError:
+        except BSBLANError, AttributeError, TimeoutError:
             LOGGER.debug(
                 "DHW schedule not available on device at %s",
                 self.config_entry.data[CONF_HOST],

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -183,13 +183,18 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
 
     @override
     async def _async_update_data(self) -> BSBLanSlowData:
-        """Fetch slow-changing data from the BSB-LAN device."""
+        """Fetch slow-changing data from the BSB-LAN device.
+
+        Only the DHW config is polled here. The schedule changes rarely and is
+        refreshed separately (on startup and after a write) to avoid extra
+        serial-bus traffic on every interval, so it is carried over from the
+        previous update.
+        """
+        previous = self.data
         try:
             # Client is already initialized in async_setup_entry
             # Use include filtering to only fetch parameters we actually use
             dhw_config = await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
-            dhw_schedule = await self.client.hot_water_schedule()
-
         except (BSBLANConnectionError, BSBLANAuthError) as err:
             # If config update fails, keep existing data
             LOGGER.debug(
@@ -197,8 +202,8 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
                 self.config_entry.data[CONF_HOST],
                 err,
             )
-            if self.data:
-                return self.data
+            if previous:
+                return previous
             # First fetch failed, return empty data
             return BSBLanSlowData()
         except BSBLANError, AttributeError:
@@ -207,9 +212,50 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
                 "DHW (Domestic Hot Water) not available on device at %s",
                 self.config_entry.data[CONF_HOST],
             )
-            return BSBLanSlowData()
+            dhw_config = None
 
         return BSBLanSlowData(
             dhw_config=dhw_config,
-            dhw_schedule=dhw_schedule,
+            dhw_schedule=previous.dhw_schedule if previous else None,
         )
+
+    async def async_refresh_slow_data(self) -> None:
+        """Fetch DHW config and schedule off the polling interval.
+
+        Runs on startup (in the background) and after a schedule is written, so
+        these rarely changing values neither block startup nor add serial-bus
+        traffic on every interval. Values that fail to fetch keep their
+        previous value.
+        """
+        dhw_config = await self._async_fetch_dhw_config()
+        dhw_schedule = await self._async_fetch_dhw_schedule()
+
+        previous = self.data or BSBLanSlowData()
+        self.async_set_updated_data(
+            BSBLanSlowData(
+                dhw_config=dhw_config or previous.dhw_config,
+                dhw_schedule=dhw_schedule or previous.dhw_schedule,
+            )
+        )
+
+    async def _async_fetch_dhw_config(self) -> HotWaterConfig | None:
+        """Fetch the DHW config, returning None if unavailable."""
+        try:
+            return await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
+        except BSBLANError, AttributeError:
+            LOGGER.debug(
+                "DHW config not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
+            return None
+
+    async def _async_fetch_dhw_schedule(self) -> HotWaterSchedule | None:
+        """Fetch the DHW schedule, returning None if unavailable."""
+        try:
+            return await self.client.hot_water_schedule()
+        except BSBLANError, AttributeError:
+            LOGGER.debug(
+                "DHW schedule not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
+            return None

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -203,7 +203,7 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
         ) from err
 
     # Refresh the slow coordinator to get the updated schedule
-    await entry.runtime_data.slow_coordinator.async_request_refresh()
+    await entry.runtime_data.slow_coordinator.async_refresh_slow_data()
 
 
 async def async_sync_time(service_call: ServiceCall) -> None:

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -80,32 +80,49 @@ class BSBLANWaterHeater(BSBLanWaterHeaterDeviceEntity, WaterHeaterEntity):
         # Initialize available attribute to resolve multiple inheritance conflict
         self._attr_available = True
 
-        # Set temperature limits based on device capabilities from slow coordinator
+    @property
+    @override
+    def min_temp(self) -> float:
+        """Return the minimum temperature.
+
+        Derived from the slow-coordinator DHW config, which may still be
+        pending when the platform is set up. Falls back to the default until
+        the config becomes available.
+        """
         dhw_config = (
-            data.slow_coordinator.data.dhw_config
-            if data.slow_coordinator.data
+            self.slow_coordinator.data.dhw_config
+            if self.slow_coordinator.data
             else None
         )
-
-        # For min_temp: Use reduced_setpoint from config data (slow polling)
         if (
             dhw_config is not None
             and dhw_config.reduced_setpoint is not None
             and dhw_config.reduced_setpoint.value is not None
         ):
-            self._attr_min_temp = dhw_config.reduced_setpoint.value
-        else:
-            self._attr_min_temp = 10.0  # Default minimum
+            return dhw_config.reduced_setpoint.value
+        return 10.0  # Default minimum
 
-        # For max_temp: Use nominal_setpoint_max from config data (slow polling)
+    @property
+    @override
+    def max_temp(self) -> float:
+        """Return the maximum temperature.
+
+        Derived from the slow-coordinator DHW config, which may still be
+        pending when the platform is set up. Falls back to the default until
+        the config becomes available.
+        """
+        dhw_config = (
+            self.slow_coordinator.data.dhw_config
+            if self.slow_coordinator.data
+            else None
+        )
         if (
             dhw_config is not None
             and dhw_config.nominal_setpoint_max is not None
             and dhw_config.nominal_setpoint_max.value is not None
         ):
-            self._attr_max_temp = dhw_config.nominal_setpoint_max.value
-        else:
-            self._attr_max_temp = 65.0  # Default maximum
+            return dhw_config.nominal_setpoint_max.value
+        return 65.0  # Default maximum
 
     @property
     def _dhw(self) -> HotWaterState:

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -332,6 +332,57 @@ async def test_slow_interval_poll_preserves_cached_schedule(
     assert slow_coordinator.data.dhw_schedule == cached_schedule
 
 
+async def test_slow_interval_poll_retries_missing_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test interval polls retry the schedule until the first success.
+
+    A transient failure during the startup fetch leaves no cached schedule.
+    Interval polls must retry the schedule fetch until it succeeds, then stop
+    fetching it once cached.
+    """
+    schedule_value = mock_bsblan.hot_water_schedule.return_value
+    fetch_failed = False
+
+    async def _schedule(*args: object, **kwargs: object) -> object:
+        nonlocal fetch_failed
+        if not fetch_failed:
+            fetch_failed = True
+            raise BSBLANConnectionError("Schedule failed")
+        return schedule_value
+
+    mock_bsblan.hot_water_schedule.side_effect = _schedule
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    # The startup fetch failed, so no schedule is cached yet.
+    assert slow_coordinator.data.dhw_schedule is None
+
+    # The next interval poll retries the schedule fetch, which now succeeds.
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert slow_coordinator.data.dhw_schedule == schedule_value
+
+    # Once cached, later polls carry the schedule forward without re-fetching.
+    mock_bsblan.hot_water_schedule.reset_mock()
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not mock_bsblan.hot_water_schedule.called
+    assert slow_coordinator.data.dhw_schedule == schedule_value
+
+
 async def test_setup_does_not_block_on_slow_fetch(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -291,6 +291,46 @@ async def test_coordinator_dhw_config_update_error(
     assert mock_bsblan.hot_water_schedule.called
 
 
+async def test_slow_interval_poll_preserves_cached_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test interval polls keep the cached schedule without re-fetching it.
+
+    The schedule is fetched only off the interval (on startup and after a
+    write). An interval poll must refresh the config while carrying the cached
+    schedule over, without issuing a schedule request.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    cached_schedule = slow_coordinator.data.dhw_schedule
+    assert cached_schedule is not None
+
+    # Reset call counts recorded during the startup refresh so we only observe
+    # what the interval poll does.
+    mock_bsblan.hot_water_config.reset_mock()
+    mock_bsblan.hot_water_schedule.reset_mock()
+
+    # Advance time to trigger a slow interval poll.
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # The interval poll refreshes the config but never fetches the schedule.
+    assert mock_bsblan.hot_water_config.called
+    assert not mock_bsblan.hot_water_schedule.called
+
+    # The cached schedule is preserved across the interval poll.
+    assert slow_coordinator.data.dhw_schedule == cached_schedule
+
+
 async def test_coordinator_slow_first_fetch_failure(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the BSBLan integration."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock
 
@@ -329,6 +330,42 @@ async def test_slow_interval_poll_preserves_cached_schedule(
 
     # The cached schedule is preserved across the interval poll.
     assert slow_coordinator.data.dhw_schedule == cached_schedule
+
+
+async def test_setup_does_not_block_on_slow_fetch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test setup completes without waiting for the background slow-data fetch.
+
+    The slow-data fetch runs as a background task, so config-entry setup must
+    finish even while the fetch is still pending. Using a normal task instead
+    would make async_block_till_done wait for the fetch and hang here.
+    """
+    release = asyncio.Event()
+    config_value = mock_bsblan.hot_water_config.return_value
+
+    async def _blocking_config(*args: object, **kwargs: object) -> object:
+        await release.wait()
+        return config_value
+
+    mock_bsblan.hot_water_config.side_effect = _blocking_config
+
+    mock_config_entry.add_to_hass(hass)
+    try:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Setup finished even though the slow-data fetch is still pending.
+        assert mock_config_entry.state is ConfigEntryState.LOADED
+        assert not mock_bsblan.hot_water_schedule.called
+    finally:
+        # Release the fetch so it can complete and clean up.
+        release.set()
+        await hass.async_block_till_done()
+
+    assert mock_bsblan.hot_water_schedule.called
 
 
 async def test_coordinator_slow_first_fetch_failure(

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -332,18 +332,19 @@ async def test_slow_interval_poll_preserves_cached_schedule(
     assert slow_coordinator.data.dhw_schedule == cached_schedule
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [BSBLANConnectionError("Schedule failed"), BSBLANError("Invalid response")],
+    ids=["connection-error", "api-error"],
+)
 async def test_slow_interval_poll_retries_missing_schedule(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
     freezer: FrozenDateTimeFactory,
+    exception: Exception,
 ) -> None:
-    """Test interval polls retry the schedule until the first success.
-
-    A transient failure during the startup fetch leaves no cached schedule.
-    Interval polls must retry the schedule fetch until it succeeds, then stop
-    fetching it once cached.
-    """
+    """Test interval polls retry transient schedule failures until success."""
     schedule_value = mock_bsblan.hot_water_schedule.return_value
     fetch_failed = False
 
@@ -351,7 +352,7 @@ async def test_slow_interval_poll_retries_missing_schedule(
         nonlocal fetch_failed
         if not fetch_failed:
             fetch_failed = True
-            raise BSBLANConnectionError("Schedule failed")
+            raise exception
         return schedule_value
 
     mock_bsblan.hot_water_schedule.side_effect = _schedule
@@ -383,20 +384,14 @@ async def test_slow_interval_poll_retries_missing_schedule(
     assert slow_coordinator.data.dhw_schedule == schedule_value
 
 
-@pytest.mark.parametrize(
-    "exception",
-    [AttributeError(), BSBLANError("Schedule unsupported")],
-    ids=["missing-method", "api-error"],
-)
 async def test_slow_interval_poll_does_not_retry_unsupported_schedule(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
     freezer: FrozenDateTimeFactory,
-    exception: Exception,
 ) -> None:
     """Test interval polls do not retry an unsupported schedule."""
-    mock_bsblan.hot_water_schedule.side_effect = exception
+    mock_bsblan.hot_water_schedule.side_effect = AttributeError
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -418,12 +413,7 @@ async def test_setup_does_not_block_on_slow_fetch(
     mock_config_entry: MockConfigEntry,
     mock_bsblan: MagicMock,
 ) -> None:
-    """Test setup completes without waiting for the background slow-data fetch.
-
-    The slow-data fetch runs as a background task, so config-entry setup must
-    finish even while the fetch is still pending. Using a normal task instead
-    would make async_block_till_done wait for the fetch and hang here.
-    """
+    """Test setup does not wait for the background slow-data fetch."""
     release = asyncio.Event()
     config_value = mock_bsblan.hot_water_config.return_value
 

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -383,6 +383,36 @@ async def test_slow_interval_poll_retries_missing_schedule(
     assert slow_coordinator.data.dhw_schedule == schedule_value
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [AttributeError(), BSBLANError("Schedule unsupported")],
+    ids=["missing-method", "api-error"],
+)
+async def test_slow_interval_poll_does_not_retry_unsupported_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    exception: Exception,
+) -> None:
+    """Test interval polls do not retry an unsupported schedule."""
+    mock_bsblan.hot_water_schedule.side_effect = exception
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_bsblan.hot_water_schedule.call_count == 1
+
+    for _ in range(2):
+        freezer.tick(delta=timedelta(minutes=5, seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert mock_bsblan.hot_water_schedule.call_count == 1
+
+
 async def test_setup_does_not_block_on_slow_fetch(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -159,6 +159,32 @@ async def test_set_hot_water_schedule(
         assert actual_schedule == expected_schedule
 
 
+async def test_set_hot_water_schedule_refreshes_coordinator(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+) -> None:
+    """Test setting a schedule refreshes the slow coordinator."""
+    refreshed_schedule = MagicMock()
+    mock_bsblan.hot_water_schedule.return_value = refreshed_schedule
+    mock_bsblan.hot_water_schedule.reset_mock()
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_hot_water_schedule",
+        {
+            "device_id": water_heater_device_entry.id,
+            "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+        },
+        blocking=True,
+    )
+
+    mock_bsblan.hot_water_schedule.assert_awaited_once_with()
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    assert slow_coordinator.data.dhw_schedule is refreshed_schedule
+
+
 async def test_invalid_device_id(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -1,5 +1,6 @@
 """Tests for the BSB-LAN water heater platform."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -390,6 +391,41 @@ async def test_water_heater_custom_temperature_limits_from_config(
     assert (
         state.attributes.get("max_temp") == 75.0
     )  # Custom maximum from nominal_setpoint_max
+
+
+async def test_water_heater_temperature_limits_update_after_slow_fetch(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test temperature limits update when the background fetch completes."""
+    release = asyncio.Event()
+    config = mock_bsblan.hot_water_config.return_value
+    config.reduced_setpoint.value = 15.0
+    config.nominal_setpoint_max.value = 75.0
+
+    async def _blocking_config(*args: object, **kwargs: object) -> object:
+        await release.wait()
+        return config
+
+    mock_bsblan.hot_water_config.side_effect = _blocking_config
+
+    await setup_with_selected_platforms(
+        hass, mock_config_entry, [Platform.WATER_HEATER]
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["min_temp"] == 10.0
+    assert state.attributes["max_temp"] == 65.0
+
+    release.set()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["min_temp"] == 15.0
+    assert state.attributes["max_temp"] == 75.0
 
 
 async def test_turn_on(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The slow coordinator previously fetched the DHW schedule on every polling interval and blocked startup on a full refresh. Because BSB-LAN is a serial bus, polling rarely-changing schedules on every interval adds avoidable traffic. Fetch the DHW config and schedule via a new async_refresh_slow_data that runs in the background on startup and after a schedule write, while the interval poll only refreshes the DHW config and carries the schedule forward.

<details>
<summary>Details</summary>

This pull request refactors how the BSBLan integration for Home Assistant fetches and updates slow-changing Domestic Hot Water (DHW) configuration and schedule data. The main improvement is to avoid blocking startup and reduce unnecessary polling by fetching this data in the background and only when needed, rather than on every polling interval. This change also improves support for devices that do not provide DHW functionality.

**Improvements to DHW data fetching and polling:**

* The slow coordinator (`BSBLanSlowDataUpdateCoordinator`) now only fetches the DHW config during its regular polling; the DHW schedule is no longer fetched every interval, but is instead carried over from the previous update. This reduces serial-bus traffic and avoids unnecessary requests. [[1]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL186-R206) [[2]](diffhunk://#diff-21eece501a496ce887e972f23854c2b7a4b14d3407b80888408c881e0188fe1cL210-R261)
* A new `async_refresh_slow_data` method was added to the coordinator to fetch both DHW config and schedule off the polling interval, used on startup and after schedule changes. This ensures that rarely changing values are refreshed when needed without blocking startup or increasing polling frequency.

**Integration setup and service improvements:**

* During integration setup (`async_setup_entry`), the initial DHW config and schedule fetch is now scheduled in the background rather than awaited directly, allowing the integration to load faster and not fail on devices without DHW support. [[1]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL260-L263) [[2]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR270-R279)
* The service for setting the DHW schedule now refreshes DHW data using the new background method, ensuring updated values are available after changes.

</details>

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
