### PR TITLE
Restore KNX date, datetime, time, number, text and select states

### DIFF
--- a/homeassistant/components/knx/date.py
+++ b/homeassistant/components/knx/date.py
@@ -79,10 +79,8 @@ class _KNXDate(DateEntity, RestoreEntity):
         """Restore last state."""
         await super().async_added_to_hass()
         if (
-            not self._device.remote_value.readable
-            and (last_state := await self.async_get_last_state()) is not None
-            and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-        ):
+            last_state := await self.async_get_last_state()
+        ) is not None and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._device.remote_value.value = XKNXDate.from_date(
                 dt_date.fromisoformat(last_state.state)
             )

--- a/homeassistant/components/knx/datetime.py
+++ b/homeassistant/components/knx/datetime.py
@@ -80,10 +80,8 @@ class _KNXDateTime(DateTimeEntity, RestoreEntity):
         """Restore last state."""
         await super().async_added_to_hass()
         if (
-            not self._device.remote_value.readable
-            and (last_state := await self.async_get_last_state()) is not None
-            and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-        ):
+            last_state := await self.async_get_last_state()
+        ) is not None and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._device.remote_value.value = XKNXDateTime.from_datetime(
                 datetime.fromisoformat(last_state.state).astimezone(
                     dt_util.get_default_time_zone()

--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -82,10 +82,8 @@ class _KnxNumber(RestoreNumber):
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()
-        if (
-            not self._device.sensor_value.readable
-            and (last_state := await self.async_get_last_state())
-            and (last_number_data := await self.async_get_last_number_data())
+        if (last_state := await self.async_get_last_state()) and (
+            last_number_data := await self.async_get_last_number_data()
         ):
             if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._device.sensor_value.value = last_number_data.native_value

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -83,9 +83,7 @@ class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()
-        if not self._device.remote_value.readable and (
-            last_state := await self.async_get_last_state()
-        ):
+        if last_state := await self.async_get_last_state():
             if (
                 last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
                 and (option := self._option_payloads.get(last_state.state)) is not None

--- a/homeassistant/components/knx/text.py
+++ b/homeassistant/components/knx/text.py
@@ -81,9 +81,7 @@ class _KnxText(TextEntity, RestoreEntity):
     async def async_added_to_hass(self) -> None:
         """Restore last state."""
         await super().async_added_to_hass()
-        if not self._device.remote_value.readable and (
-            last_state := await self.async_get_last_state()
-        ):
+        if last_state := await self.async_get_last_state():
             if last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                 self._device.remote_value.value = last_state.state
 

--- a/homeassistant/components/knx/time.py
+++ b/homeassistant/components/knx/time.py
@@ -79,10 +79,8 @@ class _KNXTime(TimeEntity, RestoreEntity):
         """Restore last state."""
         await super().async_added_to_hass()
         if (
-            not self._device.remote_value.readable
-            and (last_state := await self.async_get_last_state()) is not None
-            and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-        ):
+            last_state := await self.async_get_last_state()
+        ) is not None and last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             self._device.remote_value.value = XknxTime.from_time(
                 dt_time.fromisoformat(last_state.state)
             )

--- a/tests/components/knx/test_date.py
+++ b/tests/components/knx/test_date.py
@@ -5,7 +5,11 @@ from homeassistant.components.date import (
     DOMAIN as DATE_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.components.knx.const import CONF_RESPOND_TO_READ, KNX_ADDRESS
+from homeassistant.components.knx.const import (
+    CONF_RESPOND_TO_READ,
+    CONF_STATE_ADDRESS,
+    KNX_ADDRESS,
+)
 from homeassistant.components.knx.schema import DateSchema
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, State
@@ -88,6 +92,33 @@ async def test_date_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) ->
         test_passive_address,
         (0x18, 0x02, 0x18),
     )
+    state = hass.states.get("date.test")
+    assert state.state == "2024-02-24"
+
+
+async def test_date_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX date with state_address restores state until bus read completes."""
+    test_address = "1/1/1"
+    test_state_address = "2/2/2"
+    fake_state = State("date.test", "2023-07-24")
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            DateSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: test_address,
+                CONF_STATE_ADDRESS: test_state_address,
+            }
+        }
+    )
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(test_state_address)
+    state = hass.states.get("date.test")
+    assert state.state == "2023-07-24"
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_response(test_state_address, (0x18, 0x02, 0x18))
     state = hass.states.get("date.test")
     assert state.state == "2024-02-24"
 

--- a/tests/components/knx/test_datetime.py
+++ b/tests/components/knx/test_datetime.py
@@ -5,7 +5,11 @@ from homeassistant.components.datetime import (
     DOMAIN as DATETIME_DOMAIN,
     SERVICE_SET_VALUE,
 )
-from homeassistant.components.knx.const import CONF_RESPOND_TO_READ, KNX_ADDRESS
+from homeassistant.components.knx.const import (
+    CONF_RESPOND_TO_READ,
+    CONF_STATE_ADDRESS,
+    KNX_ADDRESS,
+)
 from homeassistant.components.knx.schema import DateTimeSchema
 from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant, State
@@ -91,6 +95,36 @@ async def test_date_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) ->
     await knx.receive_write(
         test_passive_address,
         (0x78, 0x01, 0x01, 0x73, 0x04, 0x05, 0x20, 0x80),
+    )
+    state = hass.states.get("datetime.test")
+    assert state.state == "2020-01-01T18:04:05+00:00"
+
+
+async def test_datetime_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX datetime with state_address restores state until bus read completes."""
+    await hass.config.async_set_time_zone("Europe/Vienna")
+    test_address = "1/1/1"
+    test_state_address = "2/2/2"
+    fake_state = State("datetime.test", "2022-03-03T03:04:05+00:00")
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            DateTimeSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: test_address,
+                CONF_STATE_ADDRESS: test_state_address,
+            }
+        }
+    )
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(test_state_address)
+    state = hass.states.get("datetime.test")
+    assert state.state == "2022-03-03T03:04:05+00:00"
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_response(
+        test_state_address, (0x78, 0x01, 0x01, 0x73, 0x04, 0x05, 0x20, 0x80)
     )
     state = hass.states.get("datetime.test")
     assert state.state == "2020-01-01T18:04:05+00:00"

--- a/tests/components/knx/test_number.py
+++ b/tests/components/knx/test_number.py
@@ -5,7 +5,11 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.knx.const import CONF_RESPOND_TO_READ, KNX_ADDRESS
+from homeassistant.components.knx.const import (
+    CONF_RESPOND_TO_READ,
+    CONF_STATE_ADDRESS,
+    KNX_ADDRESS,
+)
 from homeassistant.components.knx.schema import NumberSchema
 from homeassistant.const import CONF_NAME, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant, State
@@ -108,6 +112,43 @@ async def test_number_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) 
 
     # update from KNX passive address
     await knx.receive_write(test_passive_address, (0x4E, 0xDE))
+    state = hass.states.get("number.test")
+    assert state.state == "9000.96"
+
+
+async def test_number_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX number with state_address restores state until bus read completes."""
+    test_address = "1/1/1"
+    test_state_address = "2/2/2"
+
+    RESTORE_DATA = {
+        "native_max_value": None,  # Ignored by KNX number
+        "native_min_value": None,  # Ignored by KNX number
+        "native_step": None,  # Ignored by KNX number
+        "native_unit_of_measurement": None,  # Ignored by KNX number
+        "native_value": 160.0,
+    }
+    mock_restore_cache_with_extra_data(
+        hass, ((State("number.test", "abc"), RESTORE_DATA),)
+    )
+
+    await knx.setup_integration(
+        {
+            NumberSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: test_address,
+                CONF_STATE_ADDRESS: test_state_address,
+                CONF_TYPE: "illuminance",
+            }
+        }
+    )
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(test_state_address)
+    state = hass.states.get("number.test")
+    assert state.state == "160.0"
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_response(test_state_address, (0x4E, 0xDE))
     state = hass.states.get("number.test")
     assert state.state == "9000.96"
 

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -125,6 +125,40 @@ async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit) -> Non
     await knx.assert_no_telegram()
 
 
+async def test_select_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX select with state_address restores state until bus read completes."""
+    _options = [
+        {CONF_PAYLOAD: 0b00, SelectSchema.CONF_OPTION: "No control"},
+        {CONF_PAYLOAD: 0b10, SelectSchema.CONF_OPTION: "Control - Off"},
+        {CONF_PAYLOAD: 0b11, SelectSchema.CONF_OPTION: "Control - On"},
+    ]
+    test_address = "1/1/1"
+    test_state_address = "2/2/2"
+    fake_state = State("select.test", "Control - On")
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            SelectSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: test_address,
+                CONF_STATE_ADDRESS: test_state_address,
+                CONF_PAYLOAD_LENGTH: 0,
+                SelectSchema.CONF_OPTIONS: _options,
+            }
+        }
+    )
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(test_state_address)
+    state = hass.states.get("select.test")
+    assert state.state == "Control - On"
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_response(test_state_address, 0b10)
+    state = hass.states.get("select.test")
+    assert state.state == "Control - Off"
+
+
 async def test_select_dpt_20_103_all_options(
     hass: HomeAssistant, knx: KNXTestKit
 ) -> None:

--- a/tests/components/knx/test_text.py
+++ b/tests/components/knx/test_text.py
@@ -1,6 +1,10 @@
 """Test KNX number."""
 
-from homeassistant.components.knx.const import CONF_RESPOND_TO_READ, KNX_ADDRESS
+from homeassistant.components.knx.const import (
+    CONF_RESPOND_TO_READ,
+    CONF_STATE_ADDRESS,
+    KNX_ADDRESS,
+)
 from homeassistant.components.knx.schema import TextSchema
 from homeassistant.components.text import TextMode
 from homeassistant.const import CONF_NAME, Platform
@@ -97,6 +101,36 @@ async def test_text_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) ->
     # update from KNX passive address
     await knx.receive_write(
         test_passive_address,
+        (0x68, 0x61, 0x6C, 0x6C, 0x6F, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0),
+    )
+    state = hass.states.get("text.test")
+    assert state.state == "hallo"
+
+
+async def test_text_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX text with state_address restores state until bus read completes."""
+    test_address = "1/1/1"
+    test_state_address = "2/2/2"
+    fake_state = State("text.test", "test test")
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            TextSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: test_address,
+                CONF_STATE_ADDRESS: test_state_address,
+            }
+        }
+    )
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(test_state_address)
+    state = hass.states.get("text.test")
+    assert state.state == "test test"
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_response(
+        test_state_address,
         (0x68, 0x61, 0x6C, 0x6C, 0x6F, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0),
     )
     state = hass.states.get("text.test")

--- a/tests/components/knx/test_time.py
+++ b/tests/components/knx/test_time.py
@@ -1,6 +1,10 @@
 """Test KNX time."""
 
-from homeassistant.components.knx.const import CONF_RESPOND_TO_READ, KNX_ADDRESS
+from homeassistant.components.knx.const import (
+    CONF_RESPOND_TO_READ,
+    CONF_STATE_ADDRESS,
+    KNX_ADDRESS,
+)
 from homeassistant.components.knx.schema import TimeSchema
 from homeassistant.components.time import (
     ATTR_TIME,
@@ -88,6 +92,33 @@ async def test_time_restore_and_respond(hass: HomeAssistant, knx: KNXTestKit) ->
         test_passive_address,
         (0x0C, 0x00, 0x00),
     )
+    state = hass.states.get("time.test")
+    assert state.state == "12:00:00"
+
+
+async def test_time_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test KNX time with state_address restores state until bus read completes."""
+    test_address = "1/1/1"
+    test_state_address = "2/2/2"
+    fake_state = State("time.test", "01:02:03")
+    mock_restore_cache(hass, (fake_state,))
+
+    await knx.setup_integration(
+        {
+            TimeSchema.PLATFORM: {
+                CONF_NAME: "test",
+                KNX_ADDRESS: test_address,
+                CONF_STATE_ADDRESS: test_state_address,
+            }
+        }
+    )
+    # StateUpdater initialize state - restored value is used before response is received
+    await knx.assert_read(test_state_address)
+    state = hass.states.get("time.test")
+    assert state.state == "01:02:03"
+
+    # bus reports a different value than restored - state updates to the real value
+    await knx.receive_response(test_state_address, (0x0C, 0x00, 0x00))
     state = hass.states.get("time.test")
     assert state.state == "12:00:00"
 


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Follow-up to #176352, which made the KNX `switch` platform restore its last
known state unconditionally so that a switch with a configured `state_address`
no longer reports a wrong/`unknown` value in the window between startup and the
first `GroupValueRead` response from the bus.

The same pattern applies to the other KNX platforms that, until now, only
restored their state when **no** state address was configured (guarded by
`not self._device.<remote>.readable`). With a state address configured, these
entities showed `unknown` (or, for `number`, the initialization default) for as
long as it takes the initial bus read to complete after a restart.

This PR removes that guard for the following platforms so the last known state
is restored unconditionally and used to bridge the gap until the initial bus
read response arrives:

- `date`
- `datetime`
- `time`
- `number`
- `text`
- `select`

`binary_sensor` and `sensor` already restore unconditionally, and `switch` was
handled in #176352. No entity property changes are needed: these platforms
already return `None` (mapped to `unknown`) when their value is unset, and
`number` is never `None`. The restore setters only set the internal value and
do not send to the bus, so the `StateUpdater`'s initial read still fires as
before.

A focused test was added per platform verifying that, with a `state_address`
configured, the restored value is shown after the read telegram is issued but
before the response, and that a differing bus response then updates the entity.

cc @pos-ei-don 

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176352
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46836
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
