### PR TITLE
Rename "advanced_options" section to "additional_options" in Template

### DIFF
--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -29,7 +29,14 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import async_get_integration
 from homeassistant.util.hass_dict import HassKey
 
-from .const import CONF_MAX, CONF_MIN, CONF_STEP, DOMAIN, PLATFORMS
+from .const import (
+    CONF_ADDITIONAL_OPTIONS,
+    CONF_MAX,
+    CONF_MIN,
+    CONF_STEP,
+    DOMAIN,
+    PLATFORMS,
+)
 from .coordinator import TriggerUpdateCoordinator
 from .helpers import async_get_blueprints
 
@@ -140,6 +147,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             hass.config_entries.async_update_entry(
                 config_entry, version=1, minor_version=2
             )
+
+        options = {**config_entry.options}
+        # The "advanced_options" section was renamed to "additional_options"
+        if (additional := options.pop("advanced_options", None)) is not None:
+            options[CONF_ADDITIONAL_OPTIONS] = additional
+        hass.config_entries.async_update_entry(
+            config_entry, options=options, version=2, minor_version=1
+        )
 
     _LOGGER.debug(
         "Migration to configuration version %s.%s successful",

--- a/homeassistant/components/template/config_flow.py
+++ b/homeassistant/components/template/config_flow.py
@@ -60,7 +60,7 @@ from .alarm_control_panel import (
 )
 from .binary_sensor import async_create_preview_binary_sensor
 from .const import (
-    CONF_ADVANCED_OPTIONS,
+    CONF_ADDITIONAL_OPTIONS,
     CONF_AVAILABILITY,
     CONF_PRESS,
     CONF_TURN_OFF,
@@ -157,7 +157,7 @@ _SCHEMA_STATE: dict[vol.Marker, Any] = {
 def generate_schema(domain: str, flow_type: str) -> vol.Schema:
     """Generate schema."""
     schema: dict[vol.Marker, Any] = {}
-    advanced_options: dict[vol.Marker, Any] = {}
+    additional_options: dict[vol.Marker, Any] = {}
 
     if flow_type == "config":
         schema = {vol.Required(CONF_NAME): selector.TextSelector()}
@@ -240,7 +240,7 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
             vol.Optional(CONF_LATITUDE): selector.TemplateSelector(),
             vol.Optional(CONF_LONGITUDE): selector.TemplateSelector(),
         }
-        advanced_options |= {
+        additional_options |= {
             vol.Optional(CONF_LOCATION_ACCURACY): selector.TemplateSelector(),
         }
 
@@ -445,11 +445,11 @@ def generate_schema(domain: str, flow_type: str) -> vol.Schema:
 
     schema |= {
         vol.Optional(CONF_DEVICE_ID): selector.DeviceSelector(),
-        vol.Optional(CONF_ADVANCED_OPTIONS): section(
+        vol.Optional(CONF_ADDITIONAL_OPTIONS): section(
             vol.Schema(
                 {
                     vol.Optional(CONF_AVAILABILITY): selector.TemplateSelector(),
-                    **advanced_options,
+                    **additional_options,
                 }
             ),
             {"collapsed": True},
@@ -782,8 +782,7 @@ class TemplateConfigFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     options_flow = OPTIONS_FLOW
     options_flow_reloads = True
 
-    MINOR_VERSION = 2
-    VERSION = 1
+    VERSION = 2
 
     @callback
     @override
@@ -901,9 +900,9 @@ def ws_start_preview(
         return
 
     config: dict = msg["user_input"]
-    advanced_options = config.pop(CONF_ADVANCED_OPTIONS, {})
+    additional_options = config.pop(CONF_ADDITIONAL_OPTIONS, {})
     preview_entity = CREATE_PREVIEW_ENTITY[template_type](
-        hass, name, {**config, **advanced_options}
+        hass, name, {**config, **additional_options}
     )
     preview_entity.hass = hass
     preview_entity.registry_entry = entity_registry_entry

--- a/homeassistant/components/template/const.py
+++ b/homeassistant/components/template/const.py
@@ -3,7 +3,7 @@
 from homeassistant.const import Platform
 from homeassistant.helpers.typing import ConfigType
 
-CONF_ADVANCED_OPTIONS = "advanced_options"
+CONF_ADDITIONAL_OPTIONS = "additional_options"
 CONF_ATTRIBUTE_TEMPLATES = "attribute_templates"
 CONF_ATTRIBUTES = "attributes"
 CONF_AVAILABILITY = "availability"

--- a/homeassistant/components/template/helpers.py
+++ b/homeassistant/components/template/helpers.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.singleton import singleton
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.util import slugify
 
-from .const import CONF_ADVANCED_OPTIONS, CONF_DEFAULT_ENTITY_ID, DOMAIN
+from .const import CONF_ADDITIONAL_OPTIONS, CONF_DEFAULT_ENTITY_ID, DOMAIN
 from .entity import AbstractTemplateEntity
 from .template_entity import TemplateEntity
 from .trigger_entity import TriggerEntity
@@ -240,8 +240,8 @@ async def async_setup_template_entry(
     options = dict(config_entry.options)
     options.pop("template_type")
 
-    if advanced_options := options.pop(CONF_ADVANCED_OPTIONS, None):
-        options = {**options, **advanced_options}
+    if additional_options := options.pop(CONF_ADDITIONAL_OPTIONS, None):
+        options = {**options, **additional_options}
 
     if replace_value_template and CONF_VALUE_TEMPLATE in options:
         options[CONF_STATE] = options.pop(CONF_VALUE_TEMPLATE)

--- a/homeassistant/components/template/strings.json
+++ b/homeassistant/components/template/strings.json
@@ -1,6 +1,6 @@
 {
   "common": {
-    "advanced_options": "Advanced options",
+    "additional_options": "Additional options",
     "availability": "Availability template",
     "availability_description": "Defines a template to get the `available` state of the entity. If the template either fails to render or returns `True`, `\"1\"`, `\"true\"`, `\"yes\"`, `\"on\"`, `\"enable\"`, or a non-zero number, the entity will be `available`. If the template returns any other value, the entity will be `unavailable`. If not configured, the entity will always be `available`. Note that the string comparison is not case sensitive; `\"TrUe\"` and `\"yEs\"` are allowed.",
     "code_format": "Code format",
@@ -42,14 +42,14 @@
           "value_template": "Defines a template to set the state of the alarm panel. Valid output values from the template are `armed_away`, `armed_home`, `armed_night`, `armed_vacation`, `arming`, `disarmed`, `pending`, and `triggered`."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template alarm control panel"
@@ -66,14 +66,14 @@
           "state": "The sensor is `on` if the template evaluates as `True`, `yes`, `on`, `enable` or a positive number. Any other value will render it as `off`."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template binary sensor"
@@ -90,14 +90,14 @@
           "press": "Defines actions to run when button is pressed."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template button"
@@ -124,14 +124,14 @@
           "stop_cover": "Defines actions to run when the cover is stopped."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template cover"
@@ -152,7 +152,7 @@
           "name": "[%key:common::config_flow::data::name%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
               "location_accuracy": "Location accuracy"
@@ -161,7 +161,7 @@
               "availability": "[%key:component::template::common::availability_description%]",
               "location_accuracy": "Defines a template to get the accuracy of the device tracker's location in meters. Valid values are numbers greater than or equal to `0`."
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template device tracker"
@@ -180,14 +180,14 @@
           "event_types": "Defines a template for a list of available event types."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template event"
@@ -213,14 +213,14 @@
           "turn_on": "Defines actions to run when the fan is turned on. Receives variables `percentage` and/or `preset_mode`."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template fan"
@@ -238,14 +238,14 @@
           "verify_ssl": "Enable or disable SSL certificate verification. Disable to use an http URL, or if you have a self-signed SSL certificate and haven’t installed the CA certificate to enable verification."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template image"
@@ -277,14 +277,14 @@
           "turn_on": "Defines actions to run when the light is turned on."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template light"
@@ -308,14 +308,14 @@
           "unlock": "Defines actions to run when the lock is unlocked."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template lock"
@@ -342,14 +342,14 @@
           "unit_of_measurement": "Defines the unit of measurement of the number, if any."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template number"
@@ -369,14 +369,14 @@
           "state": "Template for the select’s current value."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template select"
@@ -396,14 +396,14 @@
           "unit_of_measurement": "Defines the unit of measurement for the sensor, if any. This will also display the value based on the number format setting in the user profile and influence the graphical presentation in the history visualization as a continuous value."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template sensor"
@@ -423,14 +423,14 @@
           "value_template": "Defines a template to set the state of the switch. If not defined, the switch will optimistically assume all commands are successful."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template switch"
@@ -465,14 +465,14 @@
           "update_percentage": "Defines a template to get the update completion percentage."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template update"
@@ -529,14 +529,14 @@
           "stop": "Defines actions to run when the vacuum is stopped."
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template vacuum"
@@ -562,11 +562,11 @@
           "temperature_unit": "The temperature unit"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template weather"
@@ -621,14 +621,14 @@
           "value_template": "[%key:component::template::config::step::alarm_control_panel::data_description::value_template%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::alarm_control_panel::title%]"
@@ -644,14 +644,14 @@
           "state": "[%key:component::template::config::step::binary_sensor::data_description::state%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::binary_sensor::title%]"
@@ -666,14 +666,14 @@
           "press": "[%key:component::template::config::step::button::data_description::press%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::button::title%]"
@@ -698,14 +698,14 @@
           "stop_cover": "[%key:component::template::config::step::cover::data_description::stop_cover%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::cover::title%]"
@@ -724,16 +724,16 @@
           "longitude": "[%key:component::template::config::step::device_tracker::data_description::longitude%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]",
-              "location_accuracy": "[%key:component::template::config::step::device_tracker::sections::advanced_options::data::location_accuracy%]"
+              "location_accuracy": "[%key:component::template::config::step::device_tracker::sections::additional_options::data::location_accuracy%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]",
-              "location_accuracy": "[%key:component::template::config::step::device_tracker::sections::advanced_options::data_description::location_accuracy%]"
+              "location_accuracy": "[%key:component::template::config::step::device_tracker::sections::additional_options::data_description::location_accuracy%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::device_tracker::title%]"
@@ -751,14 +751,14 @@
           "event_types": "[%key:component::template::config::step::event::data_description::event_types%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::event::title%]"
@@ -783,14 +783,14 @@
           "turn_on": "[%key:component::template::config::step::fan::data_description::turn_on%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::fan::title%]"
@@ -807,14 +807,14 @@
           "verify_ssl": "[%key:component::template::config::step::image::data_description::verify_ssl%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::image::title%]"
@@ -846,14 +846,14 @@
           "turn_on": "[%key:component::template::config::step::light::data_description::turn_on%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::light::title%]"
@@ -876,14 +876,14 @@
           "unlock": "[%key:component::template::config::step::lock::data_description::unlock%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::lock::title%]"
@@ -908,14 +908,14 @@
           "step": "[%key:component::template::config::step::number::data_description::step%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::number::title%]"
@@ -935,14 +935,14 @@
           "state": "[%key:component::template::config::step::select::data_description::state%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::select::title%]"
@@ -961,14 +961,14 @@
           "unit_of_measurement": "[%key:component::template::config::step::sensor::data_description::unit_of_measurement%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::sensor::title%]"
@@ -988,14 +988,14 @@
           "value_template": "[%key:component::template::config::step::switch::data_description::value_template%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::switch::title%]"
@@ -1030,14 +1030,14 @@
           "update_percentage": "[%key:component::template::config::step::update::data_description::update_percentage%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "Template update"
@@ -1071,14 +1071,14 @@
           "stop": "[%key:component::template::config::step::vacuum::data_description::stop%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
             "data_description": {
               "availability": "[%key:component::template::common::availability_description%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::vacuum::title%]"
@@ -1104,11 +1104,11 @@
           "temperature_unit": "[%key:component::template::config::step::weather::data_description::temperature_unit%]"
         },
         "sections": {
-          "advanced_options": {
+          "additional_options": {
             "data": {
               "availability": "[%key:component::template::common::availability%]"
             },
-            "name": "[%key:component::template::common::advanced_options%]"
+            "name": "[%key:component::template::common::additional_options%]"
           }
         },
         "title": "[%key:component::template::config::step::weather::title%]"

--- a/tests/components/template/test_config_flow.py
+++ b/tests/components/template/test_config_flow.py
@@ -321,7 +321,7 @@ async def test_config_flow(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == template_type
 
-    availability = {"advanced_options": {"availability": "{{ True }}"}}
+    availability = {"additional_options": {"availability": "{{ True }}"}}
 
     with patch(
         "homeassistant.components.template.async_setup_entry", wraps=async_setup_entry
@@ -1103,7 +1103,7 @@ async def test_config_flow_preview(
     assert result["preview"] == "template"
 
     availability = {
-        "advanced_options": {
+        "additional_options": {
             "availability": "{{ is_state('binary_sensor.available', 'on') }}"
         }
     }

--- a/tests/components/template/test_device_tracker.py
+++ b/tests/components/template/test_device_tracker.py
@@ -150,7 +150,7 @@ async def test_setup_config_entry(
         options={
             "name": TEST_TRACKER.object_id,
             **TEST_MINIMUM_REQUIREMENTS,
-            "advanced_options": {"location_accuracy": "{{ 10 }}"},
+            "additional_options": {"location_accuracy": "{{ 10 }}"},
             "template_type": device_tracker.DOMAIN,
         },
         title="My template",

--- a/tests/components/template/test_init.py
+++ b/tests/components/template/test_init.py
@@ -578,8 +578,41 @@ async def test_migration_1_1(
     template_entity_entry = entity_registry.async_get("sensor.my_template")
     assert template_entity_entry.device_id == device_entry.id
 
-    assert template_config_entry.version == 1
-    assert template_config_entry.minor_version == 2
+    assert template_config_entry.version == 2
+    assert template_config_entry.minor_version == 1
+
+
+async def test_migration_1_2(
+    hass: HomeAssistant,
+) -> None:
+    """Test migration from v1.2 renames the advanced_options section."""
+
+    template_config_entry = MockConfigEntry(
+        data={},
+        domain=DOMAIN,
+        options={
+            "name": "My template",
+            "template_type": "sensor",
+            "state": "{{ 'foo' }}",
+            "advanced_options": {"availability": "{{ True }}"},
+        },
+        title="My template",
+        version=1,
+        minor_version=2,
+    )
+    template_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(template_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert template_config_entry.state is ConfigEntryState.LOADED
+    assert "advanced_options" not in template_config_entry.options
+    assert template_config_entry.options["additional_options"] == {
+        "availability": "{{ True }}"
+    }
+
+    assert template_config_entry.version == 2
+    assert template_config_entry.minor_version == 1
 
 
 async def test_migration_from_future_version(
@@ -595,7 +628,7 @@ async def test_migration_from_future_version(
             "state": "{{ 'foo' }}",
         },
         title="My template",
-        version=2,
+        version=3,
         minor_version=1,
     )
     config_entry.add_to_hass(hass)


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Alternative to #174056. This PR also renames the section key `advanced_options` to `additional_options`. Since the section key is stored in config entries, we'll have to do a major version config entry bump.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #174028
- This PR is related to issue: #174056
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
