### PR TITLE
Enhance DHW schedule management with refresh and error handling

### DIFF
--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -181,6 +181,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             update_interval=SCAN_INTERVAL_SLOW,
         )
         self._dhw_schedule_refresh_pending = True
+        self._dhw_schedule_refresh_generation = 0
         self._retry_schedule_errors = False
 
     @override
@@ -212,12 +213,18 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
 
         dhw_schedule = previous.dhw_schedule
         if self._dhw_schedule_refresh_pending:
+            refresh_generation = self._dhw_schedule_refresh_generation
             refreshed_schedule, retryable = await self._async_fetch_dhw_schedule()
             if refreshed_schedule is not None:
                 dhw_schedule = refreshed_schedule
-                self._dhw_schedule_refresh_pending = False
-                self._retry_schedule_errors = False
-            elif not retryable and not self._retry_schedule_errors:
+                if refresh_generation == self._dhw_schedule_refresh_generation:
+                    self._dhw_schedule_refresh_pending = False
+                    self._retry_schedule_errors = False
+            elif (
+                refresh_generation == self._dhw_schedule_refresh_generation
+                and not retryable
+                and not self._retry_schedule_errors
+            ):
                 self._dhw_schedule_refresh_pending = False
 
         return BSBLanSlowData(
@@ -228,6 +235,7 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
     async def async_refresh_schedule_after_write(self) -> None:
         """Refresh slow data after a successful schedule write."""
         self._dhw_schedule_refresh_pending = True
+        self._dhw_schedule_refresh_generation += 1
         self._retry_schedule_errors = True
         await self.async_refresh()
 

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -180,36 +180,72 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
             name=f"{DOMAIN}_slow_{config_entry.data[CONF_HOST]}",
             update_interval=SCAN_INTERVAL_SLOW,
         )
+        self._dhw_schedule_refresh_pending = True
+        self._retry_schedule_errors = False
 
     @override
     async def _async_update_data(self) -> BSBLanSlowData:
-        """Fetch slow-changing data from the BSB-LAN device."""
-        try:
-            # Client is already initialized in async_setup_entry
-            # Use include filtering to only fetch parameters we actually use
-            dhw_config = await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
-            dhw_schedule = await self.client.hot_water_schedule()
+        """Fetch slow-changing data from the BSB-LAN device.
 
+        Only the DHW config is polled here. The schedule changes rarely and is
+        refreshed separately (on startup and after a write) to avoid extra
+        serial-bus traffic on every interval, so it is carried over from the
+        previous update.
+        """
+        previous = self.data or BSBLanSlowData()
+        dhw_config: HotWaterConfig | None
+        try:
+            dhw_config = await self.client.hot_water_config(include=DHW_CONFIG_INCLUDE)
         except (BSBLANConnectionError, BSBLANAuthError) as err:
-            # If config update fails, keep existing data
             LOGGER.debug(
                 "Failed to fetch DHW config from %s: %s",
                 self.config_entry.data[CONF_HOST],
                 err,
             )
-            if self.data:
-                return self.data
-            # First fetch failed, return empty data
-            return BSBLanSlowData()
-        except BSBLANError, AttributeError:
-            # Device does not support DHW functionality
+            dhw_config = previous.dhw_config
+        except BSBLANError, AttributeError, TimeoutError:
             LOGGER.debug(
                 "DHW (Domestic Hot Water) not available on device at %s",
                 self.config_entry.data[CONF_HOST],
             )
-            return BSBLanSlowData()
+            dhw_config = previous.dhw_config
+
+        dhw_schedule = previous.dhw_schedule
+        if self._dhw_schedule_refresh_pending:
+            refreshed_schedule, retryable = await self._async_fetch_dhw_schedule()
+            if refreshed_schedule is not None:
+                dhw_schedule = refreshed_schedule
+                self._dhw_schedule_refresh_pending = False
+                self._retry_schedule_errors = False
+            elif not retryable and not self._retry_schedule_errors:
+                self._dhw_schedule_refresh_pending = False
 
         return BSBLanSlowData(
             dhw_config=dhw_config,
             dhw_schedule=dhw_schedule,
         )
+
+    async def async_refresh_schedule_after_write(self) -> None:
+        """Refresh slow data after a successful schedule write."""
+        self._dhw_schedule_refresh_pending = True
+        self._retry_schedule_errors = True
+        await self.async_refresh()
+
+    async def _async_fetch_dhw_schedule(
+        self,
+    ) -> tuple[HotWaterSchedule | None, bool]:
+        """Fetch the DHW schedule, returning None if unavailable."""
+        try:
+            return await self.client.hot_water_schedule(), False
+        except BSBLANConnectionError, BSBLANAuthError, TimeoutError:
+            LOGGER.debug(
+                "DHW schedule not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
+            return None, True
+        except BSBLANError, AttributeError:
+            LOGGER.debug(
+                "DHW schedule not available on device at %s",
+                self.config_entry.data[CONF_HOST],
+            )
+            return None, False

--- a/homeassistant/components/bsblan/coordinator.py
+++ b/homeassistant/components/bsblan/coordinator.py
@@ -9,6 +9,7 @@ from bsblan import (
     BSBLANAuthError,
     BSBLANConnectionError,
     BSBLANError,
+    BSBLANMalformedResponseError,
     HotWaterConfig,
     HotWaterSchedule,
     HotWaterState,
@@ -182,7 +183,6 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         )
         self._dhw_schedule_refresh_pending = True
         self._dhw_schedule_refresh_generation = 0
-        self._retry_schedule_errors = False
 
     @override
     async def _async_update_data(self) -> BSBLanSlowData:
@@ -219,11 +219,9 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
                 dhw_schedule = refreshed_schedule
                 if refresh_generation == self._dhw_schedule_refresh_generation:
                     self._dhw_schedule_refresh_pending = False
-                    self._retry_schedule_errors = False
             elif (
                 refresh_generation == self._dhw_schedule_refresh_generation
                 and not retryable
-                and not self._retry_schedule_errors
             ):
                 self._dhw_schedule_refresh_pending = False
 
@@ -236,7 +234,6 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         """Refresh slow data after a successful schedule write."""
         self._dhw_schedule_refresh_pending = True
         self._dhw_schedule_refresh_generation += 1
-        self._retry_schedule_errors = True
         await self.async_refresh()
 
     async def _async_fetch_dhw_schedule(
@@ -245,7 +242,12 @@ class BSBLanSlowCoordinator(BSBLanCoordinator[BSBLanSlowData]):
         """Fetch the DHW schedule, returning None if unavailable."""
         try:
             return await self.client.hot_water_schedule(), False
-        except BSBLANConnectionError, BSBLANAuthError, TimeoutError:
+        except (
+            BSBLANConnectionError,
+            BSBLANAuthError,
+            BSBLANMalformedResponseError,
+            TimeoutError,
+        ):
             LOGGER.debug(
                 "DHW schedule not available on device at %s",
                 self.config_entry.data[CONF_HOST],

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -203,7 +203,7 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
         ) from err
 
     # Refresh the slow coordinator to get the updated schedule
-    await entry.runtime_data.slow_coordinator.async_request_refresh()
+    await entry.runtime_data.slow_coordinator.async_refresh_schedule_after_write()
 
 
 async def async_sync_time(service_call: ServiceCall) -> None:

--- a/homeassistant/components/bsblan/services.py
+++ b/homeassistant/components/bsblan/services.py
@@ -174,7 +174,7 @@ async def set_hot_water_schedule(service_call: ServiceCall) -> None:
         ) from err
 
     # Refresh the slow coordinator to get the updated schedule
-    await entry.runtime_data.slow_coordinator.async_request_refresh()
+    await entry.runtime_data.slow_coordinator.async_refresh_schedule_after_write()
 
 
 async def async_sync_time(service_call: ServiceCall) -> None:

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -275,9 +275,11 @@ async def test_coordinator_dhw_config_update_error(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    # Mock DHW config methods to fail, but keep state/sensor working
+    mock_bsblan.hot_water_config.reset_mock()
+    mock_bsblan.hot_water_schedule.reset_mock()
+
+    # Mock the DHW config method to fail, but keep state/sensor working
     mock_bsblan.hot_water_config.side_effect = BSBLANConnectionError("Config failed")
-    mock_bsblan.hot_water_schedule.side_effect = BSBLANAuthError("Schedule failed")
 
     # Advance time by 5+ minutes to trigger config update (slow polling)
     freezer.tick(delta=301)  # 5 minutes + 1 second
@@ -289,7 +291,153 @@ async def test_coordinator_dhw_config_update_error(
 
     # Verify the error handling paths were executed
     assert mock_bsblan.hot_water_config.called
-    assert mock_bsblan.hot_water_schedule.called
+    assert not mock_bsblan.hot_water_schedule.called
+
+
+async def test_slow_interval_poll_preserves_cached_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test interval polls keep the cached schedule without re-fetching it.
+
+    The schedule is fetched only off the interval (on startup and after a
+    write). An interval poll must refresh the config while carrying the cached
+    schedule over, without issuing a schedule request.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    cached_schedule = slow_coordinator.data.dhw_schedule
+    assert cached_schedule is not None
+
+    # Reset call counts recorded during the startup refresh so we only observe
+    # what the interval poll does.
+    mock_bsblan.hot_water_config.reset_mock()
+    mock_bsblan.hot_water_schedule.reset_mock()
+
+    # Advance time to trigger a slow interval poll.
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # The interval poll refreshes the config but never fetches the schedule.
+    assert mock_bsblan.hot_water_config.called
+    assert not mock_bsblan.hot_water_schedule.called
+
+    # The cached schedule is preserved across the interval poll.
+    assert slow_coordinator.data.dhw_schedule == cached_schedule
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        BSBLANConnectionError("Schedule failed"),
+        BSBLANAuthError("Authentication failed"),
+        TimeoutError,
+    ],
+    ids=["connection-error", "auth-error", "timeout"],
+)
+async def test_slow_interval_poll_retries_missing_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+    exception: Exception,
+) -> None:
+    """Test interval polls retry transient schedule failures until success."""
+    schedule_value = mock_bsblan.hot_water_schedule.return_value
+    fetch_failed = False
+
+    async def _schedule(*args: object, **kwargs: object) -> object:
+        nonlocal fetch_failed
+        if not fetch_failed:
+            fetch_failed = True
+            raise exception
+        return schedule_value
+
+    mock_bsblan.hot_water_schedule.side_effect = _schedule
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    # The startup fetch failed, so no schedule is cached yet.
+    assert slow_coordinator.data.dhw_schedule is None
+
+    # The next interval poll retries the schedule fetch, which now succeeds.
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert slow_coordinator.data.dhw_schedule == schedule_value
+
+    # Once cached, later polls carry the schedule forward without re-fetching.
+    mock_bsblan.hot_water_schedule.reset_mock()
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not mock_bsblan.hot_water_schedule.called
+    assert slow_coordinator.data.dhw_schedule == schedule_value
+
+
+async def test_slow_interval_poll_does_not_retry_unsupported_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test interval polls do not retry an unsupported schedule."""
+    mock_bsblan.hot_water_schedule.side_effect = BSBLANError(
+        "No hot water schedule parameters available"
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_bsblan.hot_water_schedule.call_count == 1
+
+    for _ in range(2):
+        freezer.tick(delta=timedelta(minutes=5, seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert mock_bsblan.hot_water_schedule.call_count == 1
+
+
+async def test_slow_interval_poll_stops_retrying_unsupported_schedule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a pending retry stops when the schedule is unsupported."""
+    mock_bsblan.hot_water_schedule.side_effect = [
+        BSBLANConnectionError("Schedule failed"),
+        BSBLANError("No hot water schedule parameters available"),
+    ]
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    for _ in range(2):
+        freezer.tick(delta=timedelta(minutes=5, seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert mock_bsblan.hot_water_schedule.call_count == 2
 
 
 async def test_setup_does_not_block_on_slow_fetch(

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -8,6 +8,7 @@ from bsblan import (
     BSBLANAuthError,
     BSBLANConnectionError,
     BSBLANError,
+    BSBLANUnsupportedFeatureError,
     BSBLANVersionError,
     State,
 )
@@ -300,12 +301,7 @@ async def test_slow_interval_poll_preserves_cached_schedule(
     mock_bsblan: MagicMock,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test interval polls keep the cached schedule without re-fetching it.
-
-    The schedule is fetched only off the interval (on startup and after a
-    write). An interval poll must refresh the config while carrying the cached
-    schedule over, without issuing a schedule request.
-    """
+    """Test interval polls preserve the cached schedule without refetching it."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
@@ -397,7 +393,7 @@ async def test_slow_interval_poll_does_not_retry_unsupported_schedule(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test interval polls do not retry an unsupported schedule."""
-    mock_bsblan.hot_water_schedule.side_effect = BSBLANError(
+    mock_bsblan.hot_water_schedule.side_effect = BSBLANUnsupportedFeatureError(
         "No hot water schedule parameters available"
     )
 
@@ -425,7 +421,7 @@ async def test_slow_interval_poll_stops_retrying_unsupported_schedule(
     """Test a pending retry stops when the schedule is unsupported."""
     mock_bsblan.hot_water_schedule.side_effect = [
         BSBLANConnectionError("Schedule failed"),
-        BSBLANError("No hot water schedule parameters available"),
+        BSBLANUnsupportedFeatureError("No hot water schedule parameters available"),
     ]
 
     mock_config_entry.add_to_hass(hass)

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -348,16 +348,7 @@ async def test_slow_interval_poll_retries_missing_schedule(
 ) -> None:
     """Test interval polls retry transient schedule failures until success."""
     schedule_value = mock_bsblan.hot_water_schedule.return_value
-    fetch_failed = False
-
-    async def _schedule(*args: object, **kwargs: object) -> object:
-        nonlocal fetch_failed
-        if not fetch_failed:
-            fetch_failed = True
-            raise exception
-        return schedule_value
-
-    mock_bsblan.hot_water_schedule.side_effect = _schedule
+    mock_bsblan.hot_water_schedule.side_effect = [exception, schedule_value]
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,5 +1,6 @@
 """Tests for BSB-LAN services."""
 
+import asyncio
 from datetime import time, timedelta
 from typing import Any
 from unittest.mock import MagicMock
@@ -191,6 +192,57 @@ async def test_set_hot_water_schedule_refreshes_coordinator(
     mock_bsblan.hot_water_schedule.assert_awaited_once_with()
     assert slow_coordinator.data.dhw_schedule is refreshed_schedule
     assert updates == 1
+
+
+async def test_overlapping_schedule_writes_preserve_latest_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+) -> None:
+    """Test an in-flight refresh does not consume a newer refresh request."""
+    first_fetch_started = asyncio.Event()
+    release_first_fetch = asyncio.Event()
+    stale_schedule = MagicMock()
+    refreshed_schedule = MagicMock()
+    fetch_count = 0
+
+    async def _schedule() -> MagicMock:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            first_fetch_started.set()
+            await release_first_fetch.wait()
+            return stale_schedule
+        return refreshed_schedule
+
+    mock_bsblan.hot_water_schedule.reset_mock()
+    mock_bsblan.hot_water_schedule.side_effect = _schedule
+    service_data = {
+        "device_id": water_heater_device_entry.id,
+        "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+    }
+
+    first_write = asyncio.create_task(
+        hass.services.async_call(
+            DOMAIN, "set_hot_water_schedule", service_data, blocking=True
+        )
+    )
+    await first_fetch_started.wait()
+    second_write = asyncio.create_task(
+        hass.services.async_call(
+            DOMAIN, "set_hot_water_schedule", service_data, blocking=True
+        )
+    )
+    await asyncio.sleep(0)
+    release_first_fetch.set()
+    await asyncio.gather(first_write, second_write)
+
+    assert mock_bsblan.hot_water_schedule.await_count == 2
+    assert (
+        mock_config_entry.runtime_data.slow_coordinator.data.dhw_schedule
+        is refreshed_schedule
+    )
 
 
 async def test_set_hot_water_schedule_retries_failed_refresh(

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,6 +1,6 @@
 """Tests for BSB-LAN services."""
 
-from datetime import time
+from datetime import time, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -15,7 +15,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 # Test constants
 TEST_DEVICE_MAC = "00:80:41:19:69:90"
@@ -157,6 +157,75 @@ async def test_set_hot_water_schedule(
     for key, expected_schedule in expected_schedules.items():
         actual_schedule = getattr(dhw_schedule, key)
         assert actual_schedule == expected_schedule
+
+
+async def test_set_hot_water_schedule_refreshes_coordinator(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+) -> None:
+    """Test setting a schedule refreshes the slow coordinator."""
+    refreshed_schedule = MagicMock()
+    mock_bsblan.hot_water_schedule.return_value = refreshed_schedule
+    mock_bsblan.hot_water_schedule.reset_mock()
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    updates = 0
+
+    def _handle_update() -> None:
+        nonlocal updates
+        updates += 1
+
+    slow_coordinator.async_add_listener(_handle_update)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_hot_water_schedule",
+        {
+            "device_id": water_heater_device_entry.id,
+            "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+        },
+        blocking=True,
+    )
+
+    mock_bsblan.hot_water_schedule.assert_awaited_once_with()
+    assert slow_coordinator.data.dhw_schedule is refreshed_schedule
+    assert updates == 1
+
+
+async def test_set_hot_water_schedule_retries_failed_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a failed post-write refresh is retried on the next interval."""
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    old_schedule = slow_coordinator.data.dhw_schedule
+    refreshed_schedule = MagicMock()
+    mock_bsblan.hot_water_schedule.side_effect = [
+        BSBLANError("Invalid response"),
+        refreshed_schedule,
+    ]
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_hot_water_schedule",
+        {
+            "device_id": water_heater_device_entry.id,
+            "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+        },
+        blocking=True,
+    )
+
+    assert slow_coordinator.data.dhw_schedule is old_schedule
+
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert slow_coordinator.data.dhw_schedule is refreshed_schedule
 
 
 async def test_invalid_device_id(

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,5 +1,6 @@
 """Tests for BSB-LAN services."""
 
+import asyncio
 from datetime import time, timedelta
 from typing import Any
 from unittest.mock import MagicMock
@@ -195,6 +196,57 @@ async def test_set_hot_water_schedule_refreshes_coordinator(
     mock_bsblan.hot_water_schedule.assert_awaited_once_with()
     assert slow_coordinator.data.dhw_schedule is refreshed_schedule
     assert updates == 1
+
+
+async def test_overlapping_schedule_writes_preserve_latest_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+) -> None:
+    """Test an in-flight refresh does not consume a newer refresh request."""
+    first_fetch_started = asyncio.Event()
+    release_first_fetch = asyncio.Event()
+    stale_schedule = MagicMock()
+    refreshed_schedule = MagicMock()
+    fetch_count = 0
+
+    async def _schedule() -> MagicMock:
+        nonlocal fetch_count
+        fetch_count += 1
+        if fetch_count == 1:
+            first_fetch_started.set()
+            await release_first_fetch.wait()
+            return stale_schedule
+        return refreshed_schedule
+
+    mock_bsblan.hot_water_schedule.reset_mock()
+    mock_bsblan.hot_water_schedule.side_effect = _schedule
+    service_data = {
+        "device_id": water_heater_device_entry.id,
+        "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+    }
+
+    first_write = asyncio.create_task(
+        hass.services.async_call(
+            DOMAIN, "set_hot_water_schedule", service_data, blocking=True
+        )
+    )
+    await first_fetch_started.wait()
+    second_write = asyncio.create_task(
+        hass.services.async_call(
+            DOMAIN, "set_hot_water_schedule", service_data, blocking=True
+        )
+    )
+    await asyncio.sleep(0)
+    release_first_fetch.set()
+    await asyncio.gather(first_write, second_write)
+
+    assert mock_bsblan.hot_water_schedule.await_count == 2
+    assert (
+        mock_config_entry.runtime_data.slow_coordinator.data.dhw_schedule
+        is refreshed_schedule
+    )
 
 
 async def test_set_hot_water_schedule_retries_failed_refresh(

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -5,7 +5,14 @@ from datetime import time, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
-from bsblan import BSBLANError, DaySchedule, DeviceTime, TimeSlot
+from bsblan import (
+    BSBLANError,
+    BSBLANMalformedResponseError,
+    BSBLANUnsupportedFeatureError,
+    DaySchedule,
+    DeviceTime,
+    TimeSlot,
+)
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
@@ -261,7 +268,7 @@ async def test_set_hot_water_schedule_retries_failed_refresh(
     old_schedule = slow_coordinator.data.dhw_schedule
     refreshed_schedule = MagicMock()
     mock_bsblan.hot_water_schedule.side_effect = [
-        BSBLANError("Invalid response"),
+        BSBLANMalformedResponseError("Invalid response"),
         refreshed_schedule,
     ]
 
@@ -282,6 +289,36 @@ async def test_set_hot_water_schedule_retries_failed_refresh(
     await hass.async_block_till_done()
 
     assert slow_coordinator.data.dhw_schedule is refreshed_schedule
+
+
+async def test_set_hot_water_schedule_does_not_retry_unsupported_refresh(
+    hass: HomeAssistant,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a post-write refresh does not retry an unsupported schedule."""
+    mock_bsblan.hot_water_schedule.reset_mock()
+    mock_bsblan.hot_water_schedule.side_effect = BSBLANUnsupportedFeatureError(
+        "No hot water schedule parameters available"
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_hot_water_schedule",
+        {
+            "device_id": water_heater_device_entry.id,
+            "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+        },
+        blocking=True,
+    )
+
+    for _ in range(2):
+        freezer.tick(delta=timedelta(minutes=5, seconds=1))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    mock_bsblan.hot_water_schedule.assert_awaited_once_with()
 
 
 async def test_invalid_device_id(

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -1,6 +1,6 @@
 """Tests for BSB-LAN services."""
 
-from datetime import time
+from datetime import time, timedelta
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -15,7 +15,7 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 # Test constants
 TEST_DEVICE_MAC = "00:80:41:19:69:90"
@@ -161,6 +161,75 @@ async def test_set_hot_water_schedule(
     for key, expected_schedule in expected_schedules.items():
         actual_schedule = getattr(dhw_schedule, key)
         assert actual_schedule == expected_schedule
+
+
+async def test_set_hot_water_schedule_refreshes_coordinator(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+) -> None:
+    """Test setting a schedule refreshes the slow coordinator."""
+    refreshed_schedule = MagicMock()
+    mock_bsblan.hot_water_schedule.return_value = refreshed_schedule
+    mock_bsblan.hot_water_schedule.reset_mock()
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    updates = 0
+
+    def _handle_update() -> None:
+        nonlocal updates
+        updates += 1
+
+    slow_coordinator.async_add_listener(_handle_update)
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_hot_water_schedule",
+        {
+            "device_id": water_heater_device_entry.id,
+            "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+        },
+        blocking=True,
+    )
+
+    mock_bsblan.hot_water_schedule.assert_awaited_once_with()
+    assert slow_coordinator.data.dhw_schedule is refreshed_schedule
+    assert updates == 1
+
+
+async def test_set_hot_water_schedule_retries_failed_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_bsblan: MagicMock,
+    water_heater_device_entry: dr.DeviceEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a failed post-write refresh is retried on the next interval."""
+    slow_coordinator = mock_config_entry.runtime_data.slow_coordinator
+    old_schedule = slow_coordinator.data.dhw_schedule
+    refreshed_schedule = MagicMock()
+    mock_bsblan.hot_water_schedule.side_effect = [
+        BSBLANError("Invalid response"),
+        refreshed_schedule,
+    ]
+
+    await hass.services.async_call(
+        DOMAIN,
+        "set_hot_water_schedule",
+        {
+            "device_id": water_heater_device_entry.id,
+            "monday_slots": [{"start_time": time(6, 0), "end_time": time(8, 0)}],
+        },
+        blocking=True,
+    )
+
+    assert slow_coordinator.data.dhw_schedule is old_schedule
+
+    freezer.tick(delta=timedelta(minutes=5, seconds=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert slow_coordinator.data.dhw_schedule is refreshed_schedule
 
 
 async def test_invalid_device_id(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid fetching the BSB-LAN domestic-hot-water (DHW) schedule during every slow coordinator update.

The schedule changes infrequently, so it is cached and refreshed only during setup and after a schedule write. Transient schedule-fetch errors are retried on a later update, while unsupported schedules stop retrying. Refresh generations ensure an overlapping schedule write cannot discard a newer refresh request.

This reduces unnecessary BSB-LAN/serial-bus traffic while keeping the cached schedule current after changes.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
