### PR TITLE
Add exception translation keys to energieleser 

### DIFF
--- a/homeassistant/components/energieleser/coordinator.py
+++ b/homeassistant/components/energieleser/coordinator.py
@@ -52,14 +52,29 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
             device = await self.client.get_device()
         except EnergieleserUnknownDeviceError as err:
             raise UpdateFailed(
-                f"Unknown or unsupported device type for {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="unknown_device",
+                translation_placeholders={
+                    "device_id": self.device_id,
+                    "error": str(err),
+                },
             ) from err
         except EnergieleserConnectionError as err:
             raise UpdateFailed(
-                f"Cannot connect to energieleser device {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="connection_error",
+                translation_placeholders={
+                    "device_id": self.device_id,
+                    "error": str(err),
+                },
             ) from err
         except EnergieleserError as err:
             raise UpdateFailed(
-                f"Error communicating with energieleser device {self.device_id}: {err}"
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={
+                    "device_id": self.device_id,
+                    "error": str(err),
+                },
             ) from err
         return device

--- a/homeassistant/components/energieleser/coordinator.py
+++ b/homeassistant/components/energieleser/coordinator.py
@@ -56,7 +56,6 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
                 translation_key="unknown_device",
                 translation_placeholders={
                     "device_id": self.device_id,
-                    "error": str(err),
                 },
             ) from err
         except EnergieleserConnectionError as err:
@@ -65,7 +64,6 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
                 translation_key="connection_error",
                 translation_placeholders={
                     "device_id": self.device_id,
-                    "error": str(err),
                 },
             ) from err
         except EnergieleserError as err:
@@ -74,7 +72,6 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
                 translation_key="communication_error",
                 translation_placeholders={
                     "device_id": self.device_id,
-                    "error": str(err),
                 },
             ) from err
         return device

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -66,7 +66,7 @@ rules:
   entity-device-class: done
   entity-disabled-by-default: done
   entity-translations: done
-  exception-translations: todo
+  exception-translations: done
   icon-translations: todo
   reconfiguration-flow: done
   repair-issues: todo

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -92,5 +92,16 @@
         "name": "Water today"
       }
     }
+  },
+  "exceptions": {
+    "communication_error": {
+      "message": "An error occurred while communicating with the device {device_id}: {error}"
+    },
+    "connection_error": {
+      "message": "An error occurred while connecting to the device {device_id}: {error}"
+    },
+    "unknown_device": {
+      "message": "The device type for {device_id} is unknown or unsupported: {error}"
+    }
   }
 }

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -95,13 +95,13 @@
   },
   "exceptions": {
     "communication_error": {
-      "message": "An error occurred while communicating with the device {device_id}: {error}"
+      "message": "An error occurred while communicating with the device {device_id}"
     },
     "connection_error": {
-      "message": "An error occurred while connecting to the device {device_id}: {error}"
+      "message": "An error occurred while connecting to the device {device_id}"
     },
     "unknown_device": {
-      "message": "The device type for {device_id} is unknown or unsupported: {error}"
+      "message": "The device type for {device_id} is unknown or unsupported"
     }
   }
 }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds exception translation keys to energieleser

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr