### PR TITLE
Add entry unload and discovery lifecycle tests to iZone

### DIFF
--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -8,7 +8,7 @@ from pizone import Controller, Zone
 import pytest
 
 from homeassistant.components.izone import discovery as izone_discovery
-from homeassistant.components.izone.const import DATA_DISCOVERY_SERVICE, DOMAIN
+from homeassistant.components.izone.const import DOMAIN
 from homeassistant.const import CONF_EXCLUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -161,9 +161,7 @@ async def async_install_discovery_service(
             return_value=mock_pi_disco,
         ),
     ):
-        service = await izone_discovery.async_start_discovery_service(hass)
-    assert DATA_DISCOVERY_SERVICE in hass.data
-    return service
+        return await izone_discovery.async_start_discovery_service(hass)
 
 
 @pytest.fixture

--- a/tests/components/izone/test_init.py
+++ b/tests/components/izone/test_init.py
@@ -1,0 +1,122 @@
+"""Tests for iZone integration setup and unload."""
+
+from unittest.mock import patch
+
+from homeassistant.components.izone import discovery as izone_discovery
+from homeassistant.components.izone.const import DATA_DISCOVERY_SERVICE, DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from .conftest import async_install_discovery_service, create_mock_controller
+
+from tests.common import MockConfigEntry
+
+
+async def test_unload_last_entry_does_not_stop_discovery_when_controller_on_lan(
+    hass: HomeAssistant,
+) -> None:
+    """Unload leaves discovery running so controllers stay discoverable on the LAN."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    await async_install_discovery_service(hass, controller)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.climate.async_setup_entry",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert DATA_DISCOVERY_SERVICE in hass.data
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    assert DATA_DISCOVERY_SERVICE in hass.data
+
+
+async def test_setup_entry_after_unload_reuses_discovery(
+    hass: HomeAssistant,
+) -> None:
+    """A new entry setup reuses the discovery service left running after unload."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    service = await async_install_discovery_service(hass, controller)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.climate.async_setup_entry",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert DATA_DISCOVERY_SERVICE in hass.data
+
+    second = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000002",
+        data={},
+        version=2,
+    )
+    second.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.climate.async_setup_entry",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(second.entry_id)
+    await hass.async_block_till_done()
+
+    assert second.state is ConfigEntryState.LOADED
+    assert hass.data[DATA_DISCOVERY_SERVICE] is service
+
+
+async def test_idle_stop_after_unload_when_no_controllers(
+    hass: HomeAssistant,
+) -> None:
+    """Idle-stop clears discovery once the entry is gone and no controllers remain."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    service = await async_install_discovery_service(hass, controller)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.climate.async_setup_entry",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.config_entries.async_remove(entry.entry_id)
+    await hass.async_block_till_done()
+
+    service.pi_disco.controllers.clear()
+
+    await izone_discovery.async_maybe_stop_discovery_service(hass)
+    await hass.async_block_till_done()
+
+    assert DATA_DISCOVERY_SERVICE not in hass.data

--- a/tests/components/izone/test_init.py
+++ b/tests/components/izone/test_init.py
@@ -1,9 +1,10 @@
 """Tests for iZone integration setup and unload."""
 
+import asyncio
 from unittest.mock import patch
 
 from homeassistant.components.izone import discovery as izone_discovery
-from homeassistant.components.izone.const import DATA_DISCOVERY_SERVICE, DOMAIN
+from homeassistant.components.izone.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -14,60 +15,49 @@ from tests.common import MockConfigEntry
 
 async def test_unload_last_entry_does_not_stop_discovery_when_controller_on_lan(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Unload leaves discovery running so controllers stay discoverable on the LAN."""
     controller = create_mock_controller("000000001", "192.0.2.1")
-    await async_install_discovery_service(hass, controller)
+    service = await async_install_discovery_service(hass, controller)
 
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="000000001",
-        data={},
-        version=2,
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.izone.climate.async_setup_entry",
         return_value=True,
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert DATA_DISCOVERY_SERVICE in hass.data
-
-    assert await hass.config_entries.async_unload(entry.entry_id)
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.NOT_LOADED
-    assert DATA_DISCOVERY_SERVICE in hass.data
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    service.pi_disco.close.assert_not_awaited()
+    assert service.remove_stop_listener is not None
 
 
 async def test_setup_entry_after_unload_reuses_discovery(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """A new entry setup reuses the discovery service left running after unload."""
     controller = create_mock_controller("000000001", "192.0.2.1")
     service = await async_install_discovery_service(hass, controller)
 
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="000000001",
-        data={},
-        version=2,
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     with patch(
         "homeassistant.components.izone.climate.async_setup_entry",
         return_value=True,
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert await hass.config_entries.async_unload(entry.entry_id)
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
-    assert DATA_DISCOVERY_SERVICE in hass.data
+    service.pi_disco.close.assert_not_awaited()
 
     second = MockConfigEntry(
         domain=DOMAIN,
@@ -85,38 +75,44 @@ async def test_setup_entry_after_unload_reuses_discovery(
     await hass.async_block_till_done()
 
     assert second.state is ConfigEntryState.LOADED
-    assert hass.data[DATA_DISCOVERY_SERVICE] is service
+    assert await izone_discovery.async_start_discovery_service(hass) is service
+    service.pi_disco.start_discovery.assert_awaited_once()
+    service.pi_disco.close.assert_not_awaited()
 
 
 async def test_idle_stop_after_unload_when_no_controllers(
     hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Idle-stop clears discovery once the entry is gone and no controllers remain."""
-    controller = create_mock_controller("000000001", "192.0.2.1")
-    service = await async_install_discovery_service(hass, controller)
-
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        unique_id="000000001",
-        data={},
-        version=2,
-    )
-    entry.add_to_hass(hass)
-
     with patch(
-        "homeassistant.components.izone.climate.async_setup_entry",
-        return_value=True,
+        "homeassistant.components.izone.discovery.DISCOVERY_IDLE_SECONDS",
+        0,
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
+        controller = create_mock_controller("000000001", "192.0.2.1")
+        service = await async_install_discovery_service(hass, controller)
 
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.config_entries.async_remove(entry.entry_id)
-    await hass.async_block_till_done()
+        mock_config_entry.add_to_hass(hass)
 
-    service.pi_disco.controllers.clear()
+        with patch(
+            "homeassistant.components.izone.climate.async_setup_entry",
+            return_value=True,
+        ):
+            assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
-    await izone_discovery.async_maybe_stop_discovery_service(hass)
-    await hass.async_block_till_done()
+        assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.config_entries.async_remove(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
 
-    assert DATA_DISCOVERY_SERVICE not in hass.data
+        service.pi_disco.controllers.clear()
+
+        # call_later(0) → maybe_stop task; drain until discovery closes.
+        for _ in range(5):
+            if service.remove_stop_listener is None:
+                break
+            await asyncio.sleep(0)
+            await hass.async_block_till_done()
+
+    service.pi_disco.close.assert_awaited_once()
+    assert service.remove_stop_listener is None


### PR DESCRIPTION
## Breaking change


## Proposed change

Follow-up to #169251. Add integration-level tests for entry setup/unload and discovery lifecycle:

- Unload does not stop discovery when a controller remains on the LAN
- A later setup reuses the running discovery service
- Idle-stop clears discovery once entries are removed and no controllers remain

Independent of the discovery test split/refactor in #176253 / #176255.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #169251
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

## Test plan

- [x] `uv run pytest tests/components/izone/test_init.py -q`
- [x] `prek run -d tests/components/izone/`

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure