### PR TITLE
Refactor Whirlpool time sensor into a shared base class

### DIFF
--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -332,29 +332,29 @@ class WhirlpoolSensor(WhirlpoolEntity, SensorEntity):
         return self.entity_description.value_fn(self._appliance)
 
 
-class WasherDryerTimeSensorBase(WhirlpoolEntity, RestoreSensor, ABC):
-    """Abstract base class for Whirlpool washer/dryer time sensors."""
+class WhirlpoolTimeSensorBase(WhirlpoolEntity, RestoreSensor, ABC):
+    """Abstract base class for Whirlpool end-time timestamp sensors."""
 
     _attr_should_poll = True
-    _appliance: Washer | Dryer
 
-    def __init__(
-        self, appliance: Washer | Dryer, description: SensorEntityDescription
-    ) -> None:
-        """Initialize the washer/dryer sensor."""
-        super().__init__(appliance, unique_id_suffix=f"-{description.key}")
-        self.entity_description = description
+    def __init__(self, appliance: Appliance, unique_id_suffix: str) -> None:
+        """Initialize the time sensor."""
+        super().__init__(appliance, unique_id_suffix=unique_id_suffix)
 
         self._running: bool | None = None
         self._value: datetime | None = None
 
     @abstractmethod
-    def _is_machine_state_finished(self) -> bool:
-        """Return true if the machine is in a finished state."""
+    def _is_finished(self) -> bool:
+        """Return true if the timer/cycle is in a finished state."""
 
     @abstractmethod
-    def _is_machine_state_running(self) -> bool:
-        """Return true if the machine is in a running state."""
+    def _is_running(self) -> bool:
+        """Return true if the timer/cycle is in a running state."""
+
+    @abstractmethod
+    def _get_seconds_remaining(self) -> int:
+        """Return the number of seconds remaining."""
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -374,21 +374,52 @@ class WasherDryerTimeSensorBase(WhirlpoolEntity, RestoreSensor, ABC):
         """Calculate the time stamp for completion."""
         now = utcnow()
 
-        if self._is_machine_state_finished() and self._running:
+        if self._is_finished() and self._running:
             self._running = False
             self._value = now
 
-        if self._is_machine_state_running():
+        if self._is_running():
             self._running = True
-            new_timestamp = now + timedelta(
-                seconds=self._appliance.get_time_remaining()
-            )
+            new_timestamp = now + timedelta(seconds=self._get_seconds_remaining())
             if self._value is None or (
                 isinstance(self._value, datetime)
                 and abs(new_timestamp - self._value) > timedelta(seconds=60)
             ):
                 self._value = new_timestamp
         return self._value
+
+
+class WasherDryerTimeSensorBase(WhirlpoolTimeSensorBase, ABC):
+    """Abstract base class for Whirlpool washer/dryer time sensors."""
+
+    _appliance: Washer | Dryer
+
+    def __init__(
+        self, appliance: Washer | Dryer, description: SensorEntityDescription
+    ) -> None:
+        """Initialize the washer/dryer sensor."""
+        super().__init__(appliance, unique_id_suffix=f"-{description.key}")
+        self.entity_description = description
+
+    @abstractmethod
+    def _is_machine_state_finished(self) -> bool:
+        """Return true if the machine is in a finished state."""
+
+    @abstractmethod
+    def _is_machine_state_running(self) -> bool:
+        """Return true if the machine is in a running state."""
+
+    @override
+    def _is_finished(self) -> bool:
+        return self._is_machine_state_finished()
+
+    @override
+    def _is_running(self) -> bool:
+        return self._is_machine_state_running()
+
+    @override
+    def _get_seconds_remaining(self) -> int:
+        return self._appliance.get_time_remaining()
 
 
 class WasherTimeSensor(WasherDryerTimeSensorBase):

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -368,8 +368,8 @@ class WhirlpoolTimeSensorBase(WhirlpoolEntity, RestoreSensor, ABC):
         """Update status of Whirlpool."""
         await self._appliance.fetch_data()
 
-    @override
     @property
+    @override
     def native_value(self) -> datetime | None:
         """Calculate the time stamp for completion."""
         now = utcnow()

--- a/homeassistant/components/whirlpool/sensor.py
+++ b/homeassistant/components/whirlpool/sensor.py
@@ -389,77 +389,58 @@ class WhirlpoolTimeSensorBase(WhirlpoolEntity, RestoreSensor, ABC):
         return self._value
 
 
-class WasherDryerTimeSensorBase(WhirlpoolTimeSensorBase, ABC):
-    """Abstract base class for Whirlpool washer/dryer time sensors."""
-
-    _appliance: Washer | Dryer
-
-    def __init__(
-        self, appliance: Washer | Dryer, description: SensorEntityDescription
-    ) -> None:
-        """Initialize the washer/dryer sensor."""
-        super().__init__(appliance, unique_id_suffix=f"-{description.key}")
-        self.entity_description = description
-
-    @abstractmethod
-    def _is_machine_state_finished(self) -> bool:
-        """Return true if the machine is in a finished state."""
-
-    @abstractmethod
-    def _is_machine_state_running(self) -> bool:
-        """Return true if the machine is in a running state."""
-
-    @override
-    def _is_finished(self) -> bool:
-        return self._is_machine_state_finished()
-
-    @override
-    def _is_running(self) -> bool:
-        return self._is_machine_state_running()
-
-    @override
-    def _get_seconds_remaining(self) -> int:
-        return self._appliance.get_time_remaining()
-
-
-class WasherTimeSensor(WasherDryerTimeSensorBase):
+class WasherTimeSensor(WhirlpoolTimeSensorBase):
     """A timestamp class for Whirlpool washers."""
 
     _appliance: Washer
 
+    def __init__(self, appliance: Washer, description: SensorEntityDescription) -> None:
+        """Initialize the washer sensor."""
+        super().__init__(appliance, unique_id_suffix=f"-{description.key}")
+        self.entity_description = description
+
     @override
-    def _is_machine_state_finished(self) -> bool:
-        """Return true if the machine is in a finished state."""
+    def _is_finished(self) -> bool:
         return self._appliance.get_machine_state() in {
             WasherMachineState.Complete,
             WasherMachineState.Standby,
         }
 
     @override
-    def _is_machine_state_running(self) -> bool:
-        """Return true if the machine is in a running state."""
+    def _is_running(self) -> bool:
         return (
             self._appliance.get_machine_state() is WasherMachineState.RunningMainCycle
         )
 
+    @override
+    def _get_seconds_remaining(self) -> int:
+        return self._appliance.get_time_remaining()
 
-class DryerTimeSensor(WasherDryerTimeSensorBase):
+
+class DryerTimeSensor(WhirlpoolTimeSensorBase):
     """A timestamp class for Whirlpool dryers."""
 
     _appliance: Dryer
 
+    def __init__(self, appliance: Dryer, description: SensorEntityDescription) -> None:
+        """Initialize the dryer sensor."""
+        super().__init__(appliance, unique_id_suffix=f"-{description.key}")
+        self.entity_description = description
+
     @override
-    def _is_machine_state_finished(self) -> bool:
-        """Return true if the machine is in a finished state."""
+    def _is_finished(self) -> bool:
         return self._appliance.get_machine_state() in {
             DryerMachineState.Complete,
             DryerMachineState.Standby,
         }
 
     @override
-    def _is_machine_state_running(self) -> bool:
-        """Return true if the machine is in a running state."""
+    def _is_running(self) -> bool:
         return self._appliance.get_machine_state() is DryerMachineState.RunningMainCycle
+
+    @override
+    def _get_seconds_remaining(self) -> int:
+        return self._appliance.get_time_remaining()
 
 
 class WhirlpoolOvenCavitySensor(WhirlpoolOvenEntity, SensorEntity):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Extracts the shared "end time" timestamp logic (drift-guard math,
`RestoreSensor` integration, running/finished state tracking) out of
`WasherDryerTimeSensorBase` into a new, more general
`WhirlpoolTimeSensorBase`, using three abstract hooks (`_is_finished`,
`_is_running`, `_get_seconds_remaining`) instead of hard-coding the
washer/dryer-specific `get_time_remaining()` call.

This is a pure refactor with no behavior change: the washer and dryer
sensor classes are functionally identical, and the existing washer/dryer
sensor tests pass unmodified against the new base class, which is the
actual regression check for this PR.

It's groundwork for an upcoming [oven kitchen-timer sensor](https://github.com/home-assistant/core/pull/176463), which needs
the same end-time/restore/drift-guard behavior against a different
underlying API (a `KitchenTimer` object rather than `Washer`/`Dryer`).
Splitting this out lets that feature PR stay small, and lets this
refactor be reviewed and merged independently on its own merits.

Also includes a follow-up fix: `@override` needs to decorate the
underlying function, not the already-built `property` object, for the
override marker to actually take effect. Matches the same fix the
maintainer applied on the sibling oven-light PR (#176364) for the
identical pattern — this codebase inherited the wrong ordering from the
pre-existing `WasherDryerTimeSensorBase.native_value`, verbatim.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr