### PR TITLE
Move get_in_zones_attribute to a shared zone helpers module

### DIFF
--- a/homeassistant/components/zone/condition.py
+++ b/homeassistant/components/zone/condition.py
@@ -43,25 +43,13 @@ from homeassistant.helpers.typing import ConfigType
 
 from . import in_zone
 from .const import DOMAIN
+from .helpers import get_in_zones_attribute
 
 _OPTIONS_SCHEMA_DICT: dict[vol.Marker, Any] = {
     vol.Required(CONF_ENTITY_ID): cv.entity_ids,
     vol.Required("zone"): cv.entity_ids,
 }
 _CONDITION_SCHEMA = vol.Schema({CONF_OPTIONS: _OPTIONS_SCHEMA_DICT})
-
-
-def _get_in_zones_attribute(state: State) -> str | None:
-    """Return the in_zones attribute for the tracked entity, or None.
-
-    Only person and device_tracker entities report zone membership; each
-    exposes it under its own platform enum. Any other domain returns None.
-    """
-    if state.domain == PERSON_DOMAIN:
-        return PersonEntityStateAttribute.IN_ZONES
-    if state.domain == DEVICE_TRACKER_DOMAIN:
-        return DeviceTrackerEntityStateAttribute.IN_ZONES
-    return None
 
 
 def zone(
@@ -101,7 +89,7 @@ def zone(
 
     # Prefer the in_zones attribute reported by the entity (e.g. person,
     # device_tracker) over recomputing membership from coordinates.
-    if (in_zones_attr := _get_in_zones_attribute(entity)) is not None and (
+    if (in_zones_attr := get_in_zones_attribute(entity)) is not None and (
         in_zones := entity.attributes.get(in_zones_attr)
     ) is not None:
         return zone_ent.entity_id in in_zones
@@ -219,7 +207,7 @@ class _ZoneTargetConditionBase(EntityConditionBase):
 
     def _in_target_zone(self, entity_state: State) -> bool:
         """Check if the entity is currently in the selected zone."""
-        if (in_zones_attr := _get_in_zones_attribute(entity_state)) and (
+        if (in_zones_attr := get_in_zones_attribute(entity_state)) and (
             in_zones := entity_state.attributes.get(in_zones_attr)
         ):
             return self._zone in in_zones

--- a/homeassistant/components/zone/helpers.py
+++ b/homeassistant/components/zone/helpers.py
@@ -1,0 +1,24 @@
+"""Helpers for the zone integration."""
+
+from homeassistant.components.device_tracker import (
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
+    DeviceTrackerEntityStateAttribute,
+)
+from homeassistant.components.person import (
+    DOMAIN as PERSON_DOMAIN,
+    PersonEntityStateAttribute,
+)
+from homeassistant.core import State
+
+
+def get_in_zones_attribute(state: State) -> str | None:
+    """Return the in_zones attribute for the tracked entity, or None.
+
+    Only person and device_tracker entities report zone membership; each
+    exposes it under its own platform enum. Any other domain returns None.
+    """
+    if state.domain == PERSON_DOMAIN:
+        return PersonEntityStateAttribute.IN_ZONES
+    if state.domain == DEVICE_TRACKER_DOMAIN:
+        return DeviceTrackerEntityStateAttribute.IN_ZONES
+    return None

--- a/homeassistant/components/zone/trigger.py
+++ b/homeassistant/components/zone/trigger.py
@@ -44,8 +44,8 @@ from homeassistant.helpers.trigger import (
 from homeassistant.helpers.typing import ConfigType
 
 from . import condition
-from .condition import _get_in_zones_attribute
 from .const import DOMAIN
+from .helpers import get_in_zones_attribute
 
 EVENT_ENTER = "enter"
 EVENT_LEAVE = "leave"
@@ -64,7 +64,7 @@ def _state_has_zone_info(state: State) -> bool:
     tracker); other entities are matched by their coordinates.
     """
     return location.has_location(state) or (
-        (in_zones_attr := _get_in_zones_attribute(state)) is not None
+        (in_zones_attr := get_in_zones_attribute(state)) is not None
         and in_zones_attr in state.attributes
     )
 
@@ -199,7 +199,7 @@ class ZoneTriggerBase(EntityTriggerBase):
 
     def _in_target_zone(self, state: State) -> bool:
         """Check if the entity is in the selected zone."""
-        if (in_zones_attr := _get_in_zones_attribute(state)) and (
+        if (in_zones_attr := get_in_zones_attribute(state)) and (
             in_zones := state.attributes.get(in_zones_attr)
         ):
             return self._zone in in_zones


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #175998, which introduced `_get_in_zones_attribute` in the zone condition module to select the `in_zones` state attribute based on the entity domain (person or device_tracker).

The zone trigger consumed it via `from .condition import _get_in_zones_attribute`, importing a private helper across modules. This moves it to a shared `zone/helpers.py` module and makes it public as `get_in_zones_attribute`, so both `condition.py` and `trigger.py` import it from a common place.

Pure refactor: no behaviour change.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
