### PR TITLE
Add izone climate test for fault-shaped controller bootstrap

### DIFF
--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -6,8 +6,8 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.climate import ClimateEntityFeature
-from homeassistant.components.izone.climate import ControllerDevice
 from homeassistant.core import HomeAssistant
+import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
 from . import setup_controller, setup_integration
@@ -310,17 +310,40 @@ async def test_setup_entry_only_adds_entities_for_matching_config_entry(
     assert unique_ids == {"000000001", "000000001_z1"}
 
 
-def test_controller_device_init_fault_bootstrap() -> None:
-    """ControllerDevice survives bootstrap when controller has fault-shaped defaults."""
-    controller = create_mock_controller(
-        ras_mode="zones",
-        sys_type="0",
-        zones_total=0,
-        free_air_enabled=False,
+@pytest.mark.parametrize("mock_zones", [[]])
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            ras_mode="zones",
+            sys_type="0",
+            zones_total=0,
+            free_air_enabled=False,
+        )
+    ],
+)
+async def test_controller_device_init_fault_bootstrap(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Controller climate entity is created with fault-shaped controller defaults."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_000000001"
+    assert hass.states.get(entity_id) is not None
+
+    entry_entities = er.async_entries_for_config_entry(
+        entity_registry, mock_config_entry.entry_id
     )
-    controller.zones = []
+    assert {entity.unique_id for entity in entry_entities} == {"000000001"}
 
-    device = ControllerDevice(controller)
-
-    assert device.device_info["model"] == "0"
-    assert device.zones == {}
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+    device_entry = device_registry.async_get(entity_entry.device_id)
+    assert device_entry is not None
+    assert device_entry.model == "0"

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -322,5 +322,5 @@ def test_controller_device_init_fault_bootstrap() -> None:
 
     device = ControllerDevice(controller)
 
-    assert device._attr_device_info["model"] == "0"
+    assert device.device_info["model"] == "0"
     assert device.zones == {}

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -6,6 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.izone.climate import ControllerDevice
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.entity_registry as er
 
@@ -307,3 +308,19 @@ async def test_setup_entry_only_adds_entities_for_matching_config_entry(
     unique_ids = {entity.unique_id for entity in entry_entities}
 
     assert unique_ids == {"000000001", "000000001_z1"}
+
+
+def test_controller_device_init_fault_bootstrap() -> None:
+    """ControllerDevice survives bootstrap when controller has fault-shaped defaults."""
+    controller = create_mock_controller(
+        ras_mode="zones",
+        sys_type="0",
+        zones_total=0,
+        free_air_enabled=False,
+    )
+    controller.zones = []
+
+    device = ControllerDevice(controller)
+
+    assert device._attr_device_info["model"] == "0"
+    assert device.zones == {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds `test_controller_device_init_fault_bootstrap` to verify `ControllerDevice`
initializes when the controller exposes empty zone data and fault-shaped defaults
(pizone 1.3.4 safe property reads).

Follow-up to #176341 (merged).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: follow-up to #176341
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

Made with [Cursor](https://cursor.com)