### PR TITLE
Add inverter model selector to solax config flow

### DIFF
--- a/homeassistant/components/solax/__init__.py
+++ b/homeassistant/components/solax/__init__.py
@@ -1,10 +1,12 @@
 """The solax component."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
+from importlib.metadata import entry_points
 import logging
 
-from solax import InverterResponse, RealTimeAPI, real_time_api
+from solax import InverterResponse, RealTimeAPI, discover
 from solax.inverter import InverterError
 
 from homeassistant.config_entries import ConfigEntry
@@ -13,11 +15,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
+from .const import CONF_SOLAX_INVERTER, SOLAX_ENTRY_POINT_GROUP
 from .coordinator import SolaxDataUpdateCoordinator
 
 PLATFORMS = [Platform.SENSOR]
 
 SCAN_INTERVAL = timedelta(seconds=30)
+
+INVERTERS_ENTRY_POINTS = {
+    ep.name: ep.load() for ep in entry_points(group=SOLAX_ENTRY_POINT_GROUP)
+}
 
 
 @dataclass(slots=True)
@@ -36,12 +43,20 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass: HomeAssistant, entry: SolaxConfigEntry) -> bool:
     """Set up the sensors from a ConfigEntry."""
 
+    if inverter_name := entry.data.get(CONF_SOLAX_INVERTER):
+        invset = {INVERTERS_ENTRY_POINTS[inverter_name]}
+    else:
+        invset = set(INVERTERS_ENTRY_POINTS.values())
+
     try:
-        api = await real_time_api(
+        inverter = await discover(
             entry.data[CONF_IP_ADDRESS],
             entry.data[CONF_PORT],
             entry.data[CONF_PASSWORD],
+            inverters=invset,
+            return_when=asyncio.FIRST_COMPLETED,
         )
+        api = RealTimeAPI(inverter)
     except Exception as err:
         raise ConfigEntryNotReady from err
 

--- a/homeassistant/components/solax/config_flow.py
+++ b/homeassistant/components/solax/config_flow.py
@@ -1,28 +1,41 @@
 """Config flow for solax integration."""
 
+import asyncio
+from importlib.metadata import entry_points
 import logging
 from typing import Any, override
 
-from solax import real_time_api
+from solax import discover
 from solax.discovery import DiscoveryError
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, selector
 
-from .const import DOMAIN
+from .const import CONF_SOLAX_INVERTER, DOMAIN, SOLAX_ENTRY_POINT_GROUP
 
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_PORT = 80
 DEFAULT_PASSWORD = ""
 
+INVERTERS_ENTRY_POINTS = {
+    ep.name: ep.load() for ep in entry_points(group=SOLAX_ENTRY_POINT_GROUP)
+}
+
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_IP_ADDRESS): cv.string,
         vol.Optional(CONF_PORT, default=DEFAULT_PORT): cv.port,
         vol.Optional(CONF_PASSWORD, default=DEFAULT_PASSWORD): cv.string,
+        vol.Optional(CONF_SOLAX_INVERTER): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=list(INVERTERS_ENTRY_POINTS.keys()),
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                multiple=False,
+            )
+        ),
     }
 )
 
@@ -30,10 +43,19 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 async def validate_api(data) -> str:
     """Validate the credentials."""
 
-    api = await real_time_api(
-        data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_PASSWORD]
+    if inverter_name := data.get(CONF_SOLAX_INVERTER):
+        invset = {INVERTERS_ENTRY_POINTS[inverter_name]}
+    else:
+        invset = set(INVERTERS_ENTRY_POINTS.values())
+
+    inverter = await discover(
+        data[CONF_IP_ADDRESS],
+        data[CONF_PORT],
+        data[CONF_PASSWORD],
+        inverters=invset,
+        return_when=asyncio.FIRST_COMPLETED,
     )
-    response = await api.get_data()
+    response = await inverter.get_data()
     return response.serial_number
 
 

--- a/homeassistant/components/solax/const.py
+++ b/homeassistant/components/solax/const.py
@@ -3,3 +3,7 @@
 DOMAIN = "solax"
 
 MANUFACTURER = "SolaX Power"
+
+CONF_SOLAX_INVERTER = "solax.inverters"
+
+SOLAX_ENTRY_POINT_GROUP = "solax.inverter"

--- a/homeassistant/components/solax/sensor.py
+++ b/homeassistant/components/solax/sensor.py
@@ -97,6 +97,7 @@ async def async_setup_entry(
     resp = coordinator.data
     serial = resp.serial_number
     version = resp.version
+    model = type(api.inverter).__name__
     entities: list[InverterSensorEntity] = []
     for sensor, (idx, measurement) in api.inverter.sensor_map().items():
         description = SENSOR_DESCRIPTIONS[(measurement.unit, measurement.is_monotonic)]
@@ -109,6 +110,7 @@ async def async_setup_entry(
                 uid,
                 serial,
                 version,
+                model,
                 sensor,
                 description,
             )
@@ -128,6 +130,7 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
         uid: str,
         serial: str,
         version: str,
+        model: str,
         key: str,
         entity_description: SensorEntityDescription,
     ) -> None:
@@ -139,6 +142,7 @@ class InverterSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, serial)},
             manufacturer=MANUFACTURER,
+            model=f"Inverter: {model}",
             name=f"{manufacturer} {serial}",
             sw_version=version,
         )

--- a/homeassistant/components/solax/strings.json
+++ b/homeassistant/components/solax/strings.json
@@ -12,7 +12,8 @@
         "data": {
           "ip_address": "[%key:common::config_flow::data::ip%]",
           "password": "[%key:common::config_flow::data::password%]",
-          "port": "[%key:common::config_flow::data::port%]"
+          "port": "[%key:common::config_flow::data::port%]",
+          "solax.inverters": "Inverter model"
         }
       }
     }

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -2,19 +2,18 @@
 
 from unittest.mock import patch
 
-from solax import RealTimeAPI
 from solax.inverter import InverterResponse
 from solax.inverters import X1MiniV34
 
 from homeassistant import config_entries
-from homeassistant.components.solax.const import DOMAIN
+from homeassistant.components.solax.const import CONF_SOLAX_INVERTER, DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-def __mock_real_time_api_success():
-    return RealTimeAPI(X1MiniV34)
+def __mock_discover_success():
+    return X1MiniV34
 
 
 def __mock_get_data():
@@ -37,10 +36,10 @@ async def test_form_success(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "homeassistant.components.solax.config_flow.real_time_api",
-            return_value=__mock_real_time_api_success(),
+            "homeassistant.components.solax.config_flow.discover",
+            return_value=__mock_discover_success(),
         ),
-        patch("solax.RealTimeAPI.get_data", return_value=__mock_get_data()),
+        patch("solax.Inverter.get_data", return_value=__mock_get_data()),
         patch(
             "homeassistant.components.solax.async_setup_entry",
             return_value=True,
@@ -48,7 +47,12 @@ async def test_form_success(hass: HomeAssistant) -> None:
     ):
         entry_result = await hass.config_entries.flow.async_configure(
             flow["flow_id"],
-            {CONF_IP_ADDRESS: "192.168.1.87", CONF_PORT: 80, CONF_PASSWORD: "password"},
+            {
+                CONF_IP_ADDRESS: "192.168.1.87",
+                CONF_PORT: 80,
+                CONF_PASSWORD: "password",
+                CONF_SOLAX_INVERTER: "x1_mini_v34",
+            },
         )
         await hass.async_block_till_done()
 
@@ -58,6 +62,7 @@ async def test_form_success(hass: HomeAssistant) -> None:
         CONF_IP_ADDRESS: "192.168.1.87",
         CONF_PORT: 80,
         CONF_PASSWORD: "password",
+        CONF_SOLAX_INVERTER: "x1_mini_v34",
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -71,7 +76,7 @@ async def test_form_connect_error(hass: HomeAssistant) -> None:
     assert flow["errors"] == {}
 
     with patch(
-        "homeassistant.components.solax.config_flow.real_time_api",
+        "homeassistant.components.solax.config_flow.discover",
         side_effect=ConnectionError,
     ):
         entry_result = await hass.config_entries.flow.async_configure(
@@ -92,7 +97,7 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
     assert flow["errors"] == {}
 
     with patch(
-        "homeassistant.components.solax.config_flow.real_time_api",
+        "homeassistant.components.solax.config_flow.discover",
         side_effect=Exception,
     ):
         entry_result = await hass.config_entries.flow.async_configure(

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -1,6 +1,7 @@
 """Tests for the solax config flow."""
 
-from unittest.mock import patch
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from solax.inverter import InverterResponse
 from solax.inverters import X1MiniV34
@@ -12,8 +13,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 
-def __mock_discover_success():
-    return X1MiniV34
+def __mock_discover_success() -> MagicMock:
+    return MagicMock(spec=X1MiniV34, get_data=AsyncMock(return_value=__mock_get_data()))
 
 
 def __mock_get_data():
@@ -38,8 +39,7 @@ async def test_form_success(hass: HomeAssistant) -> None:
         patch(
             "homeassistant.components.solax.config_flow.discover",
             return_value=__mock_discover_success(),
-        ),
-        patch("solax.Inverter.get_data", return_value=__mock_get_data()),
+        ) as mock_discover,
         patch(
             "homeassistant.components.solax.async_setup_entry",
             return_value=True,
@@ -56,6 +56,13 @@ async def test_form_success(hass: HomeAssistant) -> None:
         )
         await hass.async_block_till_done()
 
+    mock_discover.assert_called_once_with(
+        "192.168.1.87",
+        80,
+        "password",
+        inverters={X1MiniV34},
+        return_when=asyncio.FIRST_COMPLETED,
+    )
     assert entry_result["type"] is FlowResultType.CREATE_ENTRY
     assert entry_result["title"] == "ABCDEFGHIJ"
     assert entry_result["data"] == {

--- a/tests/components/solax/test_config_flow.py
+++ b/tests/components/solax/test_config_flow.py
@@ -3,10 +3,12 @@
 import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from solax.inverter import InverterResponse
+import pytest
+from solax.inverter import Inverter, InverterResponse
 from solax.inverters import X1MiniV34
 
 from homeassistant import config_entries
+from homeassistant.components.solax.config_flow import INVERTERS_ENTRY_POINTS
 from homeassistant.components.solax.const import CONF_SOLAX_INVERTER, DOMAIN
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import HomeAssistant
@@ -27,13 +29,39 @@ def __mock_get_data():
     )
 
 
-async def test_form_success(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("user_input_extra", "expected_inverters"),
+    [
+        pytest.param(
+            {CONF_SOLAX_INVERTER: "x1_mini_v34"},
+            {X1MiniV34},
+            id="explicit_inverter",
+        ),
+        pytest.param(
+            {},
+            set(INVERTERS_ENTRY_POINTS.values()),
+            id="auto_discovery",
+        ),
+    ],
+)
+async def test_form_success(
+    hass: HomeAssistant,
+    user_input_extra: dict[str, str],
+    expected_inverters: set[type[Inverter]],
+) -> None:
     """Test successful form."""
     flow = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     assert flow["type"] is FlowResultType.FORM
     assert flow["errors"] == {}
+
+    user_input = {
+        CONF_IP_ADDRESS: "192.168.1.87",
+        CONF_PORT: 80,
+        CONF_PASSWORD: "password",
+        **user_input_extra,
+    }
 
     with (
         patch(
@@ -46,13 +74,7 @@ async def test_form_success(hass: HomeAssistant) -> None:
         ) as mock_setup_entry,
     ):
         entry_result = await hass.config_entries.flow.async_configure(
-            flow["flow_id"],
-            {
-                CONF_IP_ADDRESS: "192.168.1.87",
-                CONF_PORT: 80,
-                CONF_PASSWORD: "password",
-                CONF_SOLAX_INVERTER: "x1_mini_v34",
-            },
+            flow["flow_id"], user_input
         )
         await hass.async_block_till_done()
 
@@ -60,17 +82,12 @@ async def test_form_success(hass: HomeAssistant) -> None:
         "192.168.1.87",
         80,
         "password",
-        inverters={X1MiniV34},
+        inverters=expected_inverters,
         return_when=asyncio.FIRST_COMPLETED,
     )
     assert entry_result["type"] is FlowResultType.CREATE_ENTRY
     assert entry_result["title"] == "ABCDEFGHIJ"
-    assert entry_result["data"] == {
-        CONF_IP_ADDRESS: "192.168.1.87",
-        CONF_PORT: 80,
-        CONF_PASSWORD: "password",
-        CONF_SOLAX_INVERTER: "x1_mini_v34",
-    }
+    assert entry_result["data"] == user_input
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
solax 3.2.4 introduced a bug in the auto discovery process (see https://github.com/home-assistant/core/issues/175394), so users can now optionally pick their inverter model explicitly during setup instead of relying solely on auto-detection. The detected model is also now shown in the device info panel

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Solax integration relies on the solax python library, which supports many types of Solax inverters.
The library uses parallel auto-discovery code to test all the inverter types against the inverter being 
configured, and selects the one that "matches". 
Release 3.2.4 of the library introduced a new inverter type which matches against the wrong types of inverters (for example X1 hybrid G4, which has its own inverter type). This results in HA selecting the wrong inverter type randomly
(this is sensitive to timing). This breaks the solax integration config randomly.

This is not the first time this has happened. The auto-discovery code is handy, but fragile. 

This change modifies the config flow to add the possibility to select an inverter type and bypass the auto-discovery code. The choice is optional, and the code reverts to the old behavior if no inverter type is selected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175394
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46787
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ x] I understand the code I am submitting and can explain how it works.
- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ x] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [ x] I have followed the [perfect PR recommendations][perfect-pr]
- [x ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ x] Tests have been added to verify that the new code works.
- [ x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
