### PR TITLE
Resolve SMLIGHT radio entity names based on types

### DIFF
--- a/homeassistant/components/smlight/button.py
+++ b/homeassistant/components/smlight/button.py
@@ -18,7 +18,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, ZWAVE_TYPES
 from .coordinator import SmConfigEntry, SmDataUpdateCoordinator
 from .entity import SmEntity
 
@@ -128,6 +128,15 @@ class SmButton(SmEntity, ButtonEntity):
         self.idx = idx
         button = f"_{idx}" if idx else ""
         self._attr_unique_id = f"{coordinator.unique_id}-{description.key}{button}"
+
+        if (
+            idx < len(coordinator.data.info.radios)
+            and coordinator.data.info.radios[idx].zb_type in ZWAVE_TYPES
+        ):
+            if description.key == "zigbee_restart":
+                self._attr_translation_key = "z_wave_restart"
+            elif description.key == "zigbee_flash_mode":
+                self._attr_translation_key = "z_wave_flash_mode"
 
     @override
     async def async_press(self) -> None:

--- a/homeassistant/components/smlight/const.py
+++ b/homeassistant/components/smlight/const.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 from enum import StrEnum
 import logging
 
+from pysmlight.const import ZB_TYPES
+
 DOMAIN = "smlight"
 
 ATTR_MANUFACTURER = "SMLIGHT"
@@ -26,3 +28,6 @@ class BLEScannerMode(StrEnum):
     AUTO = "auto"
     ACTIVE = "active"
     PASSIVE = "passive"
+
+
+ZWAVE_TYPES = tuple(k for k, v in ZB_TYPES.items() if v.lower().startswith("zwave"))

--- a/homeassistant/components/smlight/sensor.py
+++ b/homeassistant/components/smlight/sensor.py
@@ -20,7 +20,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.util.dt import utcnow
 
-from .const import UPTIME_DEVIATION
+from .const import UPTIME_DEVIATION, ZWAVE_TYPES
 from .coordinator import SmConfigEntry, SmDataUpdateCoordinator
 from .entity import SmEntity
 
@@ -159,7 +159,8 @@ async def async_setup_entry(
 
     entities.extend(
         SmInfoSensorEntity(coordinator, RADIO_INFO, idx)
-        for idx, _ in enumerate(coordinator.data.info.radios)
+        for idx, radio in enumerate(coordinator.data.info.radios)
+        if radio.zb_type not in ZWAVE_TYPES
     )
 
     if coordinator.data.sensors.zb_temp2 is not None:

--- a/homeassistant/components/smlight/strings.json
+++ b/homeassistant/components/smlight/strings.json
@@ -84,6 +84,12 @@
       "reconnect_zigbee_router": {
         "name": "Reconnect Zigbee router"
       },
+      "z_wave_flash_mode": {
+        "name": "Z-Wave flash mode"
+      },
+      "z_wave_restart": {
+        "name": "Z-Wave restart"
+      },
       "zigbee_flash_mode": {
         "name": "Zigbee flash mode"
       },
@@ -159,6 +165,9 @@
     "update": {
       "core_update": {
         "name": "Core firmware"
+      },
+      "z_wave_update": {
+        "name": "Z-Wave firmware"
       },
       "zigbee_update": {
         "name": "Zigbee firmware"

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER, ZWAVE_TYPES
 from .coordinator import SmConfigEntry, SmFirmwareUpdateCoordinator, SmFwData
 from .entity import SmEntity
 
@@ -77,7 +77,8 @@ async def async_setup_entry(
 
     entities.extend(
         SmUpdateEntity(coordinator, ZB_UPDATE_ENTITY, idx)
-        for idx, _ in enumerate(radios)
+        for idx, radio in enumerate(radios)
+        if radio.zb_type != -1
     )
 
     async_add_entities(entities)
@@ -113,6 +114,14 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
         self._firmware: Firmware | None = None
         self._unload: list[Callable] = []
         self.idx = idx
+
+        if (
+            coordinator.data
+            and idx < len(coordinator.data.info.radios)
+            and coordinator.data.info.radios[idx].zb_type in ZWAVE_TYPES
+        ):
+            if description.key == "zigbee_update":
+                self._attr_translation_key = "z_wave_update"
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/smlight/update.py
+++ b/homeassistant/components/smlight/update.py
@@ -116,9 +116,9 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
         self.idx = idx
 
         if (
-            coordinator.data
-            and idx < len(coordinator.data.info.radios)
-            and coordinator.data.info.radios[idx].zb_type in ZWAVE_TYPES
+            (data := coordinator.data)
+            and idx < len(data.info.radios)
+            and data.info.radios[idx].zb_type in ZWAVE_TYPES
         ):
             if description.key == "zigbee_update":
                 self._attr_translation_key = "z_wave_update"
@@ -182,7 +182,16 @@ class SmUpdateEntity(SmEntity, UpdateEntity):
     def release_notes(self) -> str | None:
         """Return release notes for firmware."""
         if "zigbee" in self.entity_description.key:
-            notes = f"### {'ZNP' if self.idx else 'EZSP'} Firmware\n\n"
+            radio_desc = "Zigbee"
+            if (data := self.coordinator.data) and self.idx < len(data.info.radios):
+                radio = data.info.radios[self.idx]
+                if radio.zb_type in ZWAVE_TYPES:
+                    radio_desc = "Z-Wave"
+                elif radio.zb_hw and "EFR32" in radio.zb_hw:
+                    radio_desc = "EZSP"
+                elif radio.zb_hw and "CC2" in radio.zb_hw:
+                    radio_desc = "ZNP"
+            notes = f"### {radio_desc} Firmware\n\n"
         else:
             notes = "### Core Firmware\n\n"
 

--- a/tests/components/smlight/conftest.py
+++ b/tests/components/smlight/conftest.py
@@ -3,6 +3,7 @@
 from collections.abc import AsyncGenerator, Generator
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from pysmlight import Radio
 from pysmlight.exceptions import SmlightAuthError
 from pysmlight.models import BleFeatures
 from pysmlight.sse import sseClient
@@ -152,7 +153,14 @@ def mock_smlight_client(request: pytest.FixtureRequest) -> Generator[MagicMock]:
 MOCK_ULTIMA = Info(
     MAC="AA:BB:CC:DD:EE:FF",
     model="SLZB-Ultima3",
+    addons={"zwave": True},
     ble=BleFeatures(ble_enabled=True, proxy_enabled=True),
+    u_device=True,
+    radios=[
+        Radio(zb_type=0, chip_index=0),
+        Radio(zb_type=1, chip_index=1),
+        Radio(zb_type=5, chip_index=2),
+    ],
 )
 
 

--- a/tests/components/smlight/test_button.py
+++ b/tests/components/smlight/test_button.py
@@ -156,23 +156,15 @@ async def test_remove_router_reconnect(
         ("zigbee_flash_mode", 1),
     ],
 )
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_ultima_client")
 async def test_multi_radio_buttons_u_device(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     key: str,
     idx: int,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
 ) -> None:
     """Test per-radio restart and flash mode buttons on a u-device."""
-    mock_smlight_client.get_info.side_effect = None
-    info = Info.from_dict(
-        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
-    )
-    info.u_device = True
-    mock_smlight_client.get_info.return_value = info
-
     await setup_integration(hass, mock_config_entry)
 
     unique_id_suffix = f"_{idx}" if idx else ""
@@ -200,16 +192,9 @@ async def test_multi_radio_press_calls_idx(
     method: str,
     idx: int,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
+    mock_ultima_client: MagicMock,
 ) -> None:
     """Test pressing per-radio buttons passes the correct idx to the command."""
-    mock_smlight_client.get_info.side_effect = None
-    info = Info.from_dict(
-        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
-    )
-    info.u_device = True
-    mock_smlight_client.get_info.return_value = info
-
     await setup_integration(hass, mock_config_entry)
 
     unique_id_suffix = f"_{idx}" if idx else ""
@@ -217,7 +202,7 @@ async def test_multi_radio_press_calls_idx(
     entity_id = entity_registry.async_get_entity_id(BUTTON_DOMAIN, DOMAIN, unique_id)
     assert entity_id is not None
 
-    mock_method = getattr(mock_smlight_client.cmds, method)
+    mock_method = getattr(mock_ultima_client.cmds, method)
 
     await hass.services.async_call(
         BUTTON_DOMAIN,
@@ -249,29 +234,66 @@ async def test_multi_radio_buttons_shared_non_u_device(
     )
 
 
-@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_ultima_client")
 async def test_router_button_with_3_radios(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
 ) -> None:
     """Test creation of router buttons for device with 3 radios."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = Info(
-        MAC="AA:BB:CC:DD:EE:FF",
-        radios=[
-            Radio(zb_type=0, chip_index=0),
-            Radio(zb_type=1, chip_index=1),
-            Radio(zb_type=0, chip_index=2),
-        ],
-    )
     await setup_integration(hass, mock_config_entry)
 
     entities = er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
     )
-    assert len(entities) == 4
+    router_entities = [e for e in entities if "reconnect_zigbee_router" in e.unique_id]
+    assert len(router_entities) == 1
 
     entity = entity_registry.async_get("button.mock_title_reconnect_zigbee_router")
     assert entity is not None
+    assert entity.unique_id == "aa:bb:cc:dd:ee:ff-reconnect_zigbee_router_1"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_ultima_client")
+async def test_zwave_radio_naming(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test Z-Wave radio (index 2) button entity naming."""
+    await setup_integration(hass, mock_config_entry)
+
+    restart_btn = hass.states.get("button.mock_title_z_wave_restart")
+    assert restart_btn is not None
+    assert restart_btn.name == "Mock Title Z-Wave restart"
+
+    flash_btn = hass.states.get("button.mock_title_z_wave_flash_mode")
+    assert flash_btn is not None
+    assert flash_btn.name == "Mock Title Z-Wave flash mode"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_zwave_radio_naming_mr10(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test Z-Wave radio (index 1) button entity naming for MR10/MRW10."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info(
+        MAC="AA:BB:CC:DD:EE:FF",
+        model="SLZB-MRW10",
+        u_device=True,
+        radios=[
+            Radio(zb_type=0, chip_index=0),
+            Radio(zb_type=5, chip_index=1),
+        ],
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    restart_btn = hass.states.get("button.mock_title_z_wave_restart")
+    assert restart_btn is not None
+    assert restart_btn.name == "Mock Title Z-Wave restart"
+
+    flash_btn = hass.states.get("button.mock_title_z_wave_flash_mode")
+    assert flash_btn is not None
+    assert flash_btn.name == "Mock Title Z-Wave flash mode"

--- a/tests/components/smlight/test_sensor.py
+++ b/tests/components/smlight/test_sensor.py
@@ -14,11 +14,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import setup_integration
 
-from tests.common import (
-    MockConfigEntry,
-    async_load_json_object_fixture,
-    snapshot_platform,
-)
+from tests.common import MockConfigEntry, snapshot_platform
 
 pytestmark = [
     pytest.mark.usefixtures(
@@ -95,16 +91,12 @@ async def test_zigbee2_temp_sensor(
     assert state.state == "20.45"
 
 
+@pytest.mark.usefixtures("mock_ultima_client")
 async def test_zigbee_type_sensors(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_smlight_client: MagicMock,
 ) -> None:
-    """Test for zigbee type sensor with second radio."""
-    mock_smlight_client.get_info.side_effect = None
-    mock_smlight_client.get_info.return_value = Info.from_dict(
-        await async_load_json_object_fixture(hass, "info-MR1.json", DOMAIN)
-    )
+    """Test for zigbee type sensor with multiple radios."""
     await setup_integration(hass, mock_config_entry)
 
     state = hass.states.get("sensor.mock_title_zigbee_type")
@@ -114,6 +106,9 @@ async def test_zigbee_type_sensors(
     state = hass.states.get("sensor.mock_title_zigbee_type_2")
     assert state
     assert state.state == "router"
+
+    # Radio 3 is Z-Wave, so no Zigbee-type sensor should be created
+    assert hass.states.get("sensor.mock_title_zigbee_type_3") is None
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")

--- a/tests/components/smlight/test_update.py
+++ b/tests/components/smlight/test_update.py
@@ -391,3 +391,40 @@ async def test_update_blank_release_notes(
     result = await ws_client.receive_json()
     await hass.async_block_till_done()
     assert result["result"] is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_ultima_client")
+async def test_zwave_update_naming(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test Z-Wave radio (index 2) update entity naming."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("update.mock_title_z_wave_firmware")
+    assert state is not None
+    assert state.name == "Mock Title Z-Wave firmware"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_zwave_update_naming_mr10(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smlight_client: MagicMock,
+) -> None:
+    """Test Z-Wave radio (index 1) update entity naming for MR10/MRW10."""
+    mock_smlight_client.get_info.side_effect = None
+    mock_smlight_client.get_info.return_value = Info(
+        MAC="AA:BB:CC:DD:EE:FF",
+        model="SLZB-MRW10",
+        u_device=True,
+        radios=[
+            Radio(zb_type=0, chip_index=0),
+            Radio(zb_type=5, chip_index=1),
+        ],
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("update.mock_title_z_wave_firmware")
+    assert state is not None
+    assert state.name == "Mock Title Z-Wave firmware"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some SMLIGHT SLZB devices are equipped with Z-Wave radios instead of Zigbee. This PR updates and renames the translation strings for the affected entities to properly represent them as Z-Wave sensors rather than using the generic "Zigbee" naming.

Also refactors the Ultima mocks to a centralized version that represents the overall physical characteristics of Ultima devices. This cleans up various individual mocks to be more consistent across all tests.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
