### PR TITLE
Fix duplicate Hikvision binary sensor unique IDs

### DIFF
--- a/homeassistant/components/hikvision/binary_sensor.py
+++ b/homeassistant/components/hikvision/binary_sensor.py
@@ -252,17 +252,29 @@ async def async_setup_entry(
                 sensor_type,
             )
 
-    async_add_entities(
-        HikvisionBinarySensor(
-            entry=entry,
-            description=BINARY_SENSOR_DESCRIPTIONS[sensor_type],
-            sensor_type=sensor_type,
-            channel=channel_info[1],
-        )
-        for sensor_type, channel_list in sensors.items()
-        if sensor_type in BINARY_SENSOR_DESCRIPTIONS
-        for channel_info in channel_list
-    )
+    entities: list[HikvisionBinarySensor] = []
+    for sensor_type, channel_list in sensors.items():
+        if sensor_type not in BINARY_SENSOR_DESCRIPTIONS:
+            continue
+        # pyhik can report the same channel more than once for a sensor type
+        # (e.g. when a channel has several notification methods enabled), so
+        # deduplicate on the channel to avoid colliding unique IDs.
+        seen_channels: set[int] = set()
+        for channel_info in channel_list:
+            channel = channel_info[1]
+            if channel in seen_channels:
+                continue
+            seen_channels.add(channel)
+            entities.append(
+                HikvisionBinarySensor(
+                    entry=entry,
+                    description=BINARY_SENSOR_DESCRIPTIONS[sensor_type],
+                    sensor_type=sensor_type,
+                    channel=channel,
+                )
+            )
+
+    async_add_entities(entities)
 
 
 class HikvisionBinarySensor(HikvisionEntity, BinarySensorEntity):

--- a/tests/components/hikvision/test_binary_sensor.py
+++ b/tests/components/hikvision/test_binary_sensor.py
@@ -165,6 +165,43 @@ async def test_binary_sensor_nvr_device(
     assert len(states) == 2
 
 
+@pytest.mark.parametrize("amount_of_channels", [2])
+async def test_binary_sensor_duplicate_channels_deduplicated(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_hikcamera: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test duplicate channel entries do not create colliding unique IDs.
+
+    pyhik can report the same channel several times for a sensor type when the
+    channel has multiple notification methods enabled. Only one entity should be
+    created per channel and no duplicate unique ID warnings should occur.
+    """
+    mock_hikcamera.return_value.get_type = "NVR"
+    mock_hikcamera.return_value.current_event_states = {
+        # Channel 1 reported three times, channel 2 reported twice.
+        "Line Crossing": [(False, 1), (False, 1), (False, 1), (False, 2), (False, 2)],
+    }
+
+    await setup_integration(hass, mock_config_entry)
+
+    # One entity per distinct channel, not one per reported entry.
+    states = hass.states.async_entity_ids("binary_sensor")
+    assert len(states) == 2
+
+    unique_ids = {
+        entry.unique_id
+        for entry in er.async_entries_for_config_entry(
+            entity_registry, mock_config_entry.entry_id
+        )
+    }
+    assert unique_ids == {
+        f"{TEST_DEVICE_ID}_Line Crossing_1",
+        f"{TEST_DEVICE_ID}_Line Crossing_2",
+    }
+
+
 async def test_binary_sensor_state_on(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
## Proposed change

Hikvision binary sensors were being silently dropped with `Platform hikvision does not generate unique IDs. ID ..._Line Crossing_1 already exists - ignoring`.

pyhik's `current_event_states` can return the same channel more than once for a given sensor type — it appends the channel once per enabled notification method, and after the 0.4.3 bump the accepted method set widened from `{center, HTTP}` to `{center, HTTP, record, email, beep}`. On NVRs (where recording etc. is typically on) that means several identical `[state, channel, ...]` entries per event, which we turned into multiple entities sharing the unique ID `{device_id}_{sensor_type}_{channel}`. The registry kept the first and ignored the rest, so channels like a second camera's Line Crossing / Field Detection disappeared.

This deduplicates on the channel when building the entities, so each channel gets exactly one binary sensor. The unique ID format is unchanged, so existing entities keep their IDs and history.

Fixes #174798

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes #174798

## Checklist

- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.
