### PR TITLE
Bump python-izone to 1.3.4

### DIFF
--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -308,10 +308,10 @@ class ControllerDevice(ClimateEntity):
         """Return current operation ie. heat, cool, idle."""
         if not self._controller.is_on:
             return HVACMode.OFF
-        if (mode := self._controller.mode) == Controller.Mode.FREE_AIR:
+        if (mode := self._controller.mode) is Controller.Mode.FREE_AIR:
             return HVACMode.FAN_ONLY
         for key, value in self._state_to_pizone.items():
-            if value == mode:
+            if value is mode:
                 return key
         raise RuntimeError("Should be unreachable")
 
@@ -345,7 +345,7 @@ class ControllerDevice(ClimateEntity):
     @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if self._controller.mode == Controller.Mode.FREE_AIR:
+        if self._controller.mode is Controller.Mode.FREE_AIR:
             return self._controller.temp_supply
         return self._controller.temp_return
 
@@ -390,7 +390,7 @@ class ControllerDevice(ClimateEntity):
         return self.control_zone_setpoint
 
     @property
-    def supply_temperature(self) -> float:
+    def supply_temperature(self) -> float | None:
         """Return the current supply, or in duct, temperature."""
         return self._controller.temp_supply
 
@@ -488,7 +488,7 @@ class ZoneDevice(ClimateEntity):
         self._controller = controller
         self._zone = zone
 
-        if zone.type != Zone.Type.AUTO:
+        if zone.type is not Zone.Type.AUTO:
             self._state_to_pizone = {
                 HVACMode.OFF: Zone.Mode.CLOSE,
                 HVACMode.FAN_ONLY: Zone.Mode.OPEN,
@@ -555,7 +555,7 @@ class ZoneDevice(ClimateEntity):
     @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""
-        if self._zone.mode == Zone.Mode.AUTO:
+        if self._zone.mode is Zone.Mode.AUTO:
             return self._attr_supported_features
         return self._attr_supported_features & ~ClimateEntityFeature.TARGET_TEMPERATURE
 
@@ -565,7 +565,7 @@ class ZoneDevice(ClimateEntity):
         """Return current operation ie. heat, cool, idle."""
         mode = self._zone.mode
         for key, value in self._state_to_pizone.items():
-            if value == mode:
+            if value is mode:
                 return key
         return None
 
@@ -577,7 +577,7 @@ class ZoneDevice(ClimateEntity):
 
     @property
     @override
-    def current_temperature(self) -> float:
+    def current_temperature(self) -> float | None:
         """Return the current temperature."""
         return self._zone.temp_current
 
@@ -585,7 +585,7 @@ class ZoneDevice(ClimateEntity):
     @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach."""
-        if self._zone.type != Zone.Type.AUTO:
+        if self._zone.type is not Zone.Type.AUTO:
             return None
         return self._zone.temp_setpoint
 
@@ -628,7 +628,7 @@ class ZoneDevice(ClimateEntity):
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
-        if self._zone.mode != Zone.Mode.AUTO:
+        if self._zone.mode is not Zone.Mode.AUTO:
             return
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
             await self._controller.wrap_and_catch(self._zone.set_temp_setpoint(temp))
@@ -643,12 +643,12 @@ class ZoneDevice(ClimateEntity):
     @property
     def is_on(self) -> bool:
         """Return true if on."""
-        return self._zone.mode != Zone.Mode.CLOSE
+        return self._zone.mode is not Zone.Mode.CLOSE
 
     @override
     async def async_turn_on(self) -> None:
         """Turn device on (open zone)."""
-        if self._zone.type == Zone.Type.AUTO:
+        if self._zone.type is Zone.Type.AUTO:
             await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.AUTO))
         else:
             await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.OPEN))

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -3,6 +3,7 @@
 import asyncio
 from collections.abc import Callable
 import logging
+from typing import override
 
 import pizone
 
@@ -135,23 +136,28 @@ class DiscoveryService(pizone.Listener):
             self._idle_stop_handle = None
 
     # Listener interface
+    @override
     def controller_discovered(self, ctrl: pizone.Controller) -> None:
         """Handle new controller discovery."""
         self.async_schedule_idle_stop()
         async_dispatcher_send(self.hass, DISPATCH_CONTROLLER_DISCOVERED, ctrl)
 
+    @override
     def controller_disconnected(self, ctrl: pizone.Controller, ex: Exception) -> None:
         """On disconnect from controller."""
         async_dispatcher_send(self.hass, DISPATCH_CONTROLLER_DISCONNECTED, ctrl, ex)
 
+    @override
     def controller_reconnected(self, ctrl: pizone.Controller) -> None:
         """On reconnect to controller."""
         async_dispatcher_send(self.hass, DISPATCH_CONTROLLER_RECONNECTED, ctrl)
 
+    @override
     def controller_update(self, ctrl: pizone.Controller) -> None:
         """System update message is received from the controller."""
         async_dispatcher_send(self.hass, DISPATCH_CONTROLLER_UPDATE, ctrl)
 
+    @override
     def zone_update(self, ctrl: pizone.Controller, zone: pizone.Zone) -> None:
         """Zone update message is received from the controller."""
         async_dispatcher_send(self.hass, DISPATCH_ZONE_UPDATE, ctrl, zone)

--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -10,5 +10,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pizone"],
-  "requirements": ["python-izone==1.2.10"]
+  "requirements": ["python-izone==1.3.4"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2682,7 +2682,7 @@ python-homewizard-energy==10.1.0
 python-hpilo==4.4.3
 
 # homeassistant.components.izone
-python-izone==1.2.10
+python-izone==1.3.4
 
 # homeassistant.components.joaoapps_join
 python-join-api==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump `python-izone` from `1.2.10` to `1.3.4` for the iZone integration.

Library release notes: https://github.com/Swamp-Ig/pizone/releases/tag/v1.3.4  
Compare: https://github.com/Swamp-Ig/pizone/compare/v1.2.10...v1.3.4

Since `1.2.10`, the library modernizes packaging (Python 3.14, uv/Hatchling,
`py.typed`), moves HTTP to aiohttp, and clarifies error handling:

- Cached property reads do not raise when disconnected
- `ConnectionError` for transport failures; `ControllerCommandError` for
  reachable devices that reject a request
- Layered connection state:
  - `Controller.bridge_connected` — ASH bridge HTTP transport
  - `Controller.connected` — bridge **and** valid iZone AC subsystem data
  - `Power.connected` — power monitor I/O when enabled
- Fault `SystemSettings` no longer overwrites cached state during partial outages

Shipped as `1.3.4` because PyPI `1.3.0`–`1.3.3` remain yanked.

### Integration typing updates (no runtime behaviour change)

`py.typed` in 1.3.4 exposes typed enums and nullable temperatures, which
requires mechanical mypy fixes in the integration:

- `discovery.py`: `@override` on `pizone.Listener` callback methods
- `climate.py`: enum identity comparisons (`is` / `is not`) for mypy
  `home-assistant-enum-identity-compare` once library enums are typed
- `climate.py`: `supply_temperature` and zone `current_temperature` return
  `float | None` to match `temp_supply` / `temp_current` in pizone 1.3.4

Entity availability still uses existing `controller_disconnected` /
`controller_reconnected` listeners; no other integration logic changes.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

Made with [Cursor](https://cursor.com)