### PR TITLE
Add WyBot integration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2064,6 +2064,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/ws66i/ @ssaenger
 /homeassistant/components/wsdot/ @ucodery
 /tests/components/wsdot/ @ucodery
+/homeassistant/components/wybot/ @bassrock
+/tests/components/wybot/ @bassrock
 /homeassistant/components/wyoming/ @synesthesiam
 /tests/components/wyoming/ @synesthesiam
 /homeassistant/components/xbox/ @tr4nt0r

--- a/homeassistant/components/wybot/__init__.py
+++ b/homeassistant/components/wybot/__init__.py
@@ -1,0 +1,56 @@
+"""The WyBot integration."""
+
+from wybot import WybotAuthError, WybotConnectionError, WyBotHTTPClient
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+from .coordinator import WyBotCoordinator
+
+PLATFORMS: list[Platform] = [Platform.VACUUM]
+
+type WyBotConfigEntry = ConfigEntry[WyBotCoordinator]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: WyBotConfigEntry) -> bool:
+    """Set up WyBot from a config entry."""
+    wybot_http_client = WyBotHTTPClient(
+        entry.data[CONF_USERNAME],
+        entry.data[CONF_PASSWORD],
+        session=async_get_clientsession(hass),
+    )
+
+    try:
+        await wybot_http_client.authenticate()
+    except WybotAuthError as err:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN, translation_key="invalid_auth"
+        ) from err
+    except WybotConnectionError as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN, translation_key="cannot_connect"
+        ) from err
+
+    coordinator = WyBotCoordinator(
+        hass, wybot_http_client=wybot_http_client, config_entry=entry
+    )
+    entry.runtime_data = coordinator
+
+    # Register cleanup before the first refresh: that refresh can start the MQTT
+    # background task, so a later setup failure must still tear it down.
+    entry.async_on_unload(coordinator.async_stop)
+
+    await coordinator.async_config_entry_first_refresh()
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: WyBotConfigEntry) -> bool:
+    """Unload a config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/wybot/bluetooth_adapter.py
+++ b/homeassistant/components/wybot/bluetooth_adapter.py
@@ -1,0 +1,38 @@
+"""Home Assistant-backed Bluetooth adapter for the pywybot BLE client.
+
+Implements pywybot's ``BluetoothAdapter`` protocol on top of Home Assistant's
+Bluetooth stack so the library can discover and resolve WyBot BLE devices
+without depending on Home Assistant itself.
+"""
+
+from bleak.backends.device import BLEDevice
+
+from homeassistant.components.bluetooth import (
+    async_ble_device_from_address,
+    async_discovered_service_info,
+    async_scanner_count,
+)
+from homeassistant.core import HomeAssistant
+
+
+class HomeAssistantBluetoothAdapter:
+    """Supply BLE discovery to pywybot using Home Assistant's Bluetooth stack."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the adapter with a Home Assistant instance."""
+        self._hass = hass
+
+    def scanner_count(self) -> int:
+        """Return the number of active connectable BLE scanners."""
+        return async_scanner_count(self._hass, connectable=True)
+
+    def discovered_devices(self) -> list[BLEDevice]:
+        """Return the currently discovered connectable BLE devices."""
+        return [
+            info.device
+            for info in async_discovered_service_info(self._hass, connectable=True)
+        ]
+
+    def device_from_address(self, address: str) -> BLEDevice | None:
+        """Resolve a connectable BLEDevice for ``address``, or None."""
+        return async_ble_device_from_address(self._hass, address, connectable=True)

--- a/homeassistant/components/wybot/config_flow.py
+++ b/homeassistant/components/wybot/config_flow.py
@@ -1,0 +1,174 @@
+"""Config flow for WyBot integration."""
+
+from collections.abc import Mapping
+import logging
+from typing import Any, override
+
+import voluptuous as vol
+from wybot import WybotAuthError, WybotConnectionError, WyBotHTTPClient
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
+
+async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
+    """Validate the user input allows us to connect.
+
+    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
+    """
+    client = WyBotHTTPClient(
+        data[CONF_USERNAME],
+        data[CONF_PASSWORD],
+        session=async_get_clientsession(hass),
+    )
+
+    try:
+        await client.authenticate()
+    except WybotAuthError as err:
+        raise InvalidAuth from err
+    except WybotConnectionError as err:
+        raise CannotConnect from err
+
+    # Return info that you want to store in the config entry. The user_id
+    # uniquely identifies the WyBot account and is used as the entry unique_id.
+    return {"title": data[CONF_USERNAME], "user_id": client.user_id}
+
+
+class WyBotConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for WyBot."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial step."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                # Key the entry on the WyBot account so the same account
+                # cannot be configured twice (unique-config-entry).
+                await self.async_set_unique_id(info["user_id"])
+                self._abort_if_unique_id_configured()
+                return self.async_create_entry(title=info["title"], data=user_input)
+
+        return self.async_show_form(
+            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle re-authentication when stored credentials become invalid."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm re-authentication by collecting a new password."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            data = {
+                CONF_USERNAME: reauth_entry.data[CONF_USERNAME],
+                CONF_PASSWORD: user_input[CONF_PASSWORD],
+            }
+            try:
+                info = await validate_input(self.hass, data)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(info["user_id"])
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(
+                    reauth_entry,
+                    data_updates={CONF_PASSWORD: user_input[CONF_PASSWORD]},
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
+            description_placeholders={"username": reauth_entry.data[CONF_USERNAME]},
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Let the user change the WyBot account credentials."""
+        errors: dict[str, str] = {}
+        reconfigure_entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            try:
+                info = await validate_input(self.hass, user_input)
+            except CannotConnect:
+                errors["base"] = "cannot_connect"
+            except InvalidAuth:
+                errors["base"] = "invalid_auth"
+            except Exception:
+                _LOGGER.exception("Unexpected exception")
+                errors["base"] = "unknown"
+            else:
+                await self.async_set_unique_id(info["user_id"])
+                self._abort_if_unique_id_mismatch(reason="wrong_account")
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry,
+                    title=info["title"],
+                    data_updates={
+                        CONF_USERNAME: user_input[CONF_USERNAME],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USERNAME,
+                        default=reconfigure_entry.data[CONF_USERNAME],
+                    ): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )
+
+
+class CannotConnect(HomeAssistantError):
+    """Error to indicate we cannot connect."""
+
+
+class InvalidAuth(HomeAssistantError):
+    """Error to indicate there is invalid auth."""

--- a/homeassistant/components/wybot/const.py
+++ b/homeassistant/components/wybot/const.py
@@ -1,0 +1,7 @@
+"""Constants for the WyBot integration."""
+
+DOMAIN = "wybot"
+MANUFACTURER = "WyBot"
+
+# Disable BLE commands after N consecutive failures.
+BLE_MAX_CONSECUTIVE_FAILURES = 3

--- a/homeassistant/components/wybot/coordinator.py
+++ b/homeassistant/components/wybot/coordinator.py
@@ -1,0 +1,1014 @@
+"""DataUpdateCoordinator for the WyBot integration."""
+
+import asyncio
+from datetime import datetime, timedelta
+import logging
+import time
+from typing import Any, override
+
+from wybot import WybotAuthError, WyBotBLEClient, WyBotHTTPClient, WyBotMQTTClient
+from wybot.dp_models import GenericDP
+from wybot.models import Command, Device, Docker, Group, MQTTMessage, MQTTMessageKind
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from .bluetooth_adapter import HomeAssistantBluetoothAdapter
+from .const import BLE_MAX_CONSECUTIVE_FAILURES, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+# Consecutive failed update cycles before the integration is marked not-ready.
+# pywybot itself retries each HTTP request with backoff, so this counts whole
+# cycles, not individual attempts.
+MAX_HTTP_RETRIES = 3
+
+# Overall update timeout — safety net; individual operations have their own timeouts
+UPDATE_TIMEOUT = 120
+
+# BLE failure recovery — re-enable BLE after this many seconds
+BLE_RECOVERY_SECONDS = 300  # 5 minutes
+
+# Mark the integration unavailable when no transport (BLE, MQTT, or the HTTP
+# keepalive) has succeeded within this window. Longer than the HTTP keepalive
+# interval (60s) so a couple of missed cycles do not cause flapping.
+AVAILABILITY_TIMEOUT = timedelta(minutes=3)
+
+
+class WyBotCoordinator(DataUpdateCoordinator):
+    """Coordinates data between WyBot and Home Assistant.
+
+    Architecture: BLE-primary with MQTT fallback
+    - BLE polling is attempted first for all devices in range
+    - MQTT is used only when BLE fails or device is out of range
+    - HTTP session refresh keeps MQTT session alive for fallback
+    """
+
+    wybot_http_client: WyBotHTTPClient
+    wybot_mqtt_client: WyBotMQTTClient
+    wybot_ble_client: WyBotBLEClient
+    hass: HomeAssistant
+    data: dict[str, Group]
+    initial_load: bool = False
+    _connection_available: bool = True
+    _http_failure_count: int = 0
+    _mqtt_failure_count: int = 0
+    _last_status_query_time: float = 0.0
+    _last_http_refresh_time: float = 0.0
+    _online_devices: set[str] = set()
+    _initial_query_start_time: float = 0.0
+
+    # BLE command tracking
+    _ble_command_enabled: bool = True
+    _ble_command_failures: dict[str, int]  # device_id -> consecutive failure count
+    _ble_disabled_at: dict[str, float]  # device_id -> time.time() when BLE was disabled
+
+    # Track last MQTT data received
+    _last_mqtt_data: dict[str, datetime]  # device_id -> last MQTT data time
+
+    # Track last BLE poll time
+    _last_ble_poll: dict[str, datetime]  # device_id -> last BLE poll time
+
+    # Track data source per device (for diagnostics and logging)
+    _data_source: dict[str, str]  # device_id -> "ble" | "mqtt"
+
+    # Track BLE availability per device
+    _ble_available: dict[str, bool]  # device_id -> last BLE poll succeeded
+
+    # MQTT lazy connection state
+    _mqtt_connected: bool = False
+    # Time of the most recent successful MQTT (re)connect (diagnostic)
+    _mqtt_last_connected_at: datetime | None = None
+
+    # Time of the most recent successful HTTP contact with the WyBot cloud
+    _last_http_success: datetime | None = None
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        wybot_http_client: WyBotHTTPClient,
+        config_entry: ConfigEntry,
+    ) -> None:
+        """Initialize my coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="WyBot Coordinator",
+            update_interval=timedelta(seconds=30),
+        )
+        self.wybot_http_client = wybot_http_client
+        self.wybot_mqtt_client = WyBotMQTTClient(self.on_message)
+        # DON'T connect MQTT here - use lazy connection when needed as fallback
+        self.wybot_ble_client = WyBotBLEClient(HomeAssistantBluetoothAdapter(hass))
+        self.data = {}
+
+        # Initialize data tracking
+        self._last_mqtt_data = {}
+        self._last_ble_poll = {}
+        self._data_source = {}
+        self._ble_available = {}
+
+        # Initialize BLE command tracking
+        self._ble_command_failures = {}
+        self._ble_disabled_at = {}
+        self._online_devices = set()
+
+    async def async_stop(self) -> None:
+        """Stop the MQTT client.
+
+        Always disconnect: pywybot's connect() starts a background reconnect
+        task, and a later subscription error can clear _mqtt_connected while
+        that task keeps running, so gating disconnect on the flag would leak it.
+        """
+        _LOGGER.info("Stopping MQTT client")
+        await self.wybot_mqtt_client.disconnect()
+        self._mqtt_connected = False
+
+    async def _ensure_mqtt_connected(self) -> bool:
+        """Lazy connect to MQTT (only when needed as fallback).
+
+        Self-healing: if our flag claims connected but the client disagrees,
+        reset and reconnect. This catches silent drops where the disconnect
+        callback didn't fire or aiomqtt's auto-retry is wedged.
+
+        Returns:
+            True if MQTT is connected, False otherwise
+        """
+        if self._mqtt_connected:
+            if self.wybot_mqtt_client.is_connected():
+                return True
+            _LOGGER.warning(
+                "MQTT state drift detected: flag says connected, client says no; reconnecting"
+            )
+            self._mqtt_connected = False
+
+        _LOGGER.info("Connecting to MQTT (fallback mode)")
+        try:
+            # connect() waits for the link to actually come up and reports the
+            # result, so we never mark ourselves connected before publishes can
+            # be delivered.
+            if not await self.wybot_mqtt_client.connect():
+                _LOGGER.warning("MQTT connection did not come up in time")
+                self._mqtt_connected = False
+                return False
+            self._mqtt_connected = True
+            self._mqtt_last_connected_at = dt_util.utcnow()
+            # Subscribe to topics for all known devices
+            if self.data:
+                await self.subscribe_mqtt(self.data)
+        except Exception as err:  # noqa: BLE001
+            # Transport failures must not crash the coordinator; MQTT is a
+            # fallback layer, so degrade gracefully and retry next cycle.
+            _LOGGER.warning("MQTT connection failed: %s", err)
+            self._mqtt_connected = False
+            return False
+        _LOGGER.info("MQTT connected successfully (fallback ready)")
+        return True
+
+    def _record_mqtt_data_received(self, device_id: str) -> None:
+        """Record that MQTT data was received from a device.
+
+        Marks data_source="mqtt" only when a real MQTT message arrives, so
+        the diagnostic sensor doesn't flap on every poll cycle that *tried*
+        MQTT fallback.
+
+        Args:
+            device_id: The device ID that sent data
+        """
+        self._last_mqtt_data[device_id] = dt_util.utcnow()
+        self._data_source[device_id] = "mqtt"
+        _LOGGER.debug("Recorded MQTT data received from device %s", device_id)
+
+    def get_last_ble_communication(self, device_id: str) -> datetime | None:
+        """Get the last successful BLE communication time for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            datetime of last BLE communication, or None if never communicated via BLE
+        """
+        return self._last_ble_poll.get(device_id)
+
+    def get_last_mqtt_communication(self, device_id: str) -> datetime | None:
+        """Get the last MQTT data received time for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            datetime of last MQTT data, or None if never received MQTT data
+        """
+        return self._last_mqtt_data.get(device_id)
+
+    def get_data_source(self, device_id: str) -> str | None:
+        """Get the current data source for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            "ble" or "mqtt" depending on last successful poll, or None if unknown
+        """
+        return self._data_source.get(device_id)
+
+    def is_ble_available(self, device_id: str) -> bool | None:
+        """Check if BLE is available for a device.
+
+        Args:
+            device_id: The device ID to query
+
+        Returns:
+            True if last BLE poll succeeded, False if failed, None if never tried
+        """
+        return self._ble_available.get(device_id)
+
+    def _get_device_ble_info(self, group: Group) -> tuple[str | None, str | None]:
+        """Get the BLE name and device ID for a group.
+
+        Prefers docker BLE name since dock relays to robot.
+
+        Args:
+            group: The device group
+
+        Returns:
+            Tuple of (ble_name, device_id) or (None, None) if no BLE available
+        """
+        if group.docker and group.docker.ble_name:
+            return group.docker.ble_name, group.docker.docker_id
+        if group.device and group.device.ble_name:
+            return group.device.ble_name, group.device.device_id
+        return None, None
+
+    @staticmethod
+    def _mqtt_query_ids(group: Group) -> list[str]:
+        """Return the device IDs to query over MQTT for a group.
+
+        The robot and dock publish their DPs on separate MQTT topics, so both
+        must be queried on fallback: robot entities/vacuum consume the robot's
+        DPs while the dock sensors consume the dock's.
+        """
+        ids: list[str] = []
+        if group.device:
+            ids.append(group.device.device_id)
+        if group.docker:
+            ids.append(group.docker.docker_id)
+        return ids
+
+    def _update_device_dps_from_ble(
+        self, group: Group, device_id: str, dps: list[dict[str, Any]]
+    ) -> None:
+        """Update device DPs from BLE response.
+
+        Args:
+            group: The device group to update
+            device_id: The device ID
+            dps: List of DP dicts from BLE response
+        """
+        if not dps:
+            return
+
+        # Create a command-like structure to reuse existing DP processing
+        cmd_data: dict[str, Any] = {"cmd": 5, "ts": 0, "dp": dps}
+        command = Command(**cmd_data)
+        dp_dict: dict[str, Any] = command.get_dps_as_keyed_dict()
+
+        if group.docker and group.docker.docker_id == device_id:
+            group.docker.dps = {**group.docker.dps, **dp_dict}
+            _LOGGER.debug(
+                "Updated docker %s DPs from BLE: %s",
+                device_id,
+                list(dp_dict.keys()),
+            )
+        elif group.device:
+            group.device.dps = {**group.device.dps, **dp_dict}
+            _LOGGER.debug(
+                "Updated device %s DPs from BLE: %s",
+                device_id,
+                list(dp_dict.keys()),
+            )
+
+    def _maybe_recover_ble(self, device_id: str) -> None:
+        """Re-enable BLE for a device if enough time has passed since it was disabled."""
+        disabled_at = self._ble_disabled_at.get(device_id)
+        if (
+            disabled_at is not None
+            and (time.time() - disabled_at) >= BLE_RECOVERY_SECONDS
+        ):
+            _LOGGER.info(
+                "Re-enabling BLE for device %s after %ds recovery period",
+                device_id,
+                BLE_RECOVERY_SECONDS,
+            )
+            self._ble_command_failures.pop(device_id, None)
+            self._ble_disabled_at.pop(device_id, None)
+
+    async def _poll_all_devices_via_ble(self) -> list[str]:
+        """Poll all devices via BLE (primary data source).
+
+        BLE provides faster, more reliable local communication when the device
+        is in range. This is the PRIMARY data source in the BLE-first architecture.
+
+        Returns:
+            List of device IDs that need MQTT fallback (failed BLE or no BLE name)
+        """
+        devices_needing_mqtt: list[str] = []
+        now = dt_util.utcnow()
+
+        for group_id, group in self.data.items():
+            ble_name, device_id = self._get_device_ble_info(group)
+
+            if not ble_name or not device_id:
+                # No BLE name available, will need MQTT
+                devices_needing_mqtt.extend(self._mqtt_query_ids(group))
+                continue
+
+            # Check if BLE should be recovered for this device
+            self._maybe_recover_ble(device_id)
+
+            _LOGGER.debug(
+                "BLE polling device %s via %s (primary)",
+                device_id,
+                ble_name,
+            )
+
+            try:
+                dps = await self.wybot_ble_client.query_status(ble_name)
+
+                if dps:
+                    _LOGGER.debug(
+                        "BLE poll success for %s: %d DPs received",
+                        device_id,
+                        len(dps),
+                    )
+                    self._update_device_dps_from_ble(group, device_id, dps)
+                    self.data[group_id] = group
+
+                    # Track successful BLE poll
+                    self._last_ble_poll[device_id] = now
+                    self._data_source[device_id] = "ble"
+                    self._ble_available[device_id] = True
+                else:
+                    # BLE returned no data, need MQTT fallback
+                    _LOGGER.debug(
+                        "BLE poll for %s returned no data, using MQTT fallback",
+                        device_id,
+                    )
+                    devices_needing_mqtt.extend(self._mqtt_query_ids(group))
+                    self._ble_available[device_id] = False
+
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "BLE poll failed for %s: %s, using MQTT fallback",
+                    device_id,
+                    err,
+                )
+                devices_needing_mqtt.extend(self._mqtt_query_ids(group))
+                self._ble_available[device_id] = False
+
+        return devices_needing_mqtt
+
+    async def _poll_devices_via_mqtt(self, device_ids: list[str]) -> None:
+        """Poll specific devices via MQTT (fallback).
+
+        Only called when BLE fails or device is out of range.
+
+        Args:
+            device_ids: List of device IDs that need MQTT polling
+        """
+        if not device_ids:
+            return
+
+        # Ensure MQTT is connected (lazy connection)
+        if not await self._ensure_mqtt_connected():
+            _LOGGER.warning(
+                "MQTT fallback unavailable for %d devices",
+                len(device_ids),
+            )
+            return
+
+        _LOGGER.debug(
+            "Using MQTT fallback for %d devices: %s",
+            len(device_ids),
+            device_ids,
+        )
+
+        for device_id in device_ids:
+            await self.wybot_mqtt_client.ensure_device_sends_statuses(device_id)
+            self._last_status_query_time = time.time()
+
+    async def _maybe_refresh_http_session(self) -> None:
+        """Periodically refresh HTTP session to keep MQTT fallback ready.
+
+        The WyBot cloud may only relay MQTT data for "active" users,
+        so we need to periodically refresh the HTTP session.
+        """
+        # MQTT keepalive runs every cycle, independent of the HTTP throttle, so
+        # silent drops are detected within ~30s. _ensure_mqtt_connected is
+        # drift-aware and idempotent when already healthy.
+        if self.data:
+            try:
+                await self._ensure_mqtt_connected()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("MQTT keepalive failed (non-critical): %s", err)
+
+        current_time = time.time()
+        # Throttle the HTTP session refresh to once every 60 seconds.
+        if current_time - self._last_http_refresh_time < 60.0:
+            return
+        # Advance the throttle regardless of outcome so a failing refresh does
+        # not hammer the cloud every cycle.
+        self._last_http_refresh_time = current_time
+
+        _LOGGER.debug("Refreshing HTTP session to keep MQTT fallback ready")
+        try:
+            await self.wybot_http_client.register_presence()
+            fresh = await self.wybot_http_client.get_indexed_current_grouped_devices()
+        except WybotAuthError:
+            # Credentials became invalid during normal operation — let this
+            # propagate so _async_update_data can trigger the reauth flow.
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("HTTP refresh failed (non-critical): %s", err)
+            return
+
+        if not fresh:
+            # An empty snapshot is not state-bearing: do not advance
+            # _last_http_success, or repeated empty responses would keep stale
+            # devices available instead of eventually surfacing no_data.
+            _LOGGER.debug("HTTP refresh returned no devices")
+            return
+
+        # Apply the response instead of discarding it: this is the only
+        # post-setup device-list refresh, so it is how devices added later are
+        # discovered, and it keeps _last_http_success backed by real device data.
+        new_ids = self._merge_http_groups(fresh)
+        # Subscribe any newly discovered device/dock so it receives MQTT updates
+        # when the fallback is already connected.
+        if new_ids and self._mqtt_connected:
+            try:
+                for device_id in new_ids:
+                    await self.wybot_mqtt_client.subscribe_for_device(device_id)
+            except Exception as err:  # noqa: BLE001
+                # A failed subscribe must not fail the whole update; drop the
+                # connected flag so _ensure_mqtt_connected() re-subscribes every
+                # known device next cycle (these ids are no longer "new").
+                _LOGGER.debug("MQTT subscribe failed, will retry: %s", err)
+                self._mqtt_connected = False
+        self._last_http_success = dt_util.utcnow()
+
+    def _merge_http_groups(self, fresh: dict[str, Group]) -> list[str]:
+        """Merge a cloud device-list snapshot into the coordinator data.
+
+        Newly discovered groups are added (dynamic device discovery). For groups
+        we already track, cloud DPs only fill gaps and never overwrite values a
+        more recent BLE/MQTT read already populated, preserving BLE-first data.
+
+        Returns the device/docker IDs newly discovered so the caller can
+        subscribe them to MQTT updates.
+        """
+        new_ids: list[str] = []
+        for group_id, group in fresh.items():
+            existing = self.data.get(group_id)
+            if existing is None:
+                self.data[group_id] = group
+                new_ids.append(group.device.device_id)
+                if group.docker is not None:
+                    new_ids.append(group.docker.docker_id)
+                continue
+            # A dock added to a previously dockless robot: attach it so its
+            # entities and DPs are picked up instead of being dropped.
+            if group.docker is not None and existing.docker is None:
+                existing.docker = group.docker
+                new_ids.append(group.docker.docker_id)
+            if group.device is not None and existing.device is not None:
+                existing.device.dps = {**group.device.dps, **existing.device.dps}
+            if group.docker is not None and existing.docker is not None:
+                existing.docker.dps = {**group.docker.dps, **existing.docker.dps}
+        return new_ids
+
+    def _recently_reached(self) -> bool:
+        """Return whether any transport succeeded within the availability window.
+
+        Considers the most recent BLE poll, MQTT message, and HTTP contact. A
+        full outage (all transports failing) eventually falls outside the
+        window and marks the integration unavailable instead of serving stale
+        cached data forever.
+        """
+        timestamps = [
+            *self._last_ble_poll.values(),
+            *self._last_mqtt_data.values(),
+        ]
+        if self._last_http_success is not None:
+            timestamps.append(self._last_http_success)
+        if not timestamps:
+            return False
+        return dt_util.utcnow() - max(timestamps) <= AVAILABILITY_TIMEOUT
+
+    def is_group_reachable(self, group: Group) -> bool:
+        """Return whether this specific group had recent state-bearing data.
+
+        Runtime entity availability uses only per-device BLE/MQTT freshness (the
+        transports that carry live device state), not the account-level HTTP
+        keepalive and not other groups' timestamps. This keeps one reachable
+        robot from holding an unreachable sibling available, and stops a bare
+        HTTP reachability ping from masking stale device data.
+        """
+        device_ids = [group.device.device_id]
+        if group.docker is not None:
+            device_ids.append(group.docker.docker_id)
+        now = dt_util.utcnow()
+        for device_id in device_ids:
+            for last in (
+                self._last_ble_poll.get(device_id),
+                self._last_mqtt_data.get(device_id),
+            ):
+                if last is not None and now - last <= AVAILABILITY_TIMEOUT:
+                    return True
+        return False
+
+    @override
+    async def _async_update_data(self) -> dict[str, Group]:
+        """Fetch data using BLE-primary with MQTT fallback architecture.
+
+        Priority:
+        1. BLE polling (primary) - for devices in Bluetooth range
+        2. MQTT polling (fallback) - for devices that failed BLE
+        3. HTTP session refresh - keeps MQTT fallback ready
+        """
+        try:
+            async with asyncio.timeout(UPDATE_TIMEOUT):
+                # First update: HTTP setup to get device list
+                if not self.initial_load:
+                    self.initial_load = True
+                    _LOGGER.info("Initial load: fetching device list from HTTP API")
+                    await self.wybot_http_client.register_presence()
+                    await self.http_refresh_data()
+
+                    # Log device BLE names for debugging (identifiers stay at
+                    # debug level so they are not exposed in normal logs).
+                    for group in self.data.values():
+                        if group.device:
+                            _LOGGER.debug(
+                                "Device %s BLE name: %s, type: %s",
+                                group.device.device_id,
+                                group.device.ble_name,
+                                group.device.device_type,
+                            )
+                        if group.docker:
+                            _LOGGER.debug(
+                                "Docker %s BLE name: %s, type: %s",
+                                group.docker.docker_id,
+                                group.docker.ble_name,
+                                group.docker.docker_type,
+                            )
+                    self._initial_query_start_time = time.time()
+
+                # BLE FIRST - try all devices via BLE (primary)
+                devices_needing_mqtt = await self._poll_all_devices_via_ble()
+
+                # MQTT FALLBACK - only for devices that failed BLE
+                if devices_needing_mqtt:
+                    await self._poll_devices_via_mqtt(devices_needing_mqtt)
+
+                # Keep HTTP session active for MQTT fallback readiness
+                await self._maybe_refresh_http_session()
+
+                # Update connection availability based on whether any transport
+                # actually succeeded recently — non-empty cached data alone must
+                # not mask a full outage.
+                if self.data and self._recently_reached():
+                    self._connection_available = True
+                    return self.data
+
+                # No data from any source (or all stale) — surface as a failed
+                # update so the DataUpdateCoordinator logs once now and once on
+                # recovery (log-when-unavailable) and entities go unavailable.
+                self._connection_available = False
+                raise UpdateFailed(  # noqa: TRY301
+                    translation_domain=DOMAIN, translation_key="no_data"
+                )
+
+        except (ConfigEntryAuthFailed, WybotAuthError) as err:
+            # Credentials are no longer valid — trigger the reauth flow.
+            self._connection_available = False
+            if isinstance(err, ConfigEntryAuthFailed):
+                raise
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN, translation_key="invalid_auth"
+            ) from err
+        except ConfigEntryNotReady:
+            self._connection_available = False
+            raise
+        except UpdateFailed:
+            # Already a translated update failure (e.g. no_data); preserve its
+            # specific reason instead of masking it as a generic update_failed.
+            self._connection_available = False
+            raise
+        except TimeoutError as err:
+            # DataUpdateCoordinator logs the transition to/from failure
+            # (log-when-unavailable); keep this at debug so a persistent outage
+            # does not emit an error every 30s refresh.
+            _LOGGER.debug("Timeout updating data: %s", err)
+            self._connection_available = False
+            raise UpdateFailed(
+                translation_domain=DOMAIN, translation_key="update_failed"
+            ) from err
+        except Exception as err:
+            _LOGGER.debug("Error communicating with API: %s", err)
+            self._connection_available = False
+            raise UpdateFailed(
+                translation_domain=DOMAIN, translation_key="update_failed"
+            ) from err
+
+    async def http_refresh_data(self) -> None:
+        """Refresh the device list from the HTTP API.
+
+        pywybot already retries this request with backoff internally, so this
+        issues a single call and maps its typed errors onto the coordinator's
+        failure modes. MQTT subscription is deferred to _ensure_mqtt_connected.
+        """
+        try:
+            data = await self.wybot_http_client.get_indexed_current_grouped_devices()
+        except WybotAuthError as err:
+            _LOGGER.error("Authentication failed, credentials may be invalid")
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN, translation_key="invalid_auth"
+            ) from err
+        except Exception as err:
+            self._http_failure_count += 1
+            self._connection_available = False
+            _LOGGER.warning("HTTP refresh failed: %s", err)
+            if self._http_failure_count >= MAX_HTTP_RETRIES:
+                _LOGGER.error(
+                    "HTTP connection failed repeatedly, marking as unavailable"
+                )
+                raise ConfigEntryNotReady(
+                    translation_domain=DOMAIN, translation_key="cannot_connect"
+                ) from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN, translation_key="update_failed"
+            ) from err
+
+        if not data:
+            self._connection_available = False
+            raise UpdateFailed(translation_domain=DOMAIN, translation_key="no_data")
+
+        self.data = data
+        self._http_failure_count = 0
+        self._connection_available = True
+        self._last_http_success = dt_util.utcnow()
+        # Count this as the latest HTTP refresh so the 60s keepalive throttle
+        # does not immediately fetch the same device list again this cycle.
+        self._last_http_refresh_time = time.time()
+
+    async def subscribe_mqtt(self, data: dict[str, Group]) -> None:
+        """Subscribe to MQTT updates for a device."""
+        for device in data.values():
+            await self.wybot_mqtt_client.subscribe_for_device(device.device.device_id)
+            if device.docker is not None:
+                await self.wybot_mqtt_client.subscribe_for_device(
+                    device.docker.docker_id
+                )
+
+    def on_message(self, message: MQTTMessage) -> None:
+        """Handle a parsed MQTT message from pywybot.
+
+        pywybot owns the broker topic layout and payload parsing, so this only
+        reacts to the semantic message kind: online status or device DPs.
+        """
+        device_id = message.device_id
+        data_updated = False
+
+        if message.kind is MQTTMessageKind.WILL and device_id is not None:
+            data_updated = self._handle_will(device_id, message.online)
+        elif (
+            message.kind
+            in (MQTTMessageKind.DATA_REPORT, MQTTMessageKind.COMMAND_RESPONSE)
+            and message.command is not None
+            and device_id is not None
+        ):
+            data_updated = self._apply_command_dps(device_id, message.command)
+        # QUERY_RESPONSE and OTHER carry no device data to apply. The query topic
+        # also echoes our own status queries, so it must not count toward
+        # reachability; ignoring it here keeps an offline robot from looking live.
+
+        # Notify entities only when the data actually changed. Use
+        # async_update_listeners rather than async_set_updated_data so a chatty
+        # device does not keep resetting the 30s polling timer (which would
+        # starve BLE polling).
+        if data_updated:
+            self.async_update_listeners()
+
+    def _handle_will(self, device_id: str, online: bool | None) -> bool:
+        """Apply an online/offline status update.
+
+        Returns whether the online state actually changed, so a repeated WILL
+        message neither wakes entities nor schedules another status-query burst.
+        Communication freshness is recorded for every known device regardless.
+        """
+        group = self.get_group(device_id)
+        if group is None:
+            return False
+        # Record freshness only for a known device so an unexpected /will/
+        # message cannot skew availability and diagnostics.
+        self._record_mqtt_data_received(device_id)
+        # A payload with no parseable online flag carries no state transition.
+        if online is None or online == (device_id in self._online_devices):
+            return False
+
+        if group.device.device_id == device_id:
+            group.device.online = online
+        elif group.docker is not None and group.docker.docker_id == device_id:
+            group.docker.online = online
+        if online:
+            self._online_devices.add(device_id)
+            _LOGGER.debug("Device %s came online, querying status", device_id)
+            # on_message runs in the event loop (from the MQTT listen task) but
+            # is sync; schedule the async status query only on the transition.
+            self.hass.async_create_task(
+                self.wybot_mqtt_client.ensure_device_sends_statuses(device_id)
+            )
+        else:
+            self._online_devices.discard(device_id)
+        self.data[group.id] = group
+        return True
+
+    def _apply_command_dps(self, device_id: str, command: Command) -> bool:
+        """Merge a command's DPs into the owning group.
+
+        Returns whether any DP value actually changed, so chatty duplicate
+        reports do not needlessly wake every entity. Communication freshness is
+        recorded regardless (the device was reached), but only once the payload
+        maps to a known group so a stray message cannot mark it reachable.
+        """
+        group = self.get_group(device_id)
+        if group is None:
+            return False
+        self._record_mqtt_data_received(device_id)
+        target: Device | Docker = (
+            group.docker
+            if group.docker is not None and group.docker.docker_id == device_id
+            else group.device
+        )
+        incoming_dps: dict[str, Any] = command.get_dps_as_keyed_dict()
+        changed = any(
+            key not in target.dps or target.dps[key].data != value.data
+            for key, value in incoming_dps.items()
+        )
+        if changed:
+            target.dps = {**target.dps, **incoming_dps}
+            self.data[group.id] = group
+        return changed
+
+    def get_device_or_docker(self, device_id: str) -> Device | Docker | None:
+        """Find the device or docker matching the given device ID."""
+        for device in self.data.values():
+            if device.device.device_id == device_id:
+                return device.device
+            if device.docker is not None and device.docker.docker_id == device_id:
+                return device.docker
+        return None
+
+    def get_group(self, device_id: str) -> Group | None:
+        """Find the group containing the device or docker with the given ID."""
+        for device in self.data.values():
+            if device.device.device_id == device_id:
+                return device
+            if device.docker is not None and device.docker.docker_id == device_id:
+                return device
+        return None
+
+    async def send_write_command(self, group: Group, dp: GenericDP) -> bool:
+        """Publish a command to a group's device (and docker, if present).
+
+        Returns True only if every publish was accepted by the broker, so a
+        dropped command is surfaced to the caller instead of being reported as
+        a success.
+        """
+        command = {"ts": int(time.time()), "cmd": 4, "dp": [dp.dict()]}
+        sent = await self.wybot_mqtt_client.send_write_command_for_device(
+            group.device.device_id, command
+        )
+        if group.docker is not None:
+            docker_sent = await self.wybot_mqtt_client.send_write_command_for_device(
+                group.docker.docker_id, command
+            )
+            sent = sent and docker_sent
+        return sent
+
+    async def async_send_command(self, group: Group, dp: GenericDP) -> bool:
+        """Send a command using BLE-first strategy with MQTT fallback.
+
+        Attempts to send commands via BLE first (more reliable when WiFi is flaky).
+        Falls back to MQTT if BLE fails or is disabled for this device.
+
+        Args:
+            group: The device group to send the command to
+            dp: The GenericDP data point to send
+
+        Returns:
+            True if command was sent successfully via either BLE or MQTT
+        """
+        device_id = group.device.device_id
+        ble_name = None
+
+        # Prefer docker BLE name (dock has BLE, relays to robot)
+        if group.docker and group.docker.ble_name:
+            ble_name = group.docker.ble_name
+        elif group.device and group.device.ble_name:
+            ble_name = group.device.ble_name
+
+        # Check if BLE should be recovered for this device
+        self._maybe_recover_ble(device_id)
+
+        # Check if BLE commands are enabled for this device
+        ble_enabled = (
+            self._ble_command_enabled
+            and ble_name is not None
+            and self._ble_command_failures.get(device_id, 0)
+            < BLE_MAX_CONSECUTIVE_FAILURES
+        )
+
+        if ble_enabled:
+            # ble_enabled is only True when ble_name is not None; narrow for typing.
+            assert ble_name is not None
+            _LOGGER.debug(
+                "Attempting BLE-first command for device %s via %s (DP id=%d)",
+                device_id,
+                ble_name,
+                dp.id,
+            )
+            try:
+                ble_success, ble_dps = await self.wybot_ble_client.send_command(
+                    ble_name, dp
+                )
+
+                if ble_success:
+                    _LOGGER.debug(
+                        "BLE command succeeded for device %s",
+                        device_id,
+                    )
+                    # Reset failure count on success
+                    self._ble_command_failures[device_id] = 0
+
+                    # Update state from BLE response if we got DPs
+                    if ble_dps:
+                        self._update_from_ble_dps(group, device_id, ble_dps)
+
+                    return True
+
+                # BLE failed, increment failure count
+                failures = self._ble_command_failures.get(device_id, 0) + 1
+                self._ble_command_failures[device_id] = failures
+                _LOGGER.warning(
+                    "BLE command failed for device %s (failure %d/%d), falling back to MQTT",
+                    device_id,
+                    failures,
+                    BLE_MAX_CONSECUTIVE_FAILURES,
+                )
+
+                if failures >= BLE_MAX_CONSECUTIVE_FAILURES:
+                    self._ble_disabled_at[device_id] = time.time()
+                    _LOGGER.warning(
+                        "BLE commands disabled for device %s after %d consecutive failures (will retry in %ds)",
+                        device_id,
+                        failures,
+                        BLE_RECOVERY_SECONDS,
+                    )
+
+            except Exception as err:  # noqa: BLE001
+                # BLE failed with exception, increment failure count
+                failures = self._ble_command_failures.get(device_id, 0) + 1
+                self._ble_command_failures[device_id] = failures
+                _LOGGER.warning(
+                    "BLE command exception for device %s: %s (failure %d/%d), falling back to MQTT",
+                    device_id,
+                    err,
+                    failures,
+                    BLE_MAX_CONSECUTIVE_FAILURES,
+                )
+                if failures >= BLE_MAX_CONSECUTIVE_FAILURES:
+                    self._ble_disabled_at[device_id] = time.time()
+        elif ble_name is None:
+            _LOGGER.debug(
+                "No BLE name available for device %s, using MQTT",
+                device_id,
+            )
+        elif not self._ble_command_enabled:
+            _LOGGER.debug(
+                "BLE commands globally disabled, using MQTT for device %s",
+                device_id,
+            )
+        else:
+            _LOGGER.debug(
+                "BLE commands disabled for device %s (too many failures), using MQTT",
+                device_id,
+            )
+
+        # Fallback to MQTT — make sure the fallback layer is actually connected
+        # first, otherwise the command would be published to a dead client and
+        # silently dropped (BLE-first startup leaves MQTT disconnected).
+        if not await self._ensure_mqtt_connected():
+            _LOGGER.warning(
+                "MQTT fallback unavailable; command not sent for device %s", device_id
+            )
+            return False
+        _LOGGER.debug(
+            "Sending MQTT command for device %s (DP id=%d)",
+            device_id,
+            dp.id,
+        )
+        sent = await self.send_write_command(group, dp)
+        if not sent:
+            _LOGGER.warning("MQTT command was not published for device %s", device_id)
+        return sent
+
+    def reset_ble_command_failures(self, device_id: str | None = None) -> None:
+        """Reset BLE command failure count for a device or all devices.
+
+        Args:
+            device_id: Specific device to reset, or None to reset all
+        """
+        if device_id:
+            self._ble_command_failures.pop(device_id, None)
+            _LOGGER.info("Reset BLE command failures for device %s", device_id)
+        else:
+            self._ble_command_failures.clear()
+            _LOGGER.info("Reset BLE command failures for all devices")
+
+    def _update_from_ble_dps(
+        self, group: Group, device_id: str, dps: list[dict[str, Any]]
+    ) -> None:
+        """Update device state from BLE response DPs.
+
+        Args:
+            group: The device group to update
+            device_id: The device ID
+            dps: List of DP dicts from BLE response
+        """
+        if not dps:
+            return
+
+        try:
+            # Create a command-like structure to reuse existing DP processing
+            cmd_data: dict[str, Any] = {"cmd": 5, "ts": 0, "dp": dps}
+            command = Command(**cmd_data)
+
+            dp_dict: dict[str, Any] = command.get_dps_as_keyed_dict()
+
+            # Update the appropriate device/docker
+            if group.docker and group.docker.docker_id == device_id:
+                group.docker.dps = {**group.docker.dps, **dp_dict}
+                _LOGGER.debug(
+                    "Updated docker %s DPs from BLE response",
+                    device_id,
+                )
+            elif group.device:
+                group.device.dps = {**group.device.dps, **dp_dict}
+                _LOGGER.debug(
+                    "Updated device %s DPs from BLE response",
+                    device_id,
+                )
+
+            # This data arrived over BLE, so record it as BLE communication
+            # (not MQTT) to keep the diagnostic sensors reporting the right
+            # transport.
+            self._last_ble_poll[device_id] = dt_util.utcnow()
+            self._data_source[device_id] = "ble"
+
+            # Trigger a state update
+            self.async_set_updated_data(self.data)
+
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.warning("Error updating state from BLE DPs: %s", err)
+
+    async def query_all_device_status(self) -> None:
+        """Query status for all devices by sending individual DP queries."""
+        for device_id in self.data:
+            group = self.data[device_id]
+            if self.wybot_mqtt_client.is_connected():
+                await self.wybot_mqtt_client.ensure_device_sends_statuses(
+                    group.device.device_id
+                )
+                if group.docker is not None:
+                    await self.wybot_mqtt_client.ensure_device_sends_statuses(
+                        group.docker.docker_id
+                    )
+
+    @property
+    def available(self) -> bool:
+        """Return if the coordinator is available."""
+        return self._connection_available and bool(self.data)
+
+    @property
+    def vacuums(self) -> list[str]:
+        """Return a list of vacuum device ids.
+
+        Right now we only support WyBot vacuums so we return everything, but this could be expanded
+        """
+        return list(self.data)

--- a/homeassistant/components/wybot/manifest.json
+++ b/homeassistant/components/wybot/manifest.json
@@ -1,0 +1,13 @@
+{
+  "domain": "wybot",
+  "name": "WyBot",
+  "codeowners": ["@bassrock"],
+  "config_flow": true,
+  "dependencies": ["bluetooth_adapters"],
+  "documentation": "https://www.home-assistant.io/integrations/wybot",
+  "integration_type": "hub",
+  "iot_class": "cloud_polling",
+  "loggers": ["wybot"],
+  "quality_scale": "silver",
+  "requirements": ["pywybot==1.2.0"]
+}

--- a/homeassistant/components/wybot/quality_scale.yaml
+++ b/homeassistant/components/wybot/quality_scale.yaml
@@ -1,0 +1,84 @@
+rules:
+  # --- Bronze ---
+  action-setup:
+    status: exempt
+    comment: The integration does not register any global service actions.
+  appropriate-polling:
+    status: done
+    comment: >-
+      DataUpdateCoordinator polls BLE (with MQTT fallback) every 30 seconds; the
+      HTTP session keepalive is throttled to once every 60 seconds.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency:
+    status: done
+    comment: >-
+      The WyBot client is the pywybot PyPI package (github.com/bassrock/pywybot),
+      pinned in manifest requirements.
+  docs-actions:
+    status: exempt
+    comment: No service actions are provided.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: The integration provides no triggers.
+  docs-conditions:
+    status: exempt
+    comment: The integration provides no conditions.
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # --- Silver ---
+  action-exceptions:
+    status: done
+    comment: Vacuum entity actions raise HomeAssistantError on failure.
+  config-entry-unloading: done
+  docs-configuration-parameters: done
+  docs-installation-parameters: done
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable:
+    status: done
+    comment: >-
+      _async_update_data raises UpdateFailed when no data is available, so the
+      DataUpdateCoordinator logs once on failure and once on recovery.
+  parallel-updates: done
+  reauthentication-flow: done
+  test-coverage: done
+
+  # --- Gold ---
+  devices: todo
+  diagnostics: todo
+  discovery: todo
+  discovery-update-info: todo
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: todo
+  icon-translations: todo
+  reconfiguration-flow: done
+  repair-issues: todo
+  stale-devices: todo
+
+  # --- Platinum ---
+  async-dependency: todo
+  inject-websession: todo
+  strict-typing: todo

--- a/homeassistant/components/wybot/strings.json
+++ b/homeassistant/components/wybot/strings.json
@@ -1,0 +1,75 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "Account is already configured",
+      "already_in_progress": "Configuration flow is already in progress",
+      "reauth_successful": "Re-authentication was successful",
+      "reconfigure_successful": "Reconfiguration was successful",
+      "wrong_account": "The credentials are for a different WyBot account"
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to WyBot",
+      "invalid_auth": "Invalid authentication",
+      "unknown": "Unexpected error"
+    },
+    "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "Password"
+        },
+        "data_description": {
+          "password": "The password for your WyBot account."
+        },
+        "description": "The password for {username} is no longer valid. Enter the new password.",
+        "title": "Re-authenticate WyBot"
+      },
+      "reconfigure": {
+        "data": {
+          "password": "Password",
+          "username": "Email"
+        },
+        "data_description": {
+          "password": "The password for your WyBot account.",
+          "username": "The email address for your WyBot account."
+        },
+        "description": "Update the WyBot account credentials used by this integration.",
+        "title": "Reconfigure WyBot account"
+      },
+      "user": {
+        "data": {
+          "password": "Password",
+          "username": "Email"
+        },
+        "data_description": {
+          "password": "The password for your WyBot account.",
+          "username": "The email address for your WyBot account."
+        },
+        "description": "Enter your WyBot account credentials.",
+        "title": "WyBot account"
+      }
+    }
+  },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "Unable to connect to the WyBot API."
+    },
+    "cannot_send_command": {
+      "message": "Failed to send the command to the WyBot device via Bluetooth or the cloud."
+    },
+    "device_unavailable": {
+      "message": "The WyBot device is not available to receive commands."
+    },
+    "invalid_auth": {
+      "message": "The WyBot credentials are no longer valid."
+    },
+    "invalid_fan_speed": {
+      "message": "{fan_speed} is not a supported cleaning mode."
+    },
+    "no_data": {
+      "message": "No data was received from the WyBot device via Bluetooth or the cloud."
+    },
+    "update_failed": {
+      "message": "Error communicating with the WyBot API."
+    }
+  }
+}

--- a/homeassistant/components/wybot/vacuum.py
+++ b/homeassistant/components/wybot/vacuum.py
@@ -1,0 +1,271 @@
+"""Platform for vacuum integration."""
+
+from typing import Any, override
+
+from wybot.dp_models import (
+    Battery,
+    BatteryState,
+    CleaningMode,
+    CleaningStatus,
+    CleaningStatusMode,
+    Dock,
+    DockConnectionStatus,
+    DockStatus,
+    GenericDP,
+)
+from wybot.models import Group
+
+from homeassistant.components.vacuum import (
+    StateVacuumEntity,
+    VacuumActivity,
+    VacuumEntityFeature,
+)
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers.device_registry import (
+    CONNECTION_BLUETOOTH,
+    DeviceInfo,
+    format_mac,
+)
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import WyBotConfigEntry
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import WyBotCoordinator
+
+# Commands are issued over BLE/MQTT; serialize to avoid concurrent device writes.
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WyBotConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the vacuum platform."""
+    coordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _add_new_devices() -> None:
+        """Add vacuum entities for devices discovered after setup."""
+        new_ids = [d for d in coordinator.vacuums if d not in known]
+        known.update(new_ids)
+        if new_ids:
+            async_add_entities(
+                WyBotVacuum(idx=device_id, coordinator=coordinator)
+                for device_id in new_ids
+            )
+
+    _add_new_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+
+
+class WyBotVacuum(StateVacuumEntity, CoordinatorEntity[WyBotCoordinator]):
+    """A wybot vacuum."""
+
+    # Primary entity of the device: take the device's name as the entity name.
+    _attr_has_entity_name = True
+    _attr_name = None
+
+    _data: Group | None
+    _idx: str
+    _coordinator: WyBotCoordinator
+
+    def __init__(self, idx: str, coordinator: WyBotCoordinator) -> None:
+        """Initialize the WyBot vacuum entity."""
+        super().__init__(coordinator=coordinator, context=idx)
+        self._idx = idx
+        self._coordinator = coordinator
+        # Initialize data safely
+        self._data = coordinator.data.get(self._idx) if coordinator.data else None
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        if str(self._idx) in self.coordinator.data:
+            self._data = self.coordinator.data[str(self._idx)]
+        super()._handle_coordinator_update()
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if entity is available."""
+        if not self.coordinator.available:
+            return False
+        if not self._data:
+            return False
+        if str(self._idx) not in self.coordinator.data:
+            return False
+        # Availability is not gated on the per-device online flag (the robot goes
+        # offline while submerged, but the dock keeps relaying its data). It is
+        # gated on this group's own recent BLE/MQTT freshness so a stale account
+        # (HTTP-only) or a reachable sibling robot cannot keep it available.
+        return self.coordinator.is_group_reachable(self._data)
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device information."""
+        # Use group name, fall back to device name, then device type
+        name = "Unknown"
+        model = "Unknown"
+        connections: set[tuple[str, str]] = set()
+        if self._data:
+            if self._data.name:
+                name = self._data.name
+            elif self._data.device and self._data.device.device_name:
+                name = self._data.device.device_name
+            elif self._data.device and self._data.device.device_type:
+                name = self._data.device.device_type
+            if self._data.device:
+                model = self._data.device.device_type
+                # Add Bluetooth MAC connection if available
+                if self._data.device.ble_name:
+                    connections.add(
+                        (CONNECTION_BLUETOOTH, format_mac(self._data.device.ble_name))
+                    )
+        info = DeviceInfo(
+            identifiers={(DOMAIN, str(self._idx))},
+            name=name,
+            manufacturer=MANUFACTURER,
+            model=model,
+        )
+        # Only include connections when we actually have one.
+        if connections:
+            info["connections"] = connections
+        return info
+
+    @property
+    @override
+    def unique_id(self) -> str | None:
+        """Return a unique ID."""
+        return f"{self._idx}"
+
+    @property
+    @override
+    def activity(self) -> VacuumActivity | None:
+        """Return the state of the device."""
+        if not self._data:
+            return None
+        battery = self._data.get_dp(Battery)
+        cleaning_status = self._data.get_dp(CleaningStatus)
+        dock_status = self._data.get_dp(Dock)
+        dock_connection = self._data.get_dp(DockConnectionStatus)
+
+        # Check if returning to dock via CleaningStatus (DP 0) - primary indicator
+        if cleaning_status is not None and cleaning_status.status in (
+            CleaningStatusMode.RETURNING_TO_DOCK,
+            CleaningStatusMode.RETURNING,
+        ):
+            return VacuumActivity.RETURNING
+
+        # An active cleaning status is a direct report from the robot and takes
+        # priority over the fallback dock indicators below: coordinator updates
+        # retain previously received DPs, so a stale dock RETURNING/docked/charging
+        # DP must not override a current CLEANING status.
+        if cleaning_status is not None and cleaning_status.status in (
+            CleaningStatusMode.CLEANING,
+            CleaningStatusMode.STARTING,
+        ):
+            return VacuumActivity.CLEANING
+
+        # Check if returning via Dock DP (fallback for legacy behavior)
+        if dock_status is not None and dock_status.status is DockStatus.RETURNING:
+            return VacuumActivity.RETURNING
+
+        # Check if docked - use dock status, dock connection status, or battery charging state
+        is_docked = False
+        if dock_status is not None and dock_status.status is DockStatus.DOCKED:
+            is_docked = True
+        elif dock_connection is not None:
+            is_docked = dock_connection.is_docked
+        elif battery is not None:
+            is_docked = battery.charge_state in (
+                BatteryState.CHARGING,
+                BatteryState.CHARGED,
+            )
+
+        if is_docked:
+            return VacuumActivity.DOCKED
+
+        # A stopped robot that is not docked is idle.
+        if cleaning_status is not None and cleaning_status.status is (
+            CleaningStatusMode.STOPPED
+        ):
+            return VacuumActivity.IDLE
+
+        return None
+
+    @property
+    @override
+    def fan_speed_list(self) -> list[str]:
+        """Flag vacuum cleaner robot features that are supported."""
+        return CleaningMode.CLEANING_MODES
+
+    @property
+    @override
+    def fan_speed(self) -> str | None:
+        """Return the fan speed of the vacuum cleaner."""
+        if not self._data:
+            return None
+        fan_speed = self._data.get_dp(CleaningMode)
+        if fan_speed is not None:
+            return fan_speed.cleaning_mode
+        return None
+
+    @property
+    @override
+    def supported_features(self) -> VacuumEntityFeature:
+        """Flag vacuum cleaner robot features that are supported."""
+        return (
+            VacuumEntityFeature.FAN_SPEED
+            | VacuumEntityFeature.RETURN_HOME
+            | VacuumEntityFeature.START
+            | VacuumEntityFeature.STOP
+        )
+
+    async def _async_send_command(self, dp: GenericDP) -> None:
+        """Send a command to the device, raising on failure."""
+        if not self._data:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="device_unavailable"
+            )
+        if not await self.coordinator.async_send_command(self._data, dp):
+            raise HomeAssistantError(
+                translation_domain=DOMAIN, translation_key="cannot_send_command"
+            )
+
+    @override
+    async def async_set_fan_speed(self, fan_speed: str, **kwargs: Any) -> None:
+        """Set the fan speed of the vacuum cleaner."""
+        try:
+            mode = CleaningMode(mode=fan_speed)
+        except ValueError as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_fan_speed",
+                translation_placeholders={"fan_speed": fan_speed},
+            ) from err
+        await self._async_send_command(mode)
+
+    @override
+    async def async_stop(self, **kwargs: Any) -> None:
+        """Stop the vacuum cleaner."""
+        await self._async_send_command(
+            CleaningStatus(status=CleaningStatusMode.STOPPED)
+        )
+
+    @override
+    async def async_start(self) -> None:
+        """Start the vacuum cleaner."""
+        await self._async_send_command(
+            CleaningStatus(status=CleaningStatusMode.CLEANING)
+        )
+
+    @override
+    async def async_return_to_base(self, **kwargs: Any) -> None:
+        """Return the vacuum cleaner to the dock."""
+        await self._async_send_command(Dock(status=DockStatus.RETURNING))

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -875,6 +875,7 @@ FLOWS = {
         "worldclock",
         "ws66i",
         "wsdot",
+        "wybot",
         "wyoming",
         "xbox",
         "xiaomi_aqara",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -8054,6 +8054,12 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
+    "wybot": {
+      "name": "WyBot",
+      "integration_type": "hub",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "wyoming": {
       "name": "Wyoming Protocol",
       "integration_type": "service",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2851,6 +2851,9 @@ pywmspro==0.4.2
 # homeassistant.components.ws66i
 pyws66i==1.1
 
+# homeassistant.components.wybot
+pywybot==1.2.0
+
 # homeassistant.components.xeoma
 pyxeoma==1.4.2
 

--- a/tests/components/wybot/__init__.py
+++ b/tests/components/wybot/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the WyBot integration."""

--- a/tests/components/wybot/test_bluetooth_adapter.py
+++ b/tests/components/wybot/test_bluetooth_adapter.py
@@ -1,0 +1,58 @@
+"""Tests for the Home Assistant Bluetooth adapter."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.wybot.bluetooth_adapter import (
+    HomeAssistantBluetoothAdapter,
+)
+from homeassistant.core import HomeAssistant
+
+
+async def test_scanner_count(hass: HomeAssistant) -> None:
+    """Test scanner count."""
+    adapter = HomeAssistantBluetoothAdapter(hass)
+    with patch(
+        "homeassistant.components.wybot.bluetooth_adapter.async_scanner_count",
+        return_value=3,
+    ) as mock_count:
+        assert adapter.scanner_count() == 3
+    mock_count.assert_called_once_with(hass, connectable=True)
+
+
+async def test_discovered_devices(hass: HomeAssistant) -> None:
+    """Test discovered devices."""
+    adapter = HomeAssistantBluetoothAdapter(hass)
+    dev_a = MagicMock(name="dev_a")
+    dev_b = MagicMock(name="dev_b")
+    info_a = MagicMock()
+    info_a.device = dev_a
+    info_b = MagicMock()
+    info_b.device = dev_b
+    with patch(
+        "homeassistant.components.wybot.bluetooth_adapter.async_discovered_service_info",
+        return_value=[info_a, info_b],
+    ) as mock_disc:
+        assert adapter.discovered_devices() == [dev_a, dev_b]
+    mock_disc.assert_called_once_with(hass, connectable=True)
+
+
+async def test_device_from_address(hass: HomeAssistant) -> None:
+    """Test device from address."""
+    adapter = HomeAssistantBluetoothAdapter(hass)
+    device = MagicMock(name="ble_device")
+    with patch(
+        "homeassistant.components.wybot.bluetooth_adapter.async_ble_device_from_address",
+        return_value=device,
+    ) as mock_from:
+        assert adapter.device_from_address("AA:BB:CC:DD:EE:FF") is device
+    mock_from.assert_called_once_with(hass, "AA:BB:CC:DD:EE:FF", connectable=True)
+
+
+async def test_device_from_address_none(hass: HomeAssistant) -> None:
+    """Test device from address none."""
+    adapter = HomeAssistantBluetoothAdapter(hass)
+    with patch(
+        "homeassistant.components.wybot.bluetooth_adapter.async_ble_device_from_address",
+        return_value=None,
+    ):
+        assert adapter.device_from_address("00:00:00:00:00:00") is None

--- a/tests/components/wybot/test_config_flow.py
+++ b/tests/components/wybot/test_config_flow.py
@@ -1,0 +1,271 @@
+"""Tests for the WyBot config flow."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from wybot import WybotAuthError, WybotConnectionError
+
+from homeassistant import config_entries
+from homeassistant.components.wybot.const import DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+USER = "pool@example.com"
+PASSWORD = "hunter2"
+USER_ID = "account-123"
+
+
+def _client(user_id: str = USER_ID, authenticate=None) -> MagicMock:
+    """Build a mock WyBotHTTPClient."""
+    client = MagicMock()
+    client.user_id = user_id
+    if authenticate is not None:
+        client.authenticate = AsyncMock(side_effect=authenticate)
+    else:
+        client.authenticate = AsyncMock(return_value=True)
+    return client
+
+
+def _patch_client(client: MagicMock):
+    """Patch the config-flow HTTP client."""
+    return patch(
+        "homeassistant.components.wybot.config_flow.WyBotHTTPClient",
+        return_value=client,
+    )
+
+
+def _patch_setup():
+    """Patch async_setup_entry so the flow does not fully set up."""
+    return patch("homeassistant.components.wybot.async_setup_entry", return_value=True)
+
+
+def _entry(**kwargs) -> MockConfigEntry:
+    """Build an existing account config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=kwargs.pop("unique_id", USER_ID),
+        data={CONF_USERNAME: USER, CONF_PASSWORD: PASSWORD, **kwargs},
+    )
+
+
+async def test_user_flow_success(hass: HomeAssistant) -> None:
+    """A valid account creates an entry keyed on the account id."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    with _patch_client(_client()), _patch_setup():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_USERNAME: USER, CONF_PASSWORD: PASSWORD}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == USER
+    assert result["data"][CONF_USERNAME] == USER
+    assert result["result"].unique_id == USER_ID
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected"),
+    [
+        (WybotAuthError, "invalid_auth"),
+        (WybotConnectionError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_user_flow_errors_and_recovery(
+    hass: HomeAssistant, side_effect: type[Exception], expected: str
+) -> None:
+    """Typed client errors map to form errors, then a retry succeeds."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with _patch_client(_client(authenticate=side_effect)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_USERNAME: USER, CONF_PASSWORD: PASSWORD}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected}
+
+    with _patch_client(_client()), _patch_setup():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_USERNAME: USER, CONF_PASSWORD: PASSWORD}
+        )
+        await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_user_flow_duplicate_account_aborts(hass: HomeAssistant) -> None:
+    """The same account cannot be configured twice."""
+    _entry().add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    with _patch_client(_client()):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_USERNAME: USER, CONF_PASSWORD: PASSWORD}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_reauth_success(hass: HomeAssistant) -> None:
+    """Reauth updates the stored password and reloads the entry."""
+    entry = _entry(**{CONF_PASSWORD: "old"})
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    with _patch_client(_client(user_id=USER_ID)), _patch_setup():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_PASSWORD: "new"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "new"
+
+
+async def test_reauth_wrong_account(hass: HomeAssistant) -> None:
+    """Reauthenticating with a different account is rejected."""
+    entry = _entry(**{CONF_PASSWORD: "old"})
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    with _patch_client(_client(user_id="different-account")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_PASSWORD: "new"}
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
+async def test_reauth_invalid_auth(hass: HomeAssistant) -> None:
+    """A bad password during reauth shows an error and stays on the form."""
+    entry = _entry(**{CONF_PASSWORD: "old"})
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    with _patch_client(_client(authenticate=WybotAuthError)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_PASSWORD: "bad"}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+async def _start_reconfigure(hass: HomeAssistant, entry: MockConfigEntry):
+    """Start a reconfigure flow."""
+    return await entry.start_reconfigure_flow(hass)
+
+
+async def test_reconfigure_success(hass: HomeAssistant) -> None:
+    """Reconfigure updates the stored username/password and reloads the entry."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    new_user = "new@example.com"
+    with _patch_client(_client(user_id=USER_ID)), _patch_setup():
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: new_user, CONF_PASSWORD: "newpass"},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.data[CONF_USERNAME] == new_user
+    assert entry.data[CONF_PASSWORD] == "newpass"
+    # The entry title tracks the (new) account email after reconfigure.
+    assert entry.title == new_user
+
+
+async def test_reconfigure_wrong_account(hass: HomeAssistant) -> None:
+    """Reconfiguring to a different account is rejected."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    with _patch_client(_client(user_id="different-account")):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: "other@example.com", CONF_PASSWORD: "newpass"},
+        )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
+async def test_reconfigure_invalid_auth(hass: HomeAssistant) -> None:
+    """Bad credentials during reconfigure show an error and stay on the form."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    with _patch_client(_client(authenticate=WybotAuthError)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USER, CONF_PASSWORD: "bad"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_auth"}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected"),
+    [
+        (WybotConnectionError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_reauth_errors(
+    hass: HomeAssistant, side_effect: type[Exception], expected: str
+) -> None:
+    """Connection and unexpected errors during reauth show a form error."""
+    entry = _entry(**{CONF_PASSWORD: "old"})
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    with _patch_client(_client(authenticate=side_effect)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_PASSWORD: "bad"}
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected}
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected"),
+    [
+        (WybotConnectionError, "cannot_connect"),
+        (Exception, "unknown"),
+    ],
+)
+async def test_reconfigure_errors(
+    hass: HomeAssistant, side_effect: type[Exception], expected: str
+) -> None:
+    """Connection and unexpected errors during reconfigure show a form error."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    result = await _start_reconfigure(hass, entry)
+    with _patch_client(_client(authenticate=side_effect)):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USER, CONF_PASSWORD: "bad"},
+        )
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected}

--- a/tests/components/wybot/test_coordinator.py
+++ b/tests/components/wybot/test_coordinator.py
@@ -1,0 +1,1161 @@
+"""Tests for the WyBot data update coordinator."""
+
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from wybot import WybotAuthError
+from wybot.dp_models import DP, CleaningStatus
+from wybot.models import Command, Group, MQTTMessage, MQTTMessageKind
+
+from homeassistant.components.wybot.const import BLE_MAX_CONSECUTIVE_FAILURES, DOMAIN
+from homeassistant.components.wybot.coordinator import (
+    BLE_RECOVERY_SECONDS,
+    WyBotCoordinator,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry
+
+DEVICE_ID = "dev123"
+DOCKER_ID = "dock456"
+GROUP_ID = "group1"
+
+
+def _group_data(with_docker: bool = True) -> dict:
+    """Group data."""
+    data = {
+        "device": {
+            "deviceId": DEVICE_ID,
+            "deviceName": "Pool Robot",
+            "deviceType": "S2 Pro",
+            "bleName": "CCBA97932A96",
+            "autoUpdate": "1",
+            "version": {"Firmware": "1.2.3"},
+        },
+        "docker": {
+            "dockerId": DOCKER_ID,
+            "dockerType": "DS20",
+            "bleName": "3C8427565A1A",
+            "deviceStatus": "online",
+            "dockerStatus": "active",
+            "schedule": None,
+            "version": {"Firmware": "2.0.0"},
+        },
+        "vision": {
+            "visionId": "vis789",
+            "privacy": False,
+            "log": None,
+            "video": None,
+            "picture": None,
+            "policy": True,
+        },
+        "name": "My Pool",
+        "id": GROUP_ID,
+        "autoUpdate": "1",
+    }
+    if not with_docker:
+        data["docker"] = None
+    return data
+
+
+def make_group(with_docker: bool = True) -> Group:
+    """Build a Group with a cleaning-status DP populated."""
+    group = Group(**_group_data(with_docker=with_docker))
+    group.device.dps = {"0": CleaningStatus(DP(id=0, type=4, len=1, data="03"))}
+    return group
+
+
+def make_entry(hass: HomeAssistant, **data) -> MockConfigEntry:
+    """Make an account config entry."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="acct", data=data)
+    entry.add_to_hass(hass)
+    return entry
+
+
+def make_coordinator(hass: HomeAssistant, **entry_data) -> WyBotCoordinator:
+    """Build a real coordinator with all external clients mocked out."""
+    entry = make_entry(hass, **entry_data)
+    coord = WyBotCoordinator(hass, MagicMock(), entry)
+
+    http = MagicMock()
+    http.get_indexed_current_grouped_devices = AsyncMock(return_value={})
+    http.register_presence = AsyncMock(return_value=None)
+    http.get_devices_and_status = AsyncMock(return_value=None)
+    http.authenticate = AsyncMock(return_value=True)
+    http.login = AsyncMock(return_value=None)
+    http.close = AsyncMock(return_value=None)
+    coord.wybot_http_client = http
+
+    ble = MagicMock()
+    ble.query_status = AsyncMock(return_value=None)
+    ble.send_command = AsyncMock(return_value=(True, None))
+    ble.configure_wifi = AsyncMock(return_value=True)
+    ble.scan_for_device = AsyncMock(return_value=None)
+    coord.wybot_ble_client = ble
+
+    mqtt = MagicMock()
+    mqtt.is_connected = MagicMock(return_value=True)
+    mqtt.connect = AsyncMock(return_value=True)
+    mqtt.disconnect = AsyncMock(return_value=None)
+    mqtt.subscribe_for_device = AsyncMock(return_value=None)
+    mqtt.ensure_device_sends_statuses = AsyncMock(return_value=None)
+    mqtt.send_query_command_for_device = AsyncMock(return_value=True)
+    mqtt.send_write_command_for_device = AsyncMock(return_value=True)
+    coord.wybot_mqtt_client = mqtt
+
+    return coord
+
+
+# ---------------------------------------------------------------------------
+# construction / simple accessors
+# ---------------------------------------------------------------------------
+
+
+async def test_available_and_vacuums(hass: HomeAssistant) -> None:
+    """Test available and vacuums."""
+    coord = make_coordinator(hass)
+    coord._connection_available = True
+    coord.data = {}
+    assert coord.available is False  # no data
+    coord.data = {GROUP_ID: make_group()}
+    assert coord.available is True
+    assert coord.vacuums == [GROUP_ID]
+    coord._connection_available = False
+    assert coord.available is False
+
+
+async def test_getters(hass: HomeAssistant) -> None:
+    """Test getters."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    now = dt_util.utcnow()
+    coord._last_ble_poll[DEVICE_ID] = now
+    coord._last_mqtt_data[DEVICE_ID] = now
+    coord._data_source[DEVICE_ID] = "ble"
+    coord._ble_available[DEVICE_ID] = True
+
+    assert coord.get_last_ble_communication(DEVICE_ID) == now
+    assert coord.get_last_mqtt_communication(DEVICE_ID) == now
+    assert coord.get_data_source(DEVICE_ID) == "ble"
+    assert coord.is_ble_available(DEVICE_ID) is True
+    assert coord.get_last_ble_communication("unknown") is None
+
+    group = coord.data[GROUP_ID]
+    assert coord.get_group(DEVICE_ID) is group
+    assert coord.get_group(DOCKER_ID) is group
+    assert coord.get_group("nope") is None
+    assert coord.get_device_or_docker(DEVICE_ID) is group.device
+    assert coord.get_device_or_docker(DOCKER_ID) is group.docker
+    assert coord.get_device_or_docker("nope") is None
+
+
+async def test_get_device_ble_info(hass: HomeAssistant) -> None:
+    """Test get device ble info."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    # docker preferred
+    assert coord._get_device_ble_info(group) == (group.docker.ble_name, DOCKER_ID)
+    # device-only
+    group_no_dock = make_group(with_docker=False)
+    assert coord._get_device_ble_info(group_no_dock) == (
+        group_no_dock.device.ble_name,
+        DEVICE_ID,
+    )
+    # neither BLE name
+    group_no_dock.device.ble_name = ""
+    assert coord._get_device_ble_info(group_no_dock) == (None, None)
+
+
+# ---------------------------------------------------------------------------
+# _maybe_recover_ble
+# ---------------------------------------------------------------------------
+
+
+async def test_maybe_recover_ble(hass: HomeAssistant) -> None:
+    """Test maybe recover ble."""
+    coord = make_coordinator(hass)
+    coord._ble_command_failures[DEVICE_ID] = 3
+    coord._ble_disabled_at[DEVICE_ID] = time.time() - BLE_RECOVERY_SECONDS - 1
+    coord._maybe_recover_ble(DEVICE_ID)
+    assert DEVICE_ID not in coord._ble_command_failures
+    assert DEVICE_ID not in coord._ble_disabled_at
+
+
+async def test_maybe_recover_ble_not_yet(hass: HomeAssistant) -> None:
+    """Test maybe recover ble not yet."""
+    coord = make_coordinator(hass)
+    coord._ble_command_failures[DEVICE_ID] = 3
+    coord._ble_disabled_at[DEVICE_ID] = time.time()
+    coord._maybe_recover_ble(DEVICE_ID)
+    assert coord._ble_disabled_at[DEVICE_ID]  # still disabled
+
+
+# ---------------------------------------------------------------------------
+# _update_device_dps_from_ble / _update_from_ble_dps
+# ---------------------------------------------------------------------------
+
+
+async def test_update_device_dps_from_ble_docker(hass: HomeAssistant) -> None:
+    """Test update device dps from ble docker."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dps = [{"id": 11, "type": 4, "len": 1, "data": "00"}]
+    coord._update_device_dps_from_ble(group, DOCKER_ID, dps)
+    assert "11" in group.docker.dps
+
+
+async def test_update_device_dps_from_ble_device(hass: HomeAssistant) -> None:
+    """Test update device dps from ble device."""
+    coord = make_coordinator(hass)
+    group = make_group(with_docker=False)
+    dps = [{"id": 1, "type": 4, "len": 1, "data": "00"}]
+    coord._update_device_dps_from_ble(group, DEVICE_ID, dps)
+    assert "1" in group.device.dps
+
+
+async def test_update_device_dps_from_ble_empty(hass: HomeAssistant) -> None:
+    """Test update device dps from ble empty."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    before = dict(group.docker.dps)
+    coord._update_device_dps_from_ble(group, DOCKER_ID, [])
+    assert group.docker.dps == before
+
+
+async def test_update_from_ble_dps_docker(hass: HomeAssistant) -> None:
+    """Test update from ble dps docker."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    coord.data = {GROUP_ID: group}
+    coord._update_from_ble_dps(
+        group, DOCKER_ID, [{"id": 11, "type": 4, "len": 1, "data": "00"}]
+    )
+    assert "11" in group.docker.dps
+    # BLE responses are recorded as BLE traffic, not MQTT.
+    assert DOCKER_ID in coord._last_ble_poll
+    assert DOCKER_ID not in coord._last_mqtt_data
+    assert coord._data_source[DOCKER_ID] == "ble"
+
+
+async def test_update_from_ble_dps_device(hass: HomeAssistant) -> None:
+    """Test update from ble dps device."""
+    coord = make_coordinator(hass)
+    group = make_group(with_docker=False)
+    coord.data = {GROUP_ID: group}
+    coord._update_from_ble_dps(
+        group, DEVICE_ID, [{"id": 1, "type": 4, "len": 1, "data": "01"}]
+    )
+    assert "1" in group.device.dps
+
+
+async def test_update_from_ble_dps_empty(hass: HomeAssistant) -> None:
+    """Test update from ble dps empty."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    coord.data = {GROUP_ID: group}
+    # empty returns early, no crash
+    coord._update_from_ble_dps(group, DOCKER_ID, [])
+
+
+async def test_update_from_ble_dps_error(hass: HomeAssistant) -> None:
+    """Test update from ble dps error."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    coord.data = {GROUP_ID: group}
+    # invalid dp id triggers Command parse failure -> caught, warning logged
+    coord._update_from_ble_dps(group, DOCKER_ID, [{"id": "bad"}])
+
+
+# ---------------------------------------------------------------------------
+# BLE polling
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_all_devices_via_ble_success(hass: HomeAssistant) -> None:
+    """Test poll all devices via ble success."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_ble_client.query_status.return_value = [
+        {"id": 11, "type": 4, "len": 1, "data": "00"}
+    ]
+    needing = await coord._poll_all_devices_via_ble()
+    assert needing == []
+    assert coord._ble_available[DOCKER_ID] is True
+    assert coord._data_source[DOCKER_ID] == "ble"
+
+
+async def test_poll_all_devices_via_ble_no_data(hass: HomeAssistant) -> None:
+    """Test poll all devices via ble no data."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_ble_client.query_status.return_value = None
+    needing = await coord._poll_all_devices_via_ble()
+    # Both the robot and the dock are queried over MQTT on fallback.
+    assert needing == [DEVICE_ID, DOCKER_ID]
+    assert coord._ble_available[DOCKER_ID] is False
+
+
+async def test_poll_all_devices_via_ble_exception(hass: HomeAssistant) -> None:
+    """Test poll all devices via ble exception."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_ble_client.query_status.side_effect = RuntimeError("boom")
+    needing = await coord._poll_all_devices_via_ble()
+    # Both the robot and the dock are queried over MQTT on fallback.
+    assert needing == [DEVICE_ID, DOCKER_ID]
+    assert coord._ble_available[DOCKER_ID] is False
+
+
+async def test_poll_all_devices_via_ble_no_ble_name(hass: HomeAssistant) -> None:
+    """Test poll all devices via ble no ble name."""
+    coord = make_coordinator(hass)
+    group = make_group(with_docker=False)
+    group.device.ble_name = ""
+    coord.data = {GROUP_ID: group}
+    needing = await coord._poll_all_devices_via_ble()
+    assert needing == [DEVICE_ID]
+
+
+# ---------------------------------------------------------------------------
+# MQTT polling / connection
+# ---------------------------------------------------------------------------
+
+
+async def test_poll_devices_via_mqtt_empty(hass: HomeAssistant) -> None:
+    """Test poll devices via mqtt empty."""
+    coord = make_coordinator(hass)
+    await coord._poll_devices_via_mqtt([])
+    coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_not_called()
+
+
+async def test_poll_devices_via_mqtt_success(hass: HomeAssistant) -> None:
+    """Test poll devices via mqtt success."""
+    coord = make_coordinator(hass)
+    coord._mqtt_connected = True
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    await coord._poll_devices_via_mqtt([DEVICE_ID])
+    coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_called_with(DEVICE_ID)
+
+
+async def test_poll_devices_via_mqtt_connect_fails(hass: HomeAssistant) -> None:
+    """Test poll devices via mqtt connect fails."""
+    coord = make_coordinator(hass)
+    coord.wybot_mqtt_client.connect.side_effect = RuntimeError("no broker")
+    await coord._poll_devices_via_mqtt([DEVICE_ID])
+    coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_not_called()
+
+
+async def test_ensure_mqtt_connected_already(hass: HomeAssistant) -> None:
+    """Test ensure mqtt connected already."""
+    coord = make_coordinator(hass)
+    coord._mqtt_connected = True
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    assert await coord._ensure_mqtt_connected() is True
+
+
+async def test_ensure_mqtt_connected_drift(hass: HomeAssistant) -> None:
+    """Test ensure mqtt connected drift."""
+    coord = make_coordinator(hass)
+    coord._mqtt_connected = True
+    coord.data = {GROUP_ID: make_group()}
+    # paho says disconnected first, then connect succeeds
+    coord.wybot_mqtt_client.is_connected.return_value = False
+    assert await coord._ensure_mqtt_connected() is True
+    coord.wybot_mqtt_client.connect.assert_called()
+    # subscribed for device + docker
+    assert coord.wybot_mqtt_client.subscribe_for_device.call_count >= 2
+
+
+async def test_ensure_mqtt_connected_fails(hass: HomeAssistant) -> None:
+    """Test ensure mqtt connected fails."""
+    coord = make_coordinator(hass)
+    coord.wybot_mqtt_client.connect.side_effect = RuntimeError("fail")
+    assert await coord._ensure_mqtt_connected() is False
+    assert coord._mqtt_connected is False
+
+
+async def test_ensure_mqtt_connected_not_ready(hass: HomeAssistant) -> None:
+    """connect() reporting it never came up leaves us disconnected."""
+    coord = make_coordinator(hass)
+    coord.wybot_mqtt_client.connect = AsyncMock(return_value=False)
+    assert await coord._ensure_mqtt_connected() is False
+    assert coord._mqtt_connected is False
+
+
+# ---------------------------------------------------------------------------
+# subscribe_mqtt / query_all_device_status / send_write_command
+# ---------------------------------------------------------------------------
+
+
+async def test_subscribe_mqtt(hass: HomeAssistant) -> None:
+    """Test subscribe mqtt."""
+    coord = make_coordinator(hass)
+    data = {GROUP_ID: make_group(), "g2": make_group(with_docker=False)}
+    data["g2"].device.dps = {}
+    await coord.subscribe_mqtt(data)
+    # 2 devices + 1 docker
+    assert coord.wybot_mqtt_client.subscribe_for_device.call_count == 3
+
+
+async def test_query_all_device_status(hass: HomeAssistant) -> None:
+    """Test query all device status."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    await coord.query_all_device_status()
+    assert coord.wybot_mqtt_client.ensure_device_sends_statuses.call_count == 2
+
+
+async def test_query_all_device_status_disconnected(hass: HomeAssistant) -> None:
+    """Test query all device status disconnected."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_mqtt_client.is_connected.return_value = False
+    await coord.query_all_device_status()
+    coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_not_called()
+
+
+async def test_send_write_command(hass: HomeAssistant) -> None:
+    """Test send write command."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    await coord.send_write_command(group, dp)
+    # once for device, once for docker
+    assert coord.wybot_mqtt_client.send_write_command_for_device.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# async_send_command
+# ---------------------------------------------------------------------------
+
+
+async def test_async_send_command_ble_success(hass: HomeAssistant) -> None:
+    """Test async send command ble success."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    coord.data = {GROUP_ID: group}
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (
+        True,
+        [{"id": 0, "type": 4, "len": 1, "data": "01"}],
+    )
+    assert await coord.async_send_command(group, dp) is True
+    assert coord._ble_command_failures[DEVICE_ID] == 0
+    coord.wybot_mqtt_client.send_write_command_for_device.assert_not_called()
+
+
+async def test_async_send_command_ble_device_name(hass: HomeAssistant) -> None:
+    # No docker -> uses the device ble_name branch
+    """Test async send command ble device name."""
+    coord = make_coordinator(hass)
+    group = make_group(with_docker=False)
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (True, None)
+    assert await coord.async_send_command(group, dp) is True
+    coord.wybot_ble_client.send_command.assert_awaited_once()
+
+
+async def test_async_send_command_ble_success_no_dps(hass: HomeAssistant) -> None:
+    """Test async send command ble success no dps."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (True, None)
+    assert await coord.async_send_command(group, dp) is True
+
+
+async def test_async_send_command_ble_failure_falls_back(hass: HomeAssistant) -> None:
+    """Test async send command ble failure falls back."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (False, None)
+    assert await coord.async_send_command(group, dp) is True
+    assert coord._ble_command_failures[DEVICE_ID] == 1
+    assert coord.wybot_mqtt_client.send_write_command_for_device.called
+
+
+async def test_async_send_command_ble_disables_after_max(hass: HomeAssistant) -> None:
+    """Test async send command ble disables after max."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (False, None)
+    coord._ble_command_failures[DEVICE_ID] = BLE_MAX_CONSECUTIVE_FAILURES - 1
+    assert await coord.async_send_command(group, dp) is True
+    assert coord._ble_command_failures[DEVICE_ID] == BLE_MAX_CONSECUTIVE_FAILURES
+    assert DEVICE_ID in coord._ble_disabled_at
+
+
+async def test_async_send_command_ble_exception(hass: HomeAssistant) -> None:
+    """Test async send command ble exception."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.side_effect = RuntimeError("ble err")
+    assert await coord.async_send_command(group, dp) is True
+    assert coord._ble_command_failures[DEVICE_ID] == 1
+
+
+async def test_async_send_command_ble_exception_disables(hass: HomeAssistant) -> None:
+    """Test async send command ble exception disables."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.side_effect = RuntimeError("ble err")
+    coord._ble_command_failures[DEVICE_ID] = BLE_MAX_CONSECUTIVE_FAILURES - 1
+    assert await coord.async_send_command(group, dp) is True
+    assert DEVICE_ID in coord._ble_disabled_at
+
+
+async def test_async_send_command_no_ble_name(hass: HomeAssistant) -> None:
+    """Test async send command no ble name."""
+    coord = make_coordinator(hass)
+    group = make_group(with_docker=False)
+    group.device.ble_name = ""
+    dp = group.device.dps["0"]
+    assert await coord.async_send_command(group, dp) is True
+    coord.wybot_ble_client.send_command.assert_not_called()
+    assert coord.wybot_mqtt_client.send_write_command_for_device.called
+
+
+async def test_async_send_command_ble_globally_disabled(hass: HomeAssistant) -> None:
+    """Test async send command ble globally disabled."""
+    coord = make_coordinator(hass)
+    coord._ble_command_enabled = False
+    group = make_group()
+    dp = group.device.dps["0"]
+    assert await coord.async_send_command(group, dp) is True
+    coord.wybot_ble_client.send_command.assert_not_called()
+
+
+async def test_async_send_command_ble_too_many_failures(hass: HomeAssistant) -> None:
+    """Test async send command ble too many failures."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord._ble_command_failures[DEVICE_ID] = BLE_MAX_CONSECUTIVE_FAILURES
+    assert await coord.async_send_command(group, dp) is True
+    coord.wybot_ble_client.send_command.assert_not_called()
+
+
+async def test_async_send_command_mqtt_fallback_ensures_connection(
+    hass: HomeAssistant,
+) -> None:
+    """The MQTT fallback connects the client before publishing the command."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (False, None)
+    coord._mqtt_connected = False
+    assert await coord.async_send_command(group, dp) is True
+    coord.wybot_mqtt_client.connect.assert_awaited()
+    assert coord.wybot_mqtt_client.send_write_command_for_device.called
+
+
+async def test_async_send_command_mqtt_unavailable_returns_false(
+    hass: HomeAssistant,
+) -> None:
+    """When BLE fails and MQTT cannot connect, the command is not sent."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (False, None)
+    coord._mqtt_connected = False
+    coord.wybot_mqtt_client.is_connected = MagicMock(return_value=False)
+    coord.wybot_mqtt_client.connect = AsyncMock(side_effect=RuntimeError("no mqtt"))
+    assert await coord.async_send_command(group, dp) is False
+    coord.wybot_mqtt_client.send_write_command_for_device.assert_not_called()
+
+
+async def test_async_send_command_mqtt_publish_dropped_returns_false(
+    hass: HomeAssistant,
+) -> None:
+    """A dropped MQTT publish is reported as failure, not silent success."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    dp = group.device.dps["0"]
+    coord.wybot_ble_client.send_command.return_value = (False, None)
+    coord._mqtt_connected = True
+    # Connected, but the broker dropped the publish (disconnected mid-send).
+    coord.wybot_mqtt_client.send_write_command_for_device = AsyncMock(
+        return_value=False
+    )
+    assert await coord.async_send_command(group, dp) is False
+
+
+async def test_reset_ble_command_failures(hass: HomeAssistant) -> None:
+    """Test reset ble command failures."""
+    coord = make_coordinator(hass)
+    coord._ble_command_failures = {DEVICE_ID: 2, "other": 1}
+    coord.reset_ble_command_failures(DEVICE_ID)
+    assert DEVICE_ID not in coord._ble_command_failures
+    coord.reset_ble_command_failures()
+    assert coord._ble_command_failures == {}
+
+
+# ---------------------------------------------------------------------------
+# async_stop
+# ---------------------------------------------------------------------------
+
+
+async def test_async_stop_connected(hass: HomeAssistant) -> None:
+    """Test async stop connected."""
+    coord = make_coordinator(hass)
+    coord._mqtt_connected = True
+    await coord.async_stop()
+    coord.wybot_mqtt_client.disconnect.assert_called_once()
+    assert coord._mqtt_connected is False
+
+
+async def test_async_stop_not_connected(hass: HomeAssistant) -> None:
+    """Disconnect is called even when the flag is unset to reap a leaked task."""
+    coord = make_coordinator(hass)
+    coord._mqtt_connected = False
+    await coord.async_stop()
+    coord.wybot_mqtt_client.disconnect.assert_called_once()
+    assert coord._mqtt_connected is False
+
+
+# ---------------------------------------------------------------------------
+# on_message
+# ---------------------------------------------------------------------------
+
+
+def _command(dp_id: int = 0, data: str = "03") -> Command:
+    """Build a parsed Command carrying a single DP."""
+    return Command(cmd=5, ts=0, dp=[DP(id=dp_id, type=4, len=1, data=data)])
+
+
+def _will(device_id: str, online: bool | None) -> MQTTMessage:
+    """Build a parsed WILL (online status) message."""
+    return MQTTMessage(
+        topic=f"/will/{device_id}",
+        kind=MQTTMessageKind.WILL,
+        device_id=device_id,
+        online=online,
+    )
+
+
+def _data(
+    kind: MQTTMessageKind, device_id: str, command: Command | None
+) -> MQTTMessage:
+    """Build a parsed data-carrying message."""
+    return MQTTMessage(topic="t", kind=kind, device_id=device_id, command=command)
+
+
+async def test_on_message_will_online(hass: HomeAssistant) -> None:
+    """Test on message will online."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_will(DEVICE_ID, True))
+    assert DEVICE_ID in coord._online_devices
+    assert coord.data[GROUP_ID].device.online is True
+    coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_called_with(DEVICE_ID)
+    await hass.async_block_till_done()
+
+
+async def test_on_message_will_unknown_online_records_only(
+    hass: HomeAssistant,
+) -> None:
+    """A WILL with unknown online (non-JSON upstream) records freshness only."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_will(DEVICE_ID, None))
+    assert DEVICE_ID not in coord._online_devices
+    assert coord.get_last_mqtt_communication(DEVICE_ID) is not None
+
+
+async def test_on_message_repeat_will_online_no_requery(hass: HomeAssistant) -> None:
+    """A repeated online WILL does not re-query or notify (no transition)."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.async_update_listeners = MagicMock()
+    coord.on_message(_will(DEVICE_ID, True))
+    assert coord.async_update_listeners.call_count == 1
+    assert coord.wybot_mqtt_client.ensure_device_sends_statuses.call_count == 1
+    # Same online status again: freshness recorded, but no new query or notify.
+    coord.on_message(_will(DEVICE_ID, True))
+    assert coord.async_update_listeners.call_count == 1
+    assert coord.wybot_mqtt_client.ensure_device_sends_statuses.call_count == 1
+    await hass.async_block_till_done()
+
+
+async def test_on_message_will_offline_docker(hass: HomeAssistant) -> None:
+    """Test on message will offline docker."""
+    coord = make_coordinator(hass)
+    group = make_group()
+    coord.data = {GROUP_ID: group}
+    coord._online_devices.add(DOCKER_ID)
+    coord.on_message(_will(DOCKER_ID, False))
+    assert DOCKER_ID not in coord._online_devices
+    assert coord.data[GROUP_ID].docker.online is False
+    await hass.async_block_till_done()
+
+
+async def test_on_message_will_unknown_device(hass: HomeAssistant) -> None:
+    """An unknown device id is a no-op (group is None)."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_will("unknown", True))
+    assert "unknown" not in coord._online_devices
+    await hass.async_block_till_done()
+
+
+async def test_on_message_data_report_docker(hass: HomeAssistant) -> None:
+    """A device-pushed report updates docker DPs."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_data(MQTTMessageKind.DATA_REPORT, DOCKER_ID, _command(11, "00")))
+    assert "11" in coord.data[GROUP_ID].docker.dps
+
+
+async def test_on_message_data_report_device(hass: HomeAssistant) -> None:
+    """A device-pushed report updates device DPs."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group(with_docker=False)}
+    coord.on_message(_data(MQTTMessageKind.DATA_REPORT, DEVICE_ID, _command(1, "01")))
+    assert "1" in coord.data[GROUP_ID].device.dps
+
+
+async def test_on_message_command_response_docker(hass: HomeAssistant) -> None:
+    """A command response updates docker DPs."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(
+        _data(MQTTMessageKind.COMMAND_RESPONSE, DOCKER_ID, _command(11, "01"))
+    )
+    assert "11" in coord.data[GROUP_ID].docker.dps
+
+
+async def test_on_message_command_response_device(hass: HomeAssistant) -> None:
+    """A command response updates device DPs."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group(with_docker=False)}
+    coord.on_message(
+        _data(MQTTMessageKind.COMMAND_RESPONSE, DEVICE_ID, _command(1, "01"))
+    )
+    assert "1" in coord.data[GROUP_ID].device.dps
+
+
+async def test_on_message_query_response_not_recorded(hass: HomeAssistant) -> None:
+    """Query responses (our own echoed queries) do not record reachability."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_data(MQTTMessageKind.QUERY_RESPONSE, DOCKER_ID, _command()))
+    assert coord.get_last_mqtt_communication(DOCKER_ID) is None
+
+
+async def test_on_message_command_none_is_noop(hass: HomeAssistant) -> None:
+    """A message whose payload failed to parse (command is None) is a no-op."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_data(MQTTMessageKind.DATA_REPORT, DOCKER_ID, None))
+    assert coord.get_last_mqtt_communication(DOCKER_ID) is None
+
+
+async def test_on_message_duplicate_dp_does_not_notify(hass: HomeAssistant) -> None:
+    """A duplicate report records freshness but does not wake entities again."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.async_update_listeners = MagicMock()
+
+    # First report changes data -> notifies.
+    coord.on_message(_data(MQTTMessageKind.DATA_REPORT, DOCKER_ID, _command(11, "00")))
+    assert coord.async_update_listeners.call_count == 1
+
+    # Identical report: freshness is still recorded, but no new notification.
+    last = coord.get_last_mqtt_communication(DOCKER_ID)
+    coord.on_message(_data(MQTTMessageKind.DATA_REPORT, DOCKER_ID, _command(11, "00")))
+    assert coord.async_update_listeners.call_count == 1
+    assert coord.get_last_mqtt_communication(DOCKER_ID) >= last
+
+
+async def test_on_message_unknown_group_is_noop(hass: HomeAssistant) -> None:
+    """A data report for an unknown device does not record or raise."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.on_message(_data(MQTTMessageKind.DATA_REPORT, "nope", _command(1, "01")))
+    assert coord.get_last_mqtt_communication("nope") is None
+
+
+# ---------------------------------------------------------------------------
+# http_refresh_data
+# ---------------------------------------------------------------------------
+
+
+async def test_http_refresh_data_success(hass: HomeAssistant) -> None:
+    """Test http refresh data success."""
+    coord = make_coordinator(hass)
+    data = {GROUP_ID: make_group()}
+    coord.wybot_http_client.get_indexed_current_grouped_devices.return_value = data
+    await coord.http_refresh_data()
+    assert coord.data is data
+    assert coord._http_failure_count == 0
+
+
+async def test_http_refresh_data_empty_retries(hass: HomeAssistant) -> None:
+    """Test http refresh data empty retries."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.get_indexed_current_grouped_devices.return_value = {}
+    with (
+        patch(
+            "homeassistant.components.wybot.coordinator.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coord.http_refresh_data()
+
+
+async def test_http_refresh_data_auth_error(hass: HomeAssistant) -> None:
+    """Test http refresh data auth error."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.get_indexed_current_grouped_devices.side_effect = (
+        WybotAuthError("bad")
+    )
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord.http_refresh_data()
+
+
+async def test_http_refresh_data_single_failure_updates_failed(
+    hass: HomeAssistant,
+) -> None:
+    """One failure raises UpdateFailed (pywybot already retried internally)."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.get_indexed_current_grouped_devices.side_effect = (
+        RuntimeError("net down")
+    )
+    with pytest.raises(UpdateFailed):
+        await coord.http_refresh_data()
+    assert coord._http_failure_count == 1
+    assert coord._connection_available is False
+
+
+async def test_http_refresh_data_connection_failures(hass: HomeAssistant) -> None:
+    """Repeated failures escalate to ConfigEntryNotReady."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.get_indexed_current_grouped_devices.side_effect = (
+        RuntimeError("net down")
+    )
+    coord._http_failure_count = 2  # third consecutive failure marks not-ready
+    with pytest.raises(ConfigEntryNotReady):
+        await coord.http_refresh_data()
+    assert coord._http_failure_count >= 3
+
+
+# ---------------------------------------------------------------------------
+# _async_update_data
+# ---------------------------------------------------------------------------
+
+
+async def test_async_update_data_initial_load(hass: HomeAssistant) -> None:
+    """Test async update data initial load."""
+    coord = make_coordinator(hass)
+    data = {GROUP_ID: make_group()}
+    coord.wybot_http_client.get_indexed_current_grouped_devices.return_value = data
+    coord.wybot_ble_client.query_status.return_value = [
+        {"id": 11, "type": 4, "len": 1, "data": "00"}
+    ]
+    result = await coord._async_update_data()
+    assert result is data
+    assert coord.initial_load is True
+    assert coord._connection_available is True
+
+
+async def test_async_update_data_subsequent(hass: HomeAssistant) -> None:
+    """Test async update data subsequent."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_ble_client.query_status.return_value = [
+        {"id": 11, "type": 4, "len": 1, "data": "00"}
+    ]
+    result = await coord._async_update_data()
+    assert result == coord.data
+
+
+async def test_async_update_data_no_data(hass: HomeAssistant) -> None:
+    """Test async update data no data."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {}
+    with pytest.raises(UpdateFailed) as err:
+        await coord._async_update_data()
+    # The specific no_data reason must survive, not be masked as update_failed.
+    assert err.value.translation_key == "no_data"
+    assert coord._connection_available is False
+
+
+async def test_async_update_data_full_outage_marks_unavailable(
+    hass: HomeAssistant,
+) -> None:
+    """A total transport outage marks unavailable rather than serving stale data."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_ble_client.query_status.return_value = None
+    coord.wybot_mqtt_client.is_connected = MagicMock(return_value=False)
+    coord.wybot_mqtt_client.connect = AsyncMock(side_effect=RuntimeError("no mqtt"))
+    coord.wybot_http_client.get_indexed_current_grouped_devices = AsyncMock(
+        side_effect=RuntimeError("no http")
+    )
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()
+    assert coord._connection_available is False
+
+
+async def test_async_update_data_available_via_recent_http(
+    hass: HomeAssistant,
+) -> None:
+    """Recent HTTP contact keeps the integration available without BLE/MQTT."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_ble_client.query_status.return_value = None
+    coord.wybot_mqtt_client.is_connected = MagicMock(return_value=False)
+    coord.wybot_mqtt_client.connect = AsyncMock(side_effect=RuntimeError("no mqtt"))
+    # The HTTP keepalive returns a real (non-empty) device list, so the account
+    # is reached and the integration stays available.
+    coord.wybot_http_client.get_indexed_current_grouped_devices = AsyncMock(
+        return_value={GROUP_ID: make_group()}
+    )
+    result = await coord._async_update_data()
+    assert result == coord.data
+    assert coord._connection_available is True
+
+
+async def test_recently_reached_false_when_all_stale(hass: HomeAssistant) -> None:
+    """No transport timestamps at all means the integration is not reachable."""
+    coord = make_coordinator(hass)
+    assert coord._recently_reached() is False
+
+
+async def test_async_update_data_auth_error(hass: HomeAssistant) -> None:
+    """Test async update data auth error."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.register_presence.side_effect = WybotAuthError("bad")
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord._async_update_data()
+
+
+async def test_async_update_data_config_entry_auth_failed_passthrough(
+    hass: HomeAssistant,
+) -> None:
+    """Test async update data config entry auth failed passthrough."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.get_indexed_current_grouped_devices.side_effect = (
+        WybotAuthError("bad")
+    )
+    # http_refresh_data converts to ConfigEntryAuthFailed, which passes through
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord._async_update_data()
+
+
+async def test_async_update_data_config_entry_not_ready_passthrough(
+    hass: HomeAssistant,
+) -> None:
+    """Test async update data config entry not ready passthrough."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.get_indexed_current_grouped_devices.side_effect = (
+        RuntimeError("net")
+    )
+    coord._http_failure_count = 2  # next failure escalates to ConfigEntryNotReady
+    with pytest.raises(ConfigEntryNotReady):
+        await coord._async_update_data()
+
+
+async def test_async_update_data_timeout(hass: HomeAssistant) -> None:
+    """Test async update data timeout."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {GROUP_ID: make_group()}
+    with (
+        patch.object(
+            coord, "_poll_all_devices_via_ble", side_effect=TimeoutError("slow")
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coord._async_update_data()
+
+
+async def test_async_update_data_generic_error(hass: HomeAssistant) -> None:
+    """Test async update data generic error."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {GROUP_ID: make_group()}
+    with (
+        patch.object(
+            coord, "_poll_all_devices_via_ble", side_effect=ValueError("oops")
+        ),
+        pytest.raises(UpdateFailed),
+    ):
+        await coord._async_update_data()
+
+
+async def test_async_update_data_mqtt_fallback(hass: HomeAssistant) -> None:
+    """Test async update data mqtt fallback."""
+    coord = make_coordinator(hass)
+    coord.initial_load = True
+    coord.data = {GROUP_ID: make_group()}
+    # BLE returns nothing -> device needs MQTT
+    coord.wybot_ble_client.query_status.return_value = None
+    coord._mqtt_connected = True
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    # The HTTP keepalive returns a real device list so the account stays reached.
+    coord.wybot_http_client.get_indexed_current_grouped_devices = AsyncMock(
+        return_value={GROUP_ID: make_group()}
+    )
+    result = await coord._async_update_data()
+    assert result == coord.data
+    coord.wybot_mqtt_client.ensure_device_sends_statuses.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# _maybe_refresh_http_session
+# ---------------------------------------------------------------------------
+
+
+async def test_maybe_refresh_http_session_throttled(hass: HomeAssistant) -> None:
+    """Test maybe refresh http session throttled."""
+    coord = make_coordinator(hass)
+    coord._last_http_refresh_time = time.time()
+    await coord._maybe_refresh_http_session()
+    coord.wybot_http_client.register_presence.assert_not_called()
+
+
+async def test_maybe_refresh_http_session_subscribe_failure_resets_mqtt(
+    hass: HomeAssistant,
+) -> None:
+    """A failed subscribe drops the MQTT flag for retry, not the whole update."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord._mqtt_connected = True
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    coord.wybot_http_client.get_indexed_current_grouped_devices = AsyncMock(
+        return_value={"g2": make_group(with_docker=False)}
+    )
+    coord.wybot_mqtt_client.subscribe_for_device = AsyncMock(
+        side_effect=RuntimeError("subscribe boom")
+    )
+    # Does not raise; drops the flag so the next cycle re-subscribes everything.
+    await coord._maybe_refresh_http_session()
+    assert coord._mqtt_connected is False
+    assert "g2" in coord.data
+
+
+async def test_maybe_refresh_http_session_empty_not_success(
+    hass: HomeAssistant,
+) -> None:
+    """An empty device snapshot is not counted as a state-bearing HTTP success."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord.wybot_http_client.get_indexed_current_grouped_devices = AsyncMock(
+        return_value={}
+    )
+    await coord._maybe_refresh_http_session()
+    coord.wybot_http_client.get_indexed_current_grouped_devices.assert_awaited()
+    assert coord._last_http_success is None
+
+
+async def test_maybe_refresh_http_session_runs(hass: HomeAssistant) -> None:
+    """Test maybe refresh http session runs."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord._mqtt_connected = True
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    await coord._maybe_refresh_http_session()
+    coord.wybot_http_client.register_presence.assert_called()
+    coord.wybot_http_client.get_indexed_current_grouped_devices.assert_called()
+
+
+async def test_merge_http_groups_discovers_and_gap_fills(
+    hass: HomeAssistant,
+) -> None:
+    """New groups are added; cloud DPs only fill gaps on known groups."""
+    coord = make_coordinator(hass)
+    existing = make_group()
+    existing.device.dps = {"0": "local"}  # a fresher BLE/MQTT value
+    coord.data = {GROUP_ID: existing}
+
+    incoming = make_group()
+    incoming.device.dps = {"0": "cloud", "99": "cloud-only"}
+    new_group = make_group()  # discovered with a dock
+    new_ids = coord._merge_http_groups({GROUP_ID: incoming, "g2": new_group})
+
+    # Newly discovered device and its dock are added and returned to subscribe.
+    assert "g2" in coord.data
+    assert new_group.device.device_id in new_ids
+    assert new_group.docker.docker_id in new_ids
+    # Local value is preserved; cloud only fills the missing key.
+    assert coord.data[GROUP_ID].device.dps["0"] == "local"
+    assert coord.data[GROUP_ID].device.dps["99"] == "cloud-only"
+
+
+async def test_merge_http_groups_attaches_new_dock(hass: HomeAssistant) -> None:
+    """A dock added to a previously dockless robot is attached, not dropped."""
+    coord = make_coordinator(hass)
+    dockless = make_group(with_docker=False)
+    coord.data = {GROUP_ID: dockless}
+    assert coord.data[GROUP_ID].docker is None
+
+    with_dock = make_group()  # same group, now reports a docker
+    new_ids = coord._merge_http_groups({GROUP_ID: with_dock})
+
+    assert coord.data[GROUP_ID].docker is not None
+    assert with_dock.docker.docker_id in new_ids
+
+
+async def test_maybe_refresh_http_session_discovers_and_subscribes(
+    hass: HomeAssistant,
+) -> None:
+    """The periodic HTTP refresh applies its response and subscribes new devices."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    coord._mqtt_connected = True
+    coord.wybot_mqtt_client.is_connected.return_value = True
+    new_group = make_group(with_docker=False)
+    coord.wybot_http_client.get_indexed_current_grouped_devices = AsyncMock(
+        return_value={"g2": new_group}
+    )
+    await coord._maybe_refresh_http_session()
+    assert "g2" in coord.data
+    coord.wybot_mqtt_client.subscribe_for_device.assert_any_await(
+        new_group.device.device_id
+    )
+
+
+async def test_maybe_refresh_http_session_auth_error(hass: HomeAssistant) -> None:
+    """Test maybe refresh http session auth error."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.register_presence.side_effect = WybotAuthError("bad")
+    with pytest.raises(WybotAuthError):
+        await coord._maybe_refresh_http_session()
+
+
+async def test_maybe_refresh_http_session_non_critical_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test maybe refresh http session non critical error."""
+    coord = make_coordinator(hass)
+    coord.wybot_http_client.register_presence.side_effect = RuntimeError("meh")
+    # swallowed, no raise
+    await coord._maybe_refresh_http_session()
+
+
+async def test_maybe_refresh_http_session_mqtt_keepalive_error(
+    hass: HomeAssistant,
+) -> None:
+    """Test maybe refresh http session mqtt keepalive error."""
+    coord = make_coordinator(hass)
+    coord.data = {GROUP_ID: make_group()}
+    # _ensure_mqtt_connected raising is swallowed by the keepalive try/except
+    with patch.object(
+        coord, "_ensure_mqtt_connected", AsyncMock(side_effect=RuntimeError("boom"))
+    ):
+        await coord._maybe_refresh_http_session()

--- a/tests/components/wybot/test_init.py
+++ b/tests/components/wybot/test_init.py
@@ -1,0 +1,99 @@
+"""Tests for WyBot integration setup and teardown."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from wybot import WybotAuthError, WybotConnectionError
+
+from homeassistant.components.wybot.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+USER = "pool@example.com"
+PASSWORD = "hunter2"
+USER_ID = "account-123"
+
+
+def _entry() -> MockConfigEntry:
+    """Build an account config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USER_ID,
+        data={CONF_USERNAME: USER, CONF_PASSWORD: PASSWORD},
+    )
+
+
+def _patch_http(authenticate=None):
+    """Patch the HTTP client used during setup."""
+    client = MagicMock()
+    client.user_id = USER_ID
+    if authenticate is not None:
+        client.authenticate = AsyncMock(side_effect=authenticate)
+    else:
+        client.authenticate = AsyncMock(return_value=True)
+    return patch("homeassistant.components.wybot.WyBotHTTPClient", return_value=client)
+
+
+def _fake_coordinator() -> MagicMock:
+    """Build a fake coordinator."""
+    coordinator = MagicMock()
+    coordinator.data = {}
+    coordinator.vacuums = []
+    coordinator.available = True
+    coordinator.async_config_entry_first_refresh = AsyncMock()
+    coordinator.async_stop = AsyncMock()
+    return coordinator
+
+
+async def test_setup_and_unload(hass: HomeAssistant) -> None:
+    """A valid entry sets up, stores runtime_data, and unloads cleanly."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+    coordinator = _fake_coordinator()
+
+    with (
+        _patch_http(),
+        patch(
+            "homeassistant.components.wybot.WyBotCoordinator", return_value=coordinator
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data is coordinator
+    coordinator.async_config_entry_first_refresh.assert_awaited_once()
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    coordinator.async_stop.assert_awaited()
+
+
+async def test_setup_auth_failure_triggers_reauth(hass: HomeAssistant) -> None:
+    """A rejected login raises ConfigEntryAuthFailed and starts reauth."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    with _patch_http(authenticate=WybotAuthError):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert any(flow["context"]["source"] == "reauth" for flow in flows)
+
+
+async def test_setup_connection_error_is_retried(hass: HomeAssistant) -> None:
+    """A connection error raises ConfigEntryNotReady (setup retry)."""
+    entry = _entry()
+    entry.add_to_hass(hass)
+
+    with _patch_http(authenticate=WybotConnectionError):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/wybot/test_vacuum.py
+++ b/tests/components/wybot/test_vacuum.py
@@ -1,0 +1,345 @@
+"""Tests for the WyBot vacuum platform."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from wybot.dp_models import (
+    Battery,
+    CleaningMode,
+    CleaningStatus,
+    Dock,
+    DockConnectionStatus,
+)
+
+from homeassistant.components.vacuum import VacuumActivity, VacuumEntityFeature
+from homeassistant.components.wybot.vacuum import WyBotVacuum
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from .wybot_platform_helpers import (
+    add_entity,
+    dp,
+    make_coordinator,
+    make_group,
+    setup_integration,
+)
+
+IDX = "grp1"
+
+
+def _coord(hass: HomeAssistant, device_dps=None, docker_dps=None, **kwargs):
+    """Coord."""
+    group = make_group(
+        device_dps=device_dps or {}, docker_dps=docker_dps or {}, **kwargs
+    )
+    coord, entry = make_coordinator(hass, {IDX: group})
+    return coord, entry, group
+
+
+async def test_async_setup_entry(hass: HomeAssistant) -> None:
+    """Setting up a device registers a single vacuum entity."""
+    entry = await setup_integration(hass, {IDX: make_group()})
+    ent_reg = er.async_get(hass)
+    vacuums = [
+        e
+        for e in er.async_entries_for_config_entry(ent_reg, entry.entry_id)
+        if e.domain == "vacuum"
+    ]
+    assert len(vacuums) == 1
+
+
+async def test_basic_properties(hass: HomeAssistant) -> None:
+    """Test basic properties."""
+    coord, _, _ = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.unique_id == "grp1"
+    assert ent.available is True
+    assert ent.fan_speed_list == CleaningMode.CLEANING_MODES
+    assert ent.supported_features == (
+        VacuumEntityFeature.FAN_SPEED
+        | VacuumEntityFeature.RETURN_HOME
+        | VacuumEntityFeature.START
+        | VacuumEntityFeature.STOP
+    )
+    info = ent.device_info
+    assert info["identifiers"] == {("wybot", "grp1")}
+    assert info["name"] == "My Pool"
+    assert info["model"] == "S2 Pro"
+    assert ("bluetooth", "cc:ba:97:93:2a:96") in info["connections"]
+
+
+async def test_available_branches(hass: HomeAssistant) -> None:
+    """Test available branches."""
+    coord, _, group = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    coord._connection_available = False
+    assert ent.available is False
+    coord._connection_available = True
+    ent._data = None
+    assert ent.available is False
+    ent._data = group
+    coord.data = {"other": group}
+    assert ent.available is False
+
+
+async def test_available_requires_group_freshness(hass: HomeAssistant) -> None:
+    """Availability follows this group's own BLE/MQTT freshness, not HTTP/siblings."""
+    coord, _, group = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    # Helper primed a recent BLE poll for this group -> available.
+    assert ent.available is True
+    # Drop this group's freshness: an account-level HTTP success alone must not
+    # keep it available.
+    coord._last_ble_poll.clear()
+    coord._last_mqtt_data.clear()
+    coord._last_http_success = dt_util.utcnow()
+    assert ent.available is False
+    # A recent MQTT message for this group's device restores availability.
+    coord._last_mqtt_data[group.device.device_id] = dt_util.utcnow()
+    assert ent.available is True
+
+
+async def test_device_info_fallbacks(hass: HomeAssistant) -> None:
+    # No data -> Unknown/Unknown, no connections/via.
+    """Test device info fallbacks."""
+    coord, _, _group = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    ent._data = None
+    info = ent.device_info
+    assert info["name"] == "Unknown"
+    assert info["model"] == "Unknown"
+    assert "connections" not in info
+
+    # name falsy -> device_name.
+    group2 = make_group(name="")
+    coord2, _ = make_coordinator(hass, {IDX: group2})
+    ent2 = WyBotVacuum(idx=IDX, coordinator=coord2)
+    assert ent2.device_info["name"] == "Robot"
+    # name and device_name falsy -> device_type.
+    group2.device.device_name = ""
+    assert ent2.device_info["name"] == "S2 Pro"
+
+
+async def test_device_info_no_ble_no_docker(hass: HomeAssistant) -> None:
+    """Test device info no ble no docker."""
+    group = make_group(with_docker=False)
+    group.device.ble_name = ""
+    coord, _ = make_coordinator(hass, {IDX: group})
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    info = ent.device_info
+    assert "connections" not in info
+
+
+async def test_activity_none_when_no_data(hass: HomeAssistant) -> None:
+    """Test activity none when no data."""
+    coord, _, _ = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    ent._data = None
+    assert ent.activity is None
+
+
+async def test_activity_returning_via_cleaning_status(hass: HomeAssistant) -> None:
+    # CleaningStatus data 04 -> RETURNING_TO_DOCK.
+    """Test activity returning via cleaning status."""
+    coord, _, _ = _coord(
+        hass, device_dps={"0": dp(CleaningStatus, id=0, type=4, len=1, data="04")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.RETURNING
+
+
+async def test_activity_returning_via_dock_dp(hass: HomeAssistant) -> None:
+    # Dock DP 11 data 01 -> RETURNING.
+    """Test activity returning via dock dp."""
+    coord, _, _ = _coord(
+        hass, device_dps={"11": dp(Dock, id=11, type=4, len=1, data="01")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.RETURNING
+
+
+async def test_activity_docked_via_dock_dp(hass: HomeAssistant) -> None:
+    # Dock DP 11 data 00 -> DOCKED.
+    """Test activity docked via dock dp."""
+    coord, _, _ = _coord(
+        hass, device_dps={"11": dp(Dock, id=11, type=4, len=1, data="00")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.DOCKED
+
+
+async def test_activity_docked_via_dock_connection(hass: HomeAssistant) -> None:
+    """Test activity docked via dock connection."""
+    coord, _, _ = _coord(
+        hass,
+        device_dps={"213": dp(DockConnectionStatus, id=213, type=4, len=1, data="01")},
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.DOCKED
+
+
+async def test_activity_docked_via_battery(hass: HomeAssistant) -> None:
+    """Test activity docked via battery."""
+    coord, _, _ = _coord(
+        hass, device_dps={"50": dp(Battery, id=50, type=0, len=2, data="0132")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.DOCKED
+
+
+async def test_activity_cleaning(hass: HomeAssistant) -> None:
+    """Test activity cleaning."""
+    coord, _, _ = _coord(
+        hass, device_dps={"0": dp(CleaningStatus, id=0, type=4, len=1, data="03")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.CLEANING
+
+
+async def test_activity_cleaning_overrides_stale_dock_returning(
+    hass: HomeAssistant,
+) -> None:
+    """An active CLEANING status wins over a stale dock RETURNING DP."""
+    coord, _, _ = _coord(
+        hass,
+        device_dps={
+            "0": dp(CleaningStatus, id=0, type=4, len=1, data="03"),
+            "11": dp(Dock, id=11, type=4, len=1, data="01"),  # stale RETURNING
+        },
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.CLEANING
+
+
+async def test_activity_cleaning_overrides_stale_charging(hass: HomeAssistant) -> None:
+    """An active CLEANING status wins over a stale charging/docked battery DP."""
+    coord, _, _ = _coord(
+        hass,
+        device_dps={
+            "0": dp(CleaningStatus, id=0, type=4, len=1, data="03"),
+            # Retained stale battery DP that would otherwise infer DOCKED.
+            "50": dp(Battery, id=50, type=0, len=2, data="0132"),
+        },
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.CLEANING
+
+
+async def test_activity_idle_when_stopped(hass: HomeAssistant) -> None:
+    # CleaningStatus 01 -> STOPPED -> IDLE. Battery not plugged in so not docked.
+    """A stopped robot reports IDLE, not paused."""
+    coord, _, _ = _coord(
+        hass,
+        device_dps={
+            "0": dp(CleaningStatus, id=0, type=4, len=1, data="01"),
+            "50": dp(Battery, id=50, type=0, len=2, data="004b"),
+        },
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity == VacuumActivity.IDLE
+
+
+async def test_activity_none_when_no_dps(hass: HomeAssistant) -> None:
+    """Test activity none when no dps."""
+    coord, _, _ = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.activity is None
+
+
+async def test_fan_speed(hass: HomeAssistant) -> None:
+    """Test fan speed."""
+    coord, _, _ = _coord(
+        hass, device_dps={"1": dp(CleaningMode, id=1, type=4, len=1, data="01")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.fan_speed == "Wall"
+
+
+async def test_fan_speed_no_data(hass: HomeAssistant) -> None:
+    """Test fan speed no data."""
+    coord, _, _ = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    ent._data = None
+    assert ent.fan_speed is None
+
+
+async def test_fan_speed_dp_missing(hass: HomeAssistant) -> None:
+    """Test fan speed dp missing."""
+    coord, _, _ = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    assert ent.fan_speed is None
+
+
+async def test_commands_success(hass: HomeAssistant) -> None:
+    """Test commands success."""
+    coord, _, _ = _coord(hass)
+    coord.async_send_command = AsyncMock(return_value=True)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    await ent.async_start()
+    await ent.async_stop()
+    await ent.async_return_to_base()
+    await ent.async_set_fan_speed("Wall")
+    assert coord.async_send_command.await_count == 4
+
+
+async def test_commands_failure_raises(hass: HomeAssistant) -> None:
+    """Test commands failure raises."""
+    coord, _, _ = _coord(hass)
+    coord.async_send_command = AsyncMock(return_value=False)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    with pytest.raises(HomeAssistantError):
+        await ent.async_start()
+    with pytest.raises(HomeAssistantError):
+        await ent.async_stop()
+    with pytest.raises(HomeAssistantError):
+        await ent.async_return_to_base()
+    with pytest.raises(HomeAssistantError):
+        await ent.async_set_fan_speed("Wall")
+
+
+async def test_commands_no_data_raises(hass: HomeAssistant) -> None:
+    """Test commands no data raises."""
+    coord, _, _ = _coord(hass)
+    coord.async_send_command = AsyncMock(return_value=True)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    ent._data = None
+    with pytest.raises(HomeAssistantError):
+        await ent.async_start()
+    coord.async_send_command.assert_not_awaited()
+
+
+async def test_set_fan_speed_invalid_raises(hass: HomeAssistant) -> None:
+    """An unsupported fan speed raises a validation error and sends nothing."""
+    coord, _, _ = _coord(hass)
+    coord.async_send_command = AsyncMock(return_value=True)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    with pytest.raises(ServiceValidationError):
+        await ent.async_set_fan_speed("NotAMode")
+    coord.async_send_command.assert_not_awaited()
+
+
+async def test_handle_coordinator_update_updates_data(hass: HomeAssistant) -> None:
+    """A coordinator update refreshes the entity data and writes state."""
+    coord, _, group = _coord(
+        hass, device_dps={"0": dp(CleaningStatus, id=0, type=4, len=1, data="03")}
+    )
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    await add_entity(hass, ent, domain="vacuum")
+    ent._handle_coordinator_update()
+    assert ent._data is group
+    state = hass.states.get(ent.entity_id)
+    assert state is not None
+    assert state.state == VacuumActivity.CLEANING
+
+
+async def test_handle_coordinator_update_idx_missing(hass: HomeAssistant) -> None:
+    """Test handle coordinator update idx missing."""
+    coord, _, group = _coord(hass)
+    ent = WyBotVacuum(idx=IDX, coordinator=coord)
+    await add_entity(hass, ent, domain="vacuum")
+    coord.data = {}
+    ent._handle_coordinator_update()
+    # _data retained; battery None branch (no dps) also exercised.
+    assert ent._data is group

--- a/tests/components/wybot/wybot_platform_helpers.py
+++ b/tests/components/wybot/wybot_platform_helpers.py
@@ -1,0 +1,128 @@
+"""Shared helpers for WyBot entity-platform tests.
+
+Builds a real ``WyBotCoordinator`` (its constructor is side-effect free: it
+creates MQTT/BLE client objects but does not connect) populated with real
+``Group`` models so the entity platforms can be exercised end-to-end.
+"""
+
+from copy import deepcopy
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from wybot.dp_models import DP
+from wybot.models import Group
+
+from homeassistant.components.wybot.const import DOMAIN
+from homeassistant.components.wybot.coordinator import WyBotCoordinator
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry, MockEntityPlatform
+
+GROUP_DATA = {
+    "device": {
+        "deviceId": "dev1",
+        "deviceName": "Robot",
+        "deviceType": "S2 Pro",
+        "bleName": "CCBA97932A96",
+        "autoUpdate": "1",
+        "version": {"Firmware": "1.0"},
+    },
+    "docker": {
+        "dockerId": "dock1",
+        "dockerType": "DS20",
+        "bleName": "3C8427565A1A",
+        "deviceStatus": "online",
+        "dockerStatus": "active",
+        "schedule": None,
+        "version": {"Firmware": "2.0"},
+    },
+    "vision": {
+        "visionId": "v1",
+        "privacy": False,
+        "log": None,
+        "video": None,
+        "picture": None,
+        "policy": True,
+    },
+    "name": "My Pool",
+    "id": "grp1",
+    "autoUpdate": "1",
+}
+
+
+def dp(cls, **kwargs):
+    """Wrap a raw DP into the given typed DP class."""
+    return cls(DP(**kwargs))
+
+
+def make_group(device_dps=None, docker_dps=None, with_docker=True, name="My Pool"):
+    """Build a real ``Group`` with typed DP instances attached."""
+    data = deepcopy(GROUP_DATA)
+    data["name"] = name
+    if not with_docker:
+        data["docker"] = None
+    group = Group(**data)
+    group.device.dps = device_dps or {}
+    if group.docker:
+        group.docker.dps = docker_dps or {}
+    return group
+
+
+def make_coordinator(hass: HomeAssistant, data):
+    """Build a real coordinator populated with the given ``data`` mapping."""
+    entry_data = {CONF_USERNAME: "u", CONF_PASSWORD: "p"}
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data)
+    entry.add_to_hass(hass)
+    coord = WyBotCoordinator(hass, MagicMock(), entry)
+    coord.data = data
+    coord._connection_available = True
+    # Mark each group as freshly reached over BLE so entities are available by
+    # default (per-group availability requires recent BLE/MQTT data).
+    now = dt_util.utcnow()
+    for group in data.values():
+        coord._last_ble_poll[group.device.device_id] = now
+    # Avoid scheduling a real refresh timer when entities register as listeners
+    # (keeps the test harness free of lingering timers).
+    coord.update_interval = None
+    return coord, entry
+
+
+async def add_entity(hass: HomeAssistant, entity, domain="sensor"):
+    """Add an entity to a real (mock) entity platform.
+
+    This gives the entity a platform, hass, and entity_id so
+    ``async_write_ha_state`` works exactly as it would in production.
+    """
+    platform = MockEntityPlatform(hass, domain=domain, platform_name=DOMAIN)
+    await platform.async_add_entities([entity])
+    return entity
+
+
+async def setup_integration(hass: HomeAssistant, data):
+    """Fully set up the WyBot integration with mocked clients and given data.
+
+    Returns the config entry; its ``runtime_data`` is the real coordinator
+    (pre-populated with ``data``). Entities are created by the real platform
+    setup, so callers assert against the entity registry.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "u", CONF_PASSWORD: "p"},
+    )
+    entry.add_to_hass(hass)
+
+    async def _fake_update(self):
+        self.data = data
+        self._connection_available = True
+        return data
+
+    with (
+        patch("homeassistant.components.wybot.WyBotHTTPClient") as http_cls,
+        patch.object(WyBotCoordinator, "_async_update_data", autospec=True) as update,
+    ):
+        http_cls.return_value.authenticate = AsyncMock()
+        update.side_effect = _fake_update
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a new integration for [WyBot pool robots](https://www.wybotpool.com/), a publicly available line of robotic pool cleaners with an existing user base.

This is the first PR of a stack and is intentionally scoped to a single platform at **Silver** quality scale so it is easy to review:

- Config flow for the WyBot account (username/password), with reauth and reconfigure steps.
- A `DataUpdateCoordinator` implementing a BLE-first strategy with an MQTT (cloud) fallback and an HTTP keepalive.
- A `vacuum` entity: start, stop, return-to-dock, and cleaning-mode (fan speed) selection.

Sensor, binary_sensor, and button platforms (and the move to Gold/Platinum) will follow in separate PRs once this base lands. The manifest declares `quality_scale: silver` accordingly.

All protocol and transport code (HTTP, MQTT via aiomqtt, and BLE, including MQTT topic routing and payload parsing) lives in the [`pywybot`](https://github.com/bassrock/pywybot) PyPI package, keeping this integration a thin wrapper.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#46806
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to brands pull request: home-assistant/brands#10747
- Dependency: the [`pywybot`](https://github.com/bassrock/pywybot) library (PyPI: `pywybot`)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
