### PR TITLE
tests(izone): use conftest helpers in discovery tests

### DIFF
--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -8,7 +8,7 @@ from pizone import Controller, Zone
 import pytest
 
 from homeassistant.components.izone import discovery as izone_discovery
-from homeassistant.components.izone.const import DATA_DISCOVERY_SERVICE, DOMAIN
+from homeassistant.components.izone.const import DOMAIN
 from homeassistant.const import CONF_EXCLUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -161,9 +161,7 @@ async def async_install_discovery_service(
             return_value=mock_pi_disco,
         ),
     ):
-        service = await izone_discovery.async_start_discovery_service(hass)
-    assert DATA_DISCOVERY_SERVICE in hass.data
-    return service
+        return await izone_discovery.async_start_discovery_service(hass)
 
 
 @pytest.fixture

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -6,7 +6,7 @@ import pytest
 
 from homeassistant import config_entries
 from homeassistant.components.izone import discovery as izone_discovery
-from homeassistant.components.izone.const import DATA_DISCOVERY_SERVICE, DOMAIN
+from homeassistant.components.izone.const import DOMAIN
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 
@@ -35,16 +35,16 @@ async def test_async_start_discovery_service_stops_on_home_assistant_stop(
             return_value=mock_pizone_discovery_service,
         ),
     ):
-        await izone_discovery.async_start_discovery_service(hass)
+        service = await izone_discovery.async_start_discovery_service(hass)
 
-        assert DATA_DISCOVERY_SERVICE in hass.data
+        assert service.remove_stop_listener is not None
 
         hass.bus.async_fire(EVENT_HOMEASSISTANT_STOP)
         await hass.async_block_till_done()
 
     mock_pizone_discovery_service.start_discovery.assert_awaited_once()
     mock_pizone_discovery_service.close.assert_awaited_once()
-    assert DATA_DISCOVERY_SERVICE not in hass.data
+    assert service.remove_stop_listener is None
 
 
 async def test_async_maybe_stop_keeps_running_when_actionable_flow_exists(
@@ -52,9 +52,9 @@ async def test_async_maybe_stop_keeps_running_when_actionable_flow_exists(
 ) -> None:
     """Discovery should stay running while an actionable iZone flow is in progress."""
     service = await async_install_discovery_service(hass)
-    service.async_schedule_idle_stop = Mock()
 
     with (
+        patch.object(service, "async_schedule_idle_stop") as mock_schedule,
         patch.object(
             hass.config_entries.flow,
             "async_progress_by_handler",
@@ -68,7 +68,7 @@ async def test_async_maybe_stop_keeps_running_when_actionable_flow_exists(
         await izone_discovery.async_maybe_stop_discovery_service(hass)
 
     mock_stop.assert_not_awaited()
-    service.async_schedule_idle_stop.assert_called_once()
+    mock_schedule.assert_called_once()
 
 
 async def test_async_maybe_stop_keeps_running_when_actionable_entry_exists(
@@ -83,16 +83,18 @@ async def test_async_maybe_stop_keeps_running_when_actionable_entry_exists(
     ).add_to_hass(hass)
 
     service = await async_install_discovery_service(hass)
-    service.async_schedule_idle_stop = Mock()
 
-    with patch(
-        "homeassistant.components.izone.discovery.async_stop_discovery_service",
-        new=AsyncMock(),
-    ) as mock_stop:
+    with (
+        patch.object(service, "async_schedule_idle_stop") as mock_schedule,
+        patch(
+            "homeassistant.components.izone.discovery.async_stop_discovery_service",
+            new=AsyncMock(),
+        ) as mock_stop,
+    ):
         await izone_discovery.async_maybe_stop_discovery_service(hass)
 
     mock_stop.assert_not_awaited()
-    service.async_schedule_idle_stop.assert_called_once()
+    mock_schedule.assert_called_once()
 
 
 async def test_async_maybe_stop_stops_when_only_disabled_entry_matches_controller(
@@ -110,16 +112,18 @@ async def test_async_maybe_stop_stops_when_only_disabled_entry_matches_controlle
     service = await async_install_discovery_service(
         hass, create_mock_controller("000000001")
     )
-    service.async_schedule_idle_stop = Mock()
 
-    with patch(
-        "homeassistant.components.izone.discovery.async_stop_discovery_service",
-        new=AsyncMock(),
-    ) as mock_stop:
+    with (
+        patch.object(service, "async_schedule_idle_stop") as mock_schedule,
+        patch(
+            "homeassistant.components.izone.discovery.async_stop_discovery_service",
+            new=AsyncMock(),
+        ) as mock_stop,
+    ):
         await izone_discovery.async_maybe_stop_discovery_service(hass)
 
     mock_stop.assert_awaited_once_with(hass)
-    service.async_schedule_idle_stop.assert_not_called()
+    mock_schedule.assert_not_called()
 
 
 async def test_async_discover_controllers_starts_shared_service_when_missing(
@@ -292,9 +296,9 @@ async def test_async_maybe_stop_keeps_running_when_controller_not_ignored(
     service = await async_install_discovery_service(
         hass, create_mock_controller("000000001")
     )
-    service.async_schedule_idle_stop = Mock()
 
     with (
+        patch.object(service, "async_schedule_idle_stop") as mock_schedule,
         patch.object(
             hass.config_entries.flow,
             "async_progress_by_handler",
@@ -308,7 +312,7 @@ async def test_async_maybe_stop_keeps_running_when_controller_not_ignored(
         await izone_discovery.async_maybe_stop_discovery_service(hass)
 
     mock_stop.assert_not_awaited()
-    service.async_schedule_idle_stop.assert_called_once()
+    mock_schedule.assert_called_once()
 
 
 async def test_async_stop_discovery_service_returns_when_not_started(
@@ -332,4 +336,4 @@ async def test_async_stop_discovery_service_clears_stop_listener(
 
     stop_listener.assert_called_once()
     assert service.remove_stop_listener is None
-    assert DATA_DISCOVERY_SERVICE not in hass.data
+    service.pi_disco.close.assert_awaited_once()

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -325,8 +325,11 @@ async def test_async_stop_discovery_service_clears_stop_listener(
     service = await async_install_discovery_service(hass)
 
     assert service.remove_stop_listener is not None
+    stop_listener = Mock(wraps=service.remove_stop_listener)
+    service.remove_stop_listener = stop_listener
 
     await izone_discovery.async_stop_discovery_service(hass)
 
+    stop_listener.assert_called_once()
     assert service.remove_stop_listener is None
     assert DATA_DISCOVERY_SERVICE not in hass.data

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -11,6 +11,7 @@ from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 
 from .conftest import (
+    async_install_discovery_service,
     async_load_yaml_exclude,
     create_mock_controller,
     create_mock_discovery_service,
@@ -50,8 +51,8 @@ async def test_async_maybe_stop_keeps_running_when_actionable_flow_exists(
     hass: HomeAssistant,
 ) -> None:
     """Discovery should stay running while an actionable iZone flow is in progress."""
-    service = create_mock_discovery_service()
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(hass)
+    service.async_schedule_idle_stop = Mock()
 
     with (
         patch.object(
@@ -81,8 +82,8 @@ async def test_async_maybe_stop_keeps_running_when_actionable_entry_exists(
         data={},
     ).add_to_hass(hass)
 
-    service = create_mock_discovery_service()
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(hass)
+    service.async_schedule_idle_stop = Mock()
 
     with patch(
         "homeassistant.components.izone.discovery.async_stop_discovery_service",
@@ -106,8 +107,10 @@ async def test_async_maybe_stop_stops_when_only_disabled_entry_matches_controlle
         data={},
     ).add_to_hass(hass)
 
-    service = create_mock_discovery_service(create_mock_controller("000000001"))
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(
+        hass, create_mock_controller("000000001")
+    )
+    service.async_schedule_idle_stop = Mock()
 
     with patch(
         "homeassistant.components.izone.discovery.async_stop_discovery_service",
@@ -162,8 +165,7 @@ async def test_async_discover_controllers_refresh_calls_fetch_controllers(
     hass: HomeAssistant,
 ) -> None:
     """Refresh without UID delegates to fetch_controllers with timeout."""
-    service = create_mock_discovery_service()
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(hass)
 
     controllers = await izone_discovery.async_discover_controllers(hass, refresh=True)
 
@@ -175,8 +177,7 @@ async def test_async_discover_controllers_waits_for_requested_uid(
     hass: HomeAssistant,
 ) -> None:
     """Refresh with wait_for_uid calls fetch_controller and returns all controllers."""
-    service = create_mock_discovery_service()
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(hass)
     requested = create_mock_controller("000000777", "192.0.2.77")
 
     async def _fetch_and_add(uid: str, timeout: float | None = None) -> None:
@@ -255,20 +256,18 @@ async def test_async_start_discovery_service_returns_existing_instance(
     hass: HomeAssistant,
 ) -> None:
     """Starting discovery returns existing service when already running."""
-    existing = Mock()
-    hass.data[DATA_DISCOVERY_SERVICE] = existing
+    service = await async_install_discovery_service(hass)
 
     disco = await izone_discovery.async_start_discovery_service(hass)
 
-    assert disco is existing
+    assert disco is service
 
 
 async def test_async_maybe_stop_stops_when_no_controllers_remain(
     hass: HomeAssistant,
 ) -> None:
     """Discovery stops when no controllers are tracked and nothing is actionable."""
-    service = create_mock_discovery_service()
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    await async_install_discovery_service(hass)
 
     with (
         patch.object(
@@ -290,8 +289,10 @@ async def test_async_maybe_stop_keeps_running_when_controller_not_ignored(
     hass: HomeAssistant,
 ) -> None:
     """Discovery remains active if at least one discovered controller is still actionable."""
-    service = create_mock_discovery_service(create_mock_controller("000000001"))
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(
+        hass, create_mock_controller("000000001")
+    )
+    service.async_schedule_idle_stop = Mock()
 
     with (
         patch.object(
@@ -321,15 +322,11 @@ async def test_async_stop_discovery_service_clears_stop_listener(
     hass: HomeAssistant,
 ) -> None:
     """Stop should remove the stop listener when it exists."""
-    service = Mock()
-    stop_listener = Mock()
-    service.remove_stop_listener = stop_listener
-    service.remove_config_flow_listener = None
-    service.async_cancel_idle_stop = Mock()
-    service.pi_disco.close = AsyncMock()
-    hass.data[DATA_DISCOVERY_SERVICE] = service
+    service = await async_install_discovery_service(hass)
+
+    assert service.remove_stop_listener is not None
 
     await izone_discovery.async_stop_discovery_service(hass)
 
-    stop_listener.assert_called_once()
     assert service.remove_stop_listener is None
+    assert DATA_DISCOVERY_SERVICE not in hass.data


### PR DESCRIPTION
## Breaking change


## Proposed change

Follow-up to #169251. Replace manual `hass.data[DATA_DISCOVERY_SERVICE]` injections in discovery tests with shared helpers from `conftest.py`.

[x[ **Depends on #176253** — ~~do not merge until #176253 is merged. Rebase this branch onto `dev` after #176253 lands so the PR diff shows only the refactor commit.~~ done

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #169251; depends on #176253
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

## Test plan

- [x] `uv run pytest tests/components/izone/test_discovery.py -q`
- [x] `prek run -d tests/components/izone/`

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure