### PR TITLE
Add oven light to Whirlpool

### DIFF
--- a/homeassistant/components/whirlpool/__init__.py
+++ b/homeassistant/components/whirlpool/__init__.py
@@ -21,6 +21,7 @@ PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.CLIMATE,
+    Platform.LIGHT,
     Platform.SELECT,
     Platform.SENSOR,
 ]

--- a/homeassistant/components/whirlpool/icons.json
+++ b/homeassistant/components/whirlpool/icons.json
@@ -1,5 +1,16 @@
 {
   "entity": {
+    "light": {
+      "oven_light": {
+        "default": "mdi:lightbulb"
+      },
+      "oven_light_lower": {
+        "default": "mdi:lightbulb"
+      },
+      "oven_light_upper": {
+        "default": "mdi:lightbulb"
+      }
+    },
     "sensor": {
       "dryer_state": {
         "default": "mdi:tumble-dryer"

--- a/homeassistant/components/whirlpool/icons.json
+++ b/homeassistant/components/whirlpool/icons.json
@@ -1,16 +1,5 @@
 {
   "entity": {
-    "light": {
-      "oven_light": {
-        "default": "mdi:lightbulb"
-      },
-      "oven_light_lower": {
-        "default": "mdi:lightbulb"
-      },
-      "oven_light_upper": {
-        "default": "mdi:lightbulb"
-      }
-    },
     "sensor": {
       "dryer_state": {
         "default": "mdi:tumble-dryer"

--- a/homeassistant/components/whirlpool/light.py
+++ b/homeassistant/components/whirlpool/light.py
@@ -41,8 +41,8 @@ class WhirlpoolOvenLight(WhirlpoolOvenEntity, LightEntity):
         """Initialize the oven light."""
         super().__init__(appliance, cavity, "oven_light", "-light")
 
-    @override
     @property
+    @override
     def is_on(self) -> bool | None:
         """Return whether the light is on."""
         return self._appliance.get_light(self.cavity)

--- a/homeassistant/components/whirlpool/light.py
+++ b/homeassistant/components/whirlpool/light.py
@@ -1,0 +1,62 @@
+"""Light platform for the Whirlpool Appliances integration."""
+
+from typing import Any, override
+
+from whirlpool.oven import Cavity as OvenCavity, Oven
+
+from homeassistant.components.light import ColorMode, LightEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import WhirlpoolConfigEntry
+from .entity import WhirlpoolOvenEntity
+
+PARALLEL_UPDATES = 1
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: WhirlpoolConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the light platform."""
+    appliances_manager = config_entry.runtime_data
+    async_add_entities(
+        WhirlpoolOvenLight(oven, cavity)
+        for oven in appliances_manager.ovens
+        for cavity in (OvenCavity.Upper, OvenCavity.Lower)
+        if oven.get_oven_cavity_exists(cavity)
+    )
+
+
+class WhirlpoolOvenLight(WhirlpoolOvenEntity, LightEntity):
+    """Light for an oven cavity."""
+
+    _appliance: Oven
+
+    _attr_color_mode = ColorMode.ONOFF
+    _attr_supported_color_modes = {ColorMode.ONOFF}
+
+    def __init__(self, appliance: Oven, cavity: OvenCavity) -> None:
+        """Initialize the oven light."""
+        super().__init__(appliance, cavity, "oven_light", "-light")
+
+    @override
+    @property
+    def is_on(self) -> bool:
+        """Return whether the light is on."""
+        return self._appliance.get_light(self.cavity)
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        WhirlpoolOvenLight._check_service_request(
+            await self._appliance.set_light(True, self.cavity)
+        )
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        WhirlpoolOvenLight._check_service_request(
+            await self._appliance.set_light(False, self.cavity)
+        )

--- a/homeassistant/components/whirlpool/light.py
+++ b/homeassistant/components/whirlpool/light.py
@@ -43,7 +43,7 @@ class WhirlpoolOvenLight(WhirlpoolOvenEntity, LightEntity):
 
     @override
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return whether the light is on."""
         return self._appliance.get_light(self.cavity)
 

--- a/homeassistant/components/whirlpool/strings.json
+++ b/homeassistant/components/whirlpool/strings.json
@@ -57,6 +57,17 @@
         "name": "Upper oven stop"
       }
     },
+    "light": {
+      "oven_light": {
+        "name": "Light"
+      },
+      "oven_light_lower": {
+        "name": "Lower oven light"
+      },
+      "oven_light_upper": {
+        "name": "Upper oven light"
+      }
+    },
     "select": {
       "refrigerator_temperature_level": {
         "name": "Temperature level"

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -182,6 +182,7 @@ def mock_oven_single_cavity_api():
     mock_oven.get_oven_cavity_exists.side_effect = lambda cavity: (
         cavity == oven.Cavity.Upper
     )
+    mock_oven.get_light.return_value = True
     mock_oven.get_temp.return_value = 180
     mock_oven.get_target_temp.return_value = 200
     return mock_oven
@@ -205,6 +206,7 @@ def mock_oven_dual_cavity_api():
             oven.Cavity.Lower,
         )
     )
+    mock_oven.get_light.return_value = True
     mock_oven.get_temp.return_value = 180
     mock_oven.get_target_temp.return_value = 200
     return mock_oven

--- a/tests/components/whirlpool/conftest.py
+++ b/tests/components/whirlpool/conftest.py
@@ -206,7 +206,7 @@ def mock_oven_dual_cavity_api():
             oven.Cavity.Lower,
         )
     )
-    mock_oven.get_light.return_value = True
+    mock_oven.get_light.side_effect = lambda cavity: cavity == oven.Cavity.Upper
     mock_oven.get_temp.return_value = 180
     mock_oven.get_target_temp.return_value = 200
     return mock_oven

--- a/tests/components/whirlpool/snapshots/test_light.ambr
+++ b/tests/components/whirlpool/snapshots/test_light.ambr
@@ -1,0 +1,178 @@
+# serializer version: 1
+# name: test_all_entities[light.dual_cavity_oven_lower_oven_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.dual_cavity_oven_lower_oven_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lower oven light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Lower oven light',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_light_lower',
+    'unique_id': 'said_oven_dual-light_lower',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[light.dual_cavity_oven_lower_oven_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: <ColorMode.ONOFF: 'onoff'>,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Dual cavity oven Lower oven light',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.dual_cavity_oven_lower_oven_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[light.dual_cavity_oven_upper_oven_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.dual_cavity_oven_upper_oven_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Upper oven light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Upper oven light',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_light_upper',
+    'unique_id': 'said_oven_dual-light_upper',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[light.dual_cavity_oven_upper_oven_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: <ColorMode.ONOFF: 'onoff'>,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Dual cavity oven Upper oven light',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.dual_cavity_oven_upper_oven_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[light.single_cavity_oven_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.single_cavity_oven_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light',
+    'platform': 'whirlpool',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'oven_light',
+    'unique_id': 'said_oven_single-light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[light.single_cavity_oven_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: <ColorMode.ONOFF: 'onoff'>,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Single cavity oven Light',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.single_cavity_oven_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/whirlpool/snapshots/test_light.ambr
+++ b/tests/components/whirlpool/snapshots/test_light.ambr
@@ -43,7 +43,7 @@
 # name: test_all_entities[light.dual_cavity_oven_lower_oven_light-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: <ColorMode.ONOFF: 'onoff'>,
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Dual cavity oven Lower oven light',
       <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
         <ColorMode.ONOFF: 'onoff'>,
@@ -55,7 +55,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'on',
+    'state': 'off',
   })
 # ---
 # name: test_all_entities[light.dual_cavity_oven_upper_oven_light-entry]

--- a/tests/components/whirlpool/test_light.py
+++ b/tests/components/whirlpool/test_light.py
@@ -1,0 +1,99 @@
+"""Test the Whirlpool light platform."""
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+import whirlpool
+
+from homeassistant.components.light import (
+    DOMAIN as LIGHT_DOMAIN,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import init_integration, snapshot_whirlpool_entities
+
+
+@pytest.fixture(
+    params=[
+        (
+            "light.single_cavity_oven_light",
+            "mock_oven_single_cavity_api",
+            whirlpool.oven.Cavity.Upper,
+        ),
+        (
+            "light.dual_cavity_oven_upper_oven_light",
+            "mock_oven_dual_cavity_api",
+            whirlpool.oven.Cavity.Upper,
+        ),
+        (
+            "light.dual_cavity_oven_lower_oven_light",
+            "mock_oven_dual_cavity_api",
+            whirlpool.oven.Cavity.Lower,
+        ),
+    ]
+)
+def oven_light_entity(
+    request: pytest.FixtureRequest,
+) -> tuple[str, str, whirlpool.oven.Cavity]:
+    """Parametrize the oven light entities."""
+    return request.param
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant, snapshot: SnapshotAssertion, entity_registry: er.EntityRegistry
+) -> None:
+    """Test all entities."""
+    await init_integration(hass)
+    snapshot_whirlpool_entities(hass, entity_registry, snapshot, Platform.LIGHT)
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_state"),
+    [(SERVICE_TURN_ON, True), (SERVICE_TURN_OFF, False)],
+)
+async def test_turn_on_off(
+    hass: HomeAssistant,
+    oven_light_entity: tuple[str, str, whirlpool.oven.Cavity],
+    request: pytest.FixtureRequest,
+    service: str,
+    expected_state: bool,
+) -> None:
+    """Test turning the oven light on and off."""
+    entity_id, mock_fixture, cavity = oven_light_entity
+    mock = request.getfixturevalue(mock_fixture)
+    await init_integration(hass)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    mock.set_light.assert_called_once_with(expected_state, cavity)
+
+
+@pytest.mark.parametrize("service", [SERVICE_TURN_ON, SERVICE_TURN_OFF])
+async def test_turn_on_off_failure(
+    hass: HomeAssistant,
+    oven_light_entity: tuple[str, str, whirlpool.oven.Cavity],
+    request: pytest.FixtureRequest,
+    service: str,
+) -> None:
+    """Test a failed light request raises HomeAssistantError."""
+    entity_id, mock_fixture, _ = oven_light_entity
+    mock = request.getfixturevalue(mock_fixture)
+    mock.set_light.return_value = False
+    await init_integration(hass)
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a `light` platform to the Whirlpool integration exposing each oven
cavity's light as an on/off light entity. The new `WhirlpoolOvenLight`
subclasses the existing `WhirlpoolOvenEntity` base class and is fully
cavity-aware: a single-cavity oven gets one "Light" entity, while a
dual-cavity oven gets separate "Upper oven light" and "Lower oven light"
entities.

The entity uses `ColorMode.ONOFF`, reads state from `oven.get_light(cavity)`,
and writes via `oven.set_light(on, cavity)`, raising `HomeAssistantError`
through the shared `_check_service_request` helper on failure.

Tested against a real single-cavity Whirlpool oven: the entity is created
correctly and turning it on/off toggles the physical oven light.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46805
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
