### PR TITLE
Restore KNX switch states

### DIFF
--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -87,9 +87,9 @@ class _KnxSwitch(SwitchEntity, RestoreEntity):
 
     @property
     @override
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return true if device is on."""
-        return bool(self._device.state)
+        return self._device.state
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -79,9 +79,7 @@ class _KnxSwitch(SwitchEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()
-        if not self._device.switch.readable and (
-            last_state := await self.async_get_last_state()
-        ):
+        if last_state := await self.async_get_last_state():
             if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._device.switch.value = last_state.state == STATE_ON
 

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -6,7 +6,7 @@ from homeassistant.components.knx.const import (
     KNX_ADDRESS,
 )
 from homeassistant.components.knx.schema import SwitchSchema
-from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON, Platform
+from homeassistant.const import CONF_NAME, STATE_OFF, STATE_ON, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
 
 from . import KnxEntityGenerator
@@ -70,6 +70,8 @@ async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit) -> None:
 
     # StateUpdater initialize state
     await knx.assert_read(_STATE_ADDRESS)
+    # state is unknown until the first GroupValueRead response is received
+    assert hass.states.get("switch.test").state is STATE_UNKNOWN
     await knx.receive_response(_STATE_ADDRESS, True)
     state = hass.states.get("switch.test")
     assert state.state is STATE_ON

--- a/tests/components/knx/test_switch.py
+++ b/tests/components/knx/test_switch.py
@@ -113,6 +113,39 @@ async def test_switch_state(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.assert_telegram_count(0)
 
 
+async def test_switch_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX switch with state_address restores last known state until bus read completes."""
+    _ADDRESS = "1/1/1"
+    _STATE_ADDRESS = "2/2/2"
+    fake_state = State("switch.test", STATE_ON)
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            SwitchSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: _ADDRESS,
+                CONF_STATE_ADDRESS: _STATE_ADDRESS,
+            },
+        }
+    )
+
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(_STATE_ADDRESS)
+    state = hass.states.get("switch.test")
+    assert state.state is STATE_ON
+
+    # bus confirms restored value - no additional state change expected
+    await knx.receive_response(_STATE_ADDRESS, True)
+    state = hass.states.get("switch.test")
+    assert state.state is STATE_ON
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_write(_STATE_ADDRESS, False)
+    state = hass.states.get("switch.test")
+    assert state.state is STATE_OFF
+
+
 async def test_switch_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test restoring KNX switch state and respond to read."""
     _ADDRESS = "1/1/1"


### PR DESCRIPTION
## Proposed change

`KNXSwitch.is_on` returned `bool(self._device.state)`. For a switch whose state is read from the bus (state group address configured / `readable`), `self._device.state` is `None` from startup until the first `GroupValueRead` response arrives. `bool(None)` is `False`, so the entity reported **`off`** during that window — even though the actuator was actually `on`.

On large installations the window is not negligible: after (re)connecting to the interface, the `StateUpdater` reads hundreds of state group addresses and the responses are serialized at bus speed, so an individual switch can sit at a wrong `off` for tens of seconds after every restart. Anything reacting to switch state (automations, template sensors, other integrations) then acts on a false `off`.

**Observed impact** in a real installation: an energy/load-management automation read a KNX switch (a circulation pump) as `off` for tens of seconds after every restart and made incorrect dispatch decisions — treating a still-running device as stopped — until the first state read arrived.

This PR fixes the wrong initial value in two parts:

1. **Restore last known state for all switches**, not just those without a state address. `_KnxSwitch.async_added_to_hass` already restored state via `RestoreEntity` for switches without a state address — this now applies unconditionally, so a switch with a state address also starts with its last known value instead of `None`/`off` while waiting for the bus response. If the actual value differs once the response arrives, a normal state-changed event fires, same as any other update.
2. **`unknown` as a fallback for genuinely new entities** — `KNXSwitch.is_on` forwards xknx's already-nullable `Switch.state` (typed `bool | None`) directly, so `ToggleEntity.state` maps `None` → `unknown` only when there's no last known state to restore from (e.g. an entity that has never been read from the bus before).

```python
@property
@override
def is_on(self) -> bool | None:
    """Return true if device is on."""
    return self._device.state
```

### Comparison / related cases
- **Covers were fixed similarly in #44926** ("Fix KNX cover state return open when unknown") — this PR goes a step further for switches by restoring the last known value first, only falling back to `unknown` when nothing is known yet, to minimize state-change churn for existing installations.
- The earlier switch state-initialization fix (#43536, xknx 0.15.4) is orthogonal.

Tests: `test_switch_state_restore` (readable switch restores last state, then updates once the bus responds); the existing `test_switch_state` continues to cover the no-prior-state case.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration
- [ ] New feature
- [ ] Deprecation
- [ ] Breaking change
- [ ] Code quality improvements to existing code or addition of tests

Behaviour note: a readable switch now restores its last known state on startup instead of defaulting to `off`; only entities with no prior state (e.g. newly added) report `unknown` until the first bus response arrives.

## Additional information

Related: #44926 (covers, similar issue), #51761 (RestoreEntity for non-readable switches, now unconditional), #43536 (orthogonal).

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist].
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
