### PR TITLE
Fix restoring the location of Traccar device trackers

### DIFF
--- a/homeassistant/components/traccar/device_tracker.py
+++ b/homeassistant/components/traccar/device_tracker.py
@@ -5,8 +5,12 @@ from datetime import timedelta
 import logging
 from typing import override
 
-from homeassistant.components.device_tracker import TrackerEntity
+from homeassistant.components.device_tracker import (
+    TrackerEntity,
+    TrackerEntityStateAttribute,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import ATTR_BATTERY_LEVEL, EntityStateAttribute
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -16,12 +20,8 @@ from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import DOMAIN, TRACKER_UPDATE
 from .const import (
-    ATTR_ACCURACY,
     ATTR_ALTITUDE,
-    ATTR_BATTERY,
     ATTR_BEARING,
-    ATTR_LATITUDE,
-    ATTR_LONGITUDE,
     ATTR_SPEED,
     EVENT_ALARM,
     EVENT_ALL_EVENTS,
@@ -162,15 +162,17 @@ class TraccarEntity(TrackerEntity, RestoreEntity):
             return
 
         attr = state.attributes
-        self._attr_latitude = attr.get(ATTR_LATITUDE)
-        self._attr_longitude = attr.get(ATTR_LONGITUDE)
-        self._attr_location_accuracy = attr.get(ATTR_ACCURACY, 0)
+        self._attr_latitude = attr.get(EntityStateAttribute.LATITUDE)
+        self._attr_longitude = attr.get(EntityStateAttribute.LONGITUDE)
+        self._attr_location_accuracy = attr.get(
+            TrackerEntityStateAttribute.GPS_ACCURACY, 0
+        )
         self._attr_extra_state_attributes = {
             ATTR_ALTITUDE: attr.get(ATTR_ALTITUDE),
             ATTR_BEARING: attr.get(ATTR_BEARING),
             ATTR_SPEED: attr.get(ATTR_SPEED),
         }
-        self._battery = attr.get(ATTR_BATTERY)
+        self._battery = attr.get(ATTR_BATTERY_LEVEL)
 
     @override
     async def async_will_remove_from_hass(self) -> None:

--- a/tests/components/traccar/test_device_tracker.py
+++ b/tests/components/traccar/test_device_tracker.py
@@ -1,0 +1,72 @@
+"""The tests for the Traccar device tracker platform."""
+
+import pytest
+
+from homeassistant.components.device_tracker import (
+    DOMAIN as DEVICE_TRACKER_DOMAIN,
+    TrackerEntityStateAttribute,
+)
+from homeassistant.components.device_tracker.legacy import Device
+from homeassistant.components.traccar import DOMAIN
+from homeassistant.const import (
+    ATTR_BATTERY_LEVEL,
+    CONF_WEBHOOK_ID,
+    STATE_NOT_HOME,
+    EntityStateAttribute,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import device_registry as dr
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry, mock_restore_cache
+
+DEVICE_ID = "device_1"
+ENTITY_ID = f"{DEVICE_TRACKER_DOMAIN}.{DEVICE_ID}"
+
+
+@pytest.fixture(autouse=True)
+def mock_dev_track(mock_device_tracker_conf: list[Device]) -> None:
+    """Mock device tracker config loading."""
+
+
+async def test_restore_state(hass: HomeAssistant) -> None:
+    """Test that the previous location is restored for a known device."""
+    assert await async_setup_component(hass, DEVICE_TRACKER_DOMAIN, {})
+
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_WEBHOOK_ID: "webhook_id"})
+    entry.add_to_hass(hass)
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, DEVICE_ID)},
+    )
+
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                ENTITY_ID,
+                STATE_NOT_HOME,
+                {
+                    EntityStateAttribute.LATITUDE: 1.0,
+                    EntityStateAttribute.LONGITUDE: 2.0,
+                    TrackerEntityStateAttribute.GPS_ACCURACY: 30,
+                    ATTR_BATTERY_LEVEL: 40,
+                    "altitude": 50,
+                    "bearing": 60,
+                    "speed": 70,
+                },
+            )
+        ],
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state.attributes[EntityStateAttribute.LATITUDE] == 1.0
+    assert state.attributes[EntityStateAttribute.LONGITUDE] == 2.0
+    assert state.attributes[TrackerEntityStateAttribute.GPS_ACCURACY] == 30
+    assert state.attributes[ATTR_BATTERY_LEVEL] == 40
+    assert state.attributes["altitude"] == 50
+    assert state.attributes["bearing"] == 60
+    assert state.attributes["speed"] == 70


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a Traccar device tracker entity is restored on restart, the previous location was read from the wrong state attributes.

The restore code reads the previous state's attributes using Traccar's own webhook payload constants (`ATTR_LATITUDE = "lat"`, `ATTR_LONGITUDE = "lon"`, `ATTR_ACCURACY = "accuracy"`, `ATTR_BATTERY = "batt"`), but `TrackerEntity` writes its state attributes as `latitude`, `longitude`, `gps_accuracy` and `battery_level`. As a result every restored entity came back without coordinates, with an accuracy of `0` and without a battery level, until the device reported again.

The reads now use `EntityStateAttribute.LATITUDE`/`EntityStateAttribute.LONGITUDE`, `TrackerEntityStateAttribute.GPS_ACCURACY` and `ATTR_BATTERY_LEVEL`. The altitude, bearing and speed attributes were already correct, as those constants match the extra state attributes the entity writes.

A regression test is added: it fails on `dev` with `KeyError: 'latitude'` and passes with this fix.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
