### PR TITLE
Filter Roborock A01 query protocols by supported schema

### DIFF
--- a/homeassistant/components/roborock/coordinator.py
+++ b/homeassistant/components/roborock/coordinator.py
@@ -490,6 +490,26 @@ class RoborockDataUpdateCoordinatorA01[
         return self._device
 
 
+ZEO_REQUEST_PROTOCOLS = [
+    RoborockZeoProtocol.STATE,
+    RoborockZeoProtocol.COUNTDOWN,
+    RoborockZeoProtocol.WASHING_LEFT,
+    RoborockZeoProtocol.ERROR,
+    RoborockZeoProtocol.TIMES_AFTER_CLEAN,
+    RoborockZeoProtocol.DETERGENT_EMPTY,
+    RoborockZeoProtocol.SOFTENER_EMPTY,
+    RoborockZeoProtocol.DETERGENT_TYPE,
+    RoborockZeoProtocol.SOFTENER_TYPE,
+    RoborockZeoProtocol.MODE,
+    RoborockZeoProtocol.PROGRAM,
+    RoborockZeoProtocol.TEMP,
+    RoborockZeoProtocol.RINSE_TIMES,
+    RoborockZeoProtocol.SPIN_LEVEL,
+    RoborockZeoProtocol.DRYING_MODE,
+    RoborockZeoProtocol.SOUND_SET,
+]
+
+
 class RoborockWashingMachineUpdateCoordinator(
     RoborockDataUpdateCoordinatorA01[RoborockZeoProtocol]
 ):
@@ -505,25 +525,11 @@ class RoborockWashingMachineUpdateCoordinator(
         """Initialize."""
         super().__init__(hass, config_entry, device)
         self.api = api
-        self.request_protocols: list[RoborockZeoProtocol] = []
-        # This currently only supports the washing machine protocols
+        supported_schema_ids = device.product.supported_schema_ids
         self.request_protocols = [
-            RoborockZeoProtocol.STATE,
-            RoborockZeoProtocol.COUNTDOWN,
-            RoborockZeoProtocol.WASHING_LEFT,
-            RoborockZeoProtocol.ERROR,
-            RoborockZeoProtocol.TIMES_AFTER_CLEAN,
-            RoborockZeoProtocol.DETERGENT_EMPTY,
-            RoborockZeoProtocol.SOFTENER_EMPTY,
-            RoborockZeoProtocol.DETERGENT_TYPE,
-            RoborockZeoProtocol.SOFTENER_TYPE,
-            RoborockZeoProtocol.MODE,
-            RoborockZeoProtocol.PROGRAM,
-            RoborockZeoProtocol.TEMP,
-            RoborockZeoProtocol.RINSE_TIMES,
-            RoborockZeoProtocol.SPIN_LEVEL,
-            RoborockZeoProtocol.DRYING_MODE,
-            RoborockZeoProtocol.SOUND_SET,
+            protocol
+            for protocol in ZEO_REQUEST_PROTOCOLS
+            if not supported_schema_ids or protocol in supported_schema_ids
         ]
 
     @override
@@ -538,6 +544,16 @@ class RoborockWashingMachineUpdateCoordinator(
                 translation_domain=DOMAIN,
                 translation_key="update_data_fail",
             ) from ex
+
+
+DYAD_REQUEST_PROTOCOLS = [
+    RoborockDyadDataProtocol.STATUS,
+    RoborockDyadDataProtocol.POWER,
+    RoborockDyadDataProtocol.MESH_LEFT,
+    RoborockDyadDataProtocol.BRUSH_LEFT,
+    RoborockDyadDataProtocol.ERROR,
+    RoborockDyadDataProtocol.TOTAL_RUN_TIME,
+]
 
 
 class RoborockWetDryVacUpdateCoordinator(
@@ -555,14 +571,11 @@ class RoborockWetDryVacUpdateCoordinator(
         """Initialize."""
         super().__init__(hass, config_entry, device)
         self.api = api
-        # This currenltly only supports the WetDryVac protocols
-        self.request_protocols: list[RoborockDyadDataProtocol] = [
-            RoborockDyadDataProtocol.STATUS,
-            RoborockDyadDataProtocol.POWER,
-            RoborockDyadDataProtocol.MESH_LEFT,
-            RoborockDyadDataProtocol.BRUSH_LEFT,
-            RoborockDyadDataProtocol.ERROR,
-            RoborockDyadDataProtocol.TOTAL_RUN_TIME,
+        supported_schema_ids = device.product.supported_schema_ids
+        self.request_protocols = [
+            protocol
+            for protocol in DYAD_REQUEST_PROTOCOLS
+            if not supported_schema_ids or protocol in supported_schema_ids
         ]
 
     @override

--- a/tests/components/roborock/test_binary_sensor.py
+++ b/tests/components/roborock/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Test Roborock Binary Sensor."""
 
+import copy
 from typing import Any
 
 import pytest
@@ -76,3 +77,48 @@ async def test_binary_sensors_coordinator_state(
     state = hass.states.get("binary_sensor.zeo_one_detergent")
     assert state is not None
     assert state.state == expected_state
+
+
+@pytest.mark.parametrize("platforms", [[Platform.BINARY_SENSOR]])
+async def test_zeo_request_protocols_filtered_by_schema(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test that Zeo request protocols are filtered by the device's supported schema IDs, ensuring correct entities are created."""
+    # Find the first Zeo device
+    zeo_device_1 = next(
+        (device for device in fake_devices if device.zeo is not None),
+        None,
+    )
+    assert zeo_device_1 is not None
+
+    # Create a second Zeo device without softener in its schema
+    zeo_device_2 = copy.deepcopy(zeo_device_1)
+    zeo_device_2.device_info.duid = "zeo_duid_2"
+    zeo_device_2._duid = "zeo_duid_2"
+    zeo_device_2.device_info.name = "Zeo Two"
+    zeo_device_2._name = "Zeo Two"
+    zeo_device_2.device_info.sn = "zeo_sn_2"
+
+    # Exclude softener parameters: 214 (SOFTENER_TYPE) and 227 (SOFTENER_EMPTY)
+    zeo_device_2.product.schema = [
+        schema
+        for schema in zeo_device_2.product.schema
+        if schema.id not in ("214", "227")
+    ]
+
+    # Add the second device to the list of fake devices
+    fake_devices.append(zeo_device_2)
+
+    # Now set up the integration
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify that the first Zeo device has both detergent and softener entities
+    assert hass.states.get("binary_sensor.zeo_one_detergent") is not None
+    assert hass.states.get("binary_sensor.zeo_one_softener") is not None
+
+    # Verify that the second Zeo device has detergent entities but NOT softener entities
+    assert hass.states.get("binary_sensor.zeo_two_detergent") is not None
+    assert hass.states.get("binary_sensor.zeo_two_softener") is None

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -1,5 +1,6 @@
 """Test Roborock Select platform."""
 
+import copy
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call
 
@@ -538,3 +539,48 @@ async def test_q10_cleaning_mode_select_invalid_option(
 
     assert fake_q10_vacuum.b01_q10_properties
     fake_q10_vacuum.b01_q10_properties.vacuum.set_clean_mode.assert_not_called()
+
+
+@pytest.mark.parametrize("platforms", [[Platform.SELECT]])
+async def test_zeo_request_protocols_filtered_by_schema(
+    hass: HomeAssistant,
+    mock_roborock_entry: MockConfigEntry,
+    fake_devices: list[FakeDevice],
+) -> None:
+    """Test that Zeo request protocols are filtered by the device's supported schema IDs, ensuring correct entities are created."""
+    # Find the first Zeo device
+    zeo_device_1 = next(
+        (device for device in fake_devices if device.zeo is not None),
+        None,
+    )
+    assert zeo_device_1 is not None
+
+    # Create a second Zeo device without softener in its schema
+    zeo_device_2 = copy.deepcopy(zeo_device_1)
+    zeo_device_2.device_info.duid = "zeo_duid_2"
+    zeo_device_2._duid = "zeo_duid_2"
+    zeo_device_2.device_info.name = "Zeo Two"
+    zeo_device_2._name = "Zeo Two"
+    zeo_device_2.device_info.sn = "zeo_sn_2"
+
+    # Exclude softener parameters: 214 (SOFTENER_TYPE) and 227 (SOFTENER_EMPTY)
+    zeo_device_2.product.schema = [
+        schema
+        for schema in zeo_device_2.product.schema
+        if schema.id not in ("214", "227")
+    ]
+
+    # Add the second device to the list of fake devices
+    fake_devices.append(zeo_device_2)
+
+    # Now set up the integration
+    await hass.config_entries.async_setup(mock_roborock_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Verify that the first Zeo device has both detergent and softener entities
+    assert hass.states.get("select.zeo_one_detergent_type") is not None
+    assert hass.states.get("select.zeo_one_softener_type") is not None
+
+    # Verify that the second Zeo device has detergent entities but NOT softener entities
+    assert hass.states.get("select.zeo_two_detergent_type") is not None
+    assert hass.states.get("select.zeo_two_softener_type") is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some Roborock A01-based washing machines (like the **Roborock Zeo Mini / M1**) do not have automatic fabric softener dispensers and do not support or return values for fabric softener data points (`SOFTENER_TYPE` / DP `214` and `SOFTENER_EMPTY` / DP `227`).

Because the underlying `python-roborock` library expects responses for all requested data points to complete packet merging, requesting protocols that the device does not support/return causes the query to hang. As cited in the issue debug logs:
```text
Incomplete query response
Command timed out after 10.0s
Error fetching roborock data: Failed to update data
```
This timeout error resulted in the coordinator update failing completely, rendering all integration entities unavailable after standby or reload.

This PR fixes this issue by:
1. Extracting the washing machine and wet-dry vac request protocols as module-level constants `ZEO_REQUEST_PROTOCOLS` and `DYAD_REQUEST_PROTOCOLS` in `homeassistant/components/roborock/coordinator.py`.
2. Dynamically filtering `self.request_protocols` during initialization of `RoborockWashingMachineUpdateCoordinator` and `RoborockWetDryVacUpdateCoordinator` to only request protocols supported by the device's `supported_schema_ids`.
3. Adding standalone unit tests in `tests/components/roborock/test_binary_sensor.py` and `tests/components/roborock/test_select.py` using a second mock Zeo device (with softener excluded from its product schema) to verify that only the supported entities are created.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159991
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
