### PR TITLE
Improve Mealie shopping list todo: split food item display into summary and description

### DIFF
--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -35,18 +35,66 @@ TODO_STATUS_MAP = {
 TODO_STATUS_MAP_INV = {v: k for k, v in TODO_STATUS_MAP.items()}
 
 
+def _build_description(item: ShoppingItem) -> str | None:
+    """Build a description string from quantity, unit, and note."""
+    parts: list[str] = []
+    if item.quantity:
+        qty = item.quantity
+        parts.append(str(int(qty)) if qty == int(qty) else str(qty))
+    if item.unit and item.unit.name:
+        parts.append(item.unit.name)
+    prefix = " ".join(parts)
+    note = (item.note or "").strip()
+    if prefix and note:
+        return f"{prefix}, {note}"
+    return prefix or note or None
+
+
+def _parse_description(description: str | None) -> tuple[float, str]:
+    """Parse a description string back into (quantity, note).
+
+    Format: "{qty} {unit_name}, {note}" — unit name is ignored on write since
+    we cannot resolve a unit name to a unit_id without an API call. Best-effort:
+    if the first token before a comma is numeric it becomes the quantity; anything
+    after a comma becomes the note; if there is no comma and the first token is not
+    numeric the whole string is treated as the note.
+    """
+    if not description:
+        return 0.0, ""
+
+    prefix_part, found_comma, note_part = description.partition(",")
+    note = note_part.strip() if found_comma else ""
+    prefix_part = prefix_part.strip()
+
+    tokens = prefix_part.split(None, 1)
+    quantity = 0.0
+    if tokens:
+        try:
+            quantity = float(tokens[0])
+        except ValueError:
+            if not found_comma:
+                note = prefix_part
+
+    return quantity, note
+
+
 def _convert_api_item(item: ShoppingItem) -> TodoItem:
     """Convert Mealie shopping list items into a TodoItem."""
-
+    if item.food:
+        summary = item.food.name
+        description = _build_description(item)
+    else:
+        summary = item.display
+        description = None
     return TodoItem(
-        summary=item.display,
+        summary=summary,
         uid=item.item_id,
         status=TODO_STATUS_MAP.get(
             item.checked,
             TodoItemStatus.NEEDS_ACTION,
         ),
         due=None,
-        description=None,
+        description=description,
     )
 
 
@@ -98,6 +146,7 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
         | TodoListEntityFeature.UPDATE_TODO_ITEM
         | TodoListEntityFeature.DELETE_TODO_ITEM
         | TodoListEntityFeature.MOVE_TODO_ITEM
+        | TodoListEntityFeature.SET_DESCRIPTION_ON_ITEM
     )
 
     _attr_translation_key = "shopping_list"
@@ -182,7 +231,8 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
 
         stripped_item_summary = item.summary.strip() if item.summary else item.summary
 
-        if list_item.display.strip() != stripped_item_summary:
+        current_name = list_item.food.name if list_item.food else list_item.display
+        if current_name.strip() != stripped_item_summary:
             update_shopping_item.note = stripped_item_summary
             update_shopping_item.position = position
             if update_shopping_item.is_food is not None:
@@ -190,6 +240,14 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
             update_shopping_item.food_id = None
             update_shopping_item.quantity = 0.0
             update_shopping_item.checked = item.status == TodoItemStatus.COMPLETED
+        elif item.description != _build_description(list_item):
+            # Only parse when the description actually changed; the todo component
+            # re-sends the rendered description on every update, and parsing is lossy.
+            quantity, note = _parse_description(item.description)
+            update_shopping_item.quantity = quantity
+            if list_item.food:
+                update_shopping_item.note = note
+            # For non-food items note == display == summary; only update quantity.
 
         try:
             await self.coordinator.client.update_shopping_item(

--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -72,8 +72,7 @@ def _parse_description(description: str | None) -> tuple[float, str]:
         try:
             quantity = float(tokens[0])
         except ValueError:
-            if not found_comma:
-                note = prefix_part
+            note = description
 
     return quantity, note
 
@@ -240,7 +239,7 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
             update_shopping_item.food_id = None
             update_shopping_item.quantity = 0.0
             update_shopping_item.checked = item.status == TodoItemStatus.COMPLETED
-        elif item.description != _build_description(list_item):
+        elif list_item.food and item.description != _build_description(list_item):
             # Only parse when the description actually changed; the todo component
             # re-sends the rendered description on every update, and parsing is lossy.
             quantity, note = _parse_description(item.description)

--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -36,7 +36,12 @@ TODO_STATUS_MAP_INV = {v: k for k, v in TODO_STATUS_MAP.items()}
 
 
 def _build_description(item: ShoppingItem) -> str | None:
-    """Build a description string from quantity, unit, and note."""
+    """Build a description string from quantity, unit, and note.
+
+    Food items carry a free-text note (e.g. "organic") in addition to the food
+    name, so the note is appended to the description. Non-food items store their
+    name in ``note``, which is used as the summary, so it is not repeated here.
+    """
     parts: list[str] = []
     if item.quantity:
         qty = item.quantity
@@ -44,7 +49,7 @@ def _build_description(item: ShoppingItem) -> str | None:
     if item.unit and item.unit.name:
         parts.append(item.unit.name)
     prefix = " ".join(parts)
-    note = (item.note or "").strip()
+    note = (item.note or "").strip() if item.food else ""
     if prefix and note:
         return f"{prefix}, {note}"
     return prefix or note or None
@@ -78,13 +83,13 @@ def _parse_description(description: str | None) -> tuple[float, str]:
 
 
 def _convert_api_item(item: ShoppingItem) -> TodoItem:
-    """Convert Mealie shopping list items into a TodoItem."""
-    if item.food:
-        summary = item.food.name
-        description = _build_description(item)
-    else:
-        summary = item.display
-        description = None
+    """Convert a Mealie shopping list item into a TodoItem.
+
+    The item name becomes the summary (the food name for food items, the
+    free-text note for non-food items); quantity, unit and any extra note
+    become the description.
+    """
+    summary = item.food.name if item.food else item.note
     return TodoItem(
         summary=summary,
         uid=item.item_id,
@@ -93,7 +98,7 @@ def _convert_api_item(item: ShoppingItem) -> TodoItem:
             TodoItemStatus.NEEDS_ACTION,
         ),
         due=None,
-        description=description,
+        description=_build_description(item),
     )
 
 
@@ -183,11 +188,15 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
         if len(self.shopping_items) > 0:
             position = self.shopping_items[-1].position + 1
 
+        # New items are stored as free-text notes; only the quantity can be
+        # derived from the description since a unit name cannot be resolved to a
+        # unit_id without an additional lookup.
+        quantity, _ = _parse_description(item.description)
         new_shopping_item = MutateShoppingItem(
             list_id=self._shopping_list_id,
             note=item.summary.strip() if item.summary else item.summary,
             position=position,
-            quantity=0.0,
+            quantity=quantity,
         )
         try:
             await self.coordinator.client.add_shopping_item(new_shopping_item)
@@ -230,8 +239,8 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
 
         stripped_item_summary = item.summary.strip() if item.summary else item.summary
 
-        current_name = list_item.food.name if list_item.food else list_item.display
-        if current_name.strip() != stripped_item_summary:
+        current_name = list_item.food.name if list_item.food else list_item.note
+        if (current_name or "").strip() != stripped_item_summary:
             update_shopping_item.note = stripped_item_summary
             update_shopping_item.position = position
             if update_shopping_item.is_food is not None:
@@ -239,12 +248,15 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
             update_shopping_item.food_id = None
             update_shopping_item.quantity = 0.0
             update_shopping_item.checked = item.status == TodoItemStatus.COMPLETED
-        elif list_item.food and item.description != _build_description(list_item):
+        elif item.description != _build_description(list_item):
             # Only parse when the description actually changed; the todo component
             # re-sends the rendered description on every update, and parsing is lossy.
             quantity, note = _parse_description(item.description)
             update_shopping_item.quantity = quantity
-            update_shopping_item.note = note
+            # Non-food items keep their name in ``note``, so only the quantity is
+            # editable through the description.
+            if list_item.food:
+                update_shopping_item.note = note
 
         try:
             await self.coordinator.client.update_shopping_item(

--- a/homeassistant/components/mealie/todo.py
+++ b/homeassistant/components/mealie/todo.py
@@ -244,9 +244,7 @@ class MealieShoppingListTodoListEntity(MealieEntity, TodoListEntity):
             # re-sends the rendered description on every update, and parsing is lossy.
             quantity, note = _parse_description(item.description)
             update_shopping_item.quantity = quantity
-            if list_item.food:
-                update_shopping_item.note = note
-            # For non-food items note == display == summary; only update quantity.
+            update_shopping_item.note = note
 
         try:
             await self.coordinator.client.update_shopping_item(

--- a/tests/components/mealie/snapshots/test_todo.ambr
+++ b/tests/components/mealie/snapshots/test_todo.ambr
@@ -30,7 +30,7 @@
     'platform': 'mealie',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <TodoListEntityFeature: 15>,
+    'supported_features': <TodoListEntityFeature: 79>,
     'translation_key': 'shopping_list',
     'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_e9d78ff2-4b23-4b77-a3a8-464827100b46',
     'unit_of_measurement': None,
@@ -40,7 +40,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mealie Freezer',
-      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <TodoListEntityFeature: 15>,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <TodoListEntityFeature: 79>,
     }),
     'context': <ANY>,
     'entity_id': 'todo.mealie_freezer',
@@ -81,7 +81,7 @@
     'platform': 'mealie',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <TodoListEntityFeature: 15>,
+    'supported_features': <TodoListEntityFeature: 79>,
     'translation_key': 'shopping_list',
     'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_f8438635-8211-4be8-80d0-0aa42e37a5f2',
     'unit_of_measurement': None,
@@ -91,7 +91,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mealie Special groceries',
-      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <TodoListEntityFeature: 15>,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <TodoListEntityFeature: 79>,
     }),
     'context': <ANY>,
     'entity_id': 'todo.mealie_special_groceries',
@@ -132,7 +132,7 @@
     'platform': 'mealie',
     'previous_unique_id': None,
     'suggested_object_id': None,
-    'supported_features': <TodoListEntityFeature: 15>,
+    'supported_features': <TodoListEntityFeature: 79>,
     'translation_key': 'shopping_list',
     'unique_id': 'bf1c62fe-4941-4332-9886-e54e88dbdba0_27edbaab-2ec6-441f-8490-0283ea77585f',
     'unit_of_measurement': None,
@@ -142,7 +142,7 @@
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mealie Supermarket',
-      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <TodoListEntityFeature: 15>,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <TodoListEntityFeature: 79>,
     }),
     'context': <ANY>,
     'entity_id': 'todo.mealie_supermarket',

--- a/tests/components/mealie/test_todo.py
+++ b/tests/components/mealie/test_todo.py
@@ -3,12 +3,18 @@
 from datetime import timedelta
 from unittest.mock import AsyncMock, call, patch
 
-from aiomealie import MealieError, MutateShoppingItem, ShoppingListsResponse
+from aiomealie import (
+    MealieError,
+    MutateShoppingItem,
+    ShoppingItemsResponse,
+    ShoppingListsResponse,
+)
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.mealie import DOMAIN
+from homeassistant.components.mealie.todo import _convert_api_item, _parse_description
 from homeassistant.components.todo import (
     ATTR_ITEM,
     ATTR_RENAME,
@@ -27,9 +33,115 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_fixture,
+    load_fixture,
     snapshot_platform,
 )
 from tests.typing import WebSocketGenerator
+
+
+@pytest.mark.parametrize(
+    ("item_index", "expected_summary", "expected_description"),
+    [
+        pytest.param(0, "2 Apples", None, id="non_food_keeps_display"),
+        pytest.param(1, "acorn squash", "1 can", id="food_with_unit"),
+        pytest.param(2, "aubergine", None, id="food_no_quantity"),
+        pytest.param(3, "flour", "1 US cup", id="food_with_quantity_and_unit"),
+    ],
+)
+def test_convert_api_item(
+    item_index: int,
+    expected_summary: str,
+    expected_description: str | None,
+) -> None:
+    """Test _convert_api_item splits food name into summary and quantity/unit into description."""
+    items = ShoppingItemsResponse.from_json(
+        load_fixture("get_shopping_items.json", DOMAIN)
+    ).items
+
+    todo = _convert_api_item(items[item_index])
+
+    assert todo.summary == expected_summary
+    assert todo.description == expected_description
+
+
+@pytest.mark.parametrize(
+    ("description", "expected_quantity", "expected_note"),
+    [
+        pytest.param(None, 0.0, "", id="none"),
+        pytest.param("", 0.0, "", id="empty"),
+        pytest.param("2", 2.0, "", id="quantity_only"),
+        pytest.param("2.5", 2.5, "", id="fractional_quantity"),
+        pytest.param("2 Gramm", 2.0, "", id="quantity_and_unit"),
+        pytest.param("2 Gramm, organic", 2.0, "organic", id="quantity_unit_note"),
+        pytest.param(", organic", 0.0, "organic", id="note_only_with_comma"),
+        pytest.param("buy fresh", 0.0, "buy fresh", id="text_note_no_comma"),
+        pytest.param("1 can, ripe", 1.0, "ripe", id="quantity_unit_note_short"),
+    ],
+)
+def test_parse_description(
+    description: str | None,
+    expected_quantity: float,
+    expected_note: str,
+) -> None:
+    """Test _parse_description extracts quantity and note from a description string."""
+    quantity, note = _parse_description(description)
+
+    assert quantity == expected_quantity
+    assert note == expected_note
+
+
+async def test_update_todo_item_description(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test updating description on a food item updates quantity and note."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {
+            ATTR_ITEM: "acorn squash",
+            ATTR_RENAME: "acorn squash",
+            "description": "3 can, organic",
+        },
+        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+        blocking=True,
+    )
+
+    mock_mealie_client.update_shopping_item.assert_called_once()
+    _, mutate = mock_mealie_client.update_shopping_item.call_args[0]
+    assert mutate.quantity == 3.0
+    assert mutate.note == "organic"
+
+
+async def test_update_todo_item_status_keeps_description(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test toggling status does not rewrite quantity/note from the rendered description.
+
+    The todo component re-sends the rendered description on every update; parsing it
+    back must be skipped when it is unchanged to avoid clobbering the Mealie item.
+    """
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "acorn squash", ATTR_STATUS: "completed"},
+        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+        blocking=True,
+    )
+
+    mock_mealie_client.update_shopping_item.assert_called_once()
+    _, mutate = mock_mealie_client.update_shopping_item.call_args[0]
+    assert mutate.checked is True
+    assert mutate.quantity == 1.0
+    assert mutate.note == ""
+    assert mutate.unit_id == "7bf539d4-fc78-48bc-b48e-c35ccccec34a"
 
 
 async def test_entities(

--- a/tests/components/mealie/test_todo.py
+++ b/tests/components/mealie/test_todo.py
@@ -77,7 +77,9 @@ def test_convert_api_item(
         pytest.param("2 Gramm, organic", 2.0, "organic", id="quantity_unit_note"),
         pytest.param(", organic", 0.0, "organic", id="note_only_with_comma"),
         pytest.param("buy fresh", 0.0, "buy fresh", id="text_note_no_comma"),
-        pytest.param("buy fresh, organic", 0.0, "buy fresh, organic", id="text_note_with_comma"),
+        pytest.param(
+            "buy fresh, organic", 0.0, "buy fresh, organic", id="text_note_with_comma"
+        ),
         pytest.param("1 can, ripe", 1.0, "ripe", id="quantity_unit_note_short"),
     ],
 )
@@ -130,13 +132,15 @@ async def test_update_todo_item_status_keeps_description(
     return a different (quantity, note) pair — proving the unchanged-description guard
     is load-bearing and not just incidentally passing.
     """
-    items_data = json.loads(load_fixture("get_shopping_items.json", DOMAIN))
+    items_data = json.loads(
+        await async_load_fixture(hass, "get_shopping_items.json", DOMAIN)
+    )
     items_data["items"][1]["quantity"] = 0.0
     items_data["items"][1]["note"] = "3 large"
     items_data["items"][1]["unit"] = None
     items_data["items"][1]["unitId"] = None
-    mock_mealie_client.get_shopping_items.return_value = ShoppingItemsResponse.from_json(
-        json.dumps(items_data)
+    mock_mealie_client.get_shopping_items.return_value = (
+        ShoppingItemsResponse.from_json(json.dumps(items_data))
     )
 
     await setup_integration(hass, mock_config_entry)

--- a/tests/components/mealie/test_todo.py
+++ b/tests/components/mealie/test_todo.py
@@ -1,6 +1,7 @@
 """Tests for the Mealie todo."""
 
 from datetime import timedelta
+import json
 from unittest.mock import AsyncMock, call, patch
 
 from aiomealie import (
@@ -16,6 +17,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.mealie import DOMAIN
 from homeassistant.components.mealie.todo import _convert_api_item, _parse_description
 from homeassistant.components.todo import (
+    ATTR_DESCRIPTION,
     ATTR_ITEM,
     ATTR_RENAME,
     ATTR_STATUS,
@@ -75,6 +77,7 @@ def test_convert_api_item(
         pytest.param("2 Gramm, organic", 2.0, "organic", id="quantity_unit_note"),
         pytest.param(", organic", 0.0, "organic", id="note_only_with_comma"),
         pytest.param("buy fresh", 0.0, "buy fresh", id="text_note_no_comma"),
+        pytest.param("buy fresh, organic", 0.0, "buy fresh, organic", id="text_note_with_comma"),
         pytest.param("1 can, ripe", 1.0, "ripe", id="quantity_unit_note_short"),
     ],
 )
@@ -104,7 +107,7 @@ async def test_update_todo_item_description(
         {
             ATTR_ITEM: "acorn squash",
             ATTR_RENAME: "acorn squash",
-            "description": "3 can, organic",
+            ATTR_DESCRIPTION: "3 can, organic",
         },
         target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
         blocking=True,
@@ -123,9 +126,19 @@ async def test_update_todo_item_status_keeps_description(
 ) -> None:
     """Test toggling status does not rewrite quantity/note from the rendered description.
 
-    The todo component re-sends the rendered description on every update; parsing it
-    back must be skipped when it is unchanged to avoid clobbering the Mealie item.
+    Uses a food item whose note starts with a digit so that _parse_description would
+    return a different (quantity, note) pair — proving the unchanged-description guard
+    is load-bearing and not just incidentally passing.
     """
+    items_data = json.loads(load_fixture("get_shopping_items.json", DOMAIN))
+    items_data["items"][1]["quantity"] = 0.0
+    items_data["items"][1]["note"] = "3 large"
+    items_data["items"][1]["unit"] = None
+    items_data["items"][1]["unitId"] = None
+    mock_mealie_client.get_shopping_items.return_value = ShoppingItemsResponse.from_json(
+        json.dumps(items_data)
+    )
+
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
@@ -139,9 +152,37 @@ async def test_update_todo_item_status_keeps_description(
     mock_mealie_client.update_shopping_item.assert_called_once()
     _, mutate = mock_mealie_client.update_shopping_item.call_args[0]
     assert mutate.checked is True
-    assert mutate.quantity == 1.0
-    assert mutate.note == ""
-    assert mutate.unit_id == "7bf539d4-fc78-48bc-b48e-c35ccccec34a"
+    assert mutate.quantity == 0.0
+    assert mutate.note == "3 large"
+    assert mutate.unit_id is None
+
+
+async def test_update_todo_item_nonfood_status_keeps_quantity(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test toggling status on a non-food item does not reset its quantity.
+
+    Non-food items have description=None in the todo layer, but _build_description
+    of the underlying ShoppingItem is non-None when quantity>0; the elif branch must
+    be skipped for non-food items to avoid zeroing out the quantity.
+    """
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "2 Apples", ATTR_STATUS: "completed"},
+        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+        blocking=True,
+    )
+
+    mock_mealie_client.update_shopping_item.assert_called_once()
+    _, mutate = mock_mealie_client.update_shopping_item.call_args[0]
+    assert mutate.checked is True
+    assert mutate.quantity == 2.0
+    assert mutate.note == "Apples"
 
 
 async def test_entities(

--- a/tests/components/mealie/test_todo.py
+++ b/tests/components/mealie/test_todo.py
@@ -15,7 +15,6 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.mealie import DOMAIN
-from homeassistant.components.mealie.todo import _convert_api_item, _parse_description
 from homeassistant.components.todo import (
     ATTR_DESCRIPTION,
     ATTR_ITEM,
@@ -35,46 +34,50 @@ from tests.common import (
     MockConfigEntry,
     async_fire_time_changed,
     async_load_fixture,
-    load_fixture,
     snapshot_platform,
 )
 from tests.typing import WebSocketGenerator
 
+ENTITY_SUPERMARKET = "todo.mealie_supermarket"
 
-@pytest.mark.parametrize(
-    ("item_index", "expected_summary", "expected_description"),
-    [
-        pytest.param(0, "2 Apples", None, id="non_food_keeps_display"),
-        pytest.param(1, "acorn squash", "1 can", id="food_with_unit"),
-        pytest.param(2, "aubergine", None, id="food_no_quantity"),
-        pytest.param(3, "flour", "1 US cup", id="food_with_quantity_and_unit"),
-    ],
-)
-def test_convert_api_item(
-    item_index: int,
-    expected_summary: str,
-    expected_description: str | None,
+
+async def _get_items(
+    hass_ws_client: WebSocketGenerator, entity_id: str
+) -> list[dict[str, str]]:
+    """Fetch todo items for an entity through the websocket API."""
+    client = await hass_ws_client()
+    await client.send_json_auto_id({"type": "todo/item/list", "entity_id": entity_id})
+    resp = await client.receive_json()
+    assert resp["success"]
+    return resp["result"]["items"]
+
+
+async def test_todo_items_split_name_and_description(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test _convert_api_item splits food name into summary and quantity/unit into description."""
-    items = ShoppingItemsResponse.from_json(
-        load_fixture("get_shopping_items.json", DOMAIN)
-    ).items
+    """Test items expose the name as summary and quantity/unit/note as description."""
+    await setup_integration(hass, mock_config_entry)
 
-    todo = _convert_api_item(items[item_index])
+    items = await _get_items(hass_ws_client, ENTITY_SUPERMARKET)
 
-    assert todo.summary == expected_summary
-    assert todo.description == expected_description
+    assert [(item["summary"], item.get("description")) for item in items] == [
+        ("Apples", "2"),
+        ("acorn squash", "1 can"),
+        ("aubergine", None),
+        ("flour", "1 US cup"),
+    ]
 
 
 @pytest.mark.parametrize(
     ("description", "expected_quantity", "expected_note"),
     [
-        pytest.param(None, 0.0, "", id="none"),
-        pytest.param("", 0.0, "", id="empty"),
+        pytest.param("3 can, organic", 3.0, "organic", id="quantity_unit_note"),
         pytest.param("2", 2.0, "", id="quantity_only"),
         pytest.param("2.5", 2.5, "", id="fractional_quantity"),
         pytest.param("2 Gramm", 2.0, "", id="quantity_and_unit"),
-        pytest.param("2 Gramm, organic", 2.0, "organic", id="quantity_unit_note"),
         pytest.param(", organic", 0.0, "organic", id="note_only_with_comma"),
         pytest.param("buy fresh", 0.0, "buy fresh", id="text_note_no_comma"),
         pytest.param(
@@ -83,42 +86,73 @@ def test_convert_api_item(
         pytest.param("1 can, ripe", 1.0, "ripe", id="quantity_unit_note_short"),
     ],
 )
-def test_parse_description(
-    description: str | None,
-    expected_quantity: float,
-    expected_note: str,
-) -> None:
-    """Test _parse_description extracts quantity and note from a description string."""
-    quantity, note = _parse_description(description)
-
-    assert quantity == expected_quantity
-    assert note == expected_note
-
-
-async def test_update_todo_item_description(
+async def test_update_food_item_description(
     hass: HomeAssistant,
     mock_mealie_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
+    description: str,
+    expected_quantity: float,
+    expected_note: str,
 ) -> None:
-    """Test updating description on a food item updates quantity and note."""
+    """Test editing a food item's description updates its quantity and note."""
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         TODO_DOMAIN,
         TodoServices.UPDATE_ITEM,
-        {
-            ATTR_ITEM: "acorn squash",
-            ATTR_RENAME: "acorn squash",
-            ATTR_DESCRIPTION: "3 can, organic",
-        },
-        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+        {ATTR_ITEM: "acorn squash", ATTR_DESCRIPTION: description},
+        target={ATTR_ENTITY_ID: ENTITY_SUPERMARKET},
         blocking=True,
     )
 
     mock_mealie_client.update_shopping_item.assert_called_once()
     _, mutate = mock_mealie_client.update_shopping_item.call_args[0]
-    assert mutate.quantity == 3.0
-    assert mutate.note == "organic"
+    assert mutate.quantity == expected_quantity
+    assert mutate.note == expected_note
+
+
+async def test_update_nonfood_item_description(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test editing a non-food item's description updates quantity but keeps the note."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.UPDATE_ITEM,
+        {ATTR_ITEM: "Apples", ATTR_DESCRIPTION: "5"},
+        target={ATTR_ENTITY_ID: ENTITY_SUPERMARKET},
+        blocking=True,
+    )
+
+    mock_mealie_client.update_shopping_item.assert_called_once()
+    _, mutate = mock_mealie_client.update_shopping_item.call_args[0]
+    assert mutate.quantity == 5.0
+    assert mutate.note == "Apples"
+
+
+async def test_create_item_with_description(
+    hass: HomeAssistant,
+    mock_mealie_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test creating an item derives the quantity from the description."""
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        TODO_DOMAIN,
+        TodoServices.ADD_ITEM,
+        {ATTR_ITEM: "Soda", ATTR_DESCRIPTION: "6"},
+        target={ATTR_ENTITY_ID: ENTITY_SUPERMARKET},
+        blocking=True,
+    )
+
+    mock_mealie_client.add_shopping_item.assert_called_once()
+    (mutate,) = mock_mealie_client.add_shopping_item.call_args[0]
+    assert mutate.note == "Soda"
+    assert mutate.quantity == 6.0
 
 
 async def test_update_todo_item_status_keeps_description(
@@ -128,9 +162,9 @@ async def test_update_todo_item_status_keeps_description(
 ) -> None:
     """Test toggling status does not rewrite quantity/note from the rendered description.
 
-    Uses a food item whose note starts with a digit so that _parse_description would
-    return a different (quantity, note) pair — proving the unchanged-description guard
-    is load-bearing and not just incidentally passing.
+    Uses a food item whose note starts with a digit so that parsing the description
+    back would return a different (quantity, note) pair — proving the
+    unchanged-description guard is load-bearing and not just incidentally passing.
     """
     items_data = json.loads(
         await async_load_fixture(hass, "get_shopping_items.json", DOMAIN)
@@ -149,7 +183,7 @@ async def test_update_todo_item_status_keeps_description(
         TODO_DOMAIN,
         TodoServices.UPDATE_ITEM,
         {ATTR_ITEM: "acorn squash", ATTR_STATUS: "completed"},
-        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+        target={ATTR_ENTITY_ID: ENTITY_SUPERMARKET},
         blocking=True,
     )
 
@@ -168,17 +202,17 @@ async def test_update_todo_item_nonfood_status_keeps_quantity(
 ) -> None:
     """Test toggling status on a non-food item does not reset its quantity.
 
-    Non-food items have description=None in the todo layer, but _build_description
-    of the underlying ShoppingItem is non-None when quantity>0; the elif branch must
-    be skipped for non-food items to avoid zeroing out the quantity.
+    A status toggle re-sends the rendered description, which for a non-food item
+    matches its quantity; the unchanged-description guard must keep the quantity
+    and note intact.
     """
     await setup_integration(hass, mock_config_entry)
 
     await hass.services.async_call(
         TODO_DOMAIN,
         TodoServices.UPDATE_ITEM,
-        {ATTR_ITEM: "2 Apples", ATTR_STATUS: "completed"},
-        target={ATTR_ENTITY_ID: "todo.mealie_supermarket"},
+        {ATTR_ITEM: "Apples", ATTR_STATUS: "completed"},
+        target={ATTR_ENTITY_ID: ENTITY_SUPERMARKET},
         blocking=True,
     )
 


### PR DESCRIPTION
For food items, the todo item summary now shows only the food name while quantity, unit, and note are moved into the description field (format: "{qty} {unit}, {note}"). Non-food items retain their full display string as summary.

Editing the description on a food item writes quantity and note back to Mealie; the unit field is informational only on writes since resolving a unit name to a unit_id would require an additional API call.

## Breaking change

For Mealie **food items** (items linked to a Mealie food entity), the `summary` field of the todo item now contains only the food name (e.g. `acorn squash`) instead of the full display string (e.g. `1 can acorn squash`). The quantity, unit, and note are moved into a new `description` field. Non-food (free-text) items are unchanged.

## Proposed change

The Mealie shopping list integration previously used `item.display` as the `TodoItem.summary` for all items, collapsing the food name, quantity, unit, and note into one string. This made it impossible for users or automations to distinguish the item name from its metadata, and made comparisons inconsistent (e.g. renaming "acorn squash" would incorrectly trigger if matched against "1 can acorn squash").

This PR aligns the Mealie integration with the Bring integration's approach:

- **Food items**: `summary` = food name only; `description` = `"<qty> <unit>, <note>"` (where present)
- **Non-food items**: unchanged — `summary` = free-text display; `description` = `None`

The `SET_DESCRIPTION_ON_ITEM` feature flag is also enabled, allowing the description (quantity/unit/note) to be edited directly. A guard ensures parsing is skipped when the description is re-sent unchanged by the todo component on status or rename updates — preventing lossy round-trip corruption of food items whose note starts with a digit or contains a comma.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [X] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
