### PR TITLE
Mark Netatmo entities unavailable when device or service is unreachable

### DIFF
--- a/homeassistant/components/netatmo/button.py
+++ b/homeassistant/components/netatmo/button.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import CONF_URL_CONTROL, NETATMO_CREATE_BUTTON
 from .coordinator import HOME, SIGNAL_NAME, NetatmoConfigEntry, NetatmoDevice
-from .entity import NetatmoModuleEntity
+from .entity import NetatmoReachabilityEntity
 from .helper import device_type_to_str
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ async def async_setup_entry(
     )
 
 
-class NetatmoCoverPreferredPositionButton(NetatmoModuleEntity, ButtonEntity):
+class NetatmoCoverPreferredPositionButton(NetatmoReachabilityEntity, ButtonEntity):
     """Representation of a Netatmo cover preferred position button device."""
 
     _attr_configuration_url = CONF_URL_CONTROL
@@ -69,7 +69,7 @@ class NetatmoCoverPreferredPositionButton(NetatmoModuleEntity, ButtonEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        # No state to update for button
+        self.async_write_ha_state()
 
     @override
     async def async_press(self) -> None:

--- a/homeassistant/components/netatmo/camera.py
+++ b/homeassistant/components/netatmo/camera.py
@@ -284,6 +284,8 @@ class NetatmoCamera(NetatmoModuleEntity, Camera):
             self.device.events
         )
 
+        self.async_write_ha_state()
+
     def process_events(self, event_list: list[NaEvent]) -> dict:
         """Add meta data to events."""
         events = {}

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -414,15 +414,16 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
     @override
     def available(self) -> bool:
         """If the device hasn't been able to connect, mark as unavailable."""
-        return bool(self._connected)
+        return super().available and bool(self._connected)
 
     @callback
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         if not self.device.reachable:
-            if self.available:
+            if self._connected:
                 self._connected = False
+            self.async_write_ha_state()
             return
 
         self._connected = True
@@ -457,6 +458,8 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
                     if module.boiler_status is not None:
                         self._boilerstatus = module.boiler_status
                         break
+
+        self.async_write_ha_state()
 
     async def _async_service_set_schedule(self, **kwargs: Any) -> None:
         schedule_name = kwargs.get(ATTR_SCHEDULE_NAME)

--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -290,6 +290,7 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
             elif self._attr_preset_mode in [PRESET_SCHEDULE, PRESET_HOME]:
                 self.async_update_callback()
                 self.data_handler.async_force_update(self._signal_name)
+                return
             self.async_write_ha_state()
             return
 
@@ -325,7 +326,6 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
                     self._attr_preset_mode = PRESET_MAP_NETATMO[PRESET_SCHEDULE]
 
                 self.async_update_callback()
-                self.async_write_ha_state()
                 return
 
     @property

--- a/homeassistant/components/netatmo/coordinator.py
+++ b/homeassistant/components/netatmo/coordinator.py
@@ -135,6 +135,7 @@ class NetatmoPublisher:
     subscriptions: set[CALLBACK_TYPE | None]
     method: str
     kwargs: dict
+    available: bool = True
 
 
 class NetatmoDataHandler:
@@ -254,19 +255,29 @@ class NetatmoDataHandler:
                 **self.publisher[signal_name].kwargs
             )
 
-        except (pyatmo.NoDeviceError, pyatmo.ApiError) as err:
+        except (
+            pyatmo.NoDeviceError,
+            pyatmo.ApiError,
+            TimeoutError,
+            aiohttp.ClientConnectorError,
+        ) as err:
             _LOGGER.debug(err)
             has_error = True
 
-        except (TimeoutError, aiohttp.ClientConnectorError) as err:
-            _LOGGER.debug(err)
-            return True
+        self.publisher[signal_name].available = not has_error
+        self._notify_subscribers(signal_name)
+        return has_error
 
+    def _notify_subscribers(self, signal_name: str) -> None:
+        """Notify all subscribers of a publisher to update their state."""
         for update_callback in self.publisher[signal_name].subscriptions:
             if update_callback:
                 update_callback()
 
-        return has_error
+    def is_signal_available(self, signal_name: str) -> bool:
+        """Return whether the last fetch for a publisher succeeded."""
+        publisher = self.publisher.get(signal_name)
+        return publisher is None or publisher.available
 
     async def subscribe(
         self,

--- a/homeassistant/components/netatmo/cover.py
+++ b/homeassistant/components/netatmo/cover.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import CONF_URL_CONTROL, NETATMO_CREATE_COVER
 from .coordinator import HOME, SIGNAL_NAME, NetatmoConfigEntry, NetatmoDevice
-from .entity import NetatmoModuleEntity
+from .entity import NetatmoReachabilityEntity
 from .helper import device_type_to_str
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ async def async_setup_entry(
     )
 
 
-class NetatmoCover(NetatmoModuleEntity, CoverEntity):
+class NetatmoCover(NetatmoReachabilityEntity, CoverEntity):
     """Representation of a Netatmo cover device."""
 
     _attr_supported_features = (
@@ -105,5 +105,7 @@ class NetatmoCover(NetatmoModuleEntity, CoverEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        self._attr_is_closed = self.device.current_position == 0
-        self._attr_current_cover_position = self.device.current_position
+        if self.device.reachable is not False:
+            self._attr_is_closed = self.device.current_position == 0
+            self._attr_current_cover_position = self.device.current_position
+        self.async_write_ha_state()

--- a/homeassistant/components/netatmo/entity.py
+++ b/homeassistant/components/netatmo/entity.py
@@ -35,6 +35,15 @@ class NetatmoBaseEntity(Entity):
         self._publishers: list[dict[str, Any]] = []
         self._attr_extra_state_attributes = {}
 
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True if the underlying data publishers are reachable."""
+        return super().available and all(
+            self.data_handler.is_signal_available(publisher[SIGNAL_NAME])
+            for publisher in self._publishers
+        )
+
     @override
     async def async_added_to_hass(self) -> None:
         """Entity created."""
@@ -172,6 +181,16 @@ class NetatmoModuleEntity(NetatmoDeviceEntity):
     def device_type(self) -> DeviceType:
         """Return the device type."""
         return self.device.device_type
+
+
+class NetatmoReachabilityEntity(NetatmoModuleEntity):
+    """Module entity that is unavailable when its device is unreachable."""
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return True unless the device explicitly reports as unreachable."""
+        return super().available and self.device.reachable is not False
 
 
 class NetatmoWeatherModuleEntity(NetatmoModuleEntity):

--- a/homeassistant/components/netatmo/fan.py
+++ b/homeassistant/components/netatmo/fan.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import CONF_URL_CONTROL, NETATMO_CREATE_FAN
 from .coordinator import HOME, SIGNAL_NAME, NetatmoConfigEntry, NetatmoDevice
-from .entity import NetatmoModuleEntity
+from .entity import NetatmoReachabilityEntity
 from .helper import device_type_to_str
 
 _LOGGER = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ async def async_setup_entry(
     )
 
 
-class NetatmoFan(NetatmoModuleEntity, FanEntity):
+class NetatmoFan(NetatmoReachabilityEntity, FanEntity):
     """Representation of a Netatmo fan."""
 
     _attr_preset_modes = ["slow", "fast"]
@@ -78,7 +78,9 @@ class NetatmoFan(NetatmoModuleEntity, FanEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        if self.device.fan_speed is None:
-            self._attr_preset_mode = None
-            return
-        self._attr_preset_mode = PRESETS.get(self.device.fan_speed)
+        if self.device.reachable is not False:
+            if self.device.fan_speed is None:
+                self._attr_preset_mode = None
+            else:
+                self._attr_preset_mode = PRESETS.get(self.device.fan_speed)
+        self.async_write_ha_state()

--- a/homeassistant/components/netatmo/light.py
+++ b/homeassistant/components/netatmo/light.py
@@ -20,7 +20,7 @@ from .const import (
     NETATMO_CREATE_LIGHT,
 )
 from .coordinator import HOME, SIGNAL_NAME, NetatmoConfigEntry, NetatmoDevice
-from .entity import NetatmoModuleEntity
+from .entity import NetatmoModuleEntity, NetatmoReachabilityEntity
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -124,7 +124,7 @@ class NetatmoCameraLight(NetatmoModuleEntity, LightEntity):
     @override
     def available(self) -> bool:
         """If the webhook is not established, mark as unavailable."""
-        return bool(self.data_handler.webhook)
+        return super().available and bool(self.data_handler.webhook)
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -143,9 +143,10 @@ class NetatmoCameraLight(NetatmoModuleEntity, LightEntity):
     def async_update_callback(self) -> None:
         """Update the entity's state."""
         self._attr_is_on = bool(self.device.floodlight == "on")
+        self.async_write_ha_state()
 
 
-class NetatmoLight(NetatmoModuleEntity, LightEntity):
+class NetatmoLight(NetatmoReachabilityEntity, LightEntity):
     """Representation of a dimmable light by Legrand/BTicino."""
 
     _attr_name = None
@@ -200,10 +201,12 @@ class NetatmoLight(NetatmoModuleEntity, LightEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        self._attr_is_on = self.device.on is True
+        if self.device.reachable is not False:
+            self._attr_is_on = self.device.on is True
 
-        if (brightness := self.device.brightness) is not None:
-            # Netatmo uses a range of [0, 100] to control brightness
-            self._attr_brightness = round(brightness * 2.55)
-        else:
-            self._attr_brightness = None
+            if (brightness := self.device.brightness) is not None:
+                # Netatmo uses a range of [0, 100] to control brightness
+                self._attr_brightness = round(brightness * 2.55)
+            else:
+                self._attr_brightness = None
+        self.async_write_ha_state()

--- a/homeassistant/components/netatmo/quality_scale.yaml
+++ b/homeassistant/components/netatmo/quality_scale.yaml
@@ -34,7 +34,7 @@ rules:
   config-entry-unloading: done
   docs-configuration-parameters: todo
   docs-installation-parameters: todo
-  entity-unavailable: todo
+  entity-unavailable: done
   integration-owner: done
   log-when-unavailable: todo
   parallel-updates: done

--- a/homeassistant/components/netatmo/select.py
+++ b/homeassistant/components/netatmo/select.py
@@ -132,3 +132,4 @@ class NetatmoScheduleSelect(NetatmoBaseEntity, SelectEntity):
         self._attr_options = [
             schedule.name for schedule in self.home.schedules.values() if schedule.name
         ]
+        self.async_write_ha_state()

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -62,6 +62,7 @@ from .coordinator import (
 )
 from .entity import (
     NetatmoBaseEntity,
+    NetatmoDeviceEntity,
     NetatmoModuleEntity,
     NetatmoRoomEntity,
     NetatmoWeatherModuleEntity,
@@ -631,7 +632,25 @@ async def async_setup_entry(
     await add_public_entities(False)
 
 
-class NetatmoBaseSensor(NetatmoModuleEntity, SensorEntity):
+class NetatmoLegacyReachableSensor(NetatmoDeviceEntity, SensorEntity):
+    """Sensor mixin that goes unavailable, keeping its last value, when unreachable."""
+
+    @callback
+    def _async_set_unavailable_if_unreachable(self) -> bool:
+        """Set the entity unavailable and write state when the device is unreachable.
+
+        Returns True when the device is unreachable so callers return early.
+        """
+        device = cast("pyatmo.Module | pyatmo.Room", self.device)
+        if device.reachable:
+            return False
+        if self.available:
+            self._attr_available = False
+        self.async_write_ha_state()
+        return True
+
+
+class NetatmoBaseSensor(NetatmoModuleEntity, NetatmoLegacyReachableSensor):
     """Implementation of a Netatmo sensor."""
 
     entity_description: NetatmoSensorEntityDescription
@@ -666,10 +685,7 @@ class NetatmoBaseSensor(NetatmoModuleEntity, SensorEntity):
         """Update the entity's state (the legacy way)."""
         # Keep the last known value for these legacy sensors when the device is
         # unreachable to preserve the historical behavior expected by existing entities.
-        if not self.device.reachable:
-            if self.available:
-                self._attr_available = False
-            self.async_write_ha_state()
+        if self._async_set_unavailable_if_unreachable():
             return
 
         self._attr_available = True
@@ -790,10 +806,7 @@ class NetatmoClimateBatterySensor(NetatmoLegacySensor):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        if not self.device.reachable:
-            if self.available:
-                self._attr_available = False
-            self.async_write_ha_state()
+        if self._async_set_unavailable_if_unreachable():
             return
 
         self._attr_available = True
@@ -860,7 +873,7 @@ class NetatmoSensor(NetatmoBaseSensor):
         self.async_write_ha_state()
 
 
-class NetatmoRoomSensor(NetatmoRoomEntity, SensorEntity):
+class NetatmoRoomSensor(NetatmoRoomEntity, NetatmoLegacyReachableSensor):
     """Implementation of a Netatmo room sensor."""
 
     entity_description: NetatmoSensorEntityDescription
@@ -892,10 +905,7 @@ class NetatmoRoomSensor(NetatmoRoomEntity, SensorEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        if not self.device.reachable:
-            if self.available:
-                self._attr_available = False
-            self.async_write_ha_state()
+        if self._async_set_unavailable_if_unreachable():
             return
 
         self._attr_available = True

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -892,6 +892,13 @@ class NetatmoRoomSensor(NetatmoRoomEntity, SensorEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
+        if not self.device.reachable:
+            if self.available:
+                self._attr_available = False
+            self.async_write_ha_state()
+            return
+
+        self._attr_available = True
         self._attr_native_value = getattr(self.device, self.entity_description.key)
 
         self.async_write_ha_state()

--- a/homeassistant/components/netatmo/sensor.py
+++ b/homeassistant/components/netatmo/sensor.py
@@ -669,13 +669,11 @@ class NetatmoBaseSensor(NetatmoModuleEntity, SensorEntity):
         if not self.device.reachable:
             if self.available:
                 self._attr_available = False
-            return
-
-        if (state := getattr(self.device, self.entity_description.key)) is None:
+            self.async_write_ha_state()
             return
 
         self._attr_available = True
-        self._attr_native_value = state
+        self._attr_native_value = getattr(self.device, self.entity_description.key)
 
         self.async_write_ha_state()
 
@@ -700,7 +698,7 @@ class NetatmoWeatherSensor(NetatmoWeatherModuleEntity, NetatmoBaseSensor):
     @override
     def available(self) -> bool:
         """Return True if entity is available."""
-        return (
+        return super().available and (
             self.device.reachable
             or getattr(
                 self.device,
@@ -795,6 +793,7 @@ class NetatmoClimateBatterySensor(NetatmoLegacySensor):
         if not self.device.reachable:
             if self.available:
                 self._attr_available = False
+            self.async_write_ha_state()
             return
 
         self._attr_available = True
@@ -893,10 +892,7 @@ class NetatmoRoomSensor(NetatmoRoomEntity, SensorEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        if (state := getattr(self.device, self.entity_description.key)) is None:
-            return
-
-        self._attr_native_value = state
+        self._attr_native_value = getattr(self.device, self.entity_description.key)
 
         self.async_write_ha_state()
 
@@ -976,6 +972,17 @@ class NetatmoPublicSensor(NetatmoBaseEntity, SensorEntity):
         self._signal_name = f"{PUBLIC}-{area.uuid}"
         self._mode = area.mode
         self._show_on_map = area.show_on_map
+        self._publishers = [
+            {
+                "name": PUBLIC,
+                "lat_ne": area.lat_ne,
+                "lon_ne": area.lon_ne,
+                "lat_sw": area.lat_sw,
+                "lon_sw": area.lon_sw,
+                "area_name": area.area_name,
+                SIGNAL_NAME: self._signal_name,
+            }
+        ]
         await self.data_handler.subscribe(
             PUBLIC,
             self._signal_name,
@@ -1001,6 +1008,7 @@ class NetatmoPublicSensor(NetatmoBaseEntity, SensorEntity):
                 )
 
             self._attr_available = False
+            self.async_write_ha_state()
             return
 
         if values := [x for x in data.values() if x is not None]:

--- a/homeassistant/components/netatmo/switch.py
+++ b/homeassistant/components/netatmo/switch.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import CONF_URL_CONTROL, NETATMO_CREATE_SWITCH
 from .coordinator import HOME, SIGNAL_NAME, NetatmoConfigEntry, NetatmoDevice
-from .entity import NetatmoModuleEntity
+from .entity import NetatmoReachabilityEntity
 from .helper import device_type_to_str
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,7 +38,7 @@ async def async_setup_entry(
     )
 
 
-class NetatmoSwitch(NetatmoModuleEntity, SwitchEntity):
+class NetatmoSwitch(NetatmoReachabilityEntity, SwitchEntity):
     """Representation of a Netatmo switch device."""
 
     _attr_name = None
@@ -70,7 +70,9 @@ class NetatmoSwitch(NetatmoModuleEntity, SwitchEntity):
     @override
     def async_update_callback(self) -> None:
         """Update the entity's state."""
-        self._attr_is_on = self.device.on
+        if self.device.reachable is not False:
+            self._attr_is_on = self.device.on
+        self.async_write_ha_state()
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/netatmo/test_camera.py
+++ b/tests/components/netatmo/test_camera.py
@@ -697,7 +697,7 @@ async def test_setup_component_no_devices(
     """Test setup with no devices."""
     fake_post_hits = 0
 
-    async def fake_post_no_data(*args, **kwargs):
+    async def fake_post_no_data(*args: Any, **kwargs: Any):
         """Fake error during requesting backend data."""
         nonlocal fake_post_hits
         fake_post_hits += 1

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from functools import partial
 from time import time
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
@@ -119,7 +120,7 @@ async def test_setup_component_with_config(
     """Test setup of the netatmo component with dev account."""
     fake_post_hits = 0
 
-    async def fake_post(*args, **kwargs):
+    async def fake_post(*args: Any, **kwargs: Any):
         """Fake error during requesting backend data."""
         nonlocal fake_post_hits
         fake_post_hits += 1
@@ -717,7 +718,7 @@ async def test_entity_unavailable_when_device_unreachable(
             if module.get("id") == module_id:
                 module["reachable"] = reachable
 
-    async def fake_post(*args, **kwargs):
+    async def fake_post(*args: Any, **kwargs: Any):
         return await fake_post_request(
             hass, *args, msg_callback=set_reachable, **kwargs
         )

--- a/tests/components/netatmo/test_init.py
+++ b/tests/components/netatmo/test_init.py
@@ -6,6 +6,7 @@ from time import time
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
+from freezegun.api import FrozenDateTimeFactory
 from pyatmo.const import ALL_SCOPES
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -13,7 +14,12 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components import cloud, webhook
 from homeassistant.components.netatmo import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_WEBHOOK_ID, Platform
+from homeassistant.const import (
+    CONF_WEBHOOK_ID,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import (
     OAuth2TokenRequestReauthError,
@@ -656,3 +662,89 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize(
+    ("platform", "entity_id", "module_id", "initial_state"),
+    [
+        pytest.param(
+            "switch", "switch.prise", "12:34:56:80:00:12:ac:f2", "on", id="switch"
+        ),
+        pytest.param(
+            "cover", "cover.entrance_blinds", "0009999992", "closed", id="cover"
+        ),
+        pytest.param(
+            "fan",
+            "fan.centralized_ventilation_controler",
+            "12:34:56:00:01:01:01:b1",
+            "on",
+            id="fan",
+        ),
+        pytest.param(
+            "light",
+            "light.unknown_00_11_22_33_00_11_45_fe",
+            "00:11:22:33:00:11:45:fe",
+            "off",
+            id="light",
+        ),
+        pytest.param(
+            "button",
+            "button.entrance_blinds_preferred_position",
+            "0009999992",
+            STATE_UNKNOWN,
+            id="button",
+        ),
+    ],
+)
+async def test_entity_unavailable_when_device_unreachable(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    platform: str,
+    entity_id: str,
+    module_id: str,
+    initial_state: str,
+) -> None:
+    """Test that entities become unavailable when their device is unreachable."""
+    reachable = True
+
+    def set_reachable(payload: dict) -> None:
+        home = payload.get("body", {}).get("home")
+        if not isinstance(home, dict):
+            return
+        for module in home.get("modules", []):
+            if module.get("id") == module_id:
+                module["reachable"] = reachable
+
+    async def fake_post(*args, **kwargs):
+        return await fake_post_request(
+            hass, *args, msg_callback=set_reachable, **kwargs
+        )
+
+    with (
+        patch(
+            "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth"
+        ) as mock_auth,
+        patch("homeassistant.components.netatmo.coordinator.PLATFORMS", [platform]),
+        patch(
+            "homeassistant.components.netatmo.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch("homeassistant.components.netatmo.webhook.webhook_generate_url"),
+    ):
+        mock_auth.return_value.async_post_api_request.side_effect = fake_post
+        mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
+        mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(entity_id).state == initial_state
+
+    reachable = False
+    for _ in range(11):
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE

--- a/tests/components/netatmo/test_light.py
+++ b/tests/components/netatmo/test_light.py
@@ -1,5 +1,6 @@
 """The tests for Netatmo light."""
 
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from syrupy.assertion import SnapshotAssertion
@@ -113,7 +114,7 @@ async def test_setup_component_no_devices(hass: HomeAssistant, config_entry) -> 
     """Test setup with no devices."""
     fake_post_hits = 0
 
-    async def fake_post_request_no_data(*args, **kwargs):
+    async def fake_post_request_no_data(*args: Any, **kwargs: Any):
         """Fake error during requesting backend data."""
         nonlocal fake_post_hits
         fake_post_hits += 1

--- a/tests/components/netatmo/test_switch.py
+++ b/tests/components/netatmo/test_switch.py
@@ -1,6 +1,7 @@
 """The tests for Netatmo switch."""
 
 from datetime import timedelta
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -109,7 +110,7 @@ async def test_switch_unavailable_on_fetch_error(
     """Test the switch becomes unavailable when the data cannot be fetched."""
     raise_error = False
 
-    async def fake_post(*args, **kwargs):
+    async def fake_post(*args: Any, **kwargs: Any):
         if raise_error:
             raise error
         return await fake_post_request(hass, *args, **kwargs)

--- a/tests/components/netatmo/test_switch.py
+++ b/tests/components/netatmo/test_switch.py
@@ -1,7 +1,11 @@
 """The tests for Netatmo switch."""
 
+from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
+import pyatmo
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import (
@@ -9,13 +13,13 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
-from .common import selected_platforms, snapshot_platform_entities
+from .common import fake_post_request, selected_platforms, snapshot_platform_entities
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_entity(
@@ -89,3 +93,51 @@ async def test_switch_setup_and_services(
                 ]
             }
         )
+
+
+@pytest.mark.parametrize(
+    "error",
+    [TimeoutError, pyatmo.ApiError],
+    ids=["timeout", "api_error"],
+)
+async def test_switch_unavailable_on_fetch_error(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    error: type[Exception],
+) -> None:
+    """Test the switch becomes unavailable when the data cannot be fetched."""
+    raise_error = False
+
+    async def fake_post(*args, **kwargs):
+        if raise_error:
+            raise error
+        return await fake_post_request(hass, *args, **kwargs)
+
+    with (
+        patch(
+            "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth"
+        ) as mock_auth,
+        patch("homeassistant.components.netatmo.coordinator.PLATFORMS", ["switch"]),
+        patch(
+            "homeassistant.components.netatmo.async_get_config_entry_implementation",
+            return_value=AsyncMock(),
+        ),
+        patch("homeassistant.components.netatmo.webhook.webhook_generate_url"),
+    ):
+        mock_auth.return_value.async_post_api_request.side_effect = fake_post
+        mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
+        mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    switch_entity = "switch.prise"
+    assert hass.states.get(switch_entity).state == "on"
+
+    raise_error = True
+    for _ in range(11):
+        freezer.tick(timedelta(seconds=30))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(switch_entity).state == STATE_UNAVAILABLE


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements the entity-unavailable quality-scale rule for device and service reachability.

Device reachability: switch, cover, fan, dimmable light and the preferred-position button always reported available even when the device was unreachable. They now report unavailable when the device reports reachable=False. Devices that don't report reachability stay available.

Service reachability: connection errors were swallowed in the coordinator without notifying entities. The coordinator now tracks each publisher's fetch outcome and notifies subscribers on every outcome, exposed through the base entity's available.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
