### PR TITLE
Fix remap mirror edge mode for values below the input range

### DIFF
--- a/homeassistant/helpers/template/extensions/math.py
+++ b/homeassistant/helpers/template/extensions/math.py
@@ -480,7 +480,7 @@ class MathExtension(BaseTemplateExtension):
             period = math.floor(offset / range_size)
             position_in_period = offset - (period * range_size)
 
-            if (period < 0) or (period % 2 != 0):
+            if period % 2 != 0:
                 position_in_period = range_size - position_in_period
 
             value_num = in_min_num + position_in_period

--- a/tests/helpers/template/extensions/test_math.py
+++ b/tests/helpers/template/extensions/test_math.py
@@ -539,15 +539,37 @@ def test_remap_with_mirror(hass: HomeAssistant) -> None:
     """Test the mirror edge mode of the remap function."""
 
     assert [
-        MathExtension.remap(i, 0, 4, 0, 1, edges="mirror") for i in range(-4, 9)
-    ] == [1.0, 0.75, 0.5, 0.25, 0.0, 0.25, 0.5, 0.75, 1.0, 0.75, 0.5, 0.25, 0.0]
+        MathExtension.remap(i, 0, 4, 0, 1, edges="mirror") for i in range(-8, 9)
+    ] == [
+        0.0,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        0.75,
+        0.5,
+        0.25,
+        0.0,
+        0.25,
+        0.5,
+        0.75,
+        1.0,
+        0.75,
+        0.5,
+        0.25,
+        0.0,
+    ]
 
     # Test with different output range
     assert MathExtension.remap(15, 0, 10, 50, 150, edges="mirror") == 100.0
     assert MathExtension.remap(25, 0, 10, 50, 150, edges="mirror") == 100.0
+    assert MathExtension.remap(-15, 0, 10, 50, 150, edges="mirror") == 100.0
     # Test with inverted output range
     assert MathExtension.remap(15, 0, 10, 100, 0, edges="mirror") == 50.0
     assert MathExtension.remap(12, 0, 10, 100, 0, edges="mirror") == 20.0
+    # Mirroring reflects at the range boundaries, so the result for a value
+    # d below in_min matches the result for a value d above in_min
+    assert MathExtension.remap(-12, 0, 10, 100, 0, edges="mirror") == 20.0
     # Test without remapping
     assert MathExtension.remap(-0.1, 0, 1, 0, 1, edges="mirror") == pytest.approx(0.1)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `mirror` edge mode of the `remap` template function is documented as reflecting out-of-range values back into the input range "for a ping-pong effect" (a triangle wave). That is what it produces above `in_max`, but below `in_min` every second reflection period was inverted, because the reflection was applied whenever the period was negative instead of only when it was odd. Python's floored division/modulo already yield the correct parity for negative periods, so the extra `period < 0` clause was wrong.

Example: `remap(8, 0, 4, 0, 1, edges="mirror")` correctly returns `0.0`, but before this fix `remap(-8, 0, 4, 0, 1, edges="mirror")` returned `1.0` instead of `0.0`. Reflection at a boundary requires `mirror(in_min - d) == mirror(in_min + d)`.

The one-line fix drops the `period < 0` clause so the position is mirrored only on odd periods. Existing mirror behavior for values above the range and within one period below is unchanged (all previous test assertions kept; symmetric negative-side assertions added).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

No tracker issue existed. The bug was found by a code audit of the template math extension and verified against a brute-force triangle-wave oracle over dense value/range sweeps (the positive side is bit-identical before and after). Documentation needs no update: behavior now matches the documented "ping-pong" reflection.

AI disclosure, per the AI policy: this change was written with Claude (Claude Code). I reviewed the diagnosis, the one-line fix, and the tests, verified fail-before/pass-after locally, and can explain how the code works.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
