### PR TITLE
Clean up iZone climate connection error handling

### DIFF
--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 import logging
 from typing import Any, override
 
-from pizone import Controller, ControllerCommandError, Zone
+from pizone import Controller, Zone
 import voluptuous as vol
 
 from homeassistant.components.climate import (
@@ -34,6 +34,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import VolDictType
 
+from .command import izone_command_context, send_izone_command
 from .const import (
     DATA_DISCOVERY_SERVICE,
     DISPATCH_CONTROLLER_DISCONNECTED,
@@ -182,6 +183,15 @@ class ControllerDevice(ClimateEntity):
         self.zones = {}
         for zone in controller.zones:
             self.zones[zone] = ZoneDevice(self, zone)
+
+    @property
+    def device_uid(self) -> str:
+        """Return the pizone controller UID."""
+        return self._controller.device_uid
+
+    def _izone_availability_device(self) -> ControllerDevice:
+        """Return the entity that owns controller availability state."""
+        return self
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -394,25 +404,6 @@ class ControllerDevice(ClimateEntity):
         """Return the maximum temperature."""
         return self._controller.temp_max
 
-    async def wrap_and_catch(self, coro):
-        """Await a controller command, handling connection and command errors.
-
-        A rejected command (device reachable) is logged and does not affect
-        availability. A transport failure marks the controller unavailable.
-        """
-        try:
-            await coro
-        except ControllerCommandError as ex:
-            _LOGGER.warning(
-                "Controller %s rejected command: %s",
-                self._controller.device_uid,
-                ex,
-            )
-        except ConnectionError as ex:
-            self.set_available(False, ex)
-        else:
-            self.set_available(True)
-
     @override
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
@@ -420,38 +411,43 @@ class ControllerDevice(ClimateEntity):
             self.async_schedule_update_ha_state(True)
             return
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            await self.wrap_and_catch(self._controller.set_temp_setpoint(temp))
+            async with izone_command_context(self):
+                await self._controller.set_temp_setpoint(temp)
 
+    @send_izone_command
     @override
     async def async_set_fan_mode(self, fan_mode: str) -> None:
         """Set new target fan mode."""
         fan = self._fan_to_pizone[fan_mode]
-        await self.wrap_and_catch(self._controller.set_fan(fan))
+        await self._controller.set_fan(fan)
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         if hvac_mode == HVACMode.OFF:
-            await self.wrap_and_catch(self._controller.set_on(False))
+            async with izone_command_context(self):
+                await self._controller.set_on(False)
             return
         if not self._controller.is_on:
-            await self.wrap_and_catch(self._controller.set_on(True))
+            async with izone_command_context(self):
+                await self._controller.set_on(True)
         if self._controller.free_air:
             return
         mode = self._state_to_pizone[hvac_mode]
-        await self.wrap_and_catch(self._controller.set_mode(mode))
+        async with izone_command_context(self):
+            await self._controller.set_mode(mode)
 
+    @send_izone_command
     @override
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode."""
-        await self.wrap_and_catch(
-            self._controller.set_free_air(preset_mode == PRESET_ECO)
-        )
+        await self._controller.set_free_air(preset_mode == PRESET_ECO)
 
+    @send_izone_command
     @override
     async def async_turn_on(self) -> None:
         """Turn the entity on."""
-        await self.wrap_and_catch(self._controller.set_on(True))
+        await self._controller.set_on(True)
 
 
 class ZoneDevice(ClimateEntity):
@@ -495,6 +491,10 @@ class ZoneDevice(ClimateEntity):
             name=zone.name.title(),
             via_device=(DOMAIN, controller.unique_id),
         )
+
+    def _izone_availability_device(self) -> ControllerDevice:
+        """Return the entity that owns controller availability state."""
+        return self._controller
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -594,18 +594,16 @@ class ZoneDevice(ClimateEntity):
         """Return the maximum air flow."""
         return self._zone.airflow_max
 
+    @send_izone_command
     async def async_set_airflow_min(self, **kwargs):
         """Set new airflow minimum."""
-        await self._controller.wrap_and_catch(
-            self._zone.set_airflow_min(int(kwargs[ATTR_AIRFLOW]))
-        )
+        await self._zone.set_airflow_min(int(kwargs[ATTR_AIRFLOW]))
         self.async_write_ha_state()
 
+    @send_izone_command
     async def async_set_airflow_max(self, **kwargs):
         """Set new airflow maximum."""
-        await self._controller.wrap_and_catch(
-            self._zone.set_airflow_max(int(kwargs[ATTR_AIRFLOW]))
-        )
+        await self._zone.set_airflow_max(int(kwargs[ATTR_AIRFLOW]))
         self.async_write_ha_state()
 
     @override
@@ -614,13 +612,15 @@ class ZoneDevice(ClimateEntity):
         if self._zone.mode is not Zone.Mode.AUTO:
             return
         if (temp := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            await self._controller.wrap_and_catch(self._zone.set_temp_setpoint(temp))
+            async with izone_command_context(self._izone_availability_device()):
+                await self._zone.set_temp_setpoint(temp)
 
+    @send_izone_command
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         mode = self._state_to_pizone[hvac_mode]
-        await self._controller.wrap_and_catch(self._zone.set_mode(mode))
+        await self._zone.set_mode(mode)
         self.async_write_ha_state()
 
     @property
@@ -628,19 +628,21 @@ class ZoneDevice(ClimateEntity):
         """Return true if on."""
         return self._zone.mode is not Zone.Mode.CLOSE
 
+    @send_izone_command
     @override
     async def async_turn_on(self) -> None:
         """Turn device on (open zone)."""
         if self._zone.type is Zone.Type.AUTO:
-            await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.AUTO))
+            await self._zone.set_mode(Zone.Mode.AUTO)
         else:
-            await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.OPEN))
+            await self._zone.set_mode(Zone.Mode.OPEN)
         self.async_write_ha_state()
 
+    @send_izone_command
     @override
     async def async_turn_off(self) -> None:
         """Turn device off (close zone)."""
-        await self._controller.wrap_and_catch(self._zone.set_mode(Zone.Mode.CLOSE))
+        await self._zone.set_mode(Zone.Mode.CLOSE)
         self.async_write_ha_state()
 
     @property

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -421,21 +421,19 @@ class ControllerDevice(ClimateEntity):
         fan = self._fan_to_pizone[fan_mode]
         await self._controller.set_fan(fan)
 
+    @send_izone_command
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target operation mode."""
         if hvac_mode == HVACMode.OFF:
-            async with izone_command_context(self):
-                await self._controller.set_on(False)
+            await self._controller.set_on(False)
             return
         if not self._controller.is_on:
-            async with izone_command_context(self):
-                await self._controller.set_on(True)
+            await self._controller.set_on(True)
         if self._controller.free_air:
             return
         mode = self._state_to_pizone[hvac_mode]
-        async with izone_command_context(self):
-            await self._controller.set_mode(mode)
+        await self._controller.set_mode(mode)
 
     @send_izone_command
     @override

--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -1,10 +1,10 @@
 """Support for the iZone HVAC."""
 
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 import logging
-from typing import Any, Concatenate, override
+from typing import Any, override
 
-from pizone import Controller, Zone
+from pizone import Controller, ControllerCommandError, Zone
 import voluptuous as vol
 
 from homeassistant.components.climate import (
@@ -44,8 +44,6 @@ from .const import (
     DOMAIN,
     TIMEOUT_DISCOVERY,
 )
-
-type _FuncType[_T, **_P, _R] = Callable[Concatenate[_T, _P], _R]
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -116,23 +114,6 @@ async def async_setup_entry(
         IZONE_SERVICE_AIRFLOW_SCHEMA,
         "async_set_airflow_max",
     )
-
-
-def _return_on_connection_error[_DeviceT: ControllerDevice | ZoneDevice, **_P, _R, _T](
-    ret: _T = None,  # type: ignore[assignment]
-) -> Callable[[_FuncType[_DeviceT, _P, _R]], _FuncType[_DeviceT, _P, _R | _T]]:
-    def wrap(func: _FuncType[_DeviceT, _P, _R]) -> _FuncType[_DeviceT, _P, _R | _T]:
-        def wrapped_f(self: _DeviceT, *args: _P.args, **kwargs: _P.kwargs) -> _R | _T:
-            if not self.available:
-                return ret
-            try:
-                return func(self, *args, **kwargs)
-            except ConnectionError:
-                return ret
-
-        return wrapped_f
-
-    return wrap
 
 
 class ControllerDevice(ClimateEntity):
@@ -316,7 +297,6 @@ class ControllerDevice(ClimateEntity):
         raise RuntimeError("Should be unreachable")
 
     @property
-    @_return_on_connection_error([])
     @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the list of available operation modes."""
@@ -325,14 +305,12 @@ class ControllerDevice(ClimateEntity):
         return [HVACMode.OFF, *self._state_to_pizone]
 
     @property
-    @_return_on_connection_error(PRESET_NONE)
     @override
     def preset_mode(self) -> str:
         """Eco mode is external air."""
         return PRESET_ECO if self._controller.free_air else PRESET_NONE
 
     @property
-    @_return_on_connection_error([PRESET_NONE])
     @override
     def preset_modes(self) -> list[str]:
         """Available preset modes, normal or eco."""
@@ -341,7 +319,6 @@ class ControllerDevice(ClimateEntity):
         return [PRESET_NONE]
 
     @property
-    @_return_on_connection_error()
     @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
@@ -378,7 +355,6 @@ class ControllerDevice(ClimateEntity):
         return zone.target_temperature
 
     @property
-    @_return_on_connection_error()
     @override
     def target_temperature(self) -> float | None:
         """Return the temperature we try to reach.
@@ -407,23 +383,31 @@ class ControllerDevice(ClimateEntity):
         return list(self._fan_to_pizone)
 
     @property
-    @_return_on_connection_error(0.0)
     @override
     def min_temp(self) -> float:
         """Return the minimum temperature."""
         return self._controller.temp_min
 
     @property
-    @_return_on_connection_error(50.0)
     @override
     def max_temp(self) -> float:
         """Return the maximum temperature."""
         return self._controller.temp_max
 
     async def wrap_and_catch(self, coro):
-        """Catch any connection errors and set unavailable."""
+        """Await a controller command, handling connection and command errors.
+
+        A rejected command (device reachable) is logged and does not affect
+        availability. A transport failure marks the controller unavailable.
+        """
         try:
             await coro
+        except ControllerCommandError as ex:
+            _LOGGER.warning(
+                "Controller %s rejected command: %s",
+                self._controller.device_uid,
+                ex,
+            )
         except ConnectionError as ex:
             self.set_available(False, ex)
         else:
@@ -551,7 +535,6 @@ class ZoneDevice(ClimateEntity):
         return self._controller.available
 
     @property
-    @_return_on_connection_error(ClimateEntityFeature(0))
     @override
     def supported_features(self) -> ClimateEntityFeature:
         """Return the list of supported features."""

--- a/homeassistant/components/izone/command.py
+++ b/homeassistant/components/izone/command.py
@@ -1,0 +1,56 @@
+"""Helpers for sending commands to iZone controllers."""
+
+from collections.abc import Callable, Coroutine
+import contextlib
+from functools import wraps
+import logging
+from typing import Any, Concatenate, Protocol
+
+from pizone import ControllerCommandError
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class _IzoneAvailabilityDevice(Protocol):
+    @property
+    def device_uid(self) -> str: ...
+
+    def set_available(self, available: bool, ex: Exception | None = None) -> None: ...
+
+
+class _IzoneCommandEntity(Protocol):
+    def _izone_availability_device(self) -> _IzoneAvailabilityDevice: ...
+
+
+@contextlib.asynccontextmanager
+async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
+    """Handle connection and command errors for a pizone controller command.
+
+    A rejected command is logged and re-raised so multi-step sequences stop.
+    Availability is restored only by the library reconnect listener, not on
+    command success. A transport failure marks the controller unavailable.
+    """
+    try:
+        yield
+    except ControllerCommandError as ex:
+        _LOGGER.warning(
+            "Controller %s rejected command: %s",
+            availability_device.device_uid,
+            ex,
+        )
+        raise
+    except ConnectionError as ex:
+        availability_device.set_available(False, ex)
+
+
+def send_izone_command[_EntityT: _IzoneCommandEntity, **_P](
+    func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]],
+) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
+    """Wrap an entity command to handle pizone connection and command errors."""
+
+    @wraps(func)
+    async def handler(self: _EntityT, *args: _P.args, **kwargs: _P.kwargs) -> None:
+        async with izone_command_context(self._izone_availability_device()):
+            await func(self, *args, **kwargs)
+
+    return handler

--- a/homeassistant/components/izone/command.py
+++ b/homeassistant/components/izone/command.py
@@ -28,10 +28,10 @@ class _IzoneCommandEntity(Protocol):
 async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
     """Handle connection and command errors for a pizone controller command.
 
-    A rejected command is logged and re-raised so multi-step sequences stop.
-    Availability is restored only by the library reconnect listener, not on
-    command success. A transport failure marks the controller unavailable
-    and fails the service call.
+    A rejected command is logged and raised as HomeAssistantError so multi-step
+    sequences stop. Availability is restored only by the library reconnect
+    listener, not on command success. A transport failure marks the controller
+    unavailable and fails the service call.
     """
     try:
         yield
@@ -41,7 +41,9 @@ async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
             availability_device.device_uid,
             ex,
         )
-        raise
+        raise HomeAssistantError(
+            f"Controller {availability_device.device_uid} rejected command: {ex}",
+        ) from ex
     except ConnectionError as ex:
         availability_device.set_available(False, ex)
         raise HomeAssistantError(

--- a/homeassistant/components/izone/command.py
+++ b/homeassistant/components/izone/command.py
@@ -4,7 +4,7 @@ from collections.abc import Callable, Coroutine
 import contextlib
 from functools import wraps
 import logging
-from typing import Any, Concatenate, Protocol
+from typing import Any, Concatenate
 
 from pizone import ControllerCommandError
 
@@ -13,19 +13,8 @@ from homeassistant.exceptions import HomeAssistantError
 _LOGGER = logging.getLogger(__name__)
 
 
-class _IzoneAvailabilityDevice(Protocol):
-    @property
-    def device_uid(self) -> str: ...
-
-    def set_available(self, available: bool, ex: Exception | None = None) -> None: ...
-
-
-class _IzoneCommandEntity(Protocol):
-    def _izone_availability_device(self) -> _IzoneAvailabilityDevice: ...
-
-
 @contextlib.asynccontextmanager
-async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
+async def izone_command_context(availability_device: Any):
     """Handle connection and command errors for a pizone controller command.
 
     A rejected command is logged and raised as HomeAssistantError so multi-step
@@ -51,13 +40,13 @@ async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
         ) from ex
 
 
-def send_izone_command[_EntityT: _IzoneCommandEntity, **_P](
+def send_izone_command[_EntityT, **_P](
     func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]],
 ) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
     """Wrap an entity command to handle pizone connection and command errors."""
 
     @wraps(func)
-    async def handler(self: _EntityT, *args: _P.args, **kwargs: _P.kwargs) -> None:
+    async def handler(self: Any, *args: _P.args, **kwargs: _P.kwargs) -> None:
         async with izone_command_context(self._izone_availability_device()):
             await func(self, *args, **kwargs)
 

--- a/homeassistant/components/izone/command.py
+++ b/homeassistant/components/izone/command.py
@@ -8,6 +8,8 @@ from typing import Any, Concatenate, Protocol
 
 from pizone import ControllerCommandError
 
+from homeassistant.exceptions import HomeAssistantError
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -28,7 +30,8 @@ async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
 
     A rejected command is logged and re-raised so multi-step sequences stop.
     Availability is restored only by the library reconnect listener, not on
-    command success. A transport failure marks the controller unavailable.
+    command success. A transport failure marks the controller unavailable
+    and fails the service call.
     """
     try:
         yield
@@ -41,6 +44,9 @@ async def izone_command_context(availability_device: _IzoneAvailabilityDevice):
         raise
     except ConnectionError as ex:
         availability_device.set_available(False, ex)
+        raise HomeAssistantError(
+            f"Unable to connect to controller {availability_device.device_uid}",
+        ) from ex
 
 
 def send_izone_command[_EntityT: _IzoneCommandEntity, **_P](

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -47,6 +47,8 @@ def create_mock_controller(
     zone_ctrl: int = 1,
     ras_mode: str = "master",
     free_air_enabled: bool = False,
+    free_air: bool = False,
+    is_on: bool = True,
 ) -> Mock:
     """Create a mock Controller with configurable parameters."""
     controller = Mock(spec=Controller)
@@ -57,8 +59,8 @@ def create_mock_controller(
     controller.zone_ctrl = zone_ctrl
     controller.ras_mode = ras_mode
     controller.free_air_enabled = free_air_enabled
-    controller.free_air = False
-    controller.is_on = True
+    controller.free_air = free_air
+    controller.is_on = is_on
     controller.mode = Controller.Mode.COOL
     controller.temp_setpoint = 24.0
     controller.temp_return = 22.0

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -466,66 +466,170 @@ async def test_zone_command_error_handling(
     ) is expect_unavailable
 
 
-@pytest.mark.parametrize(
-    ("mock_controller", "start_unavailable"),
-    [
-        pytest.param(
-            create_mock_controller(
-                free_air_enabled=True,
-                free_air=True,
-                is_on=True,
-                zone_ctrl=1,
-                zones_total=1,
-            ),
-            False,
-            id="stays_available",
-        ),
-        pytest.param(
-            create_mock_controller(
-                free_air_enabled=True,
-                free_air=True,
-                is_on=True,
-                zone_ctrl=1,
-                zones_total=1,
-            ),
-            True,
-            id="stays_unavailable",
-        ),
-    ],
+FREE_AIR_CONTROLLER = create_mock_controller(
+    free_air_enabled=True,
+    free_air=True,
+    zone_ctrl=1,
+    zones_total=1,
 )
-async def test_set_hvac_mode_free_air_noop_does_not_change_availability(
+
+
+@pytest.mark.parametrize(
+    "mock_controller",
+    [FREE_AIR_CONTROLLER],
+)
+async def test_set_hvac_mode_free_air_noop_when_on(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_discovery: AsyncMock,
     mock_controller: AsyncMock,
-    start_unavailable: bool,
 ) -> None:
-    """Free-air early return does not send a command or flip availability."""
+    """Free-air fan_only does not send commands when the system is already on."""
     await setup_integration(hass, mock_config_entry)
     await setup_controller(hass, mock_discovery, mock_controller)
 
-    entity_id = CONTROLLER_ENTITY_ID
-    if start_unavailable:
-        mock_controller.set_fan = AsyncMock(side_effect=ConnectionError("disconnected"))
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_FAN_MODE,
-            {"entity_id": entity_id, ATTR_FAN_MODE: FAN_LOW},
-            blocking=True,
-        )
-        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
-
-    expected_state = hass.states.get(entity_id).state
     mock_controller.set_mode = AsyncMock()
     mock_controller.set_on = AsyncMock()
 
     await hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_HVAC_MODE,
-        {"entity_id": entity_id, ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
+        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
         blocking=True,
     )
 
     mock_controller.set_mode.assert_not_called()
     mock_controller.set_on.assert_not_called()
-    assert hass.states.get(entity_id).state == expected_state
+
+
+@pytest.mark.parametrize(
+    "mock_controller",
+    [FREE_AIR_CONTROLLER],
+)
+async def test_set_hvac_mode_free_air_noop_when_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Free-air fan_only invoked directly does not restore availability."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    mock_controller.set_fan = AsyncMock(side_effect=ConnectionError("disconnected"))
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
+        blocking=True,
+    )
+    assert hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
+
+    mock_controller.set_mode = AsyncMock()
+    mock_controller.set_on = AsyncMock()
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity(CONTROLLER_ENTITY_ID)
+    await entity.async_set_hvac_mode(HVACMode.FAN_ONLY)
+
+    mock_controller.set_mode.assert_not_called()
+    mock_controller.set_on.assert_not_called()
+    assert hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            free_air_enabled=True,
+            free_air=True,
+            is_on=False,
+            zone_ctrl=1,
+            zones_total=1,
+        ),
+    ],
+)
+async def test_set_hvac_mode_free_air_turns_on_when_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Free-air fan_only turns the system on before skipping the mode change."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    mock_controller.set_on = AsyncMock()
+    mock_controller.set_mode = AsyncMock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
+        blocking=True,
+    )
+
+    mock_controller.set_on.assert_called_once_with(True)
+    mock_controller.set_mode.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "mock_controller",
+    [FREE_AIR_CONTROLLER],
+)
+async def test_set_hvac_mode_off_while_free_air(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """Off is sent before the free-air early return."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    mock_controller.set_on = AsyncMock()
+    mock_controller.set_mode = AsyncMock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.OFF},
+        blocking=True,
+    )
+
+    mock_controller.set_on.assert_called_once_with(False)
+    mock_controller.set_mode.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "mock_controller",
+    [
+        create_mock_controller(
+            is_on=False,
+            zone_ctrl=1,
+            zones_total=1,
+        ),
+    ],
+)
+async def test_set_hvac_mode_connection_error_on_turn_on_skips_set_mode(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+) -> None:
+    """A transport failure turning on does not continue to set_mode."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    mock_controller.set_on = AsyncMock(side_effect=ConnectionError("disconnected"))
+    mock_controller.set_mode = AsyncMock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.COOL},
+        blocking=True,
+    )
+
+    mock_controller.set_on.assert_called_once_with(True)
+    mock_controller.set_mode.assert_not_called()
+    assert hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -370,7 +370,7 @@ async def test_controller_device_init_fault_bootstrap(
         pytest.param(
             ControllerCommandError("rejected"),
             False,
-            ControllerCommandError,
+            HomeAssistantError,
             id="command_error_stays_available",
         ),
         pytest.param(
@@ -390,7 +390,7 @@ async def test_controller_command_error_handling(
     expect_unavailable: bool,
     expected_exception: type[Exception],
 ) -> None:
-    """A rejected command is re-raised; a transport failure clears availability."""
+    """Rejected and transport failures raise HomeAssistantError; only transport clears availability."""
     await setup_integration(hass, mock_config_entry)
     await setup_controller(hass, mock_discovery, mock_controller)
 
@@ -415,7 +415,7 @@ async def test_controller_command_error_handling(
         pytest.param(
             ControllerCommandError("rejected"),
             False,
-            ControllerCommandError,
+            HomeAssistantError,
             id="command_error_stays_available",
         ),
         pytest.param(
@@ -436,7 +436,7 @@ async def test_zone_command_error_handling(
     expect_unavailable: bool,
     expected_exception: type[Exception],
 ) -> None:
-    """Zone command errors update the owning controller's availability."""
+    """Zone command errors raise HomeAssistantError; only transport clears availability."""
     await setup_integration(hass, mock_config_entry)
     await setup_controller(hass, mock_discovery, mock_controller)
 

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -8,10 +8,13 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.climate import (
     ATTR_FAN_MODE,
+    ATTR_HVAC_MODE,
     DOMAIN as CLIMATE_DOMAIN,
     FAN_LOW,
     SERVICE_SET_FAN_MODE,
+    SERVICE_SET_HVAC_MODE,
     ClimateEntityFeature,
+    HVACMode,
 )
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -22,6 +25,9 @@ from . import setup_controller, setup_integration
 from .conftest import create_mock_controller, create_mock_zone
 
 from tests.common import MockConfigEntry, snapshot_platform
+
+CONTROLLER_ENTITY_ID = "climate.izone_controller_000000001"
+ZONE_ENTITY_ID = "climate.living_room"
 
 
 async def test_basic_controller_properties(
@@ -358,16 +364,18 @@ async def test_controller_device_init_fault_bootstrap(
 
 
 @pytest.mark.parametrize(
-    ("command_error", "expect_unavailable"),
+    ("command_error", "expect_unavailable", "expect_raise"),
     [
         pytest.param(
             ControllerCommandError("rejected"),
             False,
+            True,
             id="command_error_stays_available",
         ),
         pytest.param(
             ConnectionError("disconnected"),
             True,
+            False,
             id="connection_error_marks_unavailable",
         ),
     ],
@@ -379,21 +387,145 @@ async def test_controller_command_error_handling(
     mock_controller: AsyncMock,
     command_error: Exception,
     expect_unavailable: bool,
+    expect_raise: bool,
 ) -> None:
-    """A rejected command keeps availability; a transport failure clears it."""
+    """A rejected command is re-raised; a transport failure clears availability."""
     await setup_integration(hass, mock_config_entry)
     await setup_controller(hass, mock_discovery, mock_controller)
 
-    entity_id = "climate.izone_controller_000000001"
-    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+    assert hass.states.get(CONTROLLER_ENTITY_ID).state != STATE_UNAVAILABLE
 
     mock_controller.set_fan = AsyncMock(side_effect=command_error)
-    await hass.services.async_call(
+    service_call = hass.services.async_call(
         CLIMATE_DOMAIN,
         SERVICE_SET_FAN_MODE,
-        {"entity_id": entity_id, ATTR_FAN_MODE: FAN_LOW},
+        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
+        blocking=True,
+    )
+    if expect_raise:
+        with pytest.raises(ControllerCommandError):
+            await service_call
+    else:
+        await service_call
+
+    is_unavailable = hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
+    assert is_unavailable is expect_unavailable
+
+
+@pytest.mark.parametrize(
+    ("command_error", "expect_unavailable", "expect_raise"),
+    [
+        pytest.param(
+            ControllerCommandError("rejected"),
+            False,
+            True,
+            id="command_error_stays_available",
+        ),
+        pytest.param(
+            ConnectionError("disconnected"),
+            True,
+            False,
+            id="connection_error_marks_unavailable",
+        ),
+    ],
+)
+async def test_zone_command_error_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    mock_zones: list[AsyncMock],
+    command_error: Exception,
+    expect_unavailable: bool,
+    expect_raise: bool,
+) -> None:
+    """Zone command errors update the owning controller's availability."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    assert hass.states.get(CONTROLLER_ENTITY_ID).state != STATE_UNAVAILABLE
+    assert hass.states.get(ZONE_ENTITY_ID) is not None
+
+    mock_zones[0].set_mode = AsyncMock(side_effect=command_error)
+    service_call = hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": ZONE_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.OFF},
+        blocking=True,
+    )
+    if expect_raise:
+        with pytest.raises(ControllerCommandError):
+            await service_call
+    else:
+        await service_call
+
+    is_unavailable = hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
+    assert is_unavailable is expect_unavailable
+    assert (
+        hass.states.get(ZONE_ENTITY_ID).state == STATE_UNAVAILABLE
+    ) is expect_unavailable
+
+
+@pytest.mark.parametrize(
+    ("mock_controller", "start_unavailable"),
+    [
+        pytest.param(
+            create_mock_controller(
+                free_air_enabled=True,
+                free_air=True,
+                is_on=True,
+                zone_ctrl=1,
+                zones_total=1,
+            ),
+            False,
+            id="stays_available",
+        ),
+        pytest.param(
+            create_mock_controller(
+                free_air_enabled=True,
+                free_air=True,
+                is_on=True,
+                zone_ctrl=1,
+                zones_total=1,
+            ),
+            True,
+            id="stays_unavailable",
+        ),
+    ],
+)
+async def test_set_hvac_mode_free_air_noop_does_not_change_availability(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    start_unavailable: bool,
+) -> None:
+    """Free-air early return does not send a command or flip availability."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = CONTROLLER_ENTITY_ID
+    if start_unavailable:
+        mock_controller.set_fan = AsyncMock(side_effect=ConnectionError("disconnected"))
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {"entity_id": entity_id, ATTR_FAN_MODE: FAN_LOW},
+            blocking=True,
+        )
+        assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
+
+    expected_state = hass.states.get(entity_id).state
+    mock_controller.set_mode = AsyncMock()
+    mock_controller.set_on = AsyncMock()
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {"entity_id": entity_id, ATTR_HVAC_MODE: HVACMode.FAN_ONLY},
         blocking=True,
     )
 
-    is_unavailable = hass.states.get(entity_id).state == STATE_UNAVAILABLE
-    assert is_unavailable is expect_unavailable
+    mock_controller.set_mode.assert_not_called()
+    mock_controller.set_on.assert_not_called()
+    assert hass.states.get(entity_id).state == expected_state

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -18,6 +18,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
 
@@ -364,18 +365,18 @@ async def test_controller_device_init_fault_bootstrap(
 
 
 @pytest.mark.parametrize(
-    ("command_error", "expect_unavailable", "expect_raise"),
+    ("command_error", "expect_unavailable", "expected_exception"),
     [
         pytest.param(
             ControllerCommandError("rejected"),
             False,
-            True,
+            ControllerCommandError,
             id="command_error_stays_available",
         ),
         pytest.param(
             ConnectionError("disconnected"),
             True,
-            False,
+            HomeAssistantError,
             id="connection_error_marks_unavailable",
         ),
     ],
@@ -387,7 +388,7 @@ async def test_controller_command_error_handling(
     mock_controller: AsyncMock,
     command_error: Exception,
     expect_unavailable: bool,
-    expect_raise: bool,
+    expected_exception: type[Exception],
 ) -> None:
     """A rejected command is re-raised; a transport failure clears availability."""
     await setup_integration(hass, mock_config_entry)
@@ -396,35 +397,31 @@ async def test_controller_command_error_handling(
     assert hass.states.get(CONTROLLER_ENTITY_ID).state != STATE_UNAVAILABLE
 
     mock_controller.set_fan = AsyncMock(side_effect=command_error)
-    service_call = hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
-        blocking=True,
-    )
-    if expect_raise:
-        with pytest.raises(ControllerCommandError):
-            await service_call
-    else:
-        await service_call
+    with pytest.raises(expected_exception):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {"entity_id": CONTROLLER_ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
+            blocking=True,
+        )
 
     is_unavailable = hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
     assert is_unavailable is expect_unavailable
 
 
 @pytest.mark.parametrize(
-    ("command_error", "expect_unavailable", "expect_raise"),
+    ("command_error", "expect_unavailable", "expected_exception"),
     [
         pytest.param(
             ControllerCommandError("rejected"),
             False,
-            True,
+            ControllerCommandError,
             id="command_error_stays_available",
         ),
         pytest.param(
             ConnectionError("disconnected"),
             True,
-            False,
+            HomeAssistantError,
             id="connection_error_marks_unavailable",
         ),
     ],
@@ -437,7 +434,7 @@ async def test_zone_command_error_handling(
     mock_zones: list[AsyncMock],
     command_error: Exception,
     expect_unavailable: bool,
-    expect_raise: bool,
+    expected_exception: type[Exception],
 ) -> None:
     """Zone command errors update the owning controller's availability."""
     await setup_integration(hass, mock_config_entry)
@@ -447,17 +444,13 @@ async def test_zone_command_error_handling(
     assert hass.states.get(ZONE_ENTITY_ID) is not None
 
     mock_zones[0].set_mode = AsyncMock(side_effect=command_error)
-    service_call = hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {"entity_id": ZONE_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.OFF},
-        blocking=True,
-    )
-    if expect_raise:
-        with pytest.raises(ControllerCommandError):
-            await service_call
-    else:
-        await service_call
+    with pytest.raises(expected_exception):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {"entity_id": ZONE_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.OFF},
+            blocking=True,
+        )
 
     is_unavailable = hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
     assert is_unavailable is expect_unavailable
@@ -517,12 +510,13 @@ async def test_set_hvac_mode_free_air_noop_when_unavailable(
     await setup_controller(hass, mock_discovery, mock_controller)
 
     mock_controller.set_fan = AsyncMock(side_effect=ConnectionError("disconnected"))
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_FAN_MODE,
-        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {"entity_id": CONTROLLER_ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
+            blocking=True,
+        )
     assert hass.states.get(CONTROLLER_ENTITY_ID).state == STATE_UNAVAILABLE
 
     mock_controller.set_mode = AsyncMock()
@@ -623,12 +617,13 @@ async def test_set_hvac_mode_connection_error_on_turn_on_skips_set_mode(
     mock_controller.set_on = AsyncMock(side_effect=ConnectionError("disconnected"))
     mock_controller.set_mode = AsyncMock()
 
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {"entity_id": CONTROLLER_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.COOL},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {"entity_id": CONTROLLER_ENTITY_ID, ATTR_HVAC_MODE: HVACMode.COOL},
+            blocking=True,
+        )
 
     mock_controller.set_on.assert_called_once_with(True)
     mock_controller.set_mode.assert_not_called()

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -2,10 +2,18 @@
 
 from unittest.mock import AsyncMock, patch
 
+from pizone import ControllerCommandError
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.climate import ClimateEntityFeature
+from homeassistant.components.climate import (
+    ATTR_FAN_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
+    FAN_LOW,
+    SERVICE_SET_FAN_MODE,
+    ClimateEntityFeature,
+)
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
@@ -347,3 +355,45 @@ async def test_controller_device_init_fault_bootstrap(
     device_entry = device_registry.async_get(entity_entry.device_id)
     assert device_entry is not None
     assert device_entry.model == "0"
+
+
+@pytest.mark.parametrize(
+    ("command_error", "expect_unavailable"),
+    [
+        pytest.param(
+            ControllerCommandError("rejected"),
+            False,
+            id="command_error_stays_available",
+        ),
+        pytest.param(
+            ConnectionError("disconnected"),
+            True,
+            id="connection_error_marks_unavailable",
+        ),
+    ],
+)
+async def test_controller_command_error_handling(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_discovery: AsyncMock,
+    mock_controller: AsyncMock,
+    command_error: Exception,
+    expect_unavailable: bool,
+) -> None:
+    """A rejected command keeps availability; a transport failure clears it."""
+    await setup_integration(hass, mock_config_entry)
+    await setup_controller(hass, mock_discovery, mock_controller)
+
+    entity_id = "climate.izone_controller_000000001"
+    assert hass.states.get(entity_id).state != STATE_UNAVAILABLE
+
+    mock_controller.set_fan = AsyncMock(side_effect=command_error)
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {"entity_id": entity_id, ATTR_FAN_MODE: FAN_LOW},
+        blocking=True,
+    )
+
+    is_unavailable = hass.states.get(entity_id).state == STATE_UNAVAILABLE
+    assert is_unavailable is expect_unavailable


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to the python-izone 1.3.4 bump (#176341). Replaces the legacy
`_return_on_connection_error` decorator and `wrap_and_catch` helper with a
dedicated `command.py` module.

- Removes `_return_on_connection_error` from properties and commands.
  python-izone 1.3.4 returns cached data on property reads, so those
  wrappers were dead code.
- Adds `izone_command_context` and `@send_izone_command` for consistent
  command error handling across controller and zone entities.
- `ControllerCommandError` (bridge rejected the command) is logged and
  re-raised; the entity stays available.
- `ConnectionError` (transport failure) marks the controller unavailable
  and raises `HomeAssistantError` so the service call fails.
- Availability is restored only by the pizone reconnect listener, not on
  individual command success.
- `async_set_hvac_mode` uses a single command wrapper so a failed
  power-on does not fall through to `set_mode`, and free-air mode can
  return early without sending commands.

Adds unit tests for controller/zone error handling and HVAC-mode edge
cases (free-air no-op, power-on while off, off in free air, transport
failure stopping before set_mode). Smoke-tested on hardware (commands,
disconnect, reconnect, free-air no-op via tcpdump).

Supersedes the earlier draft in #176367.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr