### PR TITLE
Make BSB-LAN slow startup refresh nonblocking

### DIFF
--- a/homeassistant/components/bsblan/__init__.py
+++ b/homeassistant/components/bsblan/__init__.py
@@ -257,10 +257,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
     # Perform first refresh of fast coordinator (required for entities)
     await fast_coordinator.async_config_entry_first_refresh()
 
-    # Refresh slow coordinator - don't fail if DHW is not available
-    # This allows the integration to work even if the device doesn't support DHW
-    await slow_coordinator.async_refresh()
-
     entry.runtime_data = BSBLanData(
         client=bsblan,
         fast_coordinator=fast_coordinator,
@@ -269,6 +265,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: BSBLanConfigEntry) -> bo
         info=info,
         static=static_per_circuit,
         available_circuits=circuits,
+    )
+
+    # Fetch slow data in the background so it does not block startup.
+    entry.async_create_background_task(
+        hass,
+        slow_coordinator.async_refresh(),
+        name=f"{DOMAIN}_slow_data_fetch_{entry.entry_id}",
     )
 
     # Register main device before forwarding platforms, so sub-devices

--- a/homeassistant/components/bsblan/water_heater.py
+++ b/homeassistant/components/bsblan/water_heater.py
@@ -80,32 +80,49 @@ class BSBLANWaterHeater(BSBLanWaterHeaterDeviceEntity, WaterHeaterEntity):
         # Initialize available attribute to resolve multiple inheritance conflict
         self._attr_available = True
 
-        # Set temperature limits based on device capabilities from slow coordinator
+    @property
+    @override
+    def min_temp(self) -> float:
+        """Return the minimum temperature.
+
+        Derived from the slow-coordinator DHW config, which may still be
+        pending when the platform is set up. Falls back to the default until
+        the config becomes available.
+        """
         dhw_config = (
-            data.slow_coordinator.data.dhw_config
-            if data.slow_coordinator.data
+            self.slow_coordinator.data.dhw_config
+            if self.slow_coordinator.data
             else None
         )
-
-        # For min_temp: Use reduced_setpoint from config data (slow polling)
         if (
             dhw_config is not None
             and dhw_config.reduced_setpoint is not None
             and dhw_config.reduced_setpoint.value is not None
         ):
-            self._attr_min_temp = dhw_config.reduced_setpoint.value
-        else:
-            self._attr_min_temp = 10.0  # Default minimum
+            return dhw_config.reduced_setpoint.value
+        return 10.0  # Default minimum
 
-        # For max_temp: Use nominal_setpoint_max from config data (slow polling)
+    @property
+    @override
+    def max_temp(self) -> float:
+        """Return the maximum temperature.
+
+        Derived from the slow-coordinator DHW config, which may still be
+        pending when the platform is set up. Falls back to the default until
+        the config becomes available.
+        """
+        dhw_config = (
+            self.slow_coordinator.data.dhw_config
+            if self.slow_coordinator.data
+            else None
+        )
         if (
             dhw_config is not None
             and dhw_config.nominal_setpoint_max is not None
             and dhw_config.nominal_setpoint_max.value is not None
         ):
-            self._attr_max_temp = dhw_config.nominal_setpoint_max.value
-        else:
-            self._attr_max_temp = 65.0  # Default maximum
+            return dhw_config.nominal_setpoint_max.value
+        return 65.0  # Default maximum
 
     @property
     def _dhw(self) -> HotWaterState:

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the BSBLan integration."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import MagicMock
 
@@ -288,6 +289,37 @@ async def test_coordinator_dhw_config_update_error(
 
     # Verify the error handling paths were executed
     assert mock_bsblan.hot_water_config.called
+    assert mock_bsblan.hot_water_schedule.called
+
+
+async def test_setup_does_not_block_on_slow_fetch(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+) -> None:
+    """Test setup does not wait for the background slow-data fetch."""
+    release = asyncio.Event()
+    config_value = mock_bsblan.hot_water_config.return_value
+
+    async def _blocking_config(*args: object, **kwargs: object) -> object:
+        await release.wait()
+        return config_value
+
+    mock_bsblan.hot_water_config.side_effect = _blocking_config
+
+    mock_config_entry.add_to_hass(hass)
+    try:
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        # Setup finished even though the slow-data fetch is still pending.
+        assert mock_config_entry.state is ConfigEntryState.LOADED
+        assert not mock_bsblan.hot_water_schedule.called
+    finally:
+        # Release the fetch so it can complete and clean up.
+        release.set()
+        await hass.async_block_till_done()
+
     assert mock_bsblan.hot_water_schedule.called
 
 

--- a/tests/components/bsblan/test_water_heater.py
+++ b/tests/components/bsblan/test_water_heater.py
@@ -1,5 +1,6 @@
 """Tests for the BSB-LAN water heater platform."""
 
+import asyncio
 from datetime import timedelta
 from unittest.mock import AsyncMock, MagicMock
 
@@ -390,6 +391,41 @@ async def test_water_heater_custom_temperature_limits_from_config(
     assert (
         state.attributes.get("max_temp") == 75.0
     )  # Custom maximum from nominal_setpoint_max
+
+
+async def test_water_heater_temperature_limits_update_after_slow_fetch(
+    hass: HomeAssistant,
+    mock_bsblan: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test temperature limits update when the background fetch completes."""
+    release = asyncio.Event()
+    config = mock_bsblan.hot_water_config.return_value
+    config.reduced_setpoint.value = 15.0
+    config.nominal_setpoint_max.value = 75.0
+
+    async def _blocking_config(*args: object, **kwargs: object) -> object:
+        await release.wait()
+        return config
+
+    mock_bsblan.hot_water_config.side_effect = _blocking_config
+
+    await setup_with_selected_platforms(
+        hass, mock_config_entry, [Platform.WATER_HEATER]
+    )
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["min_temp"] == 10.0
+    assert state.attributes["max_temp"] == 65.0
+
+    release.set()
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes["min_temp"] == 15.0
+    assert state.attributes["max_temp"] == 75.0
 
 
 async def test_turn_on(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This pull request improves the BSBLan integration's startup performance by ensuring that slow data fetching does not block setup, and refactors how water heater temperature limits are provided so they update dynamically as data becomes available. It also adds tests to verify these behaviors.

**Startup Performance Improvements:**

* The slow coordinator's data fetch is now started as a background task during setup, so the integration loads without waiting for slow data [[1]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adL260-L263) [[2]](diffhunk://#diff-fe69e1abca9daf1aec997fb5ef29442939601724b4cb06174efe7b33a65463adR270-R276).

**Water Heater Temperature Limit Handling:**

* The `min_temp` and `max_temp` properties in the water heater entity are now computed dynamically from the slow coordinator's data, falling back to defaults until the data is available, instead of being statically set at initialization.

**Testing Enhancements:**

* Added a test to ensure that integration setup does not block on slow data fetch and completes promptly.
* Added a test to verify that water heater temperature limits update after the slow data fetch completes.
* Added necessary imports for `asyncio` in test files to support the new tests [[1]](diffhunk://#diff-204acf61a2d66c4ddaeeecafce3091a75ffbd6ec806339d72b3f7591313fca97R3) [[2]](diffhunk://#diff-857292b3ae7ad8dcb3b31c2366d7c66b083121504ed7ec3053bdc8335414d56fR3).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
