### PR TITLE
feat(solax-integration): Persist discovery result and lets the user be the tie breaker instead of asyncio scheduler

### DIFF
--- a/homeassistant/components/solax/__init__.py
+++ b/homeassistant/components/solax/__init__.py
@@ -1,18 +1,28 @@
 """The solax component."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
+from importlib.metadata import entry_points
 import logging
+from typing import Any
 
-from solax import InverterResponse, RealTimeAPI, real_time_api
+from solax import InverterResponse, RealTimeAPI, discover
 from solax.inverter import InverterError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT, Platform
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_MODEL,
+    CONF_PASSWORD,
+    CONF_PORT,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .const import SOLAX_INVERTER_ENTRY_POINT_GROUP
 from .coordinator import SolaxDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -36,14 +46,21 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: SolaxConfigEntry) -> bool:
     """Set up the sensors from a ConfigEntry."""
 
+    kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
+    if model := entry.data.get(CONF_MODEL):
+        (ep,) = entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP, name=model)
+        kwargs["inverters"] = [ep.load()]
+
     try:
-        api = await real_time_api(
+        inverter = await discover(
             entry.data[CONF_IP_ADDRESS],
             entry.data[CONF_PORT],
             entry.data[CONF_PASSWORD],
+            **kwargs,
         )
     except Exception as err:
         raise ConfigEntryNotReady from err
+    api = RealTimeAPI(inverter)
 
     async def _async_update() -> InverterResponse:
         try:

--- a/homeassistant/components/solax/__init__.py
+++ b/homeassistant/components/solax/__init__.py
@@ -47,7 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolaxConfigEntry) -> boo
 
     kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
     if model := entry.data.get(CONF_MODEL):
-        kwargs["inverters"] = [INVERTER_MODELS[model]]
+        kwargs["inverters"] = [INVERTER_MODELS[model].load()]
 
     try:
         inverter = await discover(

--- a/homeassistant/components/solax/__init__.py
+++ b/homeassistant/components/solax/__init__.py
@@ -3,7 +3,6 @@
 import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
-from importlib.metadata import entry_points
 import logging
 from typing import Any
 
@@ -22,7 +21,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from .const import SOLAX_INVERTER_ENTRY_POINT_GROUP
+from .const import INVERTER_MODELS
 from .coordinator import SolaxDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
@@ -48,8 +47,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolaxConfigEntry) -> boo
 
     kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
     if model := entry.data.get(CONF_MODEL):
-        (ep,) = entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP, name=model)
-        kwargs["inverters"] = [ep.load()]
+        kwargs["inverters"] = [INVERTER_MODELS[model]]
 
     try:
         inverter = await discover(

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -41,7 +41,7 @@ class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the flow."""
         super().__init__()
         self._connection_data: dict[str, Any] = {}
-        self._discovered_inverters: dict[str, Inverter] = {}
+        self._potential_types: dict[str, Inverter] = {}
 
     def _select_model_schema(self) -> vol.Schema:
         """Return the schema listing only the discovered inverters."""
@@ -49,7 +49,7 @@ class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_MODEL): selector.SelectSelector(
                     selector.SelectSelectorConfig(
-                        options=sorted(self._discovered_inverters),
+                        options=sorted(self._potential_types),
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
                 )
@@ -96,27 +96,27 @@ class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
         try:
-            discovered = await discover(
+            potentials = await discover(
                 user_input[CONF_IP_ADDRESS],
                 user_input[CONF_PORT],
                 user_input[CONF_PASSWORD],
                 return_when=asyncio.ALL_COMPLETED,
             )
-            self._discovered_inverters = {
-                model_name_for_inverter(inverter): inverter for inverter in discovered
-            }
         except ConnectionError, DiscoveryError:
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
+            self._potential_types = {
+                model_name_for_inverter(inverter): inverter for inverter in potentials
+            }
             self._connection_data = user_input
 
-            if len(self._discovered_inverters) > 1:
+            if len(self._potential_types) > 1:
                 return await self.async_step_select_model()
 
-            model, inverter = next(iter(self._discovered_inverters.items()))
+            model, inverter = next(iter(self._potential_types.items()))
             return await self._async_finalize(
                 model, inverter, step_id="user", data_schema=STEP_USER_DATA_SCHEMA
             )
@@ -133,7 +133,7 @@ class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
             model = user_input[CONF_MODEL]
             return await self._async_finalize(
                 model,
-                self._discovered_inverters[model],
+                self._potential_types[model],
                 step_id="select_model",
                 data_schema=self._select_model_schema(),
             )

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -39,7 +39,7 @@ async def validate_api(data: dict[str, Any]) -> str:
 
     kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
     if model := data.get(CONF_MODEL):
-        kwargs["inverters"] = [INVERTER_MODELS[model]]
+        kwargs["inverters"] = [INVERTER_MODELS[model].load()]
 
     inverter = await discover(
         data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_PASSWORD], **kwargs

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -1,39 +1,61 @@
 """Config flow for solax integration."""
 
+import asyncio
+from importlib.metadata import entry_points
 import logging
 from typing import Any, override
 
-from solax import real_time_api
+from solax import RealTimeAPI, discover
 from solax.discovery import DiscoveryError
+from solax.inverter import Inverter
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
-from homeassistant.helpers import config_validation as cv
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
+from homeassistant.helpers import config_validation as cv, selector
 
-from .const import DOMAIN
+from .const import DOMAIN, SOLAX_INVERTER_ENTRY_POINT_GROUP
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 80
 DEFAULT_PASSWORD = ""
 
+
+def _get_inverter_models() -> dict[str, type[Inverter]]:
+    """Return the available inverter models keyed by their entry point name."""
+    return {
+        ep.name: ep.load()
+        for ep in entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP)
+    }
+
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Optional(CONF_MODEL): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=sorted(_get_inverter_models()),
+                mode=selector.SelectSelectorMode.DROPDOWN,
+            )
+        ),
     }
 )
 
 
-async def validate_api(data) -> str:
+async def validate_api(data: dict[str, Any]) -> str:
     """Validate the credentials."""
 
-    api = await real_time_api(
-        data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_PASSWORD]
+    kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
+    if model := data.get(CONF_MODEL):
+        kwargs["inverters"] = [_get_inverter_models()[model]]
+
+    inverter = await discover(
+        data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_PASSWORD], **kwargs
     )
-    response = await api.get_data()
+    response = await RealTimeAPI(inverter).get_data()
     return response.serial_number
 
 

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -6,7 +6,7 @@ from typing import Any, override
 
 from solax import RealTimeAPI, discover
 from solax.discovery import DiscoveryError
-from solax.inverter import Inverter
+from solax.inverter import Inverter, InverterError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -64,6 +64,9 @@ class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
         try:
             response = await RealTimeAPI(inverter).get_data()
         except ConnectionError, DiscoveryError:
+            errors["base"] = "cannot_connect"
+        except InverterError as err:
+            _LOGGER.debug("Inverter communication error: %s", err)
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -6,13 +6,14 @@ from typing import Any, override
 
 from solax import RealTimeAPI, discover
 from solax.discovery import DiscoveryError
+from solax.inverter import Inverter
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
 from homeassistant.helpers import config_validation as cv, selector
 
-from .const import DOMAIN, INVERTER_MODELS
+from .const import DOMAIN, model_name_for_inverter
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -24,56 +25,119 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
-        vol.Optional(CONF_MODEL): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=sorted(INVERTER_MODELS),
-                mode=selector.SelectSelectorMode.DROPDOWN,
-            )
-        ),
     }
 )
 
 
-async def validate_api(data: dict[str, Any]) -> str:
-    """Validate the credentials."""
-
-    kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
-    if model := data.get(CONF_MODEL):
-        kwargs["inverters"] = [INVERTER_MODELS[model].load()]
-
-    inverter = await discover(
-        data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_PASSWORD], **kwargs
-    )
-    response = await RealTimeAPI(inverter).get_data()
-    return response.serial_number
-
-
 class SolaxConfigFlow(ConfigFlow, domain=DOMAIN):
-    """Handle a config flow for Solax."""
+    """Handle a config flow for Solax.
 
-    @override
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
+    Two step flow:
+    1. Get connection data and do a discovery
+    2. If multiple inverters are returned from step 1, then show them to the user to choose one. If one is returned, skip this step.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the flow."""
+        super().__init__()
+        self._connection_data: dict[str, Any] = {}
+        self._discovered_inverters: dict[str, Inverter] = {}
+
+    def _select_model_schema(self) -> vol.Schema:
+        """Return the schema listing only the discovered inverters."""
+        return vol.Schema(
+            {
+                vol.Required(CONF_MODEL): selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=sorted(self._discovered_inverters),
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                )
+            }
+        )
+
+    async def _async_finalize(
+        self, model: str, inverter: Inverter, *, step_id: str, data_schema: vol.Schema
     ) -> ConfigFlowResult:
-        """Handle the initial step."""
-        errors: dict[str, Any] = {}
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
-            )
-
+        """Fetch the serial number and create the entry, or redisplay on error."""
+        errors: dict[str, str] = {}
         try:
-            serial_number = await validate_api(user_input)
+            response = await RealTimeAPI(inverter).get_data()
         except ConnectionError, DiscoveryError:
             errors["base"] = "cannot_connect"
         except Exception:
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            await self.async_set_unique_id(serial_number)
+            await self.async_set_unique_id(response.serial_number)
             self._abort_if_unique_id_configured()
-            return self.async_create_entry(title=serial_number, data=user_input)
+            return self.async_create_entry(
+                title=response.serial_number,
+                data={**self._connection_data, CONF_MODEL: model},
+            )
+
+        return self.async_show_form(
+            step_id=step_id, data_schema=data_schema, errors=errors
+        )
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Shows the connection form, and do the discovery.
+
+        If discovery resulted in multiple inverters, show the select_model form,
+        If only one skip and finalize.
+        """
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
+
+        errors: dict[str, str] = {}
+        try:
+            discovered = await discover(
+                user_input[CONF_IP_ADDRESS],
+                user_input[CONF_PORT],
+                user_input[CONF_PASSWORD],
+                return_when=asyncio.ALL_COMPLETED,
+            )
+            self._discovered_inverters = {
+                model_name_for_inverter(inverter): inverter for inverter in discovered
+            }
+        except ConnectionError, DiscoveryError:
+            errors["base"] = "cannot_connect"
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            errors["base"] = "unknown"
+        else:
+            self._connection_data = user_input
+
+            if len(self._discovered_inverters) > 1:
+                return await self.async_step_select_model()
+
+            model, inverter = next(iter(self._discovered_inverters.items()))
+            return await self._async_finalize(
+                model, inverter, step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+            )
 
         return self.async_show_form(
             step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_select_model(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle model selection when multiple inverters matched."""
+        if user_input is not None:
+            model = user_input[CONF_MODEL]
+            return await self._async_finalize(
+                model,
+                self._discovered_inverters[model],
+                step_id="select_model",
+                data_schema=self._select_model_schema(),
+            )
+
+        return self.async_show_form(
+            step_id="select_model", data_schema=self._select_model_schema()
         )

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -1,34 +1,23 @@
 """Config flow for solax integration."""
 
 import asyncio
-from importlib.metadata import entry_points
 import logging
 from typing import Any, override
 
 from solax import RealTimeAPI, discover
 from solax.discovery import DiscoveryError
-from solax.inverter import Inverter
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
 from homeassistant.helpers import config_validation as cv, selector
 
-from .const import DOMAIN, SOLAX_INVERTER_ENTRY_POINT_GROUP
+from .const import DOMAIN, INVERTER_MODELS
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 80
 DEFAULT_PASSWORD = ""
-
-
-def _get_inverter_models() -> dict[str, type[Inverter]]:
-    """Return the available inverter models keyed by their entry point name."""
-    return {
-        ep.name: ep.load()
-        for ep in entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP)
-    }
-
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -37,7 +26,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
         vol.Optional(CONF_MODEL): selector.SelectSelector(
             selector.SelectSelectorConfig(
-                options=sorted(_get_inverter_models()),
+                options=sorted(INVERTER_MODELS),
                 mode=selector.SelectSelectorMode.DROPDOWN,
             )
         ),
@@ -50,7 +39,7 @@ async def validate_api(data: dict[str, Any]) -> str:
 
     kwargs: dict[str, Any] = {"return_when": asyncio.FIRST_COMPLETED}
     if model := data.get(CONF_MODEL):
-        kwargs["inverters"] = [_get_inverter_models()[model]]
+        kwargs["inverters"] = [INVERTER_MODELS[model]]
 
     inverter = await discover(
         data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_PASSWORD], **kwargs

--- a/homeassistant/components/solax/const.py
+++ b/homeassistant/components/solax/const.py
@@ -3,3 +3,5 @@
 DOMAIN = "solax"
 
 MANUFACTURER = "SolaX Power"
+
+SOLAX_INVERTER_ENTRY_POINT_GROUP = "solax.inverter"

--- a/homeassistant/components/solax/const.py
+++ b/homeassistant/components/solax/const.py
@@ -2,6 +2,8 @@
 
 from importlib.metadata import EntryPoint, entry_points
 
+from solax.inverter import Inverter
+
 DOMAIN = "solax"
 
 MANUFACTURER = "SolaX Power"
@@ -11,3 +13,12 @@ SOLAX_INVERTER_ENTRY_POINT_GROUP = "solax.inverter"
 INVERTER_MODELS: dict[str, EntryPoint] = {
     ep.name: ep for ep in entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP)
 }
+
+
+def model_name_for_inverter(inverter: Inverter) -> str:
+    """Return the INVERTER_MODELS key matching a discovered inverter instance."""
+    return next(
+        name
+        for name, entry_point in INVERTER_MODELS.items()
+        if isinstance(inverter, entry_point.load())
+    )

--- a/homeassistant/components/solax/const.py
+++ b/homeassistant/components/solax/const.py
@@ -1,7 +1,15 @@
 """Constants for the solax integration."""
 
+from importlib.metadata import entry_points
+
+from solax.inverter import Inverter
+
 DOMAIN = "solax"
 
 MANUFACTURER = "SolaX Power"
 
 SOLAX_INVERTER_ENTRY_POINT_GROUP = "solax.inverter"
+
+INVERTER_MODELS: dict[str, type[Inverter]] = {
+    ep.name: ep.load() for ep in entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP)
+}

--- a/homeassistant/components/solax/const.py
+++ b/homeassistant/components/solax/const.py
@@ -1,8 +1,6 @@
 """Constants for the solax integration."""
 
-from importlib.metadata import entry_points
-
-from solax.inverter import Inverter
+from importlib.metadata import EntryPoint, entry_points
 
 DOMAIN = "solax"
 
@@ -10,6 +8,6 @@ MANUFACTURER = "SolaX Power"
 
 SOLAX_INVERTER_ENTRY_POINT_GROUP = "solax.inverter"
 
-INVERTER_MODELS: dict[str, type[Inverter]] = {
-    ep.name: ep.load() for ep in entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP)
+INVERTER_MODELS: dict[str, EntryPoint] = {
+    ep.name: ep for ep in entry_points(group=SOLAX_INVERTER_ENTRY_POINT_GROUP)
 }

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -25,7 +25,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import SolaxConfigEntry
-from .const import DOMAIN, MANUFACTURER
+from .const import DOMAIN, MANUFACTURER, model_name_for_inverter
 from .coordinator import SolaxDataUpdateCoordinator
 
 DEFAULT_PORT = 80
@@ -97,6 +97,7 @@ async def async_setup_entry(
     resp = coordinator.data
     serial = resp.serial_number
     version = resp.version
+    model = model_name_for_inverter(api.inverter)
     entities: list[InverterSensorEntity] = []
     for sensor, (idx, measurement) in api.inverter.sensor_map().items():
         description = SENSOR_DESCRIPTIONS[(measurement.unit, measurement.is_monotonic)]
@@ -109,6 +110,7 @@ async def async_setup_entry(
                 uid,
                 serial,
                 version,
+                model,
                 sensor,
                 description,
             )
@@ -128,6 +130,7 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
         uid: str,
         serial: str,
         version: str,
+        model: str,
         key: str,
         entity_description: SensorEntityDescription,
     ) -> None:
@@ -140,6 +143,7 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
             identifiers={(DOMAIN, serial)},
             manufacturer=MANUFACTURER,
             name=f"{manufacturer} {serial}",
+            model=model,
             sw_version=version,
         )
         self.key = key

--- a/homeassistant/components/solax/strings.json
+++ b/homeassistant/components/solax/strings.json
@@ -11,8 +11,12 @@
       "user": {
         "data": {
           "ip_address": "[%key:common::config_flow::data::ip%]",
+          "model": "Inverter model",
           "password": "[%key:common::config_flow::data::password%]",
           "port": "[%key:common::config_flow::data::port%]"
+        },
+        "data_description": {
+          "model": "Leave blank to automatically detect the inverter model"
         }
       }
     }

--- a/homeassistant/components/solax/strings.json
+++ b/homeassistant/components/solax/strings.json
@@ -8,15 +8,19 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "select_model": {
+        "data": {
+          "model": "Inverter model"
+        },
+        "data_description": {
+          "model": "Multiple inverter models responded at this address. Select the one that matches your device."
+        }
+      },
       "user": {
         "data": {
           "ip_address": "[%key:common::config_flow::data::ip%]",
-          "model": "Inverter model",
           "password": "[%key:common::config_flow::data::password%]",
           "port": "[%key:common::config_flow::data::port%]"
-        },
-        "data_description": {
-          "model": "Leave blank to automatically detect the inverter model"
         }
       }
     }

--- a/homeassistant/components/solax/strings.json
+++ b/homeassistant/components/solax/strings.json
@@ -13,7 +13,7 @@
           "model": "Inverter model"
         },
         "data_description": {
-          "model": "Multiple inverter models responded at this address. Select the one that matches your device."
+          "model": "Auto-discovery matched multiple inverter models at this address. Select the model that matches your device."
         }
       },
       "user": {

--- a/tests/components/solax/conftest.py
+++ b/tests/components/solax/conftest.py
@@ -1,0 +1,22 @@
+"""Fixtures for the solax integration tests."""
+
+import pytest
+
+from homeassistant.components.solax.const import DOMAIN
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock solax config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: "192.168.1.87",
+            CONF_PORT: 80,
+            CONF_PASSWORD: "password",
+        },
+        unique_id="ABCDEFGHIJ",
+    )

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -24,10 +24,11 @@ def __mock_get_data():
 
 
 @pytest.mark.parametrize(
-    "user_input",
+    ("user_input", "expected_inverters"),
     [
         pytest.param(
             {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+            None,
             id="auto_detect",
         ),
         pytest.param(
@@ -37,12 +38,15 @@ def __mock_get_data():
                 CONF_PASSWORD: "password",
                 CONF_MODEL: "x1_mini_v34",
             },
+            [X1MiniV34],
             id="model_selected",
         ),
     ],
 )
 async def test_form_success(
-    hass: HomeAssistant, user_input: dict[str, str | int]
+    hass: HomeAssistant,
+    user_input: dict[str, str | int],
+    expected_inverters: list[type] | None,
 ) -> None:
     """Test successful form."""
     flow = await hass.config_entries.flow.async_init(
@@ -55,7 +59,7 @@ async def test_form_success(
         patch(
             "homeassistant.components.solax.config_flow.discover",
             return_value=X1MiniV34,
-        ),
+        ) as mock_discover,
         patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
         patch(
             "homeassistant.components.solax.async_setup_entry",
@@ -71,6 +75,7 @@ async def test_form_success(
     assert entry_result["title"] == "ABCDEFGHIJ"
     assert entry_result["data"] == user_input
     assert len(mock_setup_entry.mock_calls) == 1
+    assert mock_discover.call_args.kwargs.get("inverters") == expected_inverters
 
 
 async def test_form_connect_error(hass: HomeAssistant) -> None:

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -2,19 +2,15 @@
 
 from unittest.mock import patch
 
-from solax import RealTimeAPI
+import pytest
 from solax.inverter import InverterResponse
 from solax.inverters import X1MiniV34
 
 from homeassistant import config_entries
 from homeassistant.components.solax.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-
-
-def __mock_real_time_api_success():
-    return RealTimeAPI(X1MiniV34)
 
 
 def __mock_get_data():
@@ -27,7 +23,27 @@ def __mock_get_data():
     )
 
 
-async def test_form_success(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    "user_input",
+    [
+        pytest.param(
+            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+            id="auto_detect",
+        ),
+        pytest.param(
+            {
+                CONF_IP_ADDRESS: "192.168.1.87",
+                CONF_PORT: 80,
+                CONF_PASSWORD: "password",
+                CONF_MODEL: "x1_mini_v34",
+            },
+            id="model_selected",
+        ),
+    ],
+)
+async def test_form_success(
+    hass: HomeAssistant, user_input: dict[str, str | int]
+) -> None:
     """Test successful form."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -37,8 +53,8 @@ async def test_form_success(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.components.solax.config_flow.real_time_api",
-            return_value=__mock_real_time_api_success(),
+            "homeassistant.components.solax.config_flow.discover",
+            return_value=X1MiniV34,
         ),
         patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
         patch(
@@ -47,18 +63,13 @@ async def test_form_success(hass: HomeAssistant) -> None:
         ) as mock_setup_entry,
     ):
         entry_result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"],
-            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+            flow["flow_id"], user_input
         )
         await hass.async_block_till_done()
 
     assert entry_result["type"] is FlowResultType.CREATE_ENTRY
     assert entry_result["title"] == "ABCDEFGHIJ"
-    assert entry_result["data"] == {
-        CONF_IP_ADDRESS: "192.168.1.87",
-        CONF_PORT: 80,
-        CONF_PASSWORD: "password",
-    }
+    assert entry_result["data"] == user_input
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -71,7 +82,7 @@ async def test_form_connect_error(hass: HomeAssistant) -> None:
     assert flow["errors"] == {}
 
     with patch(
-        "homeassistant.components.solax.config_flow.real_time_api",
+        "homeassistant.components.solax.config_flow.discover",
         side_effect=ConnectionError,
     ):
         entry_result = await hass.config_entries.flow.async_configure(
@@ -92,7 +103,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
     assert flow["errors"] == {}
 
     with patch(
-        "homeassistant.components.solax.config_flow.real_time_api",
+        "homeassistant.components.solax.config_flow.discover",
         side_effect=Exception,
     ):
         entry_result = await hass.config_entries.flow.async_configure(

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -4,7 +4,7 @@ import asyncio
 from unittest.mock import patch
 
 import pytest
-from solax.inverter import Inverter, InverterResponse
+from solax.inverter import Inverter, InverterError, InverterResponse
 from solax.inverters import X1Boost, X1MiniV34
 
 from homeassistant import config_entries
@@ -129,6 +129,7 @@ async def test_form_discover_error(
     ("side_effect", "expected_error"),
     [
         pytest.param(ConnectionError, "cannot_connect", id="cannot_connect"),
+        pytest.param(InverterError, "cannot_connect", id="inverter_error"),
         pytest.param(Exception, "unknown", id="unknown"),
     ],
 )

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -1,10 +1,11 @@
 """Tests for the solax config flow."""
 
+import asyncio
 from unittest.mock import patch
 
 import pytest
-from solax.inverter import InverterResponse
-from solax.inverters import X1MiniV34
+from solax.inverter import Inverter, InverterResponse
+from solax.inverters import X1Boost, X1MiniV34
 
 from homeassistant import config_entries
 from homeassistant.components.solax.const import DOMAIN
@@ -12,8 +13,27 @@ from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+CONNECTION_INPUT: dict[str, str | int] = {
+    CONF_IP_ADDRESS: "192.168.1.87",
+    CONF_PORT: 80,
+    CONF_PASSWORD: "password",
+}
 
-def __mock_get_data():
+
+def _build_inverter(inverter_cls: type[Inverter]) -> Inverter:
+    """Build a real inverter instance to use as a discover() return value."""
+    return next(
+        iter(
+            inverter_cls.build_all_variants(
+                CONNECTION_INPUT[CONF_IP_ADDRESS],
+                CONNECTION_INPUT[CONF_PORT],
+                CONNECTION_INPUT[CONF_PASSWORD],
+            )
+        )
+    )
+
+
+def __mock_get_data() -> InverterResponse:
     return InverterResponse(
         data=None,
         dongle_serial_number="ABCDEFGHIJ",
@@ -24,41 +44,36 @@ def __mock_get_data():
 
 
 @pytest.mark.parametrize(
-    ("user_input", "expected_inverters"),
+    ("discovered_inverter_classes", "steps", "expected_model"),
     [
+        pytest.param({X1MiniV34}, [CONNECTION_INPUT], "x1_mini_v34", id="single_match"),
         pytest.param(
-            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
-            None,
-            id="auto_detect",
-        ),
-        pytest.param(
-            {
-                CONF_IP_ADDRESS: "192.168.1.87",
-                CONF_PORT: 80,
-                CONF_PASSWORD: "password",
-                CONF_MODEL: "x1_mini_v34",
-            },
-            [X1MiniV34],
-            id="model_selected",
+            {X1MiniV34, X1Boost},
+            [CONNECTION_INPUT, {CONF_MODEL: "x1_mini_v34"}],
+            "x1_mini_v34",
+            id="multiple_matches",
         ),
     ],
 )
 async def test_form_success(
     hass: HomeAssistant,
-    user_input: dict[str, str | int],
-    expected_inverters: list[type] | None,
+    discovered_inverter_classes: set[type[Inverter]],
+    steps: list[dict[str, str | int]],
+    expected_model: str,
 ) -> None:
-    """Test successful form."""
+    """Test successful discovery and entry creation, with/without a model choice."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert flow["type"] is FlowResultType.FORM
-    assert flow["errors"] == {}
+    assert flow["errors"] is None
+
+    discovered = {_build_inverter(cls) for cls in discovered_inverter_classes}
 
     with (
         patch(
             "homeassistant.components.solax.config_flow.discover",
-            return_value=X1MiniV34,
+            return_value=discovered,
         ) as mock_discover,
         patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
         patch(
@@ -66,55 +81,119 @@ async def test_form_success(
             return_value=True,
         ) as mock_setup_entry,
     ):
-        entry_result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"], user_input
-        )
+        result = flow
+        for step_input in steps:
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], step_input
+            )
         await hass.async_block_till_done()
 
-    assert entry_result["type"] is FlowResultType.CREATE_ENTRY
-    assert entry_result["title"] == "ABCDEFGHIJ"
-    assert entry_result["data"] == user_input
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "ABCDEFGHIJ"
+    assert result["data"] == {**CONNECTION_INPUT, CONF_MODEL: expected_model}
     assert len(mock_setup_entry.mock_calls) == 1
-    assert mock_discover.call_args.kwargs.get("inverters") == expected_inverters
+    assert mock_discover.call_count == 1
+    assert mock_discover.call_args.kwargs == {"return_when": asyncio.ALL_COMPLETED}
 
 
-async def test_form_connect_error(hass: HomeAssistant) -> None:
-    """Test cannot connect form."""
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        pytest.param(ConnectionError, "cannot_connect", id="cannot_connect"),
+        pytest.param(Exception, "unknown", id="unknown"),
+    ],
+)
+async def test_form_discover_error(
+    hass: HomeAssistant, side_effect: type[Exception], expected_error: str
+) -> None:
+    """Test discovery failures redisplay the user step with an error."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert flow["type"] is FlowResultType.FORM
-    assert flow["errors"] == {}
+    assert flow["errors"] is None
 
     with patch(
-        "homeassistant.components.solax.config_flow.discover",
-        side_effect=ConnectionError,
+        "homeassistant.components.solax.config_flow.discover", side_effect=side_effect
     ):
-        entry_result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"],
-            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], CONNECTION_INPUT
         )
 
-    assert entry_result["type"] is FlowResultType.FORM
-    assert entry_result["errors"] == {"base": "cannot_connect"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": expected_error}
 
 
-async def test_form_unknown_error(hass: HomeAssistant) -> None:
-    """Test unknown error form."""
+@pytest.mark.parametrize(
+    ("side_effect", "expected_error"),
+    [
+        pytest.param(ConnectionError, "cannot_connect", id="cannot_connect"),
+        pytest.param(Exception, "unknown", id="unknown"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("discovered_inverter_classes", "steps", "expected_step_id"),
+    [
+        pytest.param({X1MiniV34}, [CONNECTION_INPUT], "user", id="single_match"),
+        pytest.param(
+            {X1MiniV34, X1Boost},
+            [CONNECTION_INPUT, {CONF_MODEL: "x1_mini_v34"}],
+            "select_model",
+            id="multiple_matches",
+        ),
+    ],
+)
+async def test_form_finalize_error(
+    hass: HomeAssistant,
+    discovered_inverter_classes: set[type[Inverter]],
+    steps: list[dict[str, str | int]],
+    expected_step_id: str,
+    side_effect: type[Exception],
+    expected_error: str,
+) -> None:
+    """Test serial-number fetch failures redisplay the current step with an error."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    assert flow["type"] is FlowResultType.FORM
-    assert flow["errors"] == {}
+    discovered = {_build_inverter(cls) for cls in discovered_inverter_classes}
+
+    with (
+        patch(
+            "homeassistant.components.solax.config_flow.discover",
+            return_value=discovered,
+        ),
+        patch("solax.RealTimeAPI.get_data", side_effect=side_effect),
+    ):
+        result = flow
+        for step_input in steps:
+            result = await hass.config_entries.flow.async_configure(
+                result["flow_id"], step_input
+            )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == expected_step_id
+    assert result["errors"] == {"base": expected_error}
+
+
+async def test_form_select_model_step_options(hass: HomeAssistant) -> None:
+    """Test the select_model step only lists the discovered inverter models."""
+    flow = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    discovered = {_build_inverter(X1MiniV34), _build_inverter(X1Boost)}
 
     with patch(
         "homeassistant.components.solax.config_flow.discover",
-        side_effect=Exception,
+        return_value=discovered,
     ):
-        entry_result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"],
-            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+        result = await hass.config_entries.flow.async_configure(
+            flow["flow_id"], CONNECTION_INPUT
         )
 
-    assert entry_result["type"] is FlowResultType.FORM
-    assert entry_result["errors"] == {"base": "unknown"}
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "select_model"
+    assert result["data_schema"].schema[CONF_MODEL].config["options"] == [
+        "x1_boost",
+        "x1_mini_v34",
+    ]

--- a/tests/components/solax/test_init.py
+++ b/tests/components/solax/test_init.py
@@ -6,7 +6,7 @@ import pytest
 from solax.inverter import InverterError, InverterResponse
 from solax.inverters import X1MiniV34
 
-from homeassistant.components.solax.const import DOMAIN, INVERTER_MODELS
+from homeassistant.components.solax.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -39,7 +39,7 @@ def __mock_get_data() -> InverterResponse:
                 CONF_PASSWORD: "password",
                 CONF_MODEL: "x1_mini_v34",
             },
-            [INVERTER_MODELS["x1_mini_v34"]],
+            [X1MiniV34],
             id="model_selected",
         ),
     ],

--- a/tests/components/solax/test_init.py
+++ b/tests/components/solax/test_init.py
@@ -2,24 +2,17 @@
 
 from unittest.mock import patch
 
-from freezegun.api import FrozenDateTimeFactory
 import pytest
-from solax.inverter import InverterError, InverterResponse
+from solax.inverter import InverterResponse
 from solax.inverters import X1MiniV34
 
-from homeassistant.components.solax import SCAN_INTERVAL
 from homeassistant.components.solax.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import (
-    CONF_IP_ADDRESS,
-    CONF_MODEL,
-    CONF_PASSWORD,
-    CONF_PORT,
-    STATE_UNAVAILABLE,
-)
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.common import MockConfigEntry
 
 
 def __mock_get_data() -> InverterResponse:
@@ -84,12 +77,12 @@ async def test_setup_entry_success(
     assert mock_discover.call_args.kwargs.get("inverters") == expected_inverters
 
 
-async def test_coordinator_update_failure(
+async def test_device_info_model(
     hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test an InverterError during a refresh marks the entities unavailable."""
+    """Test the device registry entry has the discovered inverter model set."""
     mock_config_entry.add_to_hass(hass)
 
     inverter = next(
@@ -109,23 +102,9 @@ async def test_coordinator_update_failure(
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-
-    # making sure the base state is actually healthy before the test run.
-    assert (
-        hass.states.get("sensor.solax_abcdefghij_network_voltage").state
-        != STATE_UNAVAILABLE
-    )
-
-    with patch("solax.RealTimeAPI.get_data", side_effect=InverterError):
-        freezer.tick(SCAN_INTERVAL)
-        async_fire_time_changed(hass)
-        await hass.async_block_till_done()
-
-    assert (
-        hass.states.get("sensor.solax_abcdefghij_network_voltage").state
-        == STATE_UNAVAILABLE
-    )
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "ABCDEFGHIJ")})
+    assert device is not None
+    assert device.model == "x1_mini_v34"
 
 
 async def test_setup_entry_not_ready(

--- a/tests/components/solax/test_init.py
+++ b/tests/components/solax/test_init.py
@@ -85,23 +85,19 @@ async def test_setup_entry_success(
 
 
 async def test_coordinator_update_failure(
-    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test an InverterError during a refresh marks the entities unavailable."""
-    entry_data = {
-        CONF_IP_ADDRESS: "192.168.1.87",
-        CONF_PORT: 80,
-        CONF_PASSWORD: "password",
-    }
-    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="ABCDEFGHIJ")
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     inverter = next(
         iter(
             X1MiniV34.build_all_variants(
-                entry_data[CONF_IP_ADDRESS],
-                entry_data[CONF_PORT],
-                entry_data[CONF_PASSWORD],
+                mock_config_entry.data[CONF_IP_ADDRESS],
+                mock_config_entry.data[CONF_PORT],
+                mock_config_entry.data[CONF_PASSWORD],
             )
         )
     )
@@ -110,10 +106,10 @@ async def test_coordinator_update_failure(
         patch("homeassistant.components.solax.discover", return_value=inverter),
         patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     # making sure the base state is actually healthy before the test run.
     assert (
@@ -132,20 +128,14 @@ async def test_coordinator_update_failure(
     )
 
 
-async def test_setup_entry_not_ready(hass: HomeAssistant) -> None:
+async def test_setup_entry_not_ready(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
     """Test ConfigEntryNotReady is raised when discovery fails."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={
-            CONF_IP_ADDRESS: "192.168.1.87",
-            CONF_PORT: 80,
-            CONF_PASSWORD: "password",
-        },
-    )
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     with patch("homeassistant.components.solax.discover", side_effect=ConnectionError):
-        assert not await hass.config_entries.async_setup(entry.entry_id)
+        assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/solax/test_init.py
+++ b/tests/components/solax/test_init.py
@@ -1,0 +1,131 @@
+"""Tests for the solax integration setup."""
+
+from unittest.mock import patch
+
+import pytest
+from solax.inverter import InverterError, InverterResponse
+from solax.inverters import X1MiniV34
+
+from homeassistant.components.solax.const import DOMAIN, INVERTER_MODELS
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+def __mock_get_data() -> InverterResponse:
+    return InverterResponse(
+        data=dict.fromkeys(X1MiniV34.sensor_map(), 0),
+        dongle_serial_number="ABCDEFGHIJ",
+        version="2.034.06",
+        type=4,
+        inverter_serial_number="XXXXXXX",
+    )
+
+
+@pytest.mark.parametrize(
+    ("entry_data", "expected_inverters"),
+    [
+        pytest.param(
+            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+            None,
+            id="auto_detect",
+        ),
+        pytest.param(
+            {
+                CONF_IP_ADDRESS: "192.168.1.87",
+                CONF_PORT: 80,
+                CONF_PASSWORD: "password",
+                CONF_MODEL: "x1_mini_v34",
+            },
+            [INVERTER_MODELS["x1_mini_v34"]],
+            id="model_selected",
+        ),
+    ],
+)
+async def test_setup_entry_success(
+    hass: HomeAssistant,
+    entry_data: dict[str, str | int],
+    expected_inverters: list[type] | None,
+) -> None:
+    """Test the entry loads and discover() is called with the right inverters."""
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="ABCDEFGHIJ")
+    entry.add_to_hass(hass)
+
+    inverter = next(
+        iter(
+            X1MiniV34.build_all_variants(
+                entry_data[CONF_IP_ADDRESS],
+                entry_data[CONF_PORT],
+                entry_data[CONF_PASSWORD],
+            )
+        )
+    )
+
+    with (
+        patch(
+            "homeassistant.components.solax.discover", return_value=inverter
+        ) as mock_discover,
+        patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert mock_discover.call_args.kwargs.get("inverters") == expected_inverters
+
+
+async def test_coordinator_update_failure(hass: HomeAssistant) -> None:
+    """Test an InverterError during a refresh is converted to UpdateFailed."""
+    entry_data = {
+        CONF_IP_ADDRESS: "192.168.1.87",
+        CONF_PORT: 80,
+        CONF_PASSWORD: "password",
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="ABCDEFGHIJ")
+    entry.add_to_hass(hass)
+
+    inverter = next(
+        iter(
+            X1MiniV34.build_all_variants(
+                entry_data[CONF_IP_ADDRESS],
+                entry_data[CONF_PORT],
+                entry_data[CONF_PASSWORD],
+            )
+        )
+    )
+
+    with (
+        patch("homeassistant.components.solax.discover", return_value=inverter),
+        patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    coordinator = entry.runtime_data.coordinator
+
+    with patch("solax.RealTimeAPI.get_data", side_effect=InverterError):
+        await coordinator.async_refresh()
+
+    assert coordinator.last_update_success is False
+
+
+async def test_setup_entry_not_ready(hass: HomeAssistant) -> None:
+    """Test ConfigEntryNotReady is raised when discovery fails."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_IP_ADDRESS: "192.168.1.87",
+            CONF_PORT: 80,
+            CONF_PASSWORD: "password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.solax.discover", side_effect=ConnectionError):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/solax/test_init.py
+++ b/tests/components/solax/test_init.py
@@ -2,16 +2,24 @@
 
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 from solax.inverter import InverterError, InverterResponse
 from solax.inverters import X1MiniV34
 
+from homeassistant.components.solax import SCAN_INTERVAL
 from homeassistant.components.solax.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_IP_ADDRESS, CONF_MODEL, CONF_PASSWORD, CONF_PORT
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_MODEL,
+    CONF_PASSWORD,
+    CONF_PORT,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 def __mock_get_data() -> InverterResponse:
@@ -76,8 +84,10 @@ async def test_setup_entry_success(
     assert mock_discover.call_args.kwargs.get("inverters") == expected_inverters
 
 
-async def test_coordinator_update_failure(hass: HomeAssistant) -> None:
-    """Test an InverterError during a refresh is converted to UpdateFailed."""
+async def test_coordinator_update_failure(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Test an InverterError during a refresh marks the entities unavailable."""
     entry_data = {
         CONF_IP_ADDRESS: "192.168.1.87",
         CONF_PORT: 80,
@@ -104,12 +114,22 @@ async def test_coordinator_update_failure(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert entry.state is ConfigEntryState.LOADED
-    coordinator = entry.runtime_data.coordinator
+
+    # making sure the base state is actually healthy before the test run.
+    assert (
+        hass.states.get("sensor.solax_abcdefghij_network_voltage").state
+        != STATE_UNAVAILABLE
+    )
 
     with patch("solax.RealTimeAPI.get_data", side_effect=InverterError):
-        await coordinator.async_refresh()
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
 
-    assert coordinator.last_update_success is False
+    assert (
+        hass.states.get("sensor.solax_abcdefghij_network_voltage").state
+        == STATE_UNAVAILABLE
+    )
 
 
 async def test_setup_entry_not_ready(hass: HomeAssistant) -> None:

--- a/tests/components/solax/test_sensor.py
+++ b/tests/components/solax/test_sensor.py
@@ -2,15 +2,21 @@
 
 from unittest.mock import patch
 
-from solax.inverter import InverterResponse
+from freezegun.api import FrozenDateTimeFactory
+from solax.inverter import InverterError, InverterResponse
 from solax.inverters import X1MiniV34
 
-from homeassistant.components.solax.const import DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
+from homeassistant.components.solax import SCAN_INTERVAL
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_PASSWORD,
+    CONF_PORT,
+    STATE_UNAVAILABLE,
+)
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 def __mock_get_data() -> InverterResponse:
@@ -23,12 +29,12 @@ def __mock_get_data() -> InverterResponse:
     )
 
 
-async def test_device_info_model(
+async def test_coordinator_update_failure(
     hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
+    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the device registry entry has the discovered inverter model set."""
+    """Test an InverterError during a refresh marks the entities unavailable."""
     mock_config_entry.add_to_hass(hass)
 
     inverter = next(
@@ -48,6 +54,20 @@ async def test_device_info_model(
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "ABCDEFGHIJ")})
-    assert device is not None
-    assert device.model == "x1_mini_v34"
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # making sure the base state is actually healthy before the test run.
+    assert (
+        hass.states.get("sensor.solax_abcdefghij_network_voltage").state
+        != STATE_UNAVAILABLE
+    )
+
+    with patch("solax.RealTimeAPI.get_data", side_effect=InverterError):
+        freezer.tick(SCAN_INTERVAL)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert (
+        hass.states.get("sensor.solax_abcdefghij_network_voltage").state
+        == STATE_UNAVAILABLE
+    )

--- a/tests/components/solax/test_sensor.py
+++ b/tests/components/solax/test_sensor.py
@@ -56,7 +56,6 @@ async def test_coordinator_update_failure(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    # making sure the base state is actually healthy before the test run.
     assert (
         hass.states.get("sensor.solax_abcdefghij_network_voltage").state
         != STATE_UNAVAILABLE

--- a/tests/components/solax/test_sensor.py
+++ b/tests/components/solax/test_sensor.py
@@ -1,0 +1,57 @@
+"""Tests for the solax sensor platform."""
+
+from unittest.mock import patch
+
+from solax.inverter import InverterResponse
+from solax.inverters import X1MiniV34
+
+from homeassistant.components.solax.const import DOMAIN
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+def __mock_get_data() -> InverterResponse:
+    return InverterResponse(
+        data=dict.fromkeys(X1MiniV34.sensor_map(), 0),
+        dongle_serial_number="ABCDEFGHIJ",
+        version="2.034.06",
+        type=4,
+        inverter_serial_number="XXXXXXX",
+    )
+
+
+async def test_device_info_model(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test the device registry entry has the discovered inverter model set."""
+    entry_data = {
+        CONF_IP_ADDRESS: "192.168.1.87",
+        CONF_PORT: 80,
+        CONF_PASSWORD: "password",
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="ABCDEFGHIJ")
+    entry.add_to_hass(hass)
+
+    inverter = next(
+        iter(
+            X1MiniV34.build_all_variants(
+                entry_data[CONF_IP_ADDRESS],
+                entry_data[CONF_PORT],
+                entry_data[CONF_PASSWORD],
+            )
+        )
+    )
+
+    with (
+        patch("homeassistant.components.solax.discover", return_value=inverter),
+        patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "ABCDEFGHIJ")})
+    assert device is not None
+    assert device.model == "x1_mini_v34"

--- a/tests/components/solax/test_sensor.py
+++ b/tests/components/solax/test_sensor.py
@@ -24,23 +24,19 @@ def __mock_get_data() -> InverterResponse:
 
 
 async def test_device_info_model(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the device registry entry has the discovered inverter model set."""
-    entry_data = {
-        CONF_IP_ADDRESS: "192.168.1.87",
-        CONF_PORT: 80,
-        CONF_PASSWORD: "password",
-    }
-    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id="ABCDEFGHIJ")
-    entry.add_to_hass(hass)
+    mock_config_entry.add_to_hass(hass)
 
     inverter = next(
         iter(
             X1MiniV34.build_all_variants(
-                entry_data[CONF_IP_ADDRESS],
-                entry_data[CONF_PORT],
-                entry_data[CONF_PASSWORD],
+                mock_config_entry.data[CONF_IP_ADDRESS],
+                mock_config_entry.data[CONF_PORT],
+                mock_config_entry.data[CONF_PASSWORD],
             )
         )
     )
@@ -49,7 +45,7 @@ async def test_device_info_model(
         patch("homeassistant.components.solax.discover", return_value=inverter),
         patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
     ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
     device = device_registry.async_get_device(identifiers={(DOMAIN, "ABCDEFGHIJ")})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
In Solax integration, the current auto-discovery behavior often results in multiple "valid" inverters, and it just picks one, effectively, at random. Which means one inverter could be detected as a different one, rendering the integration effectively exporting the wrong sensors (correct for the detected, but non-existing for the actual real one).

This patch allows the user to hand pick the model. If they did so, the auto-discovery is disabled and the hand picked model is chosen.

If left empty, the current auto-discovery behavior is picked up. making this backward compatible (UX wise).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46830
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
