### PR TITLE
Add Location Update Service to Metoffice Integration

### DIFF
--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -13,8 +13,9 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, SLOW_SCAN_INTERVAL
 from .coordinator import (
@@ -22,8 +23,17 @@ from .coordinator import (
     MetOfficeRuntimeData,
     MetOfficeUpdateCoordinator,
 )
+from .services import async_setup_services
 
 PLATFORMS = [Platform.SENSOR, Platform.WEATHER]
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
+    """Set up the Met Office integration."""
+    async_setup_services(hass)
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: MetOfficeConfigEntry) -> bool:

--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -75,7 +75,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MetOfficeConfigEntry) ->
     )
 
     entry.runtime_data = MetOfficeRuntimeData(
-        coordinates=f"{latitude}_{longitude}",
+        initial_coordinates=(latitude, longitude),
         hourly_coordinator=metoffice_hourly_coordinator,
         daily_coordinator=metoffice_daily_coordinator,
         twice_daily_coordinator=metoffice_twice_daily_coordinator,

--- a/homeassistant/components/metoffice/__init__.py
+++ b/homeassistant/components/metoffice/__init__.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN
+from .const import DOMAIN, SLOW_SCAN_INTERVAL
 from .coordinator import (
     MetOfficeConfigEntry,
     MetOfficeRuntimeData,
@@ -54,6 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MetOfficeConfigEntry) ->
         latitude=latitude,
         longitude=longitude,
         frequency="daily",
+        update_interval=SLOW_SCAN_INTERVAL,
     )
 
     metoffice_twice_daily_coordinator = MetOfficeUpdateCoordinator(
@@ -64,6 +65,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: MetOfficeConfigEntry) ->
         latitude=latitude,
         longitude=longitude,
         frequency="twice-daily",
+        update_interval=SLOW_SCAN_INTERVAL,
     )
 
     # Fetch initial data so we have data when entities subscribe

--- a/homeassistant/components/metoffice/config_flow.py
+++ b/homeassistant/components/metoffice/config_flow.py
@@ -80,7 +80,8 @@ class MetOfficeConfigFlow(ConfigFlow, domain=DOMAIN):
             errors = result["errors"]
 
             if not errors:
-                user_input[CONF_NAME] = result["site_name"]
+                if user_input[CONF_NAME] is None:
+                    user_input[CONF_NAME] = result["site_name"]
                 return self.async_create_entry(
                     title=user_input[CONF_NAME], data=user_input
                 )
@@ -94,6 +95,7 @@ class MetOfficeConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Required(
                     CONF_LONGITUDE, default=self.hass.config.longitude
                 ): cv.longitude,
+                vol.Optional(CONF_NAME, default=None): str,
             },
         )
 

--- a/homeassistant/components/metoffice/config_flow.py
+++ b/homeassistant/components/metoffice/config_flow.py
@@ -80,8 +80,7 @@ class MetOfficeConfigFlow(ConfigFlow, domain=DOMAIN):
             errors = result["errors"]
 
             if not errors:
-                if user_input[CONF_NAME] is None:
-                    user_input[CONF_NAME] = result["site_name"]
+                user_input[CONF_NAME] = result["site_name"]
                 return self.async_create_entry(
                     title=user_input[CONF_NAME], data=user_input
                 )
@@ -95,7 +94,6 @@ class MetOfficeConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Required(
                     CONF_LONGITUDE, default=self.hass.config.longitude
                 ): cv.longitude,
-                vol.Optional(CONF_NAME, default=None): str,
             },
         )
 

--- a/homeassistant/components/metoffice/const.py
+++ b/homeassistant/components/metoffice/const.py
@@ -39,6 +39,12 @@ ATTRIBUTION = "Data provided by the Met Office"
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=15)
 SLOW_SCAN_INTERVAL = timedelta(minutes=60)
 
+SERVICE_SET_FORECAST_LOCATION = "set_forecast_location"
+# Minimum distance in metres that location must have changed
+# to trigger an update. This is used to limit the number of
+# API queries required if location is constantly moving.
+UPDATE_MINIMUM_DISTANCE = 500
+
 CONDITION_CLASSES: dict[str, list[int]] = {
     ATTR_CONDITION_CLEAR_NIGHT: [0],
     ATTR_CONDITION_CLOUDY: [7, 8],

--- a/homeassistant/components/metoffice/const.py
+++ b/homeassistant/components/metoffice/const.py
@@ -37,6 +37,7 @@ DEFAULT_NAME = "Met Office"
 ATTRIBUTION = "Data provided by the Met Office"
 
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=15)
+SLOW_SCAN_INTERVAL = timedelta(minutes=60)
 
 CONDITION_CLASSES: dict[str, list[int]] = {
     ATTR_CONDITION_CLEAR_NIGHT: [0],

--- a/homeassistant/components/metoffice/coordinator.py
+++ b/homeassistant/components/metoffice/coordinator.py
@@ -1,6 +1,7 @@
 """Data update coordinator for the Met Office integration."""
 
 from dataclasses import dataclass
+from datetime import timedelta
 import logging
 from typing import Literal, override
 
@@ -49,6 +50,7 @@ class MetOfficeUpdateCoordinator(TimestampDataUpdateCoordinator[Forecast]):
         latitude: float,
         longitude: float,
         frequency: Literal["daily", "twice-daily", "hourly"],
+        update_interval: timedelta = DEFAULT_SCAN_INTERVAL,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
@@ -56,7 +58,7 @@ class MetOfficeUpdateCoordinator(TimestampDataUpdateCoordinator[Forecast]):
             _LOGGER,
             name=name,
             config_entry=entry,
-            update_interval=DEFAULT_SCAN_INTERVAL,
+            update_interval=update_interval,
         )
         self._connection = connection
         self._latitude = latitude

--- a/homeassistant/components/metoffice/coordinator.py
+++ b/homeassistant/components/metoffice/coordinator.py
@@ -76,13 +76,11 @@ class MetOfficeRuntimeData:
     ) -> None:
         """Updates the coordinates for the weather forecast."""
         if latitude is None and longitude is None:
-            # If neither is supplied, return to original location
             if self._current_coordinates != self._initial_coordinates:
                 await self._set_updated_coordinates(*self._initial_coordinates)
             return
 
         if latitude is None or longitude is None:
-            # Otherwise if only one is not supplied, treat as an error
             _LOGGER.error(
                 "When updating location, latitude and longitude must both be supplied or both be omitted"
             )

--- a/homeassistant/components/metoffice/coordinator.py
+++ b/homeassistant/components/metoffice/coordinator.py
@@ -1,5 +1,6 @@
 """Data update coordinator for the Met Office integration."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -17,8 +18,9 @@ from homeassistant.helpers.update_coordinator import (
     TimestampDataUpdateCoordinator,
     UpdateFailed,
 )
+from homeassistant.util import location as location_util
 
-from .const import DEFAULT_SCAN_INTERVAL
+from .const import DEFAULT_SCAN_INTERVAL, UPDATE_MINIMUM_DISTANCE
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,11 +31,69 @@ type MetOfficeConfigEntry = ConfigEntry[MetOfficeRuntimeData]
 class MetOfficeRuntimeData:
     """Met Office config entry."""
 
-    coordinates: str
+    name: str
     hourly_coordinator: MetOfficeUpdateCoordinator
     daily_coordinator: MetOfficeUpdateCoordinator
     twice_daily_coordinator: MetOfficeUpdateCoordinator
-    name: str
+
+    @property
+    def coordinates(self) -> str:
+        """Get current coordinates in string form."""
+        [current_latitude, current_longitude] = self._current_coordinates
+        return f"{current_latitude}_{current_longitude}"
+
+    def __init__(
+        self,
+        name: str,
+        initial_coordinates: tuple[float, float],
+        hourly_coordinator: MetOfficeUpdateCoordinator,
+        daily_coordinator: MetOfficeUpdateCoordinator,
+        twice_daily_coordinator: MetOfficeUpdateCoordinator,
+    ) -> None:
+        """Initialize the runtime data."""
+        self.name = name
+
+        self._initial_coordinates = initial_coordinates
+        self._current_coordinates = initial_coordinates
+
+        self.hourly_coordinator = hourly_coordinator
+        self.daily_coordinator = daily_coordinator
+        self.twice_daily_coordinator = twice_daily_coordinator
+
+    _initial_coordinates: tuple[float, float]
+    _current_coordinates: tuple[float, float]
+
+    async def update_coordinates(
+        self, latitude: float | None, longitude: float | None
+    ) -> None:
+        """Updates the coordinates for the weather forecast."""
+        if latitude is None and longitude is None:
+            # If neither is supplied, return to original location
+            [latitude, longitude] = self._initial_coordinates
+        elif latitude is None or longitude is None:
+            # Otherwise if only one is not supplied, treat as an error
+            _LOGGER.error(
+                "When updating location, latitude and longitude must both be supplied or both be omitted"
+            )
+            return
+
+        # Update the location only if we have moved significantly from the previous
+        # location. This will limit the number of times the API is queried unless
+        # moving extremely quickly.
+        [current_latitude, current_longitude] = self._current_coordinates
+        distance = location_util.distance(
+            current_latitude,
+            current_longitude,
+            latitude,
+            longitude,
+        )
+        if distance is not None and distance > UPDATE_MINIMUM_DISTANCE:
+            self._current_coordinates = (latitude, longitude)
+            await asyncio.gather(
+                self.daily_coordinator.update_location(latitude, longitude),
+                self.twice_daily_coordinator.update_location(latitude, longitude),
+                self.hourly_coordinator.update_location(latitude, longitude),
+            )
 
 
 class MetOfficeUpdateCoordinator(TimestampDataUpdateCoordinator[Forecast]):
@@ -64,6 +124,12 @@ class MetOfficeUpdateCoordinator(TimestampDataUpdateCoordinator[Forecast]):
         self._latitude = latitude
         self._longitude = longitude
         self._frequency = frequency
+
+    async def update_location(self, latitude: float, longitude: float) -> None:
+        """Update the location for the weather coordinator."""
+        self._latitude = latitude
+        self._longitude = longitude
+        await self.async_request_refresh()
 
     @override
     async def _async_update_data(self) -> Forecast:

--- a/homeassistant/components/metoffice/coordinator.py
+++ b/homeassistant/components/metoffice/coordinator.py
@@ -63,14 +63,25 @@ class MetOfficeRuntimeData:
     _initial_coordinates: tuple[float, float]
     _current_coordinates: tuple[float, float]
 
+    async def _set_updated_coordinates(self, latitude: float, longitude: float) -> None:
+        self._current_coordinates = (latitude, longitude)
+        await asyncio.gather(
+            self.daily_coordinator.update_location(latitude, longitude),
+            self.twice_daily_coordinator.update_location(latitude, longitude),
+            self.hourly_coordinator.update_location(latitude, longitude),
+        )
+
     async def update_coordinates(
         self, latitude: float | None, longitude: float | None
     ) -> None:
         """Updates the coordinates for the weather forecast."""
         if latitude is None and longitude is None:
             # If neither is supplied, return to original location
-            [latitude, longitude] = self._initial_coordinates
-        elif latitude is None or longitude is None:
+            if self._current_coordinates != self._initial_coordinates:
+                await self._set_updated_coordinates(*self._initial_coordinates)
+            return
+
+        if latitude is None or longitude is None:
             # Otherwise if only one is not supplied, treat as an error
             _LOGGER.error(
                 "When updating location, latitude and longitude must both be supplied or both be omitted"
@@ -80,20 +91,13 @@ class MetOfficeRuntimeData:
         # Update the location only if we have moved significantly from the previous
         # location. This will limit the number of times the API is queried unless
         # moving extremely quickly.
-        [current_latitude, current_longitude] = self._current_coordinates
         distance = location_util.distance(
-            current_latitude,
-            current_longitude,
+            *self._current_coordinates,
             latitude,
             longitude,
         )
         if distance is not None and distance > UPDATE_MINIMUM_DISTANCE:
-            self._current_coordinates = (latitude, longitude)
-            await asyncio.gather(
-                self.daily_coordinator.update_location(latitude, longitude),
-                self.twice_daily_coordinator.update_location(latitude, longitude),
-                self.hourly_coordinator.update_location(latitude, longitude),
-            )
+            await self._set_updated_coordinates(latitude, longitude)
 
 
 class MetOfficeUpdateCoordinator(TimestampDataUpdateCoordinator[Forecast]):

--- a/homeassistant/components/metoffice/icons.json
+++ b/homeassistant/components/metoffice/icons.json
@@ -1,0 +1,7 @@
+{
+  "services": {
+    "set_forecast_location": {
+      "service": "mdi:map-marker-radius"
+    }
+  }
+}

--- a/homeassistant/components/metoffice/services.py
+++ b/homeassistant/components/metoffice/services.py
@@ -1,10 +1,15 @@
-"""Services for the Mill integration."""
+"""Services for the Met Office integration."""
 
 import voluptuous as vol
 
-from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE
+from homeassistant.const import (
+    ATTR_CONFIG_ENTRY_ID,
+    ATTR_LATITUDE,
+    ATTR_LOCATION,
+    ATTR_LONGITUDE,
+)
 from homeassistant.core import HomeAssistant, ServiceCall, callback
-from homeassistant.helpers import config_validation as cv, service
+from homeassistant.helpers import config_validation as cv, selector, service
 
 from .const import DOMAIN, SERVICE_SET_FORECAST_LOCATION
 from .coordinator import MetOfficeConfigEntry
@@ -12,6 +17,11 @@ from .coordinator import MetOfficeConfigEntry
 SET_FORECAST_LOCATION_SCHEMA = vol.Schema(
     vol.Schema(
         {
+            vol.Required(ATTR_CONFIG_ENTRY_ID): selector.ConfigEntrySelector(
+                {
+                    "integration": DOMAIN,
+                }
+            ),
             vol.Inclusive(ATTR_LATITUDE, ATTR_LOCATION): cv.latitude,
             vol.Inclusive(ATTR_LONGITUDE, ATTR_LOCATION): cv.longitude,
         }
@@ -22,7 +32,7 @@ SET_FORECAST_LOCATION_SCHEMA = vol.Schema(
 async def set_forecast_location(call: ServiceCall) -> None:
     """Set location of forecast from service call."""
     entry: MetOfficeConfigEntry = service.async_get_config_entry(
-        call.hass, DOMAIN, None
+        call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
     await entry.runtime_data.update_coordinates(
         call.data.get(ATTR_LATITUDE), call.data.get(ATTR_LONGITUDE)

--- a/homeassistant/components/metoffice/services.py
+++ b/homeassistant/components/metoffice/services.py
@@ -1,0 +1,41 @@
+"""Services for the Mill integration."""
+
+import voluptuous as vol
+
+from homeassistant.const import ATTR_LATITUDE, ATTR_LOCATION, ATTR_LONGITUDE
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv, service
+
+from .const import DOMAIN, SERVICE_SET_FORECAST_LOCATION
+from .coordinator import MetOfficeConfigEntry
+
+SET_FORECAST_LOCATION_SCHEMA = vol.Schema(
+    vol.Schema(
+        {
+            vol.Inclusive(ATTR_LATITUDE, ATTR_LOCATION): cv.latitude,
+            vol.Inclusive(ATTR_LONGITUDE, ATTR_LOCATION): cv.longitude,
+        }
+    ),
+)
+
+
+async def set_forecast_location(call: ServiceCall) -> None:
+    """Set location of forecast from service call."""
+    entry: MetOfficeConfigEntry = service.async_get_config_entry(
+        call.hass, DOMAIN, None
+    )
+    await entry.runtime_data.update_coordinates(
+        call.data.get(ATTR_LATITUDE), call.data.get(ATTR_LONGITUDE)
+    )
+
+
+@callback
+def async_setup_services(hass: HomeAssistant) -> None:
+    """Register Metoffice services."""
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_FORECAST_LOCATION,
+        set_forecast_location,
+        schema=SET_FORECAST_LOCATION_SCHEMA,
+    )

--- a/homeassistant/components/metoffice/services.yaml
+++ b/homeassistant/components/metoffice/services.yaml
@@ -1,0 +1,20 @@
+set_forecast_location:
+  fields:
+    latitude:
+      required: false
+      example: 32.87336
+      selector:
+        number:
+          mode: box
+          min: -90
+          max: 90
+          step: any
+    longitude:
+      required: false
+      example: 117.22743
+      selector:
+        number:
+          mode: box
+          min: -180
+          max: 180
+          step: any

--- a/homeassistant/components/metoffice/services.yaml
+++ b/homeassistant/components/metoffice/services.yaml
@@ -1,5 +1,10 @@
 set_forecast_location:
   fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: metoffice
     latitude:
       required: false
       example: 32.87336

--- a/homeassistant/components/metoffice/strings.json
+++ b/homeassistant/components/metoffice/strings.json
@@ -21,7 +21,8 @@
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",
-          "longitude": "[%key:common::config_flow::data::longitude%]"
+          "longitude": "[%key:common::config_flow::data::longitude%]",
+          "name": "[%key:common::config_flow::data::name%]"
         },
         "title": "Connect to the UK Met Office"
       }

--- a/homeassistant/components/metoffice/strings.json
+++ b/homeassistant/components/metoffice/strings.json
@@ -21,8 +21,7 @@
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",
-          "longitude": "[%key:common::config_flow::data::longitude%]",
-          "name": "[%key:common::config_flow::data::name%]"
+          "longitude": "[%key:common::config_flow::data::longitude%]"
         },
         "title": "Connect to the UK Met Office"
       }

--- a/homeassistant/components/metoffice/strings.json
+++ b/homeassistant/components/metoffice/strings.json
@@ -27,5 +27,21 @@
         "title": "Connect to the UK Met Office"
       }
     }
+  },
+  "services": {
+    "set_forecast_location": {
+      "description": "Updates the location used for the weather forecast service.",
+      "fields": {
+        "latitude": {
+          "description": "Latitude of forecast location.",
+          "name": "[%key:common::config_flow::data::latitude%]"
+        },
+        "longitude": {
+          "description": "Longitude of forecast location.",
+          "name": "[%key:common::config_flow::data::longitude%]"
+        }
+      },
+      "name": "Set weather forecast location"
+    }
   }
 }

--- a/homeassistant/components/metoffice/strings.json
+++ b/homeassistant/components/metoffice/strings.json
@@ -30,8 +30,12 @@
   },
   "services": {
     "set_forecast_location": {
-      "description": "Updates the location used for the weather forecast service.",
+      "description": "Updates the location used for the weather forecast service. Omit both coordinates to restore the configured location.",
       "fields": {
+        "config_entry_id": {
+          "description": "The forecast service on which to perform this action.",
+          "name": "Target forecast"
+        },
         "latitude": {
           "description": "Latitude of forecast location.",
           "name": "[%key:common::config_flow::data::latitude%]"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

To allow for having two instances of the Metoffice service without exceeding the free daily API quota, the poll interval for Daily and Twice Daily forecasts has been reduced to once per hour instead of once every 15 minutes. This should have minimal impact. Hourly forecasts continue to have 15 minute polling interval.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Currently the Metoffice weather forecast service must be set to a specific location which cannot be changed. This means it's not possible to query forecasts for different locations without reconfiguring by e.g. deleting and recreating the forecast instance.

This PR adds a `set_forecast_location` service to allow dynamically changing the location for the forecast. This provides the opportunity to get the weather forecast for a specified location, such as of a device or person.

To reduce the number of API queries used, the location is only updated internally if the new location is more than 500 metres from the old location as the weather site locations are widely spread out.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
