### PR TITLE
Fix dynamic Roborock map image entity registration

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -237,6 +237,9 @@ class RoborockDataUpdateCoordinator(DataUpdateCoordinator[DeviceState | None]):
                 self._handle_trait_update
             )
         )
+        self._unsubs.append(
+            self.properties_api.home.add_update_listener(self._handle_trait_update)
+        )
 
     async def update_map(self) -> None:
         """Update the currently selected map."""

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -49,7 +49,8 @@ async def async_setup_entry(
             @callback
             def async_update_map_entities() -> None:
                 """Add new map entities and remove deleted ones."""
-                map_infos = coordinator.properties_api.home.home_map_info or {}
+                if (map_infos := coordinator.properties_api.home.home_map_info) is None:
+                    return
                 current_flags = set(map_infos.keys())
                 existing_flags = set(map_entities.keys())
 

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -12,6 +12,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
@@ -43,33 +44,44 @@ async def async_setup_entry(
     ) -> None:
         """Add entities for a specific coordinator."""
         if isinstance(coordinator, RoborockDataUpdateCoordinator):
-            added_map_flags: set[int] = set()
+            map_entities: dict[int, RoborockMap] = {}
 
             @callback
-            def async_create_map_entities() -> None:
-                """Create entities for maps that have not been added yet."""
+            def async_update_map_entities() -> None:
+                """Add new map entities and remove deleted ones."""
                 map_infos = coordinator.properties_api.home.home_map_info or {}
+                current_flags = set(map_infos.keys())
+                existing_flags = set(map_entities.keys())
+
+                # Add new maps
                 new_entities = []
-                for map_info in map_infos.values():
-                    if map_info.map_flag not in added_map_flags:
-                        new_entities.append(
-                            RoborockMap(
-                                config_entry,
-                                coordinator,
-                                coordinator.properties_api.home,
-                                map_info.map_flag,
-                                map_info.name,
-                            )
-                        )
-                        added_map_flags.add(map_info.map_flag)
+                for map_flag in current_flags - existing_flags:
+                    map_info = map_infos[map_flag]
+                    entity = RoborockMap(
+                        config_entry,
+                        coordinator,
+                        coordinator.properties_api.home,
+                        map_info.map_flag,
+                        map_info.name,
+                    )
+                    map_entities[map_flag] = entity
+                    new_entities.append(entity)
                 if new_entities:
                     async_add_entities(new_entities)
 
-            async_create_map_entities()
+                # Remove deleted maps
+                entity_registry = er.async_get(coordinator.hass)
+                for map_flag in existing_flags - current_flags:
+                    entity = map_entities.pop(map_flag)
+                    coordinator.hass.async_create_task(entity.async_remove())
+                    if entity.entity_id and entity_registry.async_get(entity.entity_id):
+                        entity_registry.async_remove(entity.entity_id)
+
+            async_update_map_entities()
 
             config_entry.async_on_unload(
                 coordinator.properties_api.home.add_update_listener(
-                    async_create_map_entities
+                    async_update_map_entities
                 )
             )
         elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):

--- a/homeassistant/components/roborock/image.py
+++ b/homeassistant/components/roborock/image.py
@@ -42,23 +42,38 @@ async def async_setup_entry(
         coordinator: RoborockCoordinatorType,
     ) -> None:
         """Add entities for a specific coordinator."""
-        entities: list[ImageEntity] = []
         if isinstance(coordinator, RoborockDataUpdateCoordinator):
-            entities.extend(
-                RoborockMap(
-                    config_entry,
-                    coordinator,
-                    coordinator.properties_api.home,
-                    map_info.map_flag,
-                    map_info.name,
+            added_map_flags: set[int] = set()
+
+            @callback
+            def async_create_map_entities() -> None:
+                """Create entities for maps that have not been added yet."""
+                map_infos = coordinator.properties_api.home.home_map_info or {}
+                new_entities = []
+                for map_info in map_infos.values():
+                    if map_info.map_flag not in added_map_flags:
+                        new_entities.append(
+                            RoborockMap(
+                                config_entry,
+                                coordinator,
+                                coordinator.properties_api.home,
+                                map_info.map_flag,
+                                map_info.name,
+                            )
+                        )
+                        added_map_flags.add(map_info.map_flag)
+                if new_entities:
+                    async_add_entities(new_entities)
+
+            async_create_map_entities()
+
+            config_entry.async_on_unload(
+                coordinator.properties_api.home.add_update_listener(
+                    async_create_map_entities
                 )
-                for map_info in (
-                    coordinator.properties_api.home.home_map_info or {}
-                ).values()
             )
         elif isinstance(coordinator, RoborockB01Q10UpdateCoordinator):
-            entities.append(RoborockMapQ10(coordinator))
-        async_add_entities(entities)
+            async_add_entities([RoborockMapQ10(coordinator)])
 
     for coordinator in coordinators.values():
         async_add_coordinator_entities(coordinator)

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -416,6 +416,8 @@ def make_home_trait(
     home_trait.home_map_info = home_map_info
     home_trait.current_map_data = home_map_info[current_map]
     home_trait.home_map_content = home_map_content
+    notify = attach_update_listeners(home_trait)
+    home_trait.refresh.side_effect = notify
     return home_trait
 
 

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -281,6 +281,7 @@ async def test_map_load_delayed(
     mock_roborock_entry: MockConfigEntry,
     fake_vacuum: FakeDevice,
 ) -> None:
+    """Test map entities are not created if no maps initially exist, but are added dynamically later."""
     assert fake_vacuum.v1_properties
     home_trait = fake_vacuum.v1_properties.home
 

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -288,7 +288,7 @@ async def test_map_load_delayed(
         for call in home_trait.add_update_listener.call_args_list:
             call.args[0]()
 
-    # 1. Start with no maps
+    # Start with no maps
     home_trait.home_map_info = None
     home_trait.home_map_content = None
 
@@ -300,7 +300,7 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is None
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is None
 
-    # 2. Add first map (Main Floor, flag 0)
+    # Add first map (Main Floor, flag 0)
     home_trait.home_map_info = {
         0: CombinedMapInfo(name="Main Floor", map_flag=0, rooms=[])
     }
@@ -316,7 +316,7 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is None
 
-    # 3. Add second map (Upstairs, flag 1)
+    # Add second map (Upstairs, flag 1)
     home_trait.home_map_info = {
         **home_trait.home_map_info,
         1: CombinedMapInfo(name="Upstairs", map_flag=1, rooms=[]),
@@ -334,7 +334,7 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
-    # 4. No-op update (no changes)
+    # No-op update (no changes)
     notify_listeners()
     await hass.async_block_till_done()
 
@@ -342,19 +342,7 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
-    # 5. Uninitialized map info (None)
-    home_trait.home_map_info = None
-    home_trait.home_map_content = None
-
-    # Notify update listener
-    notify_listeners()
-    await hass.async_block_till_done()
-
-    # Assert both map entities still exist (were not deleted)
-    assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
-    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
-
-    # 6. Remove first map (Main Floor, flag 0)
+    # Remove first map (Main Floor, flag 0)
     home_trait.home_map_info = {
         1: CombinedMapInfo(name="Upstairs", map_flag=1, rooms=[])
     }

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -9,7 +9,7 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from roborock import MultiMapsList, RoborockException
-from roborock.data import RoborockStateCode
+from roborock.data import CombinedMapInfo, RoborockStateCode
 from roborock.devices.traits.v1.map_content import MapContent
 
 from homeassistant.components.roborock.const import V1_LOCAL_NOT_CLEANING_INTERVAL
@@ -274,3 +274,48 @@ async def test_q10_map_image(
     resp = await client.get(f"/api/image_proxy/{entity_id}")
     assert resp.status == HTTPStatus.OK
     assert await resp.read() == b"\x89PNG-q10-new"
+
+
+async def test_map_load_delayed(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test map entities are not created if no maps initially exist, but are added dynamically later."""
+    assert fake_vacuum.v1_properties
+
+    # Start with no maps
+    fake_vacuum.v1_properties.home.home_map_info = None
+    fake_vacuum.v1_properties.home.home_map_content = None
+
+    # Setup the config entry
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Assert no map entities for fake_vacuum are created initially
+    assert hass.states.get("image.roborock_s7_maxv_main_floor") is None
+
+    # Later, maps show up
+    home_map_info = {
+        0: CombinedMapInfo(
+            name="Main Floor",
+            map_flag=0,
+            rooms=[],
+        )
+    }
+    home_map_content = {
+        0: MapContent(
+            image_content=b"\x89PNG-001",
+            map_data=None,
+        )
+    }
+    fake_vacuum.v1_properties.home.home_map_info = home_map_info
+    fake_vacuum.v1_properties.home.home_map_content = home_map_content
+
+    # Notify update listener
+    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
+        call.args[0]()
+    await hass.async_block_till_done()
+
+    # Assert map entity has been created!
+    assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -281,12 +281,16 @@ async def test_map_load_delayed(
     mock_roborock_entry: MockConfigEntry,
     fake_vacuum: FakeDevice,
 ) -> None:
-    """Test map entities are not created if no maps initially exist, but are added dynamically later."""
     assert fake_vacuum.v1_properties
+    home_trait = fake_vacuum.v1_properties.home
+
+    def notify_listeners() -> None:
+        for call in home_trait.add_update_listener.call_args_list:
+            call.args[0]()
 
     # 1. Start with no maps
-    fake_vacuum.v1_properties.home.home_map_info = None
-    fake_vacuum.v1_properties.home.home_map_content = None
+    home_trait.home_map_info = None
+    home_trait.home_map_content = None
 
     # Setup the config entry
     await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
@@ -297,25 +301,15 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is None
 
     # 2. Add first map (Main Floor, flag 0)
-    home_map_info = {
-        0: CombinedMapInfo(
-            name="Main Floor",
-            map_flag=0,
-            rooms=[],
-        )
+    home_trait.home_map_info = {
+        0: CombinedMapInfo(name="Main Floor", map_flag=0, rooms=[])
     }
-    home_map_content = {
-        0: MapContent(
-            image_content=b"\x89PNG-001",
-            map_data=None,
-        )
+    home_trait.home_map_content = {
+        0: MapContent(image_content=b"\x89PNG-001", map_data=None)
     }
-    fake_vacuum.v1_properties.home.home_map_info = home_map_info
-    fake_vacuum.v1_properties.home.home_map_content = home_map_content
 
     # Notify update listener
-    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
-        call.args[0]()
+    notify_listeners()
     await hass.async_block_till_done()
 
     # Assert first map entity is created, second is still None
@@ -323,21 +317,17 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is None
 
     # 3. Add second map (Upstairs, flag 1)
-    home_map_info[1] = CombinedMapInfo(
-        name="Upstairs",
-        map_flag=1,
-        rooms=[],
-    )
-    home_map_content[1] = MapContent(
-        image_content=b"\x89PNG-002",
-        map_data=None,
-    )
-    fake_vacuum.v1_properties.home.home_map_info = home_map_info
-    fake_vacuum.v1_properties.home.home_map_content = home_map_content
+    home_trait.home_map_info = {
+        **home_trait.home_map_info,
+        1: CombinedMapInfo(name="Upstairs", map_flag=1, rooms=[]),
+    }
+    home_trait.home_map_content = {
+        **home_trait.home_map_content,
+        1: MapContent(image_content=b"\x89PNG-002", map_data=None),
+    }
 
     # Notify update listener
-    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
-        call.args[0]()
+    notify_listeners()
     await hass.async_block_till_done()
 
     # Assert both map entities exist
@@ -345,8 +335,7 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
     # 4. No-op update (no changes)
-    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
-        call.args[0]()
+    notify_listeners()
     await hass.async_block_till_done()
 
     # Assert both map entities still exist
@@ -354,12 +343,11 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
     # 5. Uninitialized map info (None)
-    fake_vacuum.v1_properties.home.home_map_info = None
-    fake_vacuum.v1_properties.home.home_map_content = None
+    home_trait.home_map_info = None
+    home_trait.home_map_content = None
 
     # Notify update listener
-    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
-        call.args[0]()
+    notify_listeners()
     await hass.async_block_till_done()
 
     # Assert both map entities still exist (were not deleted)
@@ -367,25 +355,15 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
     # 6. Remove first map (Main Floor, flag 0)
-    home_map_info_removed = {
-        1: CombinedMapInfo(
-            name="Upstairs",
-            map_flag=1,
-            rooms=[],
-        )
+    home_trait.home_map_info = {
+        1: CombinedMapInfo(name="Upstairs", map_flag=1, rooms=[])
     }
-    home_map_content_removed = {
-        1: MapContent(
-            image_content=b"\x89PNG-002",
-            map_data=None,
-        )
+    home_trait.home_map_content = {
+        1: MapContent(image_content=b"\x89PNG-002", map_data=None)
     }
-    fake_vacuum.v1_properties.home.home_map_info = home_map_info_removed
-    fake_vacuum.v1_properties.home.home_map_content = home_map_content_removed
 
     # Notify update listener
-    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
-        call.args[0]()
+    notify_listeners()
     await hass.async_block_till_done()
 
     # Assert first map entity is removed, second still exists

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -284,7 +284,7 @@ async def test_map_load_delayed(
     """Test map entities are not created if no maps initially exist, but are added dynamically later."""
     assert fake_vacuum.v1_properties
 
-    # Start with no maps
+    # 1. Start with no maps
     fake_vacuum.v1_properties.home.home_map_info = None
     fake_vacuum.v1_properties.home.home_map_content = None
 
@@ -294,8 +294,9 @@ async def test_map_load_delayed(
 
     # Assert no map entities for fake_vacuum are created initially
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is None
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is None
 
-    # Later, maps show up
+    # 2. Add first map (Main Floor, flag 0)
     home_map_info = {
         0: CombinedMapInfo(
             name="Main Floor",
@@ -317,5 +318,63 @@ async def test_map_load_delayed(
         call.args[0]()
     await hass.async_block_till_done()
 
-    # Assert map entity has been created!
+    # Assert first map entity is created, second is still None
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is None
+
+    # 3. Add second map (Upstairs, flag 1)
+    home_map_info[1] = CombinedMapInfo(
+        name="Upstairs",
+        map_flag=1,
+        rooms=[],
+    )
+    home_map_content[1] = MapContent(
+        image_content=b"\x89PNG-002",
+        map_data=None,
+    )
+    fake_vacuum.v1_properties.home.home_map_info = home_map_info
+    fake_vacuum.v1_properties.home.home_map_content = home_map_content
+
+    # Notify update listener
+    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
+        call.args[0]()
+    await hass.async_block_till_done()
+
+    # Assert both map entities exist
+    assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
+
+    # 4. No-op update (no changes)
+    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
+        call.args[0]()
+    await hass.async_block_till_done()
+
+    # Assert both map entities still exist
+    assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
+
+    # 5. Remove first map (Main Floor, flag 0)
+    home_map_info_removed = {
+        1: CombinedMapInfo(
+            name="Upstairs",
+            map_flag=1,
+            rooms=[],
+        )
+    }
+    home_map_content_removed = {
+        1: MapContent(
+            image_content=b"\x89PNG-002",
+            map_data=None,
+        )
+    }
+    fake_vacuum.v1_properties.home.home_map_info = home_map_info_removed
+    fake_vacuum.v1_properties.home.home_map_content = home_map_content_removed
+
+    # Notify update listener
+    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
+        call.args[0]()
+    await hass.async_block_till_done()
+
+    # Assert first map entity is removed, second still exists
+    assert hass.states.get("image.roborock_s7_maxv_main_floor") is None
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None

--- a/tests/components/roborock/test_image.py
+++ b/tests/components/roborock/test_image.py
@@ -353,7 +353,20 @@ async def test_map_load_delayed(
     assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
     assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
 
-    # 5. Remove first map (Main Floor, flag 0)
+    # 5. Uninitialized map info (None)
+    fake_vacuum.v1_properties.home.home_map_info = None
+    fake_vacuum.v1_properties.home.home_map_content = None
+
+    # Notify update listener
+    for call in fake_vacuum.v1_properties.home.add_update_listener.call_args_list:
+        call.args[0]()
+    await hass.async_block_till_done()
+
+    # Assert both map entities still exist (were not deleted)
+    assert hass.states.get("image.roborock_s7_maxv_main_floor") is not None
+    assert hass.states.get("image.roborock_s7_maxv_upstairs") is not None
+
+    # 6. Remove first map (Main Floor, flag 0)
     home_map_info_removed = {
         1: CombinedMapInfo(
             name="Upstairs",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, Roborock map image entities (`RoborockMap`) are only registered during initial setup if the vacuum has map data already loaded/cached. If the home map cache (`home_map_info`) is empty or hasn't finished loading yet at startup, no map image entities are created and they are never added later.

This PR adds support for dynamically registering map image entities when map data is retrieved by subscribing to updates on the `home` trait update listener.

This fixes a race condition on startup. Tagged for beta instead of patch release to have testing through full beta cycle.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175400
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
