### PR TITLE
Fix zwave_js reload on multilevel sensor temperature scale change

### DIFF
--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -25,7 +25,11 @@ from zwave_js_server.const.command_class.multilevel_sensor import (
     CC_SPECIFIC_SENSOR_TYPE,
     TEMPERATURE_SENSORS,
 )
-from zwave_js_server.exceptions import BaseZwaveJSServerError, RssiErrorReceived
+from zwave_js_server.exceptions import (
+    BaseZwaveJSServerError,
+    RssiErrorReceived,
+    UnknownValueData,
+)
 from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.controller.statistics import ControllerStatistics
 from zwave_js_server.model.driver import Driver
@@ -829,16 +833,21 @@ class NewZWaveNumericSensor(ZWaveBaseEntity, SensorEntity):
     @override
     def on_value_update(self) -> None:
         """Handle scale changes for this value on value updated event."""
-        data = NumericSensorDataTemplate().resolve_data(self.info.primary_value)
+        try:
+            data = NumericSensorDataTemplate().resolve_data(self.info.primary_value)
+        except UnknownValueData:
+            data = NumericSensorDataTemplateData()
         if data.entity_description_key or data.unit_of_measurement:
             self.entity_description = get_entity_description(data)
             self._attr_native_unit_of_measurement = data.unit_of_measurement
-        else:
-            if isinstance(self.info, NewZwaveDiscoveryInfo):
-                self.entity_description = cast(
-                    SensorEntityDescription, self.info.entity_description
-                )
-            self.__dict__.pop("__attr_native_unit_of_measurement", None)
+        elif isinstance(self.info, NewZwaveDiscoveryInfo):
+            discovery_description = cast(
+                SensorEntityDescription, self.info.entity_description
+            )
+            self.entity_description = discovery_description
+            self._attr_native_unit_of_measurement = (
+                discovery_description.native_unit_of_measurement
+            )
         self.__dict__.pop("device_class", None)
         self.__dict__.pop("state_class", None)
         self.__dict__.pop("native_unit_of_measurement", None)

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -833,25 +833,33 @@ class NewZWaveNumericSensor(ZWaveBaseEntity, SensorEntity):
     @override
     def on_value_update(self) -> None:
         """Handle scale changes for this value on value updated event."""
+        self.__dict__.pop("device_class", None)
+        self.__dict__.pop("state_class", None)
+        self.__dict__.pop("native_unit_of_measurement", None)
+        self.__dict__.pop("suggested_unit_of_measurement", None)
+
         try:
             data = NumericSensorDataTemplate().resolve_data(self.info.primary_value)
         except UnknownValueData:
             data = NumericSensorDataTemplateData()
+
         if data.entity_description_key or data.unit_of_measurement:
             self.entity_description = get_entity_description(data)
-            self._attr_native_unit_of_measurement = data.unit_of_measurement
+            if data.unit_of_measurement is not None:
+                self._attr_native_unit_of_measurement = data.unit_of_measurement
+            else:
+                self.__dict__.pop("_attr_native_unit_of_measurement", None)
         elif isinstance(self.info, NewZwaveDiscoveryInfo):
             discovery_description = cast(
                 SensorEntityDescription, self.info.entity_description
             )
             self.entity_description = discovery_description
-            self._attr_native_unit_of_measurement = (
-                discovery_description.native_unit_of_measurement
-            )
-        self.__dict__.pop("device_class", None)
-        self.__dict__.pop("state_class", None)
-        self.__dict__.pop("native_unit_of_measurement", None)
-        self.__dict__.pop("suggested_unit_of_measurement", None)
+            if discovery_description.native_unit_of_measurement is not None:
+                self._attr_native_unit_of_measurement = (
+                    discovery_description.native_unit_of_measurement
+                )
+            else:
+                self.__dict__.pop("_attr_native_unit_of_measurement", None)
 
     @property
     @override

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -834,7 +834,13 @@ class NewZWaveNumericSensor(ZWaveBaseEntity, SensorEntity):
             self.entity_description = get_entity_description(data)
             self._attr_native_unit_of_measurement = data.unit_of_measurement
         else:
-            self.__dict__.pop("_attr_native_unit_of_measurement", None)
+            if isinstance(self.info, NewZwaveDiscoveryInfo):
+                self.entity_description = cast(
+                    SensorEntityDescription, self.info.entity_description
+                )
+            self.__dict__.pop("__attr_native_unit_of_measurement", None)
+        self.__dict__.pop("device_class", None)
+        self.__dict__.pop("state_class", None)
         self.__dict__.pop("native_unit_of_measurement", None)
         self.__dict__.pop("suggested_unit_of_measurement", None)
 

--- a/homeassistant/components/zwave_js/sensor.py
+++ b/homeassistant/components/zwave_js/sensor.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
-from enum import IntEnum
 from typing import Any, cast, override
 
 import voluptuous as vol
@@ -23,32 +22,16 @@ from zwave_js_server.const.command_class.meter import (
     MeterType,
 )
 from zwave_js_server.const.command_class.multilevel_sensor import (
-    CC_SPECIFIC_SCALE as MULTILEVEL_SENSOR_CC_SPECIFIC_SCALE,
     CC_SPECIFIC_SENSOR_TYPE,
     TEMPERATURE_SENSORS,
-    TemperatureScale,
 )
-from zwave_js_server.exceptions import (
-    BaseZwaveJSServerError,
-    RssiErrorReceived,
-    UnknownValueData,
-)
+from zwave_js_server.exceptions import BaseZwaveJSServerError, RssiErrorReceived
 from zwave_js_server.model.controller import Controller
 from zwave_js_server.model.controller.statistics import ControllerStatistics
 from zwave_js_server.model.driver import Driver
 from zwave_js_server.model.node import Node as ZwaveNode
 from zwave_js_server.model.node.statistics import NodeStatistics
-from zwave_js_server.model.value import Value as ZwaveValue
-from zwave_js_server.util.command_class.energy_production import (
-    get_energy_production_scale_type,
-)
-from zwave_js_server.util.command_class.meter import (
-    get_meter_scale_type,
-    get_meter_type,
-)
-from zwave_js_server.util.command_class.multilevel_sensor import (
-    get_multilevel_sensor_scale_type,
-)
+from zwave_js_server.util.command_class.meter import get_meter_type
 
 from homeassistant.components.sensor import (
     DOMAIN as SENSOR_DOMAIN,
@@ -831,38 +814,29 @@ class NewZWaveNumericSensor(ZWaveBaseEntity, SensorEntity):
         entity_description = info.entity_description
         if not entity_description.name or entity_description.name is UNDEFINED:
             self._attr_name = self.generate_name(include_value_name=True)
-        self._scale_type = self._get_scale_type()
 
-    def _get_scale_type(self) -> IntEnum | None:
-        """Return the scale type of the value."""
-        primary_value = self.info.primary_value
-        scale_type_function: Callable[[ZwaveValue], IntEnum] | None
-        match primary_value.command_class:
-            case CommandClass.METER:
-                scale_type_function = get_meter_scale_type
-            case CommandClass.SENSOR_MULTILEVEL:
-                scale_type_function = get_multilevel_sensor_scale_type
-            case CommandClass.ENERGY_PRODUCTION:
-                scale_type_function = get_energy_production_scale_type
-            case _:
-                scale_type_function = None
-        if scale_type_function is None:
+    @property
+    @override
+    def native_unit_of_measurement(self) -> str | None:
+        """Return unit of measurement the value is expressed in."""
+        if (unit := super().native_unit_of_measurement) is not None:
+            return unit
+        if self.info.primary_value.metadata.unit is None:
             return None
-        try:
-            scale_type = scale_type_function(primary_value)
-        except UnknownValueData:
-            return None
-
-        return scale_type
+        return str(self.info.primary_value.metadata.unit)
 
     @callback
     @override
     def on_value_update(self) -> None:
         """Handle scale changes for this value on value updated event."""
-        # TODO: Try to limit this to metadata updated event.  # pylint: disable=fixme
-        scale_type = self._get_scale_type()
-        if scale_type is not self._scale_type:
-            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
+        data = NumericSensorDataTemplate().resolve_data(self.info.primary_value)
+        if data.entity_description_key or data.unit_of_measurement:
+            self.entity_description = get_entity_description(data)
+            self._attr_native_unit_of_measurement = data.unit_of_measurement
+        else:
+            self.__dict__.pop("_attr_native_unit_of_measurement", None)
+        self.__dict__.pop("native_unit_of_measurement", None)
+        self.__dict__.pop("suggested_unit_of_measurement", None)
 
     @property
     @override
@@ -1190,9 +1164,6 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         primary_value=ZWaveValueDiscoverySchema(
             command_class={CommandClass.SENSOR_MULTILEVEL},
             type={ValueType.NUMBER},
-            all_available_cc_specific={
-                (MULTILEVEL_SENSOR_CC_SPECIFIC_SCALE, TemperatureScale.CELSIUS),
-            },
             any_available_cc_specific={
                 (CC_SPECIFIC_SENSOR_TYPE, sensor_type)
                 for sensor_type in TEMPERATURE_SENSORS
@@ -1200,31 +1171,9 @@ DISCOVERY_SCHEMAS: list[NewZWaveDiscoverySchema] = [
         ),
         entity_class=NewZWaveNumericSensor,
         entity_description=SensorEntityDescription(
-            key="temperature_celsius",
+            key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
-            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
-        ),
-    ),
-    NewZWaveDiscoverySchema(
-        platform=Platform.SENSOR,
-        primary_value=ZWaveValueDiscoverySchema(
-            command_class={CommandClass.SENSOR_MULTILEVEL},
-            type={ValueType.NUMBER},
-            all_available_cc_specific={
-                (MULTILEVEL_SENSOR_CC_SPECIFIC_SCALE, TemperatureScale.FAHRENHEIT),
-            },
-            any_available_cc_specific={
-                (CC_SPECIFIC_SENSOR_TYPE, sensor_type)
-                for sensor_type in TEMPERATURE_SENSORS
-            },
-        ),
-        entity_class=NewZWaveNumericSensor,
-        entity_description=SensorEntityDescription(
-            key="temperature_fahrenheit",
-            device_class=SensorDeviceClass.TEMPERATURE,
-            state_class=SensorStateClass.MEASUREMENT,
-            native_unit_of_measurement=UnitOfTemperature.FAHRENHEIT,
         ),
     ),
     NewZWaveDiscoverySchema(

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -825,6 +825,79 @@ async def test_unit_change(hass: HomeAssistant, zp3111, client, integration) -> 
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
 
 
+async def test_new_sensor_invalid_energy_production_scale(
+    hass: HomeAssistant, energy_production, client, integration
+) -> None:
+    """Test new-style energy production sensor handles invalid scale."""
+    entity_id = "sensor.node_2_energy_production_power"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "1.23"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
+
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": energy_production.node_id,
+            "args": {
+                "commandClassName": "Energy Production",
+                "commandClass": 144,
+                "endpoint": 0,
+                "property": "value",
+                "propertyKey": 0,
+                "propertyKeyName": "0",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Power",
+                    "ccSpecific": {"parameter": 0, "scale": 255},
+                    "unit": None,
+                },
+                "propertyName": "value",
+                "nodeId": energy_production.node_id,
+            },
+        },
+    )
+    energy_production.receive_event(event)
+    await hass.async_block_till_done()
+
+    with patch.object(
+        hass.config_entries, "async_schedule_reload"
+    ) as mock_schedule_reload:
+        event = Event(
+            "value updated",
+            {
+                "source": "node",
+                "event": "value updated",
+                "nodeId": energy_production.node_id,
+                "args": {
+                    "commandClassName": "Energy Production",
+                    "commandClass": 144,
+                    "endpoint": 0,
+                    "property": "value",
+                    "propertyKey": 0,
+                    "propertyKeyName": "0",
+                    "newValue": 2.0,
+                    "prevValue": 1.23,
+                    "propertyName": "value",
+                },
+            },
+        )
+        energy_production.receive_event(event)
+        await hass.async_block_till_done()
+
+    mock_schedule_reload.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "2.0"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
+
+
 async def test_new_sensor_invalid_scale(
     hass: HomeAssistant, multisensor_6, client, integration
 ) -> None:

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -254,8 +254,8 @@ async def test_invalid_multilevel_sensor_scale(
     assert state
     assert state.state == "9.0"
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
-    assert ATTR_DEVICE_CLASS not in state.attributes
-    assert ATTR_STATE_CLASS not in state.attributes
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
 
 
 async def test_energy_sensors(
@@ -828,15 +828,13 @@ async def test_unit_change(hass: HomeAssistant, zp3111, client, integration) -> 
 async def test_new_sensor_invalid_scale(
     hass: HomeAssistant, multisensor_6, client, integration
 ) -> None:
-    """Test new-style numeric sensor handles UnknownValueData from invalid scale."""
+    """Test new-style numeric sensor does not reload on invalid scale."""
     entity_id = AIR_TEMPERATURE_SENSOR
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "9.0"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
 
-    # Update the metadata to an invalid scale (255) to trigger UnknownValueData
-    # in _get_scale_type on the next value update
     event = Event(
         "metadata updated",
         {
@@ -864,10 +862,6 @@ async def test_new_sensor_invalid_scale(
     multisensor_6.receive_event(event)
     await hass.async_block_till_done()
 
-    # Fire a value updated event to trigger on_value_update which calls
-    # _get_scale_type - the invalid scale should raise UnknownValueData
-    # which is caught and returns None, triggering a reload since
-    # None != original TemperatureScale.CELSIUS
     with patch.object(
         hass.config_entries, "async_schedule_reload"
     ) as mock_schedule_reload:
@@ -891,7 +885,154 @@ async def test_new_sensor_invalid_scale(
         multisensor_6.receive_event(event)
         await hass.async_block_till_done()
 
-    mock_schedule_reload.assert_called_once_with(integration.entry_id)
+    mock_schedule_reload.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "68.0"
+
+
+async def test_new_sensor_native_value_unknown(
+    hass: HomeAssistant, multisensor_6, client, integration
+) -> None:
+    """Test new-style numeric sensor reports unknown when value is cleared."""
+    entity_id = AIR_TEMPERATURE_SENSOR
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": multisensor_6.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": "Air temperature",
+                "newValue": None,
+                "prevValue": 9,
+                "propertyName": "Air temperature",
+            },
+        },
+    )
+    multisensor_6.receive_event(event)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_new_sensor_on_value_update_from_template(
+    hass: HomeAssistant, aeon_smart_switch_6, client, integration
+) -> None:
+    """Test new-style numeric sensor applies template data on value update."""
+    entity_id = "sensor.smart_switch_6_electric_consumed_a"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "9.699"
+
+    with patch.object(
+        hass.config_entries, "async_schedule_reload"
+    ) as mock_schedule_reload:
+        event = Event(
+            "value updated",
+            {
+                "source": "node",
+                "event": "value updated",
+                "nodeId": aeon_smart_switch_6.node_id,
+                "args": {
+                    "commandClassName": "Meter",
+                    "commandClass": 50,
+                    "endpoint": 0,
+                    "property": "value",
+                    "propertyKey": 66817,
+                    "propertyKeyName": "Electric_A_Consumed",
+                    "newValue": 10.5,
+                    "prevValue": 9.699,
+                    "propertyName": "value",
+                },
+            },
+        )
+        aeon_smart_switch_6.receive_event(event)
+        await hass.async_block_till_done()
+
+    mock_schedule_reload.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "10.5"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfElectricCurrent.AMPERE
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.CURRENT
+
+
+async def test_new_sensor_unit_change(
+    hass: HomeAssistant, multisensor_6, client, integration
+) -> None:
+    """Test new-style numeric sensor handles unit change in place."""
+    entity_id = AIR_TEMPERATURE_SENSOR
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "9.0"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
+
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": multisensor_6.node_id,
+            "args": {
+                "commandClassName": "Multilevel Sensor",
+                "commandClass": 49,
+                "endpoint": 0,
+                "property": "Air temperature",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Air temperature",
+                    "ccSpecific": {"sensorType": 1, "scale": 1},
+                    "unit": "°F",
+                },
+                "propertyName": "Air temperature",
+                "nodeId": multisensor_6.node_id,
+            },
+        },
+    )
+    multisensor_6.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "9.0"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
+
+    with patch.object(
+        hass.config_entries, "async_schedule_reload"
+    ) as mock_schedule_reload:
+        event = Event(
+            "value updated",
+            {
+                "source": "node",
+                "event": "value updated",
+                "nodeId": multisensor_6.node_id,
+                "args": {
+                    "commandClassName": "Multilevel Sensor",
+                    "commandClass": 49,
+                    "endpoint": 0,
+                    "property": "Air temperature",
+                    "newValue": 48.2,
+                    "prevValue": 9,
+                    "propertyName": "Air temperature",
+                },
+            },
+        )
+        multisensor_6.receive_event(event)
+        await hass.async_block_till_done()
+
+    mock_schedule_reload.assert_not_called()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "9.0"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
 
 
 CONTROLLER_STATISTICS_ENTITY_PREFIX = "sensor.z_stick_gen5_usb_controller_"

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -20,13 +20,8 @@ from homeassistant.components.zwave_js.const import (
     ATTR_METER_TYPE_NAME,
     ATTR_VALUE,
     DOMAIN,
-    ENTITY_DESC_KEY_POWER,
     SERVICE_REFRESH_VALUE,
     SERVICE_RESET_METER,
-)
-from homeassistant.components.zwave_js.discovery_data_template import (
-    NumericSensorDataTemplate,
-    NumericSensorDataTemplateData,
 )
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
 from homeassistant.components.zwave_js.sensor import (
@@ -902,63 +897,122 @@ async def test_new_sensor_restores_discovery_description_on_empty_template(
 ) -> None:
     """Test new-style numeric sensor restores discovery description when template is empty."""
     entity_id = "sensor.smart_switch_6_electric_consumed_a"
-    power_data = NumericSensorDataTemplateData(ENTITY_DESC_KEY_POWER, UnitOfPower.WATT)
-    empty_data = NumericSensorDataTemplateData()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "9.699"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.CURRENT
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfElectricCurrent.AMPERE
 
-    with patch.object(
-        NumericSensorDataTemplate,
-        "resolve_data",
-        side_effect=[power_data, empty_data],
-    ):
-        event = Event(
-            "value updated",
-            {
-                "source": "node",
-                "event": "value updated",
-                "nodeId": aeon_smart_switch_6.node_id,
-                "args": {
-                    "commandClassName": "Meter",
-                    "commandClass": 50,
-                    "endpoint": 0,
-                    "property": "value",
-                    "propertyKey": 66817,
-                    "propertyKeyName": "Electric_A_Consumed",
-                    "newValue": 10.0,
-                    "prevValue": 9.699,
-                    "propertyName": "value",
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": aeon_smart_switch_6.node_id,
+            "args": {
+                "commandClassName": "Meter",
+                "commandClass": 50,
+                "endpoint": 0,
+                "property": "value",
+                "propertyKey": 66817,
+                "propertyKeyName": "Electric_A_Consumed",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Electric Consumed [A]",
+                    "ccSpecific": {"meterType": 1, "rateType": 1, "scale": 2},
+                    "unit": "W",
                 },
+                "propertyName": "value",
+                "nodeId": aeon_smart_switch_6.node_id,
             },
-        )
-        aeon_smart_switch_6.receive_event(event)
-        await hass.async_block_till_done()
-        state = hass.states.get(entity_id)
-        assert state
-        assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
+        },
+    )
+    aeon_smart_switch_6.receive_event(event)
+    await hass.async_block_till_done()
 
-        event = Event(
-            "value updated",
-            {
-                "source": "node",
-                "event": "value updated",
-                "nodeId": aeon_smart_switch_6.node_id,
-                "args": {
-                    "commandClassName": "Meter",
-                    "commandClass": 50,
-                    "endpoint": 0,
-                    "property": "value",
-                    "propertyKey": 66817,
-                    "propertyKeyName": "Electric_A_Consumed",
-                    "newValue": 11.0,
-                    "prevValue": 10.0,
-                    "propertyName": "value",
-                },
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": aeon_smart_switch_6.node_id,
+            "args": {
+                "commandClassName": "Meter",
+                "commandClass": 50,
+                "endpoint": 0,
+                "property": "value",
+                "propertyKey": 66817,
+                "propertyKeyName": "Electric_A_Consumed",
+                "newValue": 10.0,
+                "prevValue": 9.699,
+                "propertyName": "value",
             },
-        )
-        aeon_smart_switch_6.receive_event(event)
-        await hass.async_block_till_done()
+        },
+    )
+    aeon_smart_switch_6.receive_event(event)
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "10.0"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfPower.WATT
+
+    event = Event(
+        "metadata updated",
+        {
+            "source": "node",
+            "event": "metadata updated",
+            "nodeId": aeon_smart_switch_6.node_id,
+            "args": {
+                "commandClassName": "Meter",
+                "commandClass": 50,
+                "endpoint": 0,
+                "property": "value",
+                "propertyKey": 66817,
+                "propertyKeyName": "Electric_A_Consumed",
+                "metadata": {
+                    "type": "number",
+                    "readable": True,
+                    "writeable": False,
+                    "label": "Electric Consumed [A]",
+                    "ccSpecific": {"meterType": 1, "rateType": 1, "scale": -1},
+                    "unit": None,
+                },
+                "propertyName": "value",
+                "nodeId": aeon_smart_switch_6.node_id,
+            },
+        },
+    )
+    aeon_smart_switch_6.receive_event(event)
+    await hass.async_block_till_done()
+
+    event = Event(
+        "value updated",
+        {
+            "source": "node",
+            "event": "value updated",
+            "nodeId": aeon_smart_switch_6.node_id,
+            "args": {
+                "commandClassName": "Meter",
+                "commandClass": 50,
+                "endpoint": 0,
+                "property": "value",
+                "propertyKey": 66817,
+                "propertyKeyName": "Electric_A_Consumed",
+                "newValue": 11.0,
+                "prevValue": 10.0,
+                "propertyName": "value",
+            },
+        },
+    )
+    aeon_smart_switch_6.receive_event(event)
+    await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
     assert state
+    assert state.state == "11.0"
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.CURRENT
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfElectricCurrent.AMPERE
 

--- a/tests/components/zwave_js/test_sensor.py
+++ b/tests/components/zwave_js/test_sensor.py
@@ -20,8 +20,13 @@ from homeassistant.components.zwave_js.const import (
     ATTR_METER_TYPE_NAME,
     ATTR_VALUE,
     DOMAIN,
+    ENTITY_DESC_KEY_POWER,
     SERVICE_REFRESH_VALUE,
     SERVICE_RESET_METER,
+)
+from homeassistant.components.zwave_js.discovery_data_template import (
+    NumericSensorDataTemplate,
+    NumericSensorDataTemplateData,
 )
 from homeassistant.components.zwave_js.helpers import get_valueless_base_unique_id
 from homeassistant.components.zwave_js.sensor import (
@@ -889,6 +894,73 @@ async def test_new_sensor_invalid_scale(
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "68.0"
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
+
+
+async def test_new_sensor_restores_discovery_description_on_empty_template(
+    hass: HomeAssistant, aeon_smart_switch_6, client, integration
+) -> None:
+    """Test new-style numeric sensor restores discovery description when template is empty."""
+    entity_id = "sensor.smart_switch_6_electric_consumed_a"
+    power_data = NumericSensorDataTemplateData(ENTITY_DESC_KEY_POWER, UnitOfPower.WATT)
+    empty_data = NumericSensorDataTemplateData()
+
+    with patch.object(
+        NumericSensorDataTemplate,
+        "resolve_data",
+        side_effect=[power_data, empty_data],
+    ):
+        event = Event(
+            "value updated",
+            {
+                "source": "node",
+                "event": "value updated",
+                "nodeId": aeon_smart_switch_6.node_id,
+                "args": {
+                    "commandClassName": "Meter",
+                    "commandClass": 50,
+                    "endpoint": 0,
+                    "property": "value",
+                    "propertyKey": 66817,
+                    "propertyKeyName": "Electric_A_Consumed",
+                    "newValue": 10.0,
+                    "prevValue": 9.699,
+                    "propertyName": "value",
+                },
+            },
+        )
+        aeon_smart_switch_6.receive_event(event)
+        await hass.async_block_till_done()
+        state = hass.states.get(entity_id)
+        assert state
+        assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.POWER
+
+        event = Event(
+            "value updated",
+            {
+                "source": "node",
+                "event": "value updated",
+                "nodeId": aeon_smart_switch_6.node_id,
+                "args": {
+                    "commandClassName": "Meter",
+                    "commandClass": 50,
+                    "endpoint": 0,
+                    "property": "value",
+                    "propertyKey": 66817,
+                    "propertyKeyName": "Electric_A_Consumed",
+                    "newValue": 11.0,
+                    "prevValue": 10.0,
+                    "propertyName": "value",
+                },
+            },
+        )
+        aeon_smart_switch_6.receive_event(event)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.CURRENT
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfElectricCurrent.AMPERE
 
 
 async def test_new_sensor_native_value_unknown(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes #176227.

PR #165254 migrated several sensor types to `NewZWaveDiscoverySchema` and introduced `NewZWaveNumericSensor`. For multilevel temperature sensors, discovery was split into two schemas filtered by `TemperatureScale` (°C vs °F), baking a runtime-varying property into a static discovery rule. When a device later flipped scale metadata (observed on Zooz ZAC36 firmware), `NewZWaveNumericSensor.on_value_update()` called `async_schedule_reload()`, disconnecting the Z-Wave JS websocket and briefly making **all** Z-Wave entities unavailable.

This change corrects that architectural mistake without reverting the #165254 migration:

1. **Unify temperature discovery** — one `NewZWaveDiscoverySchema` matching `TEMPERATURE_SENSORS` by sensor type only (no scale filter). Static attributes (`device_class`, `state_class`) stay in the schema; native unit is not pinned at discovery time.
2. **Restore runtime unit handling** — `NewZWaveNumericSensor` mirrors the prior `ZWaveNumericSensor` pattern: resolve `NumericSensorDataTemplate` on value update, with `metadata.unit` fallback via a `native_unit_of_measurement` property (same approach as `ZwaveSensor`).
3. **Remove reload-on-scale-change** — delete `_get_scale_type()`, scale comparison, and `async_schedule_reload()` from entity value updates. This also removes the latent reload path for other migrated types (meter current, energy production power) that shared the same handler.

Migrated entity types remain on `NewZwaveDiscoveryInfo` + `NewZWaveNumericSensor` / `NewZWaveMeterSensor`. Net result: ~45 fewer lines in `sensor.py`, preserving all four entity types on the new discovery path (battery, temperature, meter current, energy production power).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176227
- This PR is related to issue: #176227
- Regressed by: #165254 (merged 2026-03-23, first release `2026.4.0`)
- Link to documentation pull request: (Not required)
- Link to developer documentation pull request: (Not required)
- Link to frontend pull request: (Not required)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
