### PR TITLE
Bump ha-philipsjs to 3.2.5

### DIFF
--- a/homeassistant/components/philips_js/manifest.json
+++ b/homeassistant/components/philips_js/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["haphilipsjs"],
-  "requirements": ["ha-philipsjs==3.3.5"],
+  "requirements": ["ha-philipsjs==3.2.5"],
   "zeroconf": ["_philipstv_s_rpc._tcp.local.", "_philipstv_rpc._tcp.local."]
 }

--- a/homeassistant/components/philips_js/manifest.json
+++ b/homeassistant/components/philips_js/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["haphilipsjs"],
-  "requirements": ["ha-philipsjs==3.2.4"],
+  "requirements": ["ha-philipsjs==3.3.5"],
   "zeroconf": ["_philipstv_s_rpc._tcp.local.", "_philipstv_rpc._tcp.local."]
 }

--- a/homeassistant/components/philips_js/manifest.json
+++ b/homeassistant/components/philips_js/manifest.json
@@ -7,6 +7,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["haphilipsjs"],
-  "requirements": ["ha-philipsjs==3.2.5"],
+  "requirements": ["ha-philipsjs==3.3.5"],
   "zeroconf": ["_philipstv_s_rpc._tcp.local.", "_philipstv_rpc._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1204,7 +1204,7 @@ ha-ffmpeg==3.2.2
 ha-iotawattpy==0.2.1
 
 # homeassistant.components.philips_js
-ha-philipsjs==3.3.5
+ha-philipsjs==3.2.5
 
 # homeassistant.components.homeassistant_hardware
 ha-silabs-firmware-client==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1204,7 +1204,7 @@ ha-ffmpeg==3.2.2
 ha-iotawattpy==0.2.1
 
 # homeassistant.components.philips_js
-ha-philipsjs==3.2.4
+ha-philipsjs==3.3.5
 
 # homeassistant.components.homeassistant_hardware
 ha-silabs-firmware-client==0.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1204,7 +1204,7 @@ ha-ffmpeg==3.2.2
 ha-iotawattpy==0.2.1
 
 # homeassistant.components.philips_js
-ha-philipsjs==3.2.5
+ha-philipsjs==3.3.5
 
 # homeassistant.components.homeassistant_hardware
 ha-silabs-firmware-client==0.3.0


### PR DESCRIPTION
## Proposed change

Bump the `ha-philipsjs` requirement to `3.2.5`.

Version `3.2.5` was published on 2026-07-10 and includes the fixes below. This PR updates Home Assistant from `3.2.4` to the installable `3.2.5` release.

This release includes several fixes relevant to the `philips_js` integration on Philips API 6.x firmware:
- Dead-endpoint caching and JSON-response hygiene
- A conditional `quirk_ambilight_mode_ignored` workaround (only applied on affected firmware)
- Ambilight turned off via cached pixels on quirked firmware, where the `OFF` style is otherwise silently ignored
- A `menuSettings` fallback for Ambilight styles on quirked Linux/Saphi firmware

Changelog/release notes: https://github.com/danielperna84/ha-philipsjs/releases/tag/3.2.5
Tag diff: https://github.com/danielperna84/ha-philipsjs/compare/3.2.4...3.2.5
Actual installable PyPI release: https://pypi.org/project/ha-philipsjs/3.2.5/

`requirements_all.txt` was updated by hand rather than via `script.gen_requirements_all`: this checkout only has the `philips_js` integration's manifest present, so running the generator would have dropped every other integration's entries. The single-line change was verified to match exactly what the generator would produce for this manifest.

Related: fixes #156776

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #156776
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by hand, not via `script.gen_requirements_all` — see note above.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
