### PR TITLE
Warn before re-homing an existing ZHA network to a discovered radio

### DIFF
--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -860,14 +860,29 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
 
             return await self.async_step_verify_radio()
 
-        return self.async_show_form(
-            step_id="confirm",
-            description_placeholders={
-                CONF_NAME: self.context.get("title_placeholders", {}).get(
-                    CONF_NAME, self._radio_mgr.device_path or ""
-                )
-            },
+        name = self.context.get("title_placeholders", {}).get(
+            CONF_NAME, self._radio_mgr.device_path or ""
         )
+
+        # ZHA is single-instance: confirming a discovery while a network already
+        # exists migrates it onto the discovered radio (see `_async_create_radio_entry`).
+        # Warn explicitly so a working coordinator is not re-homed by accident, e.g.
+        # onto a radio already used by another integration such as Zigbee2MQTT.
+        if zha_config_entries:
+            return self.async_show_form(
+                step_id="confirm_migration",
+                description_placeholders={CONF_NAME: name},
+            )
+
+        return self.async_show_form(
+            step_id="confirm", description_placeholders={CONF_NAME: name}
+        )
+
+    async def async_step_confirm_migration(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm a discovery that migrates the existing network to a new radio."""
+        return await self.async_step_confirm(user_input)
 
     @override
     async def async_step_usb(self, discovery_info: UsbServiceInfo) -> ConfigFlowResult:

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -865,9 +865,8 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
         )
 
         # ZHA is single-instance: confirming a discovery while a network already
-        # exists migrates it onto the discovered radio (see `_async_create_radio_entry`).
-        # Warn explicitly so a working coordinator is not re-homed by accident, e.g.
-        # onto a radio already used by another integration such as Zigbee2MQTT.
+        # exists switches ZHA to the discovered radio. Warn before re-homing a
+        # working coordinator (e.g. one already used by another integration).
         if zha_config_entries:
             return self.async_show_form(
                 step_id="confirm_migration",

--- a/homeassistant/components/zha/config_flow.py
+++ b/homeassistant/components/zha/config_flow.py
@@ -864,13 +864,16 @@ class ZhaConfigFlowHandler(BaseZhaFlow, ConfigFlow, domain=DOMAIN):
             CONF_NAME, self._radio_mgr.device_path or ""
         )
 
-        # ZHA is single-instance: confirming a discovery while a network already
-        # exists switches ZHA to the discovered radio. Warn before re-homing a
-        # working coordinator (e.g. one already used by another integration).
-        if zha_config_entries:
+        # ZHA is single-instance: confirming a passive discovery re-homes the
+        # existing network onto the discovered adapter. The hardware wizard sets
+        # _flow_strategy and has already opted into migration, so warn only here.
+        if zha_config_entries and self._flow_strategy is None:
             return self.async_show_form(
                 step_id="confirm_migration",
-                description_placeholders={CONF_NAME: name},
+                description_placeholders={
+                    CONF_NAME: name,
+                    "current": zha_config_entries[0].title,
+                },
             )
 
         return self.async_show_form(

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -90,7 +90,7 @@
         "title": "Overwrite adapter IEEE address"
       },
       "confirm_migration": {
-        "description": "Setting up **{name}** will migrate your existing Zigbee network onto it. Your current coordinator will go offline and every device will be unavailable until the migration finishes.\n\nOnly continue if you mean to switch radios. If you did not — for example if this adapter is already used by another integration such as Zigbee2MQTT — go back and ignore this discovery instead.",
+        "description": "Setting up **{name}** will change ZHA to use it instead of your current Zigbee radio. Your current coordinator will go offline and your devices may become unavailable.\n\nOnly continue if you mean to switch radios. If you did not — for example if this adapter is already used by another integration such as Zigbee2MQTT — go back and ignore this discovery instead.",
         "title": "Migrate to a different Zigbee radio?"
       },
       "form_new_network": {

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -89,6 +89,10 @@
         "description": "Your backup has a different IEEE address than your adapter. For your network to function properly, the IEEE address of your adapter should also be changed.\n\nThis is a permanent operation.",
         "title": "Overwrite adapter IEEE address"
       },
+      "confirm_migration": {
+        "description": "Setting up **{name}** will migrate your existing Zigbee network onto it. Your current coordinator will go offline and every device will be unavailable until the migration finishes.\n\nOnly continue if you mean to switch radios. If you did not — for example if this adapter is already used by another integration such as Zigbee2MQTT — go back and ignore this discovery instead.",
+        "title": "Migrate to a different Zigbee radio?"
+      },
       "form_new_network": {
         "title": "Forming new network"
       },

--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -90,8 +90,8 @@
         "title": "Overwrite adapter IEEE address"
       },
       "confirm_migration": {
-        "description": "Setting up **{name}** will change ZHA to use it instead of your current Zigbee radio. Your current coordinator will go offline and your devices may become unavailable.\n\nOnly continue if you mean to switch radios. If you did not — for example if this adapter is already used by another integration such as Zigbee2MQTT — go back and ignore this discovery instead.",
-        "title": "Migrate to a different Zigbee radio?"
+        "description": "Do you want to migrate your current Zigbee network from **{current}** to **{name}**?\n\n**{current}** will no longer be used by ZHA. If you did not mean to migrate — for example if **{name}** is already used by another integration such as Zigbee2MQTT — close this dialog and ignore the discovery instead.",
+        "title": "Migrate your Zigbee network?"
       },
       "form_new_network": {
         "title": "Forming new network"

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -986,49 +986,17 @@ async def test_legacy_zeroconf_discovery_already_setup(hass: HomeAssistant) -> N
     )
     await hass.async_block_till_done()
 
+    # An existing network => the discovery warns before migrating to the new radio,
+    # rather than showing the generic "set up" confirmation.
+    assert init_result["type"] is FlowResultType.FORM
+    assert init_result["step_id"] == "confirm_migration"
+
     confirm_result = await hass.config_entries.flow.async_configure(
         init_result["flow_id"],
         user_input={},
     )
 
-    # When we have an existing config entry, we migrate
-    assert confirm_result["type"] is FlowResultType.MENU
-    assert confirm_result["step_id"] == "choose_migration_strategy"
-
-
-async def test_zeroconf_discovery_migration_warns_before_rehoming(
-    hass: HomeAssistant,
-) -> None:
-    """Test a discovery warns before migrating an existing network to a new radio."""
-    MockConfigEntry(
-        domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
-    ).add_to_hass(hass)
-
-    service_info = ZeroconfServiceInfo(
-        ip_address=ip_address("192.168.1.200"),
-        ip_addresses=[ip_address("192.168.1.200")],
-        hostname="_tube_zb_gw._tcp.local.",
-        name="mock_name",
-        port=6053,
-        properties={"name": "tube_123456"},
-        type="mock_type",
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
-    )
-    await hass.async_block_till_done()
-
-    # A different radio while a network already exists => explicit migration warning
-    # instead of the generic "set up" confirmation, so a working coordinator is not
-    # re-homed by accident.
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm_migration"
-
     # Confirming still proceeds to the existing migration strategy menu.
-    confirm_result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={}
-    )
     assert confirm_result["type"] is FlowResultType.MENU
     assert confirm_result["step_id"] == "choose_migration_strategy"
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -815,7 +815,7 @@ async def test_discovery_via_usb_duplicate_unique_id(hass: HomeAssistant) -> Non
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "confirm"
+    assert result["step_id"] == "confirm_migration"
 
 
 @patch(f"zigpy_znp.{PROBE_FUNCTION_PATH}", AsyncMock(return_value=True))
@@ -992,6 +992,43 @@ async def test_legacy_zeroconf_discovery_already_setup(hass: HomeAssistant) -> N
     )
 
     # When we have an existing config entry, we migrate
+    assert confirm_result["type"] is FlowResultType.MENU
+    assert confirm_result["step_id"] == "choose_migration_strategy"
+
+
+async def test_zeroconf_discovery_migration_warns_before_rehoming(
+    hass: HomeAssistant,
+) -> None:
+    """Test a discovery warns before migrating an existing network to a new radio."""
+    MockConfigEntry(
+        domain=DOMAIN, data={CONF_DEVICE: {CONF_DEVICE_PATH: "/dev/ttyUSB1"}}
+    ).add_to_hass(hass)
+
+    service_info = ZeroconfServiceInfo(
+        ip_address=ip_address("192.168.1.200"),
+        ip_addresses=[ip_address("192.168.1.200")],
+        hostname="_tube_zb_gw._tcp.local.",
+        name="mock_name",
+        port=6053,
+        properties={"name": "tube_123456"},
+        type="mock_type",
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=service_info
+    )
+    await hass.async_block_till_done()
+
+    # A different radio while a network already exists => explicit migration warning
+    # instead of the generic "set up" confirmation, so a working coordinator is not
+    # re-homed by accident.
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm_migration"
+
+    # Confirming still proceeds to the existing migration strategy menu.
+    confirm_result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert confirm_result["type"] is FlowResultType.MENU
     assert confirm_result["step_id"] == "choose_migration_strategy"
 
@@ -1512,7 +1549,7 @@ async def test_hardware_migration_flow_strategy_advanced(
         )
 
         assert result_hardware["type"] is FlowResultType.FORM
-        assert result_hardware["step_id"] == "confirm"
+        assert result_hardware["step_id"] == "confirm_migration"
 
         result_confirm = await hass.config_entries.flow.async_configure(
             result_hardware["flow_id"], user_input={}
@@ -1592,7 +1629,7 @@ async def test_hardware_migration_flow_strategy_recommended(
         )
 
         assert result_hardware["type"] is FlowResultType.FORM
-        assert result_hardware["step_id"] == "confirm"
+        assert result_hardware["step_id"] == "confirm_migration"
 
         result_migrate = await hass.config_entries.flow.async_configure(
             result_hardware["flow_id"], user_input={}

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -986,8 +986,6 @@ async def test_legacy_zeroconf_discovery_already_setup(hass: HomeAssistant) -> N
     )
     await hass.async_block_till_done()
 
-    # An existing network => the discovery warns before migrating to the new radio,
-    # rather than showing the generic "set up" confirmation.
     assert init_result["type"] is FlowResultType.FORM
     assert init_result["step_id"] == "confirm_migration"
 
@@ -996,7 +994,6 @@ async def test_legacy_zeroconf_discovery_already_setup(hass: HomeAssistant) -> N
         user_input={},
     )
 
-    # Confirming still proceeds to the existing migration strategy menu.
     assert confirm_result["type"] is FlowResultType.MENU
     assert confirm_result["step_id"] == "choose_migration_strategy"
 

--- a/tests/components/zha/test_config_flow.py
+++ b/tests/components/zha/test_config_flow.py
@@ -1514,7 +1514,7 @@ async def test_hardware_migration_flow_strategy_advanced(
         )
 
         assert result_hardware["type"] is FlowResultType.FORM
-        assert result_hardware["step_id"] == "confirm_migration"
+        assert result_hardware["step_id"] == "confirm"
 
         result_confirm = await hass.config_entries.flow.async_configure(
             result_hardware["flow_id"], user_input={}
@@ -1594,7 +1594,7 @@ async def test_hardware_migration_flow_strategy_recommended(
         )
 
         assert result_hardware["type"] is FlowResultType.FORM
-        assert result_hardware["step_id"] == "confirm_migration"
+        assert result_hardware["step_id"] == "confirm"
 
         result_migrate = await hass.config_entries.flow.async_configure(
             result_hardware["flow_id"], user_input={}


### PR DESCRIPTION
## Proposed change

ZHA is single-instance, but discovery is used to allow migrating to a new radio (see `_async_create_radio_entry`). As a result, accepting a discovered radio while a ZHA network already exists **silently re-homes the existing ZHA config entry onto the discovered radio**. The only confirmation shown is *"Do you want to set up {name}?"*, which gives no indication that a working coordinator is about to be taken offline.

This is easy to trigger by accident: when a coordinator used by **another integration** (e.g. a SMLIGHT SLZB used by the Zigbee2MQTT add-on) is re-discovered after a firmware update / IP change, HA offers it as a *"Zigbee Home Automation → Add"* discovery. Accepting it points ZHA at that foreign coordinator; ZHA then reads a different network, fails with *"Network settings do not match most recent backup"*, and all ZHA devices go unavailable. (The repair flow correctly protects the data afterwards — this PR only prevents the accidental re-home.)

This adds a dedicated confirmation step (`confirm_migration`) with an explicit warning, shown **only when confirming a discovery will migrate an existing network to a different radio**. First-time setup (no existing entry) and the downstream `choose_migration_strategy` flow are unchanged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176437
- Link to documentation pull request:

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  Note: this PR does not add/change user-exposed config or dependencies, so the
  documentation and dependency sections above are not applicable.
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
