### PR TITLE
Improve and extend WMS WebControl pro tests

### DIFF
--- a/tests/components/wmspro/conftest.py
+++ b/tests/components/wmspro/conftest.py
@@ -83,10 +83,12 @@ async def mock_hub_configuration(
     request: pytest.FixtureRequest, hass: HomeAssistant
 ) -> AsyncGenerator[AsyncMock]:
     """Override WebControlPro._getConfiguration with a param fixture file."""
+    hub_config = await async_load_json_object_fixture(hass, request.param, DOMAIN)
     with patch(
         "wmspro.webcontrol.WebControlPro._getConfiguration",
-        return_value=await async_load_json_object_fixture(hass, request.param, DOMAIN),
+        return_value=hub_config,
     ) as mock_hub_configuration:
+        mock_hub_configuration.configure_mock(**hub_config)
         yield mock_hub_configuration
 
 
@@ -95,10 +97,12 @@ async def mock_hub_status(
     request: pytest.FixtureRequest, hass: HomeAssistant
 ) -> AsyncGenerator[AsyncMock]:
     """Override WebControlPro._getStatus with a param fixture file."""
+    hub_status = await async_load_json_object_fixture(hass, request.param, DOMAIN)
     with patch(
         "wmspro.webcontrol.WebControlPro._getStatus",
-        return_value=await async_load_json_object_fixture(hass, request.param, DOMAIN),
+        return_value=hub_status,
     ) as mock_hub_status:
+        mock_hub_status.configure_mock(**hub_status)
         yield mock_hub_status
 
 

--- a/tests/components/wmspro/fixtures/config_prod_light_switch.json
+++ b/tests/components/wmspro/fixtures/config_prod_light_switch.json
@@ -1,0 +1,32 @@
+{
+  "command": "getConfiguration",
+  "protocolVersion": "1.0.0",
+  "destinations": [
+    {
+      "id": 97358,
+      "animationType": 6,
+      "names": ["Licht", "", "", ""],
+      "actions": [
+        {
+          "id": 20,
+          "actionType": 4,
+          "actionDescription": 6
+        },
+        {
+          "id": 22,
+          "actionType": 8,
+          "actionDescription": 13
+        }
+      ]
+    }
+  ],
+  "rooms": [
+    {
+      "id": 19239,
+      "name": "Terrasse",
+      "destinations": [97358],
+      "scenes": []
+    }
+  ],
+  "scenes": []
+}

--- a/tests/components/wmspro/fixtures/status_prod_light_switch.json
+++ b/tests/components/wmspro/fixtures/status_prod_light_switch.json
@@ -1,0 +1,22 @@
+{
+  "command": "getStatus",
+  "protocolVersion": "1.0.0",
+  "details": [
+    {
+      "destinationId": 97358,
+      "data": {
+        "drivingCause": 0,
+        "heartbeatError": false,
+        "blocking": false,
+        "productData": [
+          {
+            "actionId": 20,
+            "value": {
+              "onOffState": false
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/tests/components/wmspro/test_button.py
+++ b/tests/components/wmspro/test_button.py
@@ -33,7 +33,6 @@ async def test_button_update(
     mock_hub_ping: AsyncMock,
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
-    mock_action_call: AsyncMock,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that a button entity is created and updated correctly."""
@@ -63,12 +62,16 @@ async def test_button_press(
     """Test that a button entity is pressed correctly."""
 
     assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_configuration.mock_calls) == 1
+    assert len(mock_hub_status.mock_calls) == 2
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
         entity = hass.states.get("button.terrasse_markise_identify")
         assert entity is not None
         before_state = entity.state
@@ -83,7 +86,8 @@ async def test_button_press(
         entity = hass.states.get("button.terrasse_markise_identify")
         assert entity is not None
         assert entity.state != before_state
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
 
 @pytest.mark.parametrize(
@@ -114,7 +118,6 @@ async def test_button_rotation_reset_press(
     mock_hub_ping: AsyncMock,
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
-    mock_action_call: AsyncMock,
     freezer: FrozenDateTimeFactory,
     button_entity_id: str,
     range_entity_id: str,

--- a/tests/components/wmspro/test_button.py
+++ b/tests/components/wmspro/test_button.py
@@ -39,7 +39,7 @@ async def test_button_update(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("button.terrasse_markise_identify")
     assert entity is not None
@@ -64,7 +64,7 @@ async def test_button_press(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     with patch(
         "wmspro.destination.Destination.refresh",
@@ -128,7 +128,7 @@ async def test_button_rotation_reset_press(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(range_entity_id)
     assert entity is not None

--- a/tests/components/wmspro/test_cover.py
+++ b/tests/components/wmspro/test_cover.py
@@ -148,7 +148,9 @@ async def test_cover_open_and_close(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -161,13 +163,19 @@ async def test_cover_open_and_close(
         assert entity is not None
         assert entity.state == STATE_OPEN
         assert entity.attributes[ATTR_CURRENT_POSITION] == 100
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -180,7 +188,11 @@ async def test_cover_open_and_close(
         assert entity is not None
         assert entity.state == STATE_CLOSED
         assert entity.attributes[ATTR_CURRENT_POSITION] == 0
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )
 
 
 @pytest.mark.parametrize(
@@ -238,7 +250,8 @@ async def test_cover_open_to_pos(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -251,7 +264,8 @@ async def test_cover_open_to_pos(
         assert entity is not None
         assert entity.state == STATE_OPEN
         assert entity.attributes[ATTR_CURRENT_POSITION] == 50
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
 
 @pytest.mark.parametrize(
@@ -309,7 +323,8 @@ async def test_cover_open_and_stop(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -322,13 +337,15 @@ async def test_cover_open_and_stop(
         assert entity is not None
         assert entity.state == STATE_OPEN
         assert entity.attributes[ATTR_CURRENT_POSITION] == 80
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -341,7 +358,8 @@ async def test_cover_open_and_stop(
         assert entity is not None
         assert entity.state == STATE_OPEN
         assert entity.attributes[ATTR_CURRENT_POSITION] == 80
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
 
 @pytest.mark.parametrize(
@@ -381,7 +399,9 @@ async def test_cover_tilt_open_and_close(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -393,13 +413,19 @@ async def test_cover_tilt_open_and_close(
         entity = hass.states.get(entity_id)
         assert entity is not None
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 0
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -411,7 +437,11 @@ async def test_cover_tilt_open_and_close(
         entity = hass.states.get(entity_id)
         assert entity is not None
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 50
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )
 
 
 @pytest.mark.parametrize(
@@ -451,7 +481,9 @@ async def test_cover_tilt_to_pos(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -463,7 +495,11 @@ async def test_cover_tilt_to_pos(
         entity = hass.states.get(entity_id)
         assert entity is not None
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 100
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )
 
 
 @pytest.mark.parametrize(
@@ -505,7 +541,9 @@ async def test_cover_tilt_with_open_and_close_pos(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -519,13 +557,19 @@ async def test_cover_tilt_with_open_and_close_pos(
         assert entity.state == STATE_OPEN
         assert entity.attributes[ATTR_CURRENT_POSITION] == 100
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 100
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
+        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -539,4 +583,8 @@ async def test_cover_tilt_with_open_and_close_pos(
         assert entity.state == STATE_CLOSED
         assert entity.attributes[ATTR_CURRENT_POSITION] == 0
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 0
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert (
+            len(mock_action_call.mock_calls) == before_action + 1
+            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+        )

--- a/tests/components/wmspro/test_cover.py
+++ b/tests/components/wmspro/test_cover.py
@@ -93,32 +93,48 @@ async def test_cover_update(
 
 
 @pytest.mark.parametrize(
-    ("mock_hub_configuration", "mock_hub_status", "entity_id"),
+    (
+        "mock_hub_configuration",
+        "mock_hub_status",
+        "entity_id",
+        "num_action",
+        "num_action_list",
+    ),
     [
         (
             "config_prod_awning_dimmer.json",
             "status_prod_awning.json",
             "cover.terrasse_markise",
+            1,
+            0,
         ),
         (
             "config_prod_awning_valance.json",
             "status_prod_valance.json",
             "cover.raum_0_markise_2",
+            1,
+            0,
         ),
         (
             "config_prod_roller_shutter.json",
             "status_prod_roller_shutter.json",
             "cover.wohnbereich_wohnebene_alle",
+            1,
+            0,
         ),
         (
             "config_prod_slat_drive.json",
             "status_prod_slat_drive.json",
             "cover.terrasse_lamellen",
+            1,
+            0,
         ),
         (
             "config_prod_slat_rotate.json",
             "status_prod_slat_rotate.json",
             "cover.zonwering_begane_grond_keuken_alle",
+            2,
+            1,
         ),
     ],
     indirect=["mock_hub_configuration", "mock_hub_status"],
@@ -132,6 +148,8 @@ async def test_cover_open_and_close(
     mock_action_call: AsyncMock,
     mock_action_list_call: AsyncMock,
     entity_id: str,
+    num_action: int,
+    num_action_list: int,
 ) -> None:
     """Test that a cover entity is opened and closed correctly."""
     assert await setup_config_entry(hass, mock_config_entry)
@@ -164,9 +182,10 @@ async def test_cover_open_and_close(
         assert entity.state == STATE_OPEN
         assert entity.attributes[ATTR_CURRENT_POSITION] == 100
         assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + num_action
         assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+            len(mock_action_list_call.mock_calls)
+            == before_action_list + num_action_list
         )
 
     with patch(
@@ -189,9 +208,10 @@ async def test_cover_open_and_close(
         assert entity.state == STATE_CLOSED
         assert entity.attributes[ATTR_CURRENT_POSITION] == 0
         assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + num_action
         assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+            len(mock_action_list_call.mock_calls)
+            == before_action_list + num_action_list
         )
 
 
@@ -380,7 +400,6 @@ async def test_cover_tilt_open_and_close(
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
     mock_action_call: AsyncMock,
-    mock_action_list_call: AsyncMock,
     entity_id: str,
 ) -> None:
     """Test that a cover entity is tilted open and closed correctly."""
@@ -401,7 +420,6 @@ async def test_cover_tilt_open_and_close(
     ):
         before_status = len(mock_hub_status.mock_calls)
         before_action = len(mock_action_call.mock_calls)
-        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -414,10 +432,7 @@ async def test_cover_tilt_open_and_close(
         assert entity is not None
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 0
         assert len(mock_hub_status.mock_calls) == before_status
-        assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
-        )
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
     with patch(
         "wmspro.destination.Destination.refresh",
@@ -425,7 +440,6 @@ async def test_cover_tilt_open_and_close(
     ):
         before_status = len(mock_hub_status.mock_calls)
         before_action = len(mock_action_call.mock_calls)
-        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -438,10 +452,7 @@ async def test_cover_tilt_open_and_close(
         assert entity is not None
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 50
         assert len(mock_hub_status.mock_calls) == before_status
-        assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
-        )
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
 
 @pytest.mark.parametrize(
@@ -462,7 +473,6 @@ async def test_cover_tilt_to_pos(
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
     mock_action_call: AsyncMock,
-    mock_action_list_call: AsyncMock,
     entity_id: str,
 ) -> None:
     """Test that a cover entity is tilted to correct position."""
@@ -483,7 +493,6 @@ async def test_cover_tilt_to_pos(
     ):
         before_status = len(mock_hub_status.mock_calls)
         before_action = len(mock_action_call.mock_calls)
-        before_action_list = len(mock_action_list_call.mock_calls)
 
         await hass.services.async_call(
             COVER_DOMAIN,
@@ -496,19 +505,24 @@ async def test_cover_tilt_to_pos(
         assert entity is not None
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 100
         assert len(mock_hub_status.mock_calls) == before_status
-        assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
-        )
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
 
 @pytest.mark.parametrize(
-    ("mock_hub_configuration", "mock_hub_status", "entity_id"),
+    (
+        "mock_hub_configuration",
+        "mock_hub_status",
+        "entity_id",
+        "num_action",
+        "num_action_list",
+    ),
     [
         (
             "config_prod_slat_rotate.json",
             "status_prod_slat_rotate.json",
             "cover.zonwering_begane_grond_keuken_alle",
+            2,
+            1,
         ),
     ],
     indirect=["mock_hub_configuration", "mock_hub_status"],
@@ -522,6 +536,8 @@ async def test_cover_tilt_with_open_and_close_pos(
     mock_action_call: AsyncMock,
     mock_action_list_call: AsyncMock,
     entity_id: str,
+    num_action: int,
+    num_action_list: int,
 ) -> None:
     """Test that a cover entity is tilted to correct position."""
     assert await setup_config_entry(hass, mock_config_entry)
@@ -558,9 +574,10 @@ async def test_cover_tilt_with_open_and_close_pos(
         assert entity.attributes[ATTR_CURRENT_POSITION] == 100
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 100
         assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + num_action
         assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+            len(mock_action_list_call.mock_calls)
+            == before_action_list + num_action_list
         )
 
     with patch(
@@ -584,7 +601,8 @@ async def test_cover_tilt_with_open_and_close_pos(
         assert entity.attributes[ATTR_CURRENT_POSITION] == 0
         assert entity.attributes[ATTR_CURRENT_TILT_POSITION] == 0
         assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + num_action
         assert (
-            len(mock_action_call.mock_calls) == before_action + 1
-            or len(mock_action_list_call.mock_calls) == before_action_list + 1
+            len(mock_action_list_call.mock_calls)
+            == before_action_list + num_action_list
         )

--- a/tests/components/wmspro/test_cover.py
+++ b/tests/components/wmspro/test_cover.py
@@ -60,15 +60,6 @@ async def test_cover_device(
     assert device_entry is not None
     assert device_entry == snapshot
 
-    before_status = len(mock_hub_status.mock_calls)
-
-    # Move time to next update
-    freezer.tick(SCAN_INTERVAL)
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    assert len(mock_hub_status.mock_calls) == before_status + 1
-
 
 @pytest.mark.parametrize(
     ("mock_hub_configuration", "mock_hub_status"),

--- a/tests/components/wmspro/test_cover.py
+++ b/tests/components/wmspro/test_cover.py
@@ -46,6 +46,7 @@ async def test_cover_device(
     mock_hub_ping: AsyncMock,
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
+    freezer: FrozenDateTimeFactory,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
@@ -53,11 +54,20 @@ async def test_cover_device(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "58717")})
     assert device_entry is not None
     assert device_entry == snapshot
+
+    before_status = len(mock_hub_status.mock_calls)
+
+    # Move time to next update
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert len(mock_hub_status.mock_calls) == before_status + 1
 
 
 @pytest.mark.parametrize(
@@ -78,18 +88,20 @@ async def test_cover_update(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("cover.terrasse_markise")
     assert entity is not None
     assert entity == snapshot
+
+    before_status = len(mock_hub_status.mock_calls)
 
     # Move time to next update
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(mock_hub_status.mock_calls) >= 3
+    assert len(mock_hub_status.mock_calls) == before_status + 1
 
 
 @pytest.mark.parametrize(
@@ -155,7 +167,7 @@ async def test_cover_open_and_close(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -259,7 +271,7 @@ async def test_cover_open_to_pos(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -332,7 +344,7 @@ async def test_cover_open_and_stop(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -406,7 +418,7 @@ async def test_cover_tilt_open_and_close(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -479,7 +491,7 @@ async def test_cover_tilt_to_pos(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     await hass.async_block_till_done(wait_background_tasks=True)
 
@@ -543,7 +555,7 @@ async def test_cover_tilt_with_open_and_close_pos(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     await hass.async_block_till_done(wait_background_tasks=True)
 

--- a/tests/components/wmspro/test_init.py
+++ b/tests/components/wmspro/test_init.py
@@ -56,6 +56,8 @@ async def test_config_entry_persistent_storage(
     )
 
     assert await setup_config_entry(hass, mock_config_entry)
+    assert len(mock_hub_ping.mock_calls) == 1
+    assert len(mock_hub_refresh.mock_calls) == 1
     assert config_dir.is_dir()  # created during setup
 
     assert await unload_config_entry(hass, mock_config_entry)

--- a/tests/components/wmspro/test_init.py
+++ b/tests/components/wmspro/test_init.py
@@ -89,12 +89,12 @@ async def test_device_setup(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) > 0
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     device_entries = device_registry.devices.get_devices_for_config_entry_id(
         mock_config_entry.entry_id
     )
-    assert len(device_entries) > 1
+    assert len(device_entries) > len(mock_hub_configuration.destinations)
 
     device_entries = list(
         filter(
@@ -102,6 +102,6 @@ async def test_device_setup(
             device_entries,
         )
     )
-    assert len(device_entries) > 0
+    assert len(device_entries) >= len(mock_hub_configuration.destinations)
     for device_entry in device_entries:
         assert device_entry == snapshot(name=f"device-{device_entry.serial_number}")

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -109,7 +109,8 @@ async def test_light_turn_on_and_off(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -122,13 +123,15 @@ async def test_light_turn_on_and_off(
         assert entity is not None
         assert entity.state == STATE_ON
         assert entity.attributes[ATTR_BRIGHTNESS] >= 1
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -141,7 +144,8 @@ async def test_light_turn_on_and_off(
         assert entity is not None
         assert entity.state == STATE_OFF
         assert entity.attributes[ATTR_BRIGHTNESS] is None
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
 
 @pytest.mark.parametrize(
@@ -172,7 +176,8 @@ async def test_light_dimm_on_and_off(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -185,13 +190,15 @@ async def test_light_dimm_on_and_off(
         assert entity is not None
         assert entity.state == STATE_ON
         assert entity.attributes[ATTR_BRIGHTNESS] >= 1
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -204,13 +211,15 @@ async def test_light_dimm_on_and_off(
         assert entity is not None
         assert entity.state == STATE_ON
         assert entity.attributes[ATTR_BRIGHTNESS] == 128
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             LIGHT_DOMAIN,
@@ -223,4 +232,5 @@ async def test_light_dimm_on_and_off(
         assert entity is not None
         assert entity.state == STATE_OFF
         assert entity.attributes[ATTR_BRIGHTNESS] is None
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -84,9 +84,12 @@ async def test_light_update(
 
 
 @pytest.mark.parametrize(
-    ("mock_hub_configuration", "mock_hub_status"),
-    [("config_prod_awning_dimmer.json", "status_prod_dimmer.json")],
-    indirect=True,
+    ("mock_hub_configuration", "mock_hub_status", "target_brightness"),
+    [
+        ("config_prod_awning_dimmer.json", "status_prod_dimmer.json", 1),
+        ("config_prod_light_switch.json", "status_prod_light_switch.json", 255),
+    ],
+    indirect=["mock_hub_configuration", "mock_hub_status"],
 )
 async def test_light_turn_on_and_off(
     hass: HomeAssistant,
@@ -95,6 +98,7 @@ async def test_light_turn_on_and_off(
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
     mock_action_call: AsyncMock,
+    target_brightness: int,
 ) -> None:
     """Test that a light entity is turned on and off correctly."""
     assert await setup_config_entry(hass, mock_config_entry)
@@ -105,7 +109,7 @@ async def test_light_turn_on_and_off(
     entity = hass.states.get("light.terrasse_licht")
     assert entity is not None
     assert entity.state == STATE_OFF
-    assert entity.attributes[ATTR_BRIGHTNESS] is None
+    assert entity.attributes.get(ATTR_BRIGHTNESS, None) is None
 
     with patch(
         "wmspro.destination.Destination.refresh",
@@ -124,7 +128,7 @@ async def test_light_turn_on_and_off(
         entity = hass.states.get("light.terrasse_licht")
         assert entity is not None
         assert entity.state == STATE_ON
-        assert entity.attributes[ATTR_BRIGHTNESS] >= 1
+        assert entity.attributes.get(ATTR_BRIGHTNESS, 255) == target_brightness
         assert len(mock_hub_status.mock_calls) == before_status
         assert len(mock_action_call.mock_calls) == before_action + 1
 
@@ -145,7 +149,7 @@ async def test_light_turn_on_and_off(
         entity = hass.states.get("light.terrasse_licht")
         assert entity is not None
         assert entity.state == STATE_OFF
-        assert entity.attributes[ATTR_BRIGHTNESS] is None
+        assert entity.attributes.get(ATTR_BRIGHTNESS, None) is None
         assert len(mock_hub_status.mock_calls) == before_status
         assert len(mock_action_call.mock_calls) == before_action + 1
 

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -87,7 +87,7 @@ async def test_light_update(
     ("mock_hub_configuration", "mock_hub_status", "target_brightness"),
     [
         ("config_prod_awning_dimmer.json", "status_prod_dimmer.json", 1),
-        ("config_prod_light_switch.json", "status_prod_light_switch.json", 255),
+        ("config_prod_light_switch.json", "status_prod_light_switch.json", None),
     ],
     indirect=["mock_hub_configuration", "mock_hub_status"],
 )
@@ -109,7 +109,7 @@ async def test_light_turn_on_and_off(
     entity = hass.states.get("light.terrasse_licht")
     assert entity is not None
     assert entity.state == STATE_OFF
-    assert entity.attributes.get(ATTR_BRIGHTNESS, None) is None
+    assert entity.attributes.get(ATTR_BRIGHTNESS) is None
 
     with patch(
         "wmspro.destination.Destination.refresh",
@@ -128,7 +128,10 @@ async def test_light_turn_on_and_off(
         entity = hass.states.get("light.terrasse_licht")
         assert entity is not None
         assert entity.state == STATE_ON
-        assert entity.attributes.get(ATTR_BRIGHTNESS, 255) == target_brightness
+        if target_brightness is None:
+            assert entity.attributes.get(ATTR_BRIGHTNESS) is None
+        else:
+            assert entity.attributes.get(ATTR_BRIGHTNESS) == target_brightness
         assert len(mock_hub_status.mock_calls) == before_status
         assert len(mock_action_call.mock_calls) == before_action + 1
 
@@ -149,7 +152,7 @@ async def test_light_turn_on_and_off(
         entity = hass.states.get("light.terrasse_licht")
         assert entity is not None
         assert entity.state == STATE_OFF
-        assert entity.attributes.get(ATTR_BRIGHTNESS, None) is None
+        assert entity.attributes.get(ATTR_BRIGHTNESS) is None
         assert len(mock_hub_status.mock_calls) == before_status
         assert len(mock_action_call.mock_calls) == before_action + 1
 

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -42,7 +42,7 @@ async def test_light_device(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "97358")})
     assert device_entry is not None
@@ -67,18 +67,20 @@ async def test_light_update(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("light.terrasse_licht")
     assert entity is not None
     assert entity == snapshot
+
+    before_status = len(mock_hub_status.mock_calls)
 
     # Move time to next update
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(mock_hub_status.mock_calls) >= 3
+    assert len(mock_hub_status.mock_calls) == before_status + 2
 
 
 @pytest.mark.parametrize(
@@ -98,7 +100,7 @@ async def test_light_turn_on_and_off(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("light.terrasse_licht")
     assert entity is not None
@@ -165,7 +167,7 @@ async def test_light_dimm_on_and_off(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("light.terrasse_licht")
     assert entity is not None

--- a/tests/components/wmspro/test_light.py
+++ b/tests/components/wmspro/test_light.py
@@ -98,7 +98,7 @@ async def test_light_turn_on_and_off(
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
     mock_action_call: AsyncMock,
-    target_brightness: int,
+    target_brightness: int | None,
 ) -> None:
     """Test that a light entity is turned on and off correctly."""
     assert await setup_config_entry(hass, mock_config_entry)
@@ -128,10 +128,7 @@ async def test_light_turn_on_and_off(
         entity = hass.states.get("light.terrasse_licht")
         assert entity is not None
         assert entity.state == STATE_ON
-        if target_brightness is None:
-            assert entity.attributes.get(ATTR_BRIGHTNESS) is None
-        else:
-            assert entity.attributes.get(ATTR_BRIGHTNESS) == target_brightness
+        assert entity.attributes.get(ATTR_BRIGHTNESS) == target_brightness
         assert len(mock_hub_status.mock_calls) == before_status
         assert len(mock_action_call.mock_calls) == before_action + 1
 

--- a/tests/components/wmspro/test_number.py
+++ b/tests/components/wmspro/test_number.py
@@ -100,7 +100,8 @@ async def test_number_set_value(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             NUMBER_DOMAIN,
@@ -117,7 +118,8 @@ async def test_number_set_value(
         entity = hass.states.get(entity_id)
         assert entity is not None
         assert float(entity.state) == float(target_value)
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) <= before_action + 1
 
 
 @pytest.mark.parametrize(
@@ -138,8 +140,6 @@ async def test_number_set_and_restore_value(
     mock_hub_ping: AsyncMock,
     mock_hub_configuration: AsyncMock,
     mock_hub_status: AsyncMock,
-    mock_action_call: AsyncMock,
-    freezer: FrozenDateTimeFactory,
     entity_id: str,
     initial_value: str,
     target_value: str,

--- a/tests/components/wmspro/test_number.py
+++ b/tests/components/wmspro/test_number.py
@@ -47,18 +47,20 @@ async def test_number_update(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 7
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
     assert entity == snapshot
+
+    before_status = len(mock_hub_status.mock_calls)
 
     # Move time to next update
     freezer.tick(SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(mock_hub_status.mock_calls) >= 10
+    assert len(mock_hub_status.mock_calls) == before_status + 28
 
 
 @pytest.mark.parametrize(
@@ -91,7 +93,7 @@ async def test_number_set_value(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 7
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -149,7 +151,7 @@ async def test_number_set_and_restore_value(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) == 7
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -191,7 +193,7 @@ async def test_number_update_handles_zero_value(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(
         "number.zonwering_begane_grond_keuken_alle_minimum_rotation"

--- a/tests/components/wmspro/test_number.py
+++ b/tests/components/wmspro/test_number.py
@@ -62,11 +62,11 @@ async def test_number_update(
 
 
 @pytest.mark.parametrize(
-    ("entity_id", "initial_value", "target_value"),
+    ("entity_id", "initial_value", "target_value", "num_action"),
     [
-        ("number.zonwering_begane_grond_keuken_alle_raw_rotation", "0", "80"),
-        ("number.zonwering_begane_grond_keuken_alle_minimum_rotation", "-75", "-50"),
-        ("number.zonwering_begane_grond_keuken_alle_maximum_rotation", "75", "100"),
+        ("number.zonwering_begane_grond_keuken_alle_raw_rotation", "0", "80", 1),
+        ("number.zonwering_begane_grond_keuken_alle_minimum_rotation", "-75", "-50", 0),
+        ("number.zonwering_begane_grond_keuken_alle_maximum_rotation", "75", "100", 0),
     ],
 )
 @pytest.mark.parametrize(
@@ -85,6 +85,7 @@ async def test_number_set_value(
     entity_id: str,
     initial_value: str,
     target_value: str,
+    num_action: int,
 ) -> None:
     """Test that a number entity is created and value set correctly."""
     assert await setup_config_entry(hass, mock_config_entry)
@@ -119,7 +120,7 @@ async def test_number_set_value(
         assert entity is not None
         assert float(entity.state) == float(target_value)
         assert len(mock_hub_status.mock_calls) == before_status
-        assert len(mock_action_call.mock_calls) <= before_action + 1
+        assert len(mock_action_call.mock_calls) == before_action + num_action
 
 
 @pytest.mark.parametrize(

--- a/tests/components/wmspro/test_scene.py
+++ b/tests/components/wmspro/test_scene.py
@@ -34,6 +34,7 @@ async def test_scene_room_device(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
+    assert len(mock_dest_refresh.mock_calls) == 2
 
     device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "42581")})
     assert device_entry is not None
@@ -58,6 +59,7 @@ async def test_scene_activate(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
+    assert len(mock_dest_refresh.mock_calls) == 2
 
     entity = hass.states.get("scene.raum_0_raum_0_gute_nacht")
     assert entity is not None

--- a/tests/components/wmspro/test_services.py
+++ b/tests/components/wmspro/test_services.py
@@ -39,7 +39,7 @@ async def test_set_cover_position_and_tilt_service_is_registered(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     assert hass.services.has_service(DOMAIN, SERVICE_SET_COVER_POSITION_AND_TILT)
 
@@ -69,7 +69,7 @@ async def test_set_cover_position_and_tilt_service_executes(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get(entity_id)
     assert entity is not None
@@ -128,7 +128,7 @@ async def test_set_cover_position_and_tilt_unsupported_entity_raises(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     before = len(mock_hub_status.mock_calls)
 

--- a/tests/components/wmspro/test_switch.py
+++ b/tests/components/wmspro/test_switch.py
@@ -110,7 +110,8 @@ async def test_switch_turn_on_and_off(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -122,13 +123,15 @@ async def test_switch_turn_on_and_off(
         entity = hass.states.get("switch.terasse_heizung_links")
         assert entity is not None
         assert entity.state == STATE_ON
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1
 
     with patch(
         "wmspro.destination.Destination.refresh",
         return_value=True,
     ):
-        before = len(mock_hub_status.mock_calls)
+        before_status = len(mock_hub_status.mock_calls)
+        before_action = len(mock_action_call.mock_calls)
 
         await hass.services.async_call(
             SWITCH_DOMAIN,
@@ -140,4 +143,5 @@ async def test_switch_turn_on_and_off(
         entity = hass.states.get("switch.terasse_heizung_links")
         assert entity is not None
         assert entity.state == STATE_OFF
-        assert len(mock_hub_status.mock_calls) == before
+        assert len(mock_hub_status.mock_calls) == before_status
+        assert len(mock_action_call.mock_calls) == before_action + 1

--- a/tests/components/wmspro/test_switch.py
+++ b/tests/components/wmspro/test_switch.py
@@ -42,7 +42,7 @@ async def test_switch_device(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "499120")})
     assert device_entry is not None
@@ -67,7 +67,7 @@ async def test_switch_update(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 2
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("switch.terasse_heizung_links")
     assert entity is not None
@@ -80,7 +80,7 @@ async def test_switch_update(
     async_fire_time_changed(hass)
     await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert len(mock_hub_status.mock_calls) > before
+    assert len(mock_hub_status.mock_calls) == before + 12
 
 
 @pytest.mark.parametrize(
@@ -100,7 +100,7 @@ async def test_switch_turn_on_and_off(
     assert await setup_config_entry(hass, mock_config_entry)
     assert len(mock_hub_ping.mock_calls) == 1
     assert len(mock_hub_configuration.mock_calls) == 1
-    assert len(mock_hub_status.mock_calls) >= 1
+    assert len(mock_hub_status.mock_calls) == len(mock_hub_configuration.destinations)
 
     entity = hass.states.get("switch.terasse_heizung_links")
     assert entity is not None


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Enhance mock asserts and remove unused mocks from wmspro tests
- Avoid fuzziness in test assertions, especially regarding number of calls
- Add missing test case for simple light switch without dimming (reaches 100% test coverage!)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
