### PR TITLE
Catch Honeywell hold transient errors

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -517,6 +517,17 @@ class HoneywellUSThermostat(ClimateEntity):
                 if mode in HEATING_MODES:
                     await self._device.set_hold_heat(True)
 
+            except (
+                TimeoutError,
+                AscConnectionError,
+                APIRateLimited,
+                AuthError,
+                ClientConnectionError,
+            ) as err:
+                raise HomeAssistantError(
+                    translation_domain=DOMAIN,
+                    translation_key="set_hold_failed",
+                ) from err
             except SomeComfortError as err:
                 _LOGGER.error("Couldn't set permanent hold")
                 raise HomeAssistantError(

--- a/tests/components/honeywell/test_climate.py
+++ b/tests/components/honeywell/test_climate.py
@@ -663,6 +663,43 @@ async def test_service_calls_cool_mode(
     assert "Invalid system mode returned" in caplog.text
 
 
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(TimeoutError, id="timeout"),
+        pytest.param(aiosomecomfort.ConnectionError, id="somecomfort-connection"),
+        pytest.param(aiosomecomfort.APIRateLimited, id="api-rate-limited"),
+        pytest.param(aiosomecomfort.AuthError, id="auth-error"),
+        pytest.param(ClientConnectionError, id="client-connection"),
+    ],
+)
+async def test_set_preset_hold_transient_errors_raise_home_assistant_error(
+    hass: HomeAssistant,
+    device: MagicMock,
+    config_entry: MagicMock,
+    exception: type[Exception],
+) -> None:
+    """Test transient hold errors are translated to HomeAssistantError."""
+    device.system_mode = "cool"
+
+    await init_integration(hass, config_entry)
+    entity_id = f"climate.{device.name}"
+
+    device.set_hold_cool.side_effect = exception
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: PRESET_HOLD},
+            blocking=True,
+        )
+
+    assert isinstance(exc_info.value.__cause__, exception)
+    device.set_hold_cool.assert_called_once_with(True)
+    device.set_hold_heat.assert_not_called()
+
+
 async def test_service_calls_heat_mode(
     hass: HomeAssistant,
     device: MagicMock,


### PR DESCRIPTION
## Proposed change

Catch transient Honeywell/API errors while enabling permanent hold and convert them to the existing `set_hold_failed` `HomeAssistantError`. This keeps `climate.set_preset_mode` failures consistent with the rest of the integration and avoids raw "Unexpected error" exceptions for timeout/connection failures.

Local verification:

- `uv run --no-sync pytest tests/components/honeywell/test_climate.py -q` (17 passed)
- `git diff --check` (passed)
- `uv run --no-sync ruff check homeassistant/components/honeywell/climate.py tests/components/honeywell/test_climate.py` (passed)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176247
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
