### PR TITLE
Register SwitchBee central unit device

### DIFF
--- a/homeassistant/components/switchbee/__init__.py
+++ b/homeassistant/components/switchbee/__init__.py
@@ -4,6 +4,7 @@ import logging
 import re
 
 from aiohttp import ClientSession
+from switchbee import SWITCHBEE_BRAND
 from switchbee.api import CentralUnitPolling, CentralUnitWsRPC, is_wsrpc_api
 from switchbee.api.central_unit import SwitchBeeError
 
@@ -64,6 +65,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitchBeeConfigEntry) ->
     await coordinator.async_config_entry_first_refresh()
     entry.async_on_unload(entry.add_update_listener(update_listener))
     entry.runtime_data = coordinator
+
+    # Register the central unit so the per-zone devices' via_device resolves and
+    # the hub's MAC is recorded as a connection.
+    assert api.mac is not None
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{api.name} ({api.unique_id})")},
+        connections={(dr.CONNECTION_NETWORK_MAC, api.mac)},
+        manufacturer=SWITCHBEE_BRAND,
+        name=api.name,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/switchbee/__init__.py
+++ b/homeassistant/components/switchbee/__init__.py
@@ -72,7 +72,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SwitchBeeConfigEntry) ->
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, f"{api.name} ({api.unique_id})")},
+        identifiers={(DOMAIN, coordinator.unique_id)},
         connections={(dr.CONNECTION_NETWORK_MAC, api.mac)},
         manufacturer=SWITCHBEE_BRAND,
         name=api.name,

--- a/homeassistant/components/switchbee/const.py
+++ b/homeassistant/components/switchbee/const.py
@@ -1,6 +1,5 @@
 """Constants for the SwitchBee Smart Home integration."""
 
-from switchbee.api import CentralUnitPolling, CentralUnitWsRPC
-
 DOMAIN = "switchbee"
-SCAN_INTERVAL_SEC = {CentralUnitWsRPC: 10, CentralUnitPolling: 5}
+SCAN_INTERVAL_SEC_POLLING = 5
+SCAN_INTERVAL_SEC_WSRPC = 10

--- a/homeassistant/components/switchbee/coordinator.py
+++ b/homeassistant/components/switchbee/coordinator.py
@@ -14,7 +14,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN, SCAN_INTERVAL_SEC
+from .const import DOMAIN, SCAN_INTERVAL_SEC_POLLING, SCAN_INTERVAL_SEC_WSRPC
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -46,7 +46,11 @@ class SwitchBeeCoordinator(DataUpdateCoordinator[Mapping[int, SwitchBeeBaseDevic
             _LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
-            update_interval=timedelta(seconds=SCAN_INTERVAL_SEC[type(self.api)]),
+            update_interval=timedelta(
+                seconds=SCAN_INTERVAL_SEC_WSRPC
+                if isinstance(swb_api, CentralUnitWsRPC)
+                else SCAN_INTERVAL_SEC_POLLING
+            ),
         )
 
         # Register callback for notification WsRPC

--- a/homeassistant/components/switchbee/entity.py
+++ b/homeassistant/components/switchbee/entity.py
@@ -61,10 +61,7 @@ class SwitchBeeDeviceEntity[_DeviceTypeT: SwitchBeeBaseDevice](
             manufacturer=SWITCHBEE_BRAND,
             model=coordinator.api.module_display(device.unit_id),
             suggested_area=device.zone,
-            via_device=(
-                DOMAIN,
-                f"{coordinator.api.name} ({coordinator.api.unique_id})",
-            ),
+            via_device=(DOMAIN, coordinator.unique_id),
         )
 
     @property

--- a/tests/components/switchbee/conftest.py
+++ b/tests/components/switchbee/conftest.py
@@ -1,0 +1,64 @@
+"""Common fixtures for the SwitchBee Smart Home tests."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from switchbee.api.central_unit import CUVersion
+from switchbee.device import DeviceType, HardwareType, SwitchBeeSwitch
+
+from homeassistant.components.switchbee.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return the default mocked config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="300F123456",
+        version=2,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+
+
+@pytest.fixture
+def mock_central_unit() -> Generator[AsyncMock]:
+    """Mock the SwitchBee central unit API."""
+    devices = {
+        device.id: device
+        for device in (
+            SwitchBeeSwitch(
+                id=11,
+                name="Ceiling",
+                zone="Kitchen",
+                type=DeviceType.Switch,
+                hardware=HardwareType.RegularSwitch,
+            ),
+            SwitchBeeSwitch(
+                id=21,
+                name="Wall",
+                zone="Living Room",
+                type=DeviceType.Switch,
+                hardware=HardwareType.RegularSwitch,
+            ),
+        )
+    }
+    with patch(
+        "homeassistant.components.switchbee.CentralUnitPolling", autospec=True
+    ) as mock_api:
+        central_unit = mock_api.return_value
+        central_unit.name = "Residence"
+        central_unit.mac = "A8-21-08-E7-67-B6"
+        central_unit.unique_id = "300F123456"
+        central_unit.version = CUVersion("1.4.4(4)")
+        central_unit.reconnect_count = 0
+        central_unit.devices = devices
+        central_unit.module_display.return_value = "Regular Switch"
+        yield central_unit

--- a/tests/components/switchbee/test_init.py
+++ b/tests/components/switchbee/test_init.py
@@ -1,0 +1,64 @@
+"""Tests for the SwitchBee Smart Home integration init."""
+
+import json
+from unittest.mock import patch
+
+from homeassistant.components.switchbee.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry, async_load_fixture
+
+
+async def test_central_unit_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the central unit device carries the MAC and links the zone devices."""
+    coordinator_data = json.loads(
+        await async_load_fixture(hass, "switchbee.json", DOMAIN)
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_USERNAME: "test-username",
+            CONF_PASSWORD: "test-password",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "switchbee.api.polling.CentralUnitPolling.get_configuration",
+            return_value=coordinator_data,
+        ),
+        patch(
+            "switchbee.api.polling.CentralUnitPolling.fetch_states", return_value=None
+        ),
+        patch("switchbee.api.polling.CentralUnitPolling._login", return_value=None),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    central_unit = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac("A8-21-08-E7-67-B6"))}
+    )
+    assert central_unit is not None
+    assert central_unit.identifiers == {(DOMAIN, "Residence (None)")}
+    assert central_unit.manufacturer == "SwitchBee"
+    assert central_unit.name == "Residence"
+
+    zone_devices = [
+        device
+        for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        if device.id != central_unit.id
+    ]
+    assert zone_devices
+    assert all(device.via_device_id == central_unit.id for device in zone_devices)

--- a/tests/components/switchbee/test_init.py
+++ b/tests/components/switchbee/test_init.py
@@ -1,64 +1,42 @@
 """Tests for the SwitchBee Smart Home integration init."""
 
-import json
-from unittest.mock import patch
+import pytest
 
 from homeassistant.components.switchbee.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry, async_load_fixture
+from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("mock_central_unit")
 async def test_central_unit_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the central unit device carries the MAC and links the zone devices."""
-    coordinator_data = json.loads(
-        await async_load_fixture(hass, "switchbee.json", DOMAIN)
-    )
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=2,
-        data={
-            CONF_HOST: "1.1.1.1",
-            CONF_USERNAME: "test-username",
-            CONF_PASSWORD: "test-password",
-        },
-    )
-    entry.add_to_hass(hass)
-
-    with (
-        patch(
-            "switchbee.api.polling.CentralUnitPolling.get_configuration",
-            return_value=coordinator_data,
-        ),
-        patch(
-            "switchbee.api.polling.CentralUnitPolling.fetch_states", return_value=None
-        ),
-        patch("switchbee.api.polling.CentralUnitPolling._login", return_value=None),
-    ):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    assert entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.state is ConfigEntryState.LOADED
 
     central_unit = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac("A8-21-08-E7-67-B6"))}
+        connections={(dr.CONNECTION_NETWORK_MAC, "a8:21:08:e7:67:b6")}
     )
     assert central_unit is not None
-    assert central_unit.identifiers == {(DOMAIN, "Residence (None)")}
+    assert central_unit.identifiers == {(DOMAIN, "300F123456")}
     assert central_unit.manufacturer == "SwitchBee"
     assert central_unit.name == "Residence"
 
     zone_devices = [
         device
-        for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id)
+        for device in dr.async_entries_for_config_entry(
+            device_registry, mock_config_entry.entry_id
+        )
         if device.id != central_unit.id
     ]
-    assert zone_devices
+    assert len(zone_devices) == 2
     assert all(device.via_device_id == central_unit.id for device in zone_devices)


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Every SwitchBee per-zone device sets

```python
via_device=(DOMAIN, f"{coordinator.api.name} ({coordinator.api.unique_id})")
```

but no device with that identifier is ever registered — the central unit itself is never created. So the `via_device` reference dangles (the per-zone devices never get their hub linkage) and the central unit's MAC (`api.mac`, already used to derive the config-entry unique id) is recorded nowhere.

This registers the central unit in `async_setup_entry`, using the same identifier the per-zone devices already reference so their `via_device` now resolves, and attaches the hub's MAC as a `CONNECTION_NETWORK_MAC` connection. The change is additive: on restart, existing per-zone devices get linked to the newly registered hub, so no migration is required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176307
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
