### PR TITLE
Poll faster around the delivery in Picnic

### DIFF
--- a/homeassistant/components/picnic/const.py
+++ b/homeassistant/components/picnic/const.py
@@ -1,5 +1,7 @@
 """Constants for the Picnic integration."""
 
+from datetime import timedelta
+
 DOMAIN = "picnic"
 
 SERVICE_ADD_PRODUCT_TO_CART = "add_product"
@@ -17,6 +19,11 @@ CART_DATA = "cart_data"
 SLOT_DATA = "slot_data"
 NEXT_DELIVERY_DATA = "next_delivery_data"
 LAST_ORDER_DATA = "last_order_data"
+
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=30)
+DELIVERY_UPDATE_INTERVAL = timedelta(minutes=1)
+DELIVERY_WINDOW_LEAD_TIME = timedelta(minutes=30)
+DELIVERY_WINDOW_LAG_TIME = timedelta(hours=2)
 
 SENSOR_CART_ITEMS_COUNT = "cart_items_count"
 SENSOR_CART_TOTAL_PRICE = "cart_total_price"

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -78,19 +78,18 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
 
     @staticmethod
     def _get_update_interval(next_delivery: dict) -> timedelta:
-        """Determine the polling interval for the given upcoming delivery.
+        """Poll faster around the delivery so the live ETA is picked up in time."""
+        eta = next_delivery.get("eta")
+        slot = next_delivery.get("slot")
 
-        Poll every minute around the delivery so the position-based ETA,
-        which the API only serves shortly before arrival, is picked up in
-        time. Ahead of that window, schedule no later than its start.
-        """
-        eta = next_delivery.get("eta") or {}
-        slot = next_delivery.get("slot") or {}
-
-        start = dt_util.parse_datetime(
-            str(eta.get("start") or slot.get("window_start"))
-        )
-        end = dt_util.parse_datetime(str(eta.get("end") or slot.get("window_end")))
+        if eta:
+            start = dt_util.parse_datetime(str(eta.get("start")))
+            end = dt_util.parse_datetime(str(eta.get("end")))
+        elif slot:
+            start = dt_util.parse_datetime(str(slot.get("window_start")))
+            end = dt_util.parse_datetime(str(slot.get("window_end")))
+        else:
+            return DEFAULT_UPDATE_INTERVAL
 
         if start is None or end is None:
             return DEFAULT_UPDATE_INTERVAL

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -78,15 +78,11 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
 
     @staticmethod
     def _get_update_interval(next_delivery: dict) -> timedelta:
-        """Determine the update interval based on the next delivery.
+        """Determine the polling interval for the given upcoming delivery.
 
-        The default ETA is computed when the delivery routes are planned,
-        while shortly before arrival the API switches to a live ETA based
-        on the delivery vehicle's position. With a fixed 30 minute poll
-        interval that refinement would usually arrive too late, so poll
-        every minute from just before the expected delivery until it has
-        been completed. Ahead of that fast-polling window, the next poll
-        is scheduled no later than the start of the window.
+        Poll every minute around the delivery so the position-based ETA,
+        which the API only serves shortly before arrival, is picked up in
+        time. Ahead of that window, schedule no later than its start.
         """
         eta = next_delivery.get("eta") or {}
         slot = next_delivery.get("slot") or {}

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -69,9 +69,6 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
                 "Timeout while connecting to the Picnic API", retry_after=120
             ) from error
 
-        # Poll faster around the delivery so the position-based ETA,
-        # which the API only serves shortly before arrival, is picked up
-        # while it is still actionable
         self.update_interval = self._get_update_interval(
             data.get(NEXT_DELIVERY_DATA) or {}
         )
@@ -88,7 +85,8 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         on the delivery vehicle's position. With a fixed 30 minute poll
         interval that refinement would usually arrive too late, so poll
         every minute from just before the expected delivery until it has
-        been completed.
+        been completed. Ahead of that fast-polling window, the next poll
+        is scheduled no later than the start of the window.
         """
         eta = next_delivery.get("eta") or {}
         slot = next_delivery.get("slot") or {}
@@ -98,16 +96,17 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         )
         end = dt_util.parse_datetime(str(eta.get("end") or slot.get("window_end")))
 
-        if (
-            start is not None
-            and end is not None
-            and (
-                start - DELIVERY_WINDOW_LEAD_TIME
-                <= dt_util.utcnow()
-                <= end + DELIVERY_WINDOW_LAG_TIME
-            )
-        ):
+        if start is None or end is None:
+            return DEFAULT_UPDATE_INTERVAL
+
+        now = dt_util.utcnow()
+        window_start = start - DELIVERY_WINDOW_LEAD_TIME
+
+        if window_start <= now <= end + DELIVERY_WINDOW_LAG_TIME:
             return DELIVERY_UPDATE_INTERVAL
+
+        if now < window_start:
+            return min(DEFAULT_UPDATE_INTERVAL, window_start - now)
 
         return DEFAULT_UPDATE_INTERVAL
 

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -15,10 +15,16 @@ from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import ADDRESS, CART_DATA, LAST_ORDER_DATA, NEXT_DELIVERY_DATA, SLOT_DATA
 
 type PicnicConfigEntry = ConfigEntry[PicnicUpdateCoordinator]
+
+DEFAULT_UPDATE_INTERVAL = timedelta(minutes=30)
+DELIVERY_UPDATE_INTERVAL = timedelta(minutes=1)
+DELIVERY_WINDOW_LEAD_TIME = timedelta(minutes=30)
+DELIVERY_WINDOW_LAG_TIME = timedelta(hours=2)
 
 
 class PicnicUpdateCoordinator(DataUpdateCoordinator):
@@ -42,7 +48,7 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
             logger,
             config_entry=config_entry,
             name="Picnic coordinator",
-            update_interval=timedelta(minutes=30),
+            update_interval=DEFAULT_UPDATE_INTERVAL,
         )
 
     @override
@@ -63,8 +69,47 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
                 "Timeout while connecting to the Picnic API", retry_after=120
             ) from error
 
+        # Poll faster around the delivery so the position-based ETA,
+        # which the API only serves shortly before arrival, is picked up
+        # while it is still actionable
+        self.update_interval = self._get_update_interval(
+            data.get(NEXT_DELIVERY_DATA) or {}
+        )
+
         # Return the fetched data
         return data
+
+    @staticmethod
+    def _get_update_interval(next_delivery: dict) -> timedelta:
+        """Determine the update interval based on the next delivery.
+
+        The default ETA is computed when the delivery routes are planned,
+        while shortly before arrival the API switches to a live ETA based
+        on the delivery vehicle's position. With a fixed 30 minute poll
+        interval that refinement would usually arrive too late, so poll
+        every minute from just before the expected delivery until it has
+        been completed.
+        """
+        eta = next_delivery.get("eta") or {}
+        slot = next_delivery.get("slot") or {}
+
+        start = dt_util.parse_datetime(
+            str(eta.get("start") or slot.get("window_start"))
+        )
+        end = dt_util.parse_datetime(str(eta.get("end") or slot.get("window_end")))
+
+        if (
+            start is not None
+            and end is not None
+            and (
+                start - DELIVERY_WINDOW_LEAD_TIME
+                <= dt_util.utcnow()
+                <= end + DELIVERY_WINDOW_LAG_TIME
+            )
+        ):
+            return DELIVERY_UPDATE_INTERVAL
+
+        return DEFAULT_UPDATE_INTERVAL
 
     def fetch_data(self):
         """Fetch data from the Picnic API.

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -54,6 +54,14 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
     @override
     async def _async_update_data(self) -> dict:
         """Fetch data from API endpoint."""
+        # Recompute the cadence up front from the last known delivery, so
+        # failed refreshes still cross the timing boundaries instead of
+        # keeping one-minute polling active indefinitely
+        if self.data:
+            self.update_interval = self._get_update_interval(
+                self.data.get(NEXT_DELIVERY_DATA) or {}
+            )
+
         try:
             async with asyncio.timeout(10):
                 data = await self.hass.async_add_executor_job(self.fetch_data)

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -91,14 +91,11 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
 
         start = end = None
         if eta:
-            # ValueError: raised for well-formed but invalid dates
-            with suppress(ValueError):
-                start = dt_util.parse_datetime(str(eta.get("start")))
-                end = dt_util.parse_datetime(str(eta.get("end")))
+            start = dt_util.parse_datetime(str(eta.get("start")))
+            end = dt_util.parse_datetime(str(eta.get("end")))
         if (start is None or end is None) and slot:
-            with suppress(ValueError):
-                start = dt_util.parse_datetime(str(slot.get("window_start")))
-                end = dt_util.parse_datetime(str(slot.get("window_end")))
+            start = dt_util.parse_datetime(str(slot.get("window_start")))
+            end = dt_util.parse_datetime(str(slot.get("window_end")))
 
         if start is None or end is None:
             return DEFAULT_UPDATE_INTERVAL

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -59,7 +59,7 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         # keeping one-minute polling active indefinitely
         if self.data:
             self.update_interval = self._get_update_interval(
-                self.data.get(NEXT_DELIVERY_DATA) or {}
+                self.data.get(NEXT_DELIVERY_DATA)
             )
 
         try:
@@ -77,16 +77,17 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
                 "Timeout while connecting to the Picnic API", retry_after=120
             ) from error
 
-        self.update_interval = self._get_update_interval(
-            data.get(NEXT_DELIVERY_DATA) or {}
-        )
+        self.update_interval = self._get_update_interval(data.get(NEXT_DELIVERY_DATA))
 
         # Return the fetched data
         return data
 
     @staticmethod
-    def _get_update_interval(next_delivery: dict) -> timedelta:
+    def _get_update_interval(next_delivery: dict | None) -> timedelta:
         """Poll faster around the delivery so the live ETA is picked up in time."""
+        if not next_delivery:
+            return DEFAULT_UPDATE_INTERVAL
+
         eta = next_delivery.get("eta")
         slot = next_delivery.get("slot")
 

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -112,7 +112,10 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
             return DELIVERY_UPDATE_INTERVAL
 
         if now < window_start:
-            return min(DEFAULT_UPDATE_INTERVAL, window_start - now)
+            return max(
+                DELIVERY_UPDATE_INTERVAL,
+                min(DEFAULT_UPDATE_INTERVAL, window_start - now),
+            )
 
         return DEFAULT_UPDATE_INTERVAL
 

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -93,11 +93,14 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
 
         start = end = None
         if eta:
-            start = dt_util.parse_datetime(str(eta.get("start")))
-            end = dt_util.parse_datetime(str(eta.get("end")))
+            # ValueError: parse_datetime raises for well-formed invalid dates
+            with suppress(ValueError):
+                start = dt_util.parse_datetime(str(eta.get("start")))
+                end = dt_util.parse_datetime(str(eta.get("end")))
         if (start is None or end is None) and slot:
-            start = dt_util.parse_datetime(str(slot.get("window_start")))
-            end = dt_util.parse_datetime(str(slot.get("window_end")))
+            with suppress(ValueError):
+                start = dt_util.parse_datetime(str(slot.get("window_start")))
+                end = dt_util.parse_datetime(str(slot.get("window_end")))
 
         if start is None or end is None:
             return DEFAULT_UPDATE_INTERVAL

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -54,9 +54,7 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
     @override
     async def _async_update_data(self) -> dict:
         """Fetch data from API endpoint."""
-        # Recompute the cadence up front from the last known delivery, so
-        # failed refreshes still cross the timing boundaries instead of
-        # keeping one-minute polling active indefinitely
+        # Recompute up front so failed refreshes also relax the cadence
         if self.data:
             self.update_interval = self._get_update_interval(
                 self.data.get(NEXT_DELIVERY_DATA)
@@ -93,7 +91,7 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
 
         start = end = None
         if eta:
-            # ValueError: parse_datetime raises for well-formed invalid dates
+            # ValueError: raised for well-formed but invalid dates
             with suppress(ValueError):
                 start = dt_util.parse_datetime(str(eta.get("start")))
                 end = dt_util.parse_datetime(str(eta.get("end")))

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -17,14 +17,19 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
-from .const import ADDRESS, CART_DATA, LAST_ORDER_DATA, NEXT_DELIVERY_DATA, SLOT_DATA
+from .const import (
+    ADDRESS,
+    CART_DATA,
+    DEFAULT_UPDATE_INTERVAL,
+    DELIVERY_UPDATE_INTERVAL,
+    DELIVERY_WINDOW_LAG_TIME,
+    DELIVERY_WINDOW_LEAD_TIME,
+    LAST_ORDER_DATA,
+    NEXT_DELIVERY_DATA,
+    SLOT_DATA,
+)
 
 type PicnicConfigEntry = ConfigEntry[PicnicUpdateCoordinator]
-
-DEFAULT_UPDATE_INTERVAL = timedelta(minutes=30)
-DELIVERY_UPDATE_INTERVAL = timedelta(minutes=1)
-DELIVERY_WINDOW_LEAD_TIME = timedelta(minutes=30)
-DELIVERY_WINDOW_LAG_TIME = timedelta(hours=2)
 
 
 class PicnicUpdateCoordinator(DataUpdateCoordinator):

--- a/homeassistant/components/picnic/coordinator.py
+++ b/homeassistant/components/picnic/coordinator.py
@@ -91,14 +91,13 @@ class PicnicUpdateCoordinator(DataUpdateCoordinator):
         eta = next_delivery.get("eta")
         slot = next_delivery.get("slot")
 
+        start = end = None
         if eta:
             start = dt_util.parse_datetime(str(eta.get("start")))
             end = dt_util.parse_datetime(str(eta.get("end")))
-        elif slot:
+        if (start is None or end is None) and slot:
             start = dt_util.parse_datetime(str(slot.get("window_start")))
             end = dt_util.parse_datetime(str(slot.get("window_end")))
-        else:
-            return DEFAULT_UPDATE_INTERVAL
 
         if start is None or end is None:
             return DEFAULT_UPDATE_INTERVAL

--- a/tests/components/picnic/conftest.py
+++ b/tests/components/picnic/conftest.py
@@ -37,9 +37,9 @@ def mock_picnic_api():
         client.session.auth_token = "3q29fpwhulzes"
         client.get_cart.return_value = json.loads(load_fixture("picnic/cart.json"))
         client.get_user.return_value = json.loads(load_fixture("picnic/user.json"))
-        client.get_deliveries.return_value = json.loads(
-            load_fixture("picnic/delivery.json")
-        )
+        client.get_deliveries.return_value = [
+            json.loads(load_fixture("picnic/delivery.json"))
+        ]
         client.get_delivery_position.return_value = {}
         yield client
 

--- a/tests/components/picnic/conftest.py
+++ b/tests/components/picnic/conftest.py
@@ -1,6 +1,7 @@
 """Conftest for Picnic tests."""
 
 from collections.abc import Awaitable, Callable
+from datetime import timedelta
 import json
 from unittest.mock import MagicMock, patch
 
@@ -9,11 +10,17 @@ import pytest
 from homeassistant.components.picnic import CONF_COUNTRY_CODE, DOMAIN
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry, load_fixture
 from tests.typing import WebSocketGenerator
 
 ENTITY_ID = "todo.mock_title_shopping_cart"
+
+SetupDeliveryFixture = Callable[
+    [str, tuple[timedelta, timedelta] | None, tuple[timedelta, timedelta]],
+    Awaitable[dict],
+]
 
 
 @pytest.fixture
@@ -42,6 +49,41 @@ def mock_picnic_api():
         ]
         client.get_delivery_position.return_value = {}
         yield client
+
+
+@pytest.fixture
+def setup_delivery(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+) -> SetupDeliveryFixture:
+    """Return a factory to set up the integration with the delivery in a given state."""
+
+    async def _setup(
+        status: str,
+        eta2: tuple[timedelta, timedelta] | None,
+        slot_window: tuple[timedelta, timedelta],
+    ) -> dict:
+        delivery = mock_picnic_api.get_deliveries.return_value[0]
+        delivery["status"] = status
+        delivery["delivery_time"] = None
+        # eta2 is the API's field name for the route-planning ETA
+        delivery["eta2"] = eta2 and {
+            "start": (dt_util.utcnow() + eta2[0]).isoformat(),
+            "end": (dt_util.utcnow() + eta2[1]).isoformat(),
+        }
+        delivery["slot"]["window_start"] = (
+            dt_util.utcnow() + slot_window[0]
+        ).isoformat()
+        delivery["slot"]["window_end"] = (dt_util.utcnow() + slot_window[1]).isoformat()
+
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        return delivery
+
+    return _setup
 
 
 @pytest.fixture

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -122,3 +122,58 @@ async def test_update_interval_capped_before_delivery_window(
 
     coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == timedelta(minutes=10)
+
+
+async def test_update_interval_relaxes_after_lag_window(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a still-current order relaxes to the default interval eventually."""
+    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
+    delivery["status"] = "CURRENT"
+    del delivery["delivery_time"]
+    delivery["eta2"] = {
+        "start": (dt_util.utcnow() + timedelta(minutes=10)).isoformat(),
+        "end": (dt_util.utcnow() + timedelta(minutes=30)).isoformat(),
+    }
+    mock_picnic_api.get_deliveries.return_value = [delivery]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
+
+    freezer.tick(timedelta(hours=3))
+    await coordinator.async_refresh()
+
+    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
+
+
+async def test_update_interval_uses_slot_window_without_eta(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+) -> None:
+    """Test that the slot window selects the faster interval when no ETA exists."""
+    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
+    delivery["status"] = "CURRENT"
+    del delivery["delivery_time"]
+    del delivery["eta2"]
+    delivery["slot"]["window_start"] = (
+        dt_util.utcnow() + timedelta(minutes=10)
+    ).isoformat()
+    delivery["slot"]["window_end"] = (
+        dt_util.utcnow() + timedelta(minutes=70)
+    ).isoformat()
+    mock_picnic_api.get_deliveries.return_value = [delivery]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -5,7 +5,9 @@ import json
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 
+from homeassistant.components.picnic.const import DOMAIN
 from homeassistant.components.picnic.coordinator import (
     DEFAULT_UPDATE_INTERVAL,
     DELIVERY_UPDATE_INTERVAL,
@@ -14,7 +16,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
 
 
 async def test_timeout_failed_with_retry(
@@ -32,148 +34,125 @@ async def test_timeout_failed_with_retry(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
-async def test_update_interval_default_without_current_delivery(
+async def _setup_with_delivery(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_picnic_api: MagicMock,
-) -> None:
-    """Test that the update interval is the default without an undelivered order."""
-    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
+    status: str,
+    eta2: tuple[timedelta, timedelta] | None,
+    slot_window: tuple[timedelta, timedelta] | None,
+) -> dict:
+    """Set up the integration with a delivery in the given state."""
+    # eta2 is the route-planning ETA as served by the deliveries API;
+    # the coordinator exposes it as the delivery's "eta"
+    delivery = json.loads(await async_load_fixture(hass, "delivery.json", DOMAIN))
+    delivery["status"] = status
+    delivery["delivery_time"] = None
+    delivery["eta2"] = (
+        {
+            "start": (dt_util.utcnow() + eta2[0]).isoformat(),
+            "end": (dt_util.utcnow() + eta2[1]).isoformat(),
+        }
+        if eta2 is not None
+        else None
+    )
+    if slot_window is not None:
+        delivery["slot"]["window_start"] = (
+            dt_util.utcnow() + slot_window[0]
+        ).isoformat()
+        delivery["slot"]["window_end"] = (dt_util.utcnow() + slot_window[1]).isoformat()
     mock_picnic_api.get_deliveries.return_value = [delivery]
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
+
+    return delivery
+
+
+@pytest.mark.parametrize(
+    ("status", "eta2", "slot_window", "expected_interval"),
+    [
+        # No undelivered order
+        ("COMPLETED", None, None, DEFAULT_UPDATE_INTERVAL),
+        # Delivery days away
+        (
+            "CURRENT",
+            (timedelta(days=2), timedelta(days=2, hours=1)),
+            None,
+            DEFAULT_UPDATE_INTERVAL,
+        ),
+        # Delivery under way
+        (
+            "CURRENT",
+            (timedelta(minutes=10), timedelta(minutes=30)),
+            None,
+            DELIVERY_UPDATE_INTERVAL,
+        ),
+        # Just ahead of the window: next poll capped at the window start
+        (
+            "CURRENT",
+            (timedelta(minutes=40), timedelta(minutes=60)),
+            None,
+            timedelta(minutes=10),
+        ),
+        # Long past the window while still current
+        (
+            "CURRENT",
+            (timedelta(hours=-4), timedelta(hours=-3)),
+            None,
+            DEFAULT_UPDATE_INTERVAL,
+        ),
+        # No ETA yet: the slot window selects the faster interval
+        (
+            "CURRENT",
+            None,
+            (timedelta(minutes=10), timedelta(minutes=70)),
+            DELIVERY_UPDATE_INTERVAL,
+        ),
+    ],
+)
+async def test_update_interval(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    status: str,
+    eta2: tuple[timedelta, timedelta] | None,
+    slot_window: tuple[timedelta, timedelta] | None,
+    expected_interval: timedelta,
+) -> None:
+    """Test the update interval for the various delivery states."""
+    await _setup_with_delivery(
+        hass, mock_config_entry, mock_picnic_api, status, eta2, slot_window
+    )
 
     coordinator = mock_config_entry.runtime_data
-    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
+    assert coordinator.update_interval == expected_interval
 
 
-async def test_update_interval_around_delivery(
+async def test_update_interval_relaxes_after_delivery(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_picnic_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test that the update interval tightens around the delivery and relaxes after."""
-    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
-    delivery["status"] = "CURRENT"
-    del delivery["delivery_time"]
-    delivery["eta2"] = {
-        "start": (dt_util.utcnow() - timedelta(minutes=5)).isoformat(),
-        "end": (dt_util.utcnow() + timedelta(minutes=15)).isoformat(),
-    }
-    mock_picnic_api.get_deliveries.return_value = [delivery]
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
+    """Test that the update interval returns to the default once delivered."""
+    delivery = await _setup_with_delivery(
+        hass,
+        mock_config_entry,
+        mock_picnic_api,
+        "CURRENT",
+        (timedelta(minutes=10), timedelta(minutes=30)),
+        None,
+    )
 
     coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
 
     delivery["status"] = "COMPLETED"
-    await coordinator.async_refresh()
+    freezer.tick(DELIVERY_UPDATE_INTERVAL + timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
     assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
-
-
-async def test_update_interval_default_before_delivery_day(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
-) -> None:
-    """Test that the update interval stays default while the delivery is far away."""
-    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
-    delivery["status"] = "CURRENT"
-    del delivery["delivery_time"]
-    delivery["eta2"] = {
-        "start": (dt_util.utcnow() + timedelta(days=2)).isoformat(),
-        "end": (dt_util.utcnow() + timedelta(days=2, hours=1)).isoformat(),
-    }
-    mock_picnic_api.get_deliveries.return_value = [delivery]
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
-
-
-async def test_update_interval_capped_before_delivery_window(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test that the next poll is not scheduled past the fast-polling window start."""
-    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
-    delivery["status"] = "CURRENT"
-    del delivery["delivery_time"]
-    delivery["eta2"] = {
-        "start": (dt_util.utcnow() + timedelta(minutes=40)).isoformat(),
-        "end": (dt_util.utcnow() + timedelta(minutes=60)).isoformat(),
-    }
-    mock_picnic_api.get_deliveries.return_value = [delivery]
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    assert coordinator.update_interval == timedelta(minutes=10)
-
-
-async def test_update_interval_relaxes_after_lag_window(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test that a still-current order relaxes to the default interval eventually."""
-    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
-    delivery["status"] = "CURRENT"
-    del delivery["delivery_time"]
-    delivery["eta2"] = {
-        "start": (dt_util.utcnow() + timedelta(minutes=10)).isoformat(),
-        "end": (dt_util.utcnow() + timedelta(minutes=30)).isoformat(),
-    }
-    mock_picnic_api.get_deliveries.return_value = [delivery]
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
-
-    freezer.tick(timedelta(hours=3))
-    await coordinator.async_refresh()
-
-    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
-
-
-async def test_update_interval_uses_slot_window_without_eta(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
-) -> None:
-    """Test that the slot window selects the faster interval when no ETA exists."""
-    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
-    delivery["status"] = "CURRENT"
-    del delivery["delivery_time"]
-    del delivery["eta2"]
-    delivery["slot"]["window_start"] = (
-        dt_util.utcnow() + timedelta(minutes=10)
-    ).isoformat()
-    delivery["slot"]["window_end"] = (
-        dt_util.utcnow() + timedelta(minutes=70)
-    ).isoformat()
-    mock_picnic_api.get_deliveries.return_value = [delivery]
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    coordinator = mock_config_entry.runtime_data
-    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, load_fixture
+from tests.common import MockConfigEntry, async_load_fixture
 
 
 async def test_timeout_failed_with_retry(
@@ -34,11 +34,18 @@ async def test_timeout_failed_with_retry(
 
 async def test_update_interval_default_without_current_delivery(
     hass: HomeAssistant,
-    init_integration: MockConfigEntry,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
 ) -> None:
     """Test that the update interval is the default without an undelivered order."""
-    coordinator = init_integration.runtime_data
+    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
+    mock_picnic_api.get_deliveries.return_value = [delivery]
 
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
 
 
@@ -48,7 +55,7 @@ async def test_update_interval_around_delivery(
     mock_picnic_api: MagicMock,
 ) -> None:
     """Test that the update interval tightens around the delivery and relaxes after."""
-    delivery = json.loads(load_fixture("picnic/delivery.json"))
+    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
     delivery["status"] = "CURRENT"
     del delivery["delivery_time"]
     delivery["eta2"] = {
@@ -76,7 +83,7 @@ async def test_update_interval_default_before_delivery_day(
     mock_picnic_api: MagicMock,
 ) -> None:
     """Test that the update interval stays default while the delivery is far away."""
-    delivery = json.loads(load_fixture("picnic/delivery.json"))
+    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
     delivery["status"] = "CURRENT"
     del delivery["delivery_time"]
     delivery["eta2"] = {
@@ -100,7 +107,7 @@ async def test_update_interval_capped_before_delivery_window(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that the next poll is not scheduled past the fast-polling window start."""
-    delivery = json.loads(load_fixture("picnic/delivery.json"))
+    delivery = json.loads(await async_load_fixture(hass, "picnic/delivery.json"))
     delivery["status"] = "CURRENT"
     del delivery["delivery_time"]
     delivery["eta2"] = {

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -4,6 +4,8 @@ from datetime import timedelta
 import json
 from unittest.mock import MagicMock
 
+from freezegun.api import FrozenDateTimeFactory
+
 from homeassistant.components.picnic.coordinator import (
     DEFAULT_UPDATE_INTERVAL,
     DELIVERY_UPDATE_INTERVAL,
@@ -62,7 +64,6 @@ async def test_update_interval_around_delivery(
     coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
 
-    # Once the delivery is completed, the interval returns to the default
     delivery["status"] = "COMPLETED"
     await coordinator.async_refresh()
 
@@ -90,3 +91,27 @@ async def test_update_interval_default_before_delivery_day(
 
     coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
+
+
+async def test_update_interval_capped_before_delivery_window(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that the next poll is not scheduled past the fast-polling window start."""
+    delivery = json.loads(load_fixture("picnic/delivery.json"))
+    delivery["status"] = "CURRENT"
+    del delivery["delivery_time"]
+    delivery["eta2"] = {
+        "start": (dt_util.utcnow() + timedelta(minutes=40)).isoformat(),
+        "end": (dt_util.utcnow() + timedelta(minutes=60)).isoformat(),
+    }
+    mock_picnic_api.get_deliveries.return_value = [delivery]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == timedelta(minutes=10)

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -1,11 +1,18 @@
 """Tests for the Picnic coordinator."""
 
+from datetime import timedelta
+import json
 from unittest.mock import MagicMock
 
+from homeassistant.components.picnic.coordinator import (
+    DEFAULT_UPDATE_INTERVAL,
+    DELIVERY_UPDATE_INTERVAL,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_fixture
 
 
 async def test_timeout_failed_with_retry(
@@ -21,3 +28,65 @@ async def test_timeout_failed_with_retry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_update_interval_default_without_current_delivery(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test that the update interval is the default without an undelivered order."""
+    coordinator = init_integration.runtime_data
+
+    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
+
+
+async def test_update_interval_around_delivery(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+) -> None:
+    """Test that the update interval tightens around the delivery and relaxes after."""
+    delivery = json.loads(load_fixture("picnic/delivery.json"))
+    delivery["status"] = "CURRENT"
+    del delivery["delivery_time"]
+    delivery["eta2"] = {
+        "start": (dt_util.utcnow() - timedelta(minutes=5)).isoformat(),
+        "end": (dt_util.utcnow() + timedelta(minutes=15)).isoformat(),
+    }
+    mock_picnic_api.get_deliveries.return_value = [delivery]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
+
+    # Once the delivery is completed, the interval returns to the default
+    delivery["status"] = "COMPLETED"
+    await coordinator.async_refresh()
+
+    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
+
+
+async def test_update_interval_default_before_delivery_day(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+) -> None:
+    """Test that the update interval stays default while the delivery is far away."""
+    delivery = json.loads(load_fixture("picnic/delivery.json"))
+    delivery["status"] = "CURRENT"
+    del delivery["delivery_time"]
+    delivery["eta2"] = {
+        "start": (dt_util.utcnow() + timedelta(days=2)).isoformat(),
+        "end": (dt_util.utcnow() + timedelta(days=2, hours=1)).isoformat(),
+    }
+    mock_picnic_api.get_deliveries.return_value = [delivery]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -112,11 +112,11 @@ async def _setup_with_delivery(
         ),
     ],
 )
+@pytest.mark.usefixtures("freezer")
 async def test_update_interval(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_picnic_api: MagicMock,
-    freezer: FrozenDateTimeFactory,
     status: str,
     eta2: tuple[timedelta, timedelta] | None,
     slot_window: tuple[timedelta, timedelta] | None,
@@ -155,4 +155,32 @@ async def test_update_interval_relaxes_after_delivery(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
+    assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
+
+
+async def test_update_interval_relaxes_when_refresh_fails(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that failed refreshes still relax the interval past the window."""
+    await _setup_with_delivery(
+        hass,
+        mock_config_entry,
+        mock_picnic_api,
+        "CURRENT",
+        (timedelta(minutes=10), timedelta(minutes=30)),
+        None,
+    )
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
+
+    mock_picnic_api.get_cart.return_value = None
+    freezer.tick(timedelta(hours=3))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.last_update_success is False
     assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.picnic.coordinator import (
+from homeassistant.components.picnic.const import (
     DEFAULT_UPDATE_INTERVAL,
     DELIVERY_UPDATE_INTERVAL,
 )

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -73,42 +73,47 @@ async def _setup_with_delivery(
 @pytest.mark.parametrize(
     ("status", "eta2", "slot_window", "expected_interval"),
     [
-        # No undelivered order
-        ("COMPLETED", None, None, DEFAULT_UPDATE_INTERVAL),
-        # Delivery days away
-        (
+        pytest.param(
+            "COMPLETED",
+            None,
+            None,
+            DEFAULT_UPDATE_INTERVAL,
+            id="no_undelivered_order",
+        ),
+        pytest.param(
             "CURRENT",
             (timedelta(days=2), timedelta(days=2, hours=1)),
             None,
             DEFAULT_UPDATE_INTERVAL,
+            id="delivery_days_away",
         ),
-        # Delivery under way
-        (
+        pytest.param(
             "CURRENT",
             (timedelta(minutes=10), timedelta(minutes=30)),
             None,
             DELIVERY_UPDATE_INTERVAL,
+            id="delivery_under_way",
         ),
-        # Just ahead of the window: next poll capped at the window start
-        (
+        pytest.param(
             "CURRENT",
             (timedelta(minutes=40), timedelta(minutes=60)),
             None,
             timedelta(minutes=10),
+            id="next_poll_capped_at_window_start",
         ),
-        # Long past the window while still current
-        (
+        pytest.param(
             "CURRENT",
             (timedelta(hours=-4), timedelta(hours=-3)),
             None,
             DEFAULT_UPDATE_INTERVAL,
+            id="long_past_window_still_current",
         ),
-        # No ETA yet: the slot window selects the faster interval
-        (
+        pytest.param(
             "CURRENT",
             None,
             (timedelta(minutes=10), timedelta(minutes=70)),
             DELIVERY_UPDATE_INTERVAL,
+            id="slot_window_fallback_without_eta",
         ),
     ],
 )
@@ -153,6 +158,7 @@ async def test_update_interval_relaxes_after_delivery(
     delivery["status"] = "COMPLETED"
     freezer.tick(DELIVERY_UPDATE_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
+    # The scheduled interval refresh runs as a background task
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
@@ -180,6 +186,7 @@ async def test_update_interval_relaxes_when_refresh_fails(
     mock_picnic_api.get_cart.return_value = None
     freezer.tick(timedelta(hours=3))
     async_fire_time_changed(hass)
+    # The scheduled interval refresh runs as a background task
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert coordinator.last_update_success is False

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -125,25 +125,17 @@ async def test_update_interval(
     assert coordinator.update_interval == expected_interval
 
 
-@pytest.mark.parametrize(
-    "malformed_date",
-    [
-        pytest.param("malformed", id="unparsable_eta"),
-        pytest.param("2021-02-30T12:00:00.000+01:00", id="invalid_date_eta"),
-    ],
-)
 @pytest.mark.usefixtures("freezer")
 async def test_update_interval_with_malformed_eta(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_picnic_api: MagicMock,
-    malformed_date: str,
 ) -> None:
     """Test that a malformed ETA falls back to the slot window."""
     delivery = mock_picnic_api.get_deliveries.return_value[0]
     delivery["status"] = "CURRENT"
     delivery["delivery_time"] = None
-    delivery["eta2"] = {"start": malformed_date, "end": malformed_date}
+    delivery["eta2"] = {"start": "malformed", "end": "malformed"}
     delivery["slot"]["window_start"] = (
         dt_util.utcnow() + timedelta(minutes=10)
     ).isoformat()

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -14,6 +14,8 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
+from .conftest import SetupDeliveryFixture
+
 from tests.common import MockConfigEntry, async_fire_time_changed
 
 
@@ -30,33 +32,6 @@ async def test_timeout_failed_with_retry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
-
-
-async def _setup_with_delivery(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
-    status: str,
-    eta2: tuple[timedelta, timedelta] | None,
-    slot_window: tuple[timedelta, timedelta],
-) -> dict:
-    """Set up the integration with the mocked delivery in the given state."""
-    delivery = mock_picnic_api.get_deliveries.return_value[0]
-    delivery["status"] = status
-    delivery["delivery_time"] = None
-    # eta2 is the API's field name for the route-planning ETA
-    delivery["eta2"] = eta2 and {
-        "start": (dt_util.utcnow() + eta2[0]).isoformat(),
-        "end": (dt_util.utcnow() + eta2[1]).isoformat(),
-    }
-    delivery["slot"]["window_start"] = (dt_util.utcnow() + slot_window[0]).isoformat()
-    delivery["slot"]["window_end"] = (dt_util.utcnow() + slot_window[1]).isoformat()
-
-    mock_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    return delivery
 
 
 @pytest.mark.parametrize(
@@ -115,18 +90,15 @@ async def _setup_with_delivery(
 )
 @pytest.mark.usefixtures("freezer")
 async def test_update_interval(
-    hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
+    setup_delivery: SetupDeliveryFixture,
     status: str,
     eta2: tuple[timedelta, timedelta] | None,
     slot_window: tuple[timedelta, timedelta],
     expected_interval: timedelta,
 ) -> None:
     """Test the update interval for the various delivery states."""
-    await _setup_with_delivery(
-        hass, mock_config_entry, mock_picnic_api, status, eta2, slot_window
-    )
+    await setup_delivery(status, eta2, slot_window)
 
     coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == expected_interval
@@ -161,14 +133,11 @@ async def test_update_interval_with_malformed_eta(
 async def test_update_interval_relaxes_after_delivery(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_picnic_api: MagicMock,
+    setup_delivery: SetupDeliveryFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that the update interval returns to the default once delivered."""
-    delivery = await _setup_with_delivery(
-        hass,
-        mock_config_entry,
-        mock_picnic_api,
+    delivery = await setup_delivery(
         "CURRENT",
         (timedelta(minutes=10), timedelta(minutes=30)),
         (timedelta(minutes=-15), timedelta(minutes=45)),
@@ -189,13 +158,11 @@ async def test_update_interval_relaxes_when_refresh_fails(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_picnic_api: MagicMock,
+    setup_delivery: SetupDeliveryFixture,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that failed refreshes still relax the interval past the window."""
-    await _setup_with_delivery(
-        hass,
-        mock_config_entry,
-        mock_picnic_api,
+    await setup_delivery(
         "CURRENT",
         (timedelta(minutes=10), timedelta(minutes=30)),
         (timedelta(minutes=-15), timedelta(minutes=45)),

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -92,6 +92,13 @@ async def _setup_with_delivery(
         ),
         pytest.param(
             "CURRENT",
+            (timedelta(minutes=30, seconds=30), timedelta(minutes=50)),
+            (timedelta(minutes=30, seconds=30), timedelta(minutes=50)),
+            DELIVERY_UPDATE_INTERVAL,
+            id="next_poll_never_sooner_than_delivery_interval",
+        ),
+        pytest.param(
+            "CURRENT",
             (timedelta(hours=-4), timedelta(hours=-3)),
             (timedelta(hours=-4), timedelta(hours=-3)),
             DEFAULT_UPDATE_INTERVAL,

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -126,17 +126,25 @@ async def test_update_interval(
     assert coordinator.update_interval == expected_interval
 
 
+@pytest.mark.parametrize(
+    "malformed_date",
+    [
+        pytest.param("malformed", id="unparsable_eta"),
+        pytest.param("2021-02-30T12:00:00.000+01:00", id="invalid_date_eta"),
+    ],
+)
 @pytest.mark.usefixtures("freezer")
 async def test_update_interval_with_malformed_eta(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_picnic_api: MagicMock,
+    malformed_date: str,
 ) -> None:
     """Test that a malformed ETA falls back to the slot window."""
     delivery = mock_picnic_api.get_deliveries.return_value[0]
     delivery["status"] = "CURRENT"
     delivery["delivery_time"] = None
-    delivery["eta2"] = {"start": "malformed", "end": "malformed"}
+    delivery["eta2"] = {"start": malformed_date, "end": malformed_date}
     delivery["slot"]["window_start"] = (
         dt_util.utcnow() + timedelta(minutes=10)
     ).isoformat()

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -1,13 +1,11 @@
 """Tests for the Picnic coordinator."""
 
 from datetime import timedelta
-import json
 from unittest.mock import MagicMock
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.picnic.const import DOMAIN
 from homeassistant.components.picnic.coordinator import (
     DEFAULT_UPDATE_INTERVAL,
     DELIVERY_UPDATE_INTERVAL,
@@ -16,7 +14,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, async_fire_time_changed, async_load_fixture
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_timeout_failed_with_retry(
@@ -40,28 +38,20 @@ async def _setup_with_delivery(
     mock_picnic_api: MagicMock,
     status: str,
     eta2: tuple[timedelta, timedelta] | None,
-    slot_window: tuple[timedelta, timedelta] | None,
+    slot_window: tuple[timedelta, timedelta],
 ) -> dict:
-    """Set up the integration with a delivery in the given state."""
-    # eta2 is the route-planning ETA as served by the deliveries API;
-    # the coordinator exposes it as the delivery's "eta"
-    delivery = json.loads(await async_load_fixture(hass, "delivery.json", DOMAIN))
+    """Set up the integration with the mocked delivery in the given state."""
+    delivery = mock_picnic_api.get_deliveries.return_value[0]
     delivery["status"] = status
     delivery["delivery_time"] = None
-    delivery["eta2"] = (
-        {
-            "start": (dt_util.utcnow() + eta2[0]).isoformat(),
-            "end": (dt_util.utcnow() + eta2[1]).isoformat(),
-        }
-        if eta2 is not None
-        else None
-    )
-    if slot_window is not None:
-        delivery["slot"]["window_start"] = (
-            dt_util.utcnow() + slot_window[0]
-        ).isoformat()
-        delivery["slot"]["window_end"] = (dt_util.utcnow() + slot_window[1]).isoformat()
-    mock_picnic_api.get_deliveries.return_value = [delivery]
+    # eta2 is the route-planning ETA as served by the deliveries API;
+    # the coordinator exposes it as the delivery's "eta"
+    delivery["eta2"] = eta2 and {
+        "start": (dt_util.utcnow() + eta2[0]).isoformat(),
+        "end": (dt_util.utcnow() + eta2[1]).isoformat(),
+    }
+    delivery["slot"]["window_start"] = (dt_util.utcnow() + slot_window[0]).isoformat()
+    delivery["slot"]["window_end"] = (dt_util.utcnow() + slot_window[1]).isoformat()
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
@@ -76,35 +66,35 @@ async def _setup_with_delivery(
         pytest.param(
             "COMPLETED",
             None,
-            None,
+            (timedelta(hours=-2), timedelta(hours=-1)),
             DEFAULT_UPDATE_INTERVAL,
             id="no_undelivered_order",
         ),
         pytest.param(
             "CURRENT",
             (timedelta(days=2), timedelta(days=2, hours=1)),
-            None,
+            (timedelta(days=2), timedelta(days=2, hours=1)),
             DEFAULT_UPDATE_INTERVAL,
             id="delivery_days_away",
         ),
         pytest.param(
             "CURRENT",
             (timedelta(minutes=10), timedelta(minutes=30)),
-            None,
+            (timedelta(minutes=-15), timedelta(minutes=45)),
             DELIVERY_UPDATE_INTERVAL,
             id="delivery_under_way",
         ),
         pytest.param(
             "CURRENT",
             (timedelta(minutes=40), timedelta(minutes=60)),
-            None,
+            (timedelta(minutes=40), timedelta(minutes=60)),
             timedelta(minutes=10),
             id="next_poll_capped_at_window_start",
         ),
         pytest.param(
             "CURRENT",
             (timedelta(hours=-4), timedelta(hours=-3)),
-            None,
+            (timedelta(hours=-4), timedelta(hours=-3)),
             DEFAULT_UPDATE_INTERVAL,
             id="long_past_window_still_current",
         ),
@@ -124,7 +114,7 @@ async def test_update_interval(
     mock_picnic_api: MagicMock,
     status: str,
     eta2: tuple[timedelta, timedelta] | None,
-    slot_window: tuple[timedelta, timedelta] | None,
+    slot_window: tuple[timedelta, timedelta],
     expected_interval: timedelta,
 ) -> None:
     """Test the update interval for the various delivery states."""
@@ -134,6 +124,32 @@ async def test_update_interval(
 
     coordinator = mock_config_entry.runtime_data
     assert coordinator.update_interval == expected_interval
+
+
+@pytest.mark.usefixtures("freezer")
+async def test_update_interval_with_malformed_eta(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_picnic_api: MagicMock,
+) -> None:
+    """Test that a malformed ETA falls back to the slot window."""
+    delivery = mock_picnic_api.get_deliveries.return_value[0]
+    delivery["status"] = "CURRENT"
+    delivery["delivery_time"] = None
+    delivery["eta2"] = {"start": "malformed", "end": "malformed"}
+    delivery["slot"]["window_start"] = (
+        dt_util.utcnow() + timedelta(minutes=10)
+    ).isoformat()
+    delivery["slot"]["window_end"] = (
+        dt_util.utcnow() + timedelta(minutes=70)
+    ).isoformat()
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DELIVERY_UPDATE_INTERVAL
 
 
 async def test_update_interval_relaxes_after_delivery(
@@ -149,7 +165,7 @@ async def test_update_interval_relaxes_after_delivery(
         mock_picnic_api,
         "CURRENT",
         (timedelta(minutes=10), timedelta(minutes=30)),
-        None,
+        (timedelta(minutes=-15), timedelta(minutes=45)),
     )
 
     coordinator = mock_config_entry.runtime_data
@@ -158,7 +174,6 @@ async def test_update_interval_relaxes_after_delivery(
     delivery["status"] = "COMPLETED"
     freezer.tick(DELIVERY_UPDATE_INTERVAL + timedelta(seconds=30))
     async_fire_time_changed(hass)
-    # The scheduled interval refresh runs as a background task
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert coordinator.update_interval == DEFAULT_UPDATE_INTERVAL
@@ -177,7 +192,7 @@ async def test_update_interval_relaxes_when_refresh_fails(
         mock_picnic_api,
         "CURRENT",
         (timedelta(minutes=10), timedelta(minutes=30)),
-        None,
+        (timedelta(minutes=-15), timedelta(minutes=45)),
     )
 
     coordinator = mock_config_entry.runtime_data
@@ -186,7 +201,6 @@ async def test_update_interval_relaxes_when_refresh_fails(
     mock_picnic_api.get_cart.return_value = None
     freezer.tick(timedelta(hours=3))
     async_fire_time_changed(hass)
-    # The scheduled interval refresh runs as a background task
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert coordinator.last_update_success is False

--- a/tests/components/picnic/test_coordinator.py
+++ b/tests/components/picnic/test_coordinator.py
@@ -44,8 +44,7 @@ async def _setup_with_delivery(
     delivery = mock_picnic_api.get_deliveries.return_value[0]
     delivery["status"] = status
     delivery["delivery_time"] = None
-    # eta2 is the route-planning ETA as served by the deliveries API;
-    # the coordinator exposes it as the delivery's "eta"
+    # eta2 is the API's field name for the route-planning ETA
     delivery["eta2"] = eta2 and {
         "start": (dt_util.utcnow() + eta2[0]).isoformat(),
         "end": (dt_util.utcnow() + eta2[1]).isoformat(),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The Picnic coordinator polls at a fixed 30 minute interval. The ETA sensors normally show the window computed when the delivery routes are planned; only shortly before arrival does the API serve the much more precise position-based ETA (`/deliveries/{id}/position`), which the coordinator already prefers when available. With a fixed 30 minute interval that refinement usually reaches Home Assistant after the delivery has already happened — delivery windows are only about 20 minutes wide.

This change makes the update interval dynamic: from 30 minutes before the expected delivery (position/planned ETA, falling back to the slot window) until 2 hours after it — or until the order is completed or cancelled — the coordinator polls every minute, then returns to the default 30 minutes.

Observed on a real delivery while testing: the position-based ETA shifted about 10 minutes past the planned window and kept drifting during the final half hour, and the status flip to `COMPLETED` landed between two 1-minute polls. None of that is visible in time with the fixed interval, which is exactly what "delivery arriving soon" automations need.

The 1-minute interval is conservative next to the polling cadence the position endpoint itself advertises to live clients (`query_interval` in its response), so this stays well within what the service expects.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
