### PR TITLE
Use EntityStateAttribute enum in NWS

### DIFF
--- a/homeassistant/components/nws/__init__.py
+++ b/homeassistant/components/nws/__init__.py
@@ -9,11 +9,10 @@ from pynws import NwsNoDataError, SimpleNWS, call_with_retry
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
     CONF_API_KEY,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    EntityStateAttribute,
     Platform,
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
@@ -102,8 +101,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NWSConfigEntry) -> bool:
                 translation_key="entity_unavailable",
                 translation_placeholders={"entity_id": location_entity_id},
             )
-        latitude = state.attributes[ATTR_LATITUDE]
-        longitude = state.attributes[ATTR_LONGITUDE]
+        latitude = state.attributes[EntityStateAttribute.LATITUDE]
+        longitude = state.attributes[EntityStateAttribute.LONGITUDE]
         station = None
     else:
         latitude = entry.data[CONF_LATITUDE]
@@ -217,8 +216,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: NWSConfigEntry) -> bool:
             new_state = event.data["new_state"]
             if new_state is None or not has_location(new_state):
                 return
-            new_lat = new_state.attributes[ATTR_LATITUDE]
-            new_lon = new_state.attributes[ATTR_LONGITUDE]
+            new_lat = new_state.attributes[EntityStateAttribute.LATITUDE]
+            new_lon = new_state.attributes[EntityStateAttribute.LONGITUDE]
             if (
                 new_lat == entry.runtime_data.latitude
                 and new_lon == entry.runtime_data.longitude

--- a/homeassistant/components/nws/config_flow.py
+++ b/homeassistant/components/nws/config_flow.py
@@ -9,11 +9,10 @@ import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import (
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
     CONF_API_KEY,
     CONF_LATITUDE,
     CONF_LONGITUDE,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
@@ -134,8 +133,12 @@ class NWSConfigFlow(ConfigFlow, domain=DOMAIN):
                             self.hass,
                             {
                                 CONF_API_KEY: user_input[CONF_API_KEY],
-                                CONF_LATITUDE: state.attributes[ATTR_LATITUDE],
-                                CONF_LONGITUDE: state.attributes[ATTR_LONGITUDE],
+                                CONF_LATITUDE: state.attributes[
+                                    EntityStateAttribute.LATITUDE
+                                ],
+                                CONF_LONGITUDE: state.attributes[
+                                    EntityStateAttribute.LONGITUDE
+                                ],
                             },
                         )
                         return self.async_create_entry(title=location_entity, data=data)

--- a/homeassistant/components/nws/coordinator.py
+++ b/homeassistant/components/nws/coordinator.py
@@ -8,7 +8,7 @@ import aiohttp
 from aiohttp import ClientResponseError
 from pynws import NwsError, NwsNoDataError, SimpleNWS, call_with_retry
 
-from homeassistant.const import ATTR_LATITUDE, ATTR_LONGITUDE, CONF_API_KEY
+from homeassistant.const import CONF_API_KEY, EntityStateAttribute
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import debounce
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -90,8 +90,8 @@ class NWSObservationDataUpdateCoordinator(TimestampDataUpdateCoordinator[None]):
                 self._location_entity_id,
             )
             return
-        new_lat = state.attributes[ATTR_LATITUDE]
-        new_lon = state.attributes[ATTR_LONGITUDE]
+        new_lat = state.attributes[EntityStateAttribute.LATITUDE]
+        new_lon = state.attributes[EntityStateAttribute.LONGITUDE]
         if self._previous_position is not None:
             prev_lat, prev_lon = self._previous_position
             if new_lat == prev_lat and new_lon == prev_lon:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #174633 and #176119, which introduced the base `EntityStateAttribute` enum and moved `latitude`/`longitude` onto it.

NWS reads the coordinates of its configured location entity through the ambiguous `ATTR_LATITUDE` / `ATTR_LONGITUDE` constants. Since `latitude`/`longitude` now live on the base enum, they can be read through it directly, whichever domain the location entity has (the config flow allows person, device_tracker and zone).

This migrates the state-attribute reads in `__init__.py`, `config_flow.py` and `coordinator.py`:

- `latitude` / `longitude` -> `EntityStateAttribute`

The existing `has_location` guards are unchanged.

Replaces the NWS part of #176110, which routed these reads through a new `get_location` helper and therefore depended on that PR. This version has no such dependency and needs no test changes.

No behaviour change: `EntityStateAttribute` is a `StrEnum`, so the resolved keys are identical.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
