### PR TITLE
Assign unique_id to IoTaWatt Output sensors

### DIFF
--- a/homeassistant/components/iotawatt/sensor.py
+++ b/homeassistant/components/iotawatt/sensor.py
@@ -168,6 +168,8 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
             self._attr_unique_id = (
                 f"{data.hub_mac_address}-input-{data.getChannel()}-{data.getUnit()}"
             )
+        else:
+            self._attr_unique_id = f"{data.hub_mac_address}-output-{data.getName()}"
         self.entity_description = entity_description
 
     @property
@@ -198,10 +200,7 @@ class IotaWattSensor(CoordinatorEntity[IotawattUpdater], SensorEntity):
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         if self._key not in self.coordinator.data["sensors"]:
-            if self._attr_unique_id:
-                er.async_get(self.hass).async_remove(self.entity_id)
-            else:
-                self.hass.async_create_task(self.async_remove())
+            er.async_get(self.hass).async_remove(self.entity_id)
             return
 
         if (begin := self._sensor_data.getBegin()) and (

--- a/tests/components/iotawatt/test_sensor.py
+++ b/tests/components/iotawatt/test_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.const import (
     UnitOfPower,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from . import INPUT_SENSOR, OUTPUT_SENSOR
@@ -27,7 +28,10 @@ from tests.common import async_fire_time_changed
 
 
 async def test_sensor_type_input(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    mock_iotawatt: MagicMock,
 ) -> None:
     """Test input sensors work."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -53,16 +57,24 @@ async def test_sensor_type_input(
     assert state.attributes["channel"] == "1"
     assert state.attributes["type"] == "Input"
 
+    entry = entity_registry.async_get("sensor.test_device_my_sensor")
+    assert entry is not None
+    assert entry.unique_id == "mock-mac-input-1-Watts"
+
     mock_iotawatt.getSensors.return_value["sensors"].pop("my_sensor_key")
     freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert hass.states.get("sensor.test_device_my_sensor") is None
+    assert entity_registry.async_get("sensor.test_device_my_sensor") is None
 
 
 async def test_sensor_type_output(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory, mock_iotawatt: MagicMock
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    freezer: FrozenDateTimeFactory,
+    mock_iotawatt: MagicMock,
 ) -> None:
     """Tests the sensor type of Output."""
     mock_iotawatt.getSensors.return_value["sensors"]["my_watthour_sensor_key"] = (
@@ -73,18 +85,23 @@ async def test_sensor_type_output(
 
     assert len(hass.states.async_entity_ids()) == 1
 
-    state = hass.states.get("sensor.my_watthour_sensor")
+    state = hass.states.get("sensor.test_device_my_watthour_sensor")
     assert state is not None
     assert state.state == "243"
     assert state.attributes[ATTR_STATE_CLASS] is SensorStateClass.TOTAL
-    assert state.attributes[ATTR_FRIENDLY_NAME] == "My WattHour Sensor"
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Test Device My WattHour Sensor"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfEnergy.WATT_HOUR
     assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.ENERGY
     assert state.attributes["type"] == "Output"
+
+    entry = entity_registry.async_get("sensor.test_device_my_watthour_sensor")
+    assert entry is not None
+    assert entry.unique_id == "mock-mac-output-My WattHour Sensor"
 
     mock_iotawatt.getSensors.return_value["sensors"].pop("my_watthour_sensor_key")
     freezer.tick(timedelta(seconds=30))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert hass.states.get("sensor.my_watthour_sensor") is None
+    assert hass.states.get("sensor.test_device_my_watthour_sensor") is None
+    assert entity_registry.async_get("sensor.test_device_my_watthour_sensor") is None


### PR DESCRIPTION
## Proposed change

IoTaWatt "Output" sensors (calculated/derived channels configured on
the device, as opposed to physical CT Input channels) never received
a `unique_id`, so they were never added to the entity registry. This
means they can't be renamed, assigned to an area, and don't survive
transient disappearance from the coordinator data cleanly (the code
fell back to a hard `async_remove()` instead of deregistering).

This builds a stable `unique_id` for Output sensors from the output's
name, which the IoTaWatt firmware guarantees unique per hub, mirroring
how Input sensors already use `{mac}-input-{channel}-{unit}`.

Verified against a real IoTaWatt device (not just the mocked test
suite): Output sensors and their derived WattHours energy sensors now
register correctly with stable unique_ids, e.g.
`<mac>-output-CombiIn` / `<mac>-output-CombiIn.wh`.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr