### PR TITLE
Add public API for discovered DHCP devices

### DIFF
--- a/homeassistant/components/dhcp/__init__.py
+++ b/homeassistant/components/dhcp/__init__.py
@@ -61,7 +61,12 @@ from homeassistant.loader import DHCPMatcher, async_get_dhcp
 
 from . import websocket_api
 from .const import DOMAIN, HOSTNAME, IP_ADDRESS, MAC_ADDRESS
+from .helpers import async_discovered_service_info
 from .models import DATA_DHCP, DHCPAddressData, DHCPData, DhcpMatchers
+
+__all__ = [
+    "async_discovered_service_info",
+]
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 

--- a/homeassistant/components/dhcp/helpers.py
+++ b/homeassistant/components/dhcp/helpers.py
@@ -43,7 +43,7 @@ def async_discovered_service_info(hass: HomeAssistant) -> list[DhcpServiceInfo]:
     return [
         DhcpServiceInfo(
             ip=data[IP_ADDRESS],
-            hostname=data[HOSTNAME],
+            hostname=data[HOSTNAME].lower(),
             macaddress=mac_address,
         )
         for mac_address, data in async_get_address_data_internal(hass).items()

--- a/homeassistant/components/dhcp/helpers.py
+++ b/homeassistant/components/dhcp/helpers.py
@@ -4,7 +4,9 @@ from collections.abc import Callable
 from functools import partial
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
+from .const import HOSTNAME, IP_ADDRESS
 from .models import DATA_DHCP, DHCPAddressData
 
 
@@ -33,3 +35,16 @@ def async_get_address_data_internal(
     This is not intended for use by integrations.
     """
     return hass.data[DATA_DHCP].address_data
+
+
+@callback
+def async_discovered_service_info(hass: HomeAssistant) -> list[DhcpServiceInfo]:
+    """Return the discovered DHCP devices."""
+    return [
+        DhcpServiceInfo(
+            ip=data[IP_ADDRESS],
+            hostname=data[HOSTNAME],
+            macaddress=mac_address,
+        )
+        for mac_address, data in async_get_address_data_internal(hass).items()
+    ]

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -640,7 +640,7 @@ async def test_discovered_service_info(hass: HomeAssistant) -> None:
     assert dhcp.async_discovered_service_info(hass) == []
 
     saved_callback(aiodhcpwatcher.DHCPRequest("4.3.2.2", "happy", "44:44:33:11:23:12"))
-    saved_callback(aiodhcpwatcher.DHCPRequest("4.3.2.1", "sad", "44:44:33:11:23:13"))
+    saved_callback(aiodhcpwatcher.DHCPRequest("4.3.2.1", "Sad", "44:44:33:11:23:13"))
 
     assert dhcp.async_discovered_service_info(hass) == [
         DhcpServiceInfo(

--- a/tests/components/dhcp/test_init.py
+++ b/tests/components/dhcp/test_init.py
@@ -616,6 +616,46 @@ async def test_setup_and_stop(hass: HomeAssistant) -> None:
     resolve_iface_call.assert_called_once()
 
 
+async def test_discovered_service_info(hass: HomeAssistant) -> None:
+    """Test getting the discovered DHCP devices from the cache."""
+    saved_callback: Callable[[aiodhcpwatcher.DHCPRequest], None] | None = None
+
+    async def mock_start(
+        callback: Callable[[aiodhcpwatcher.DHCPRequest], None],
+        if_indexes: list[int] | None = None,
+    ) -> None:
+        """Mock start."""
+        nonlocal saved_callback
+        saved_callback = callback
+
+    with (
+        patch("homeassistant.components.dhcp.aiodhcpwatcher.async_start", mock_start),
+        patch("homeassistant.components.dhcp.DiscoverHosts"),
+    ):
+        await async_setup_component(hass, DOMAIN, {})
+        await hass.async_block_till_done()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+        await hass.async_block_till_done()
+
+    assert dhcp.async_discovered_service_info(hass) == []
+
+    saved_callback(aiodhcpwatcher.DHCPRequest("4.3.2.2", "happy", "44:44:33:11:23:12"))
+    saved_callback(aiodhcpwatcher.DHCPRequest("4.3.2.1", "sad", "44:44:33:11:23:13"))
+
+    assert dhcp.async_discovered_service_info(hass) == [
+        DhcpServiceInfo(
+            ip="4.3.2.2",
+            hostname="happy",
+            macaddress="444433112312",
+        ),
+        DhcpServiceInfo(
+            ip="4.3.2.1",
+            hostname="sad",
+            macaddress="444433112313",
+        ),
+    ]
+
+
 async def test_setup_fails_as_root(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The Bluetooth API has `async_discovered_service_info` to get a list of all discovered Bluetooth devices for integrations to use and check the discovery cache. For DHCP we don't have a public endpoint that works similarly, but for some integrations it would make sense to see if there are already discovered devices. This PR adds a helper which exposes the list of `DhcpServiceInfo`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: home-assistant/developers.home-assistant#3250
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
