### PR TITLE
Add repair-issue reporting to energieleser 

### DIFF
--- a/homeassistant/components/energieleser/__init__.py
+++ b/homeassistant/components/energieleser/__init__.py
@@ -4,8 +4,10 @@ from energieleser import EnergieleserClient
 
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .const import DOMAIN
 from .coordinator import EnergieleserConfigEntry, EnergieleserCoordinator
 
 PLATFORMS: list[Platform] = [Platform.SENSOR]
@@ -30,4 +32,5 @@ async def async_unload_entry(
     hass: HomeAssistant, entry: EnergieleserConfigEntry
 ) -> bool:
     """Unload an energieleser config entry."""
+    ir.async_delete_issue(hass, DOMAIN, f"pin_locked_{entry.entry_id}")
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/energieleser/coordinator.py
+++ b/homeassistant/components/energieleser/coordinator.py
@@ -9,11 +9,13 @@ from energieleser import (
     EnergieleserDevice,
     EnergieleserError,
     EnergieleserUnknownDeviceError,
+    StromleserOneDevice,
 )
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN, LOGGER
@@ -74,4 +76,23 @@ class EnergieleserCoordinator(DataUpdateCoordinator[EnergieleserDevice]):
                     "device_id": self.device_id,
                 },
             ) from err
+        if isinstance(device, StromleserOneDevice):
+            issue_id = f"pin_locked_{self.config_entry.entry_id}"
+            if device.pin_locked:
+                ir.async_create_issue(
+                    self.hass,
+                    DOMAIN,
+                    issue_id,
+                    is_fixable=False,
+                    is_persistent=False,
+                    learn_more_url="https://docs.energieleser.de/en/docs/stromleser-one/installation/preparation",
+                    severity=ir.IssueSeverity.WARNING,
+                    translation_key="meter_locked",
+                    translation_placeholders={
+                        "device_name": self.config_entry.title,
+                    },
+                )
+            else:
+                ir.async_delete_issue(self.hass, DOMAIN, issue_id)
+
         return device

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -69,7 +69,7 @@ rules:
   exception-translations: done
   icon-translations: todo
   reconfiguration-flow: done
-  repair-issues: todo
+  repair-issues: done
   stale-devices:
     status: exempt
     comment: One device per config entry; the device is removed when the entry is removed.

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -103,5 +103,11 @@
     "unknown_device": {
       "message": "The device type for {device_id} is unknown or unsupported"
     }
+  },
+  "issues": {
+    "meter_locked": {
+      "description": "The electricity meter connected to {device_name} is not providing high-resolution data. You need to unlock the meter by entering the PIN provided by your electricity company or grid operator. See the linked instructions for more details.",
+      "title": "Meter PIN Required"
+    }
   }
 }

--- a/homeassistant/components/energieleser/strings.json
+++ b/homeassistant/components/energieleser/strings.json
@@ -106,7 +106,7 @@
   },
   "issues": {
     "meter_locked": {
-      "description": "The electricity meter connected to {device_name} is not providing high-resolution data. You need to unlock the meter by entering the PIN provided by your electricity company or grid operator. See the linked instructions for more details.",
+      "description": "The electricity meter connected to {device_name} is not providing high-resolution data. You need to unlock the physical meter by entering the PIN (provided by your electricity company or grid operator) directly on the meter. Once the meter is unlocked, high-resolution data will be provided and this issue will resolve itself automatically. See the linked instructions for details on how to enter the PIN.",
       "title": "Meter PIN Required"
     }
   }

--- a/tests/components/energieleser/conftest.py
+++ b/tests/components/energieleser/conftest.py
@@ -1,6 +1,7 @@
 """Fixtures for energieleser integration tests."""
 
 from collections.abc import Generator
+from dataclasses import replace
 from unittest.mock import AsyncMock, patch
 
 from energieleser import (
@@ -76,6 +77,14 @@ WASSERLESER_API_RESPONSE: dict = {
 def mock_stromleser_device() -> StromleserOneDevice:
     """Return a parsed stromleser device built from the API fixture."""
     return StromleserOneDevice.from_payload(STROMLESER_API_RESPONSE)
+
+
+@pytest.fixture
+def mock_locked_stromleser_device(
+    mock_stromleser_device: StromleserOneDevice,
+) -> StromleserOneDevice:
+    """Return a stromleser device with PIN locked."""
+    return replace(mock_stromleser_device, pin_locked=True)
 
 
 @pytest.fixture

--- a/tests/components/energieleser/test_init.py
+++ b/tests/components/energieleser/test_init.py
@@ -119,7 +119,6 @@ async def test_meter_locked_repair_issue(
         "device_name": mock_stromleser_config_entry.title,
     }
 
-    # Simulate meter unlocking on next update
     mock_energieleser_client.get_device.return_value = mock_stromleser_device
     coordinator = mock_stromleser_config_entry.runtime_data
     await coordinator.async_refresh()

--- a/tests/components/energieleser/test_init.py
+++ b/tests/components/energieleser/test_init.py
@@ -8,9 +8,11 @@ from energieleser import (
     EnergieleserUnknownDeviceError,
     StromleserOneDevice,
 )
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.energieleser.const import CONF_SW_VERSION, DOMAIN
+from homeassistant.components.energieleser.coordinator import SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_HOST
 from homeassistant.core import HomeAssistant
@@ -18,7 +20,7 @@ from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from .conftest import STROMLESER_DEVICE_ID, STROMLESER_SW_VERSION
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_energieleser_client")
@@ -99,6 +101,7 @@ async def test_meter_locked_repair_issue(
     mock_locked_stromleser_device: StromleserOneDevice,
     mock_stromleser_config_entry: MockConfigEntry,
     issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test repair issue is created when meter is locked and deleted when unlocked."""
     mock_energieleser_client.get_device.return_value = mock_locked_stromleser_device
@@ -120,8 +123,8 @@ async def test_meter_locked_repair_issue(
     }
 
     mock_energieleser_client.get_device.return_value = mock_stromleser_device
-    coordinator = mock_stromleser_config_entry.runtime_data
-    await coordinator.async_refresh()
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     assert issue_registry.async_get_issue(DOMAIN, issue_id) is None

--- a/tests/components/energieleser/test_init.py
+++ b/tests/components/energieleser/test_init.py
@@ -6,6 +6,7 @@ from energieleser import (
     EnergieleserConnectionError,
     EnergieleserError,
     EnergieleserUnknownDeviceError,
+    StromleserOneDevice,
 )
 import pytest
 
@@ -13,7 +14,7 @@ from homeassistant.components.energieleser.const import CONF_SW_VERSION, DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID, CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, issue_registry as ir
 
 from .conftest import STROMLESER_DEVICE_ID, STROMLESER_SW_VERSION
 
@@ -89,3 +90,62 @@ async def test_device_exposes_discovery_sw_version(
     )
     assert device is not None
     assert device.sw_version == STROMLESER_SW_VERSION
+
+
+async def test_meter_locked_repair_issue(
+    hass: HomeAssistant,
+    mock_energieleser_client: AsyncMock,
+    mock_stromleser_device: StromleserOneDevice,
+    mock_locked_stromleser_device: StromleserOneDevice,
+    mock_stromleser_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test repair issue is created when meter is locked and deleted when unlocked."""
+    mock_energieleser_client.get_device.return_value = mock_locked_stromleser_device
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_stromleser_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"pin_locked_{mock_stromleser_config_entry.entry_id}"
+    issue = issue_registry.async_get_issue(DOMAIN, issue_id)
+    assert issue is not None
+    assert issue.translation_key == "meter_locked"
+    assert (
+        issue.learn_more_url
+        == "https://docs.energieleser.de/en/docs/stromleser-one/installation/preparation"
+    )
+    assert issue.translation_placeholders == {
+        "device_name": mock_stromleser_config_entry.title,
+    }
+
+    # Simulate meter unlocking on next update
+    mock_energieleser_client.get_device.return_value = mock_stromleser_device
+    coordinator = mock_stromleser_config_entry.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None
+
+
+async def test_meter_locked_repair_issue_removed_on_unload(
+    hass: HomeAssistant,
+    mock_energieleser_client: AsyncMock,
+    mock_locked_stromleser_device: StromleserOneDevice,
+    mock_stromleser_config_entry: MockConfigEntry,
+    issue_registry: ir.IssueRegistry,
+) -> None:
+    """Test repair issue is deleted when entry is unloaded."""
+    mock_energieleser_client.get_device.return_value = mock_locked_stromleser_device
+    mock_stromleser_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_stromleser_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    issue_id = f"pin_locked_{mock_stromleser_config_entry.entry_id}"
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is not None
+
+    assert await hass.config_entries.async_unload(mock_stromleser_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert issue_registry.async_get_issue(DOMAIN, issue_id) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements repair issue functionality in the `energieleser` integration when a stromleser device reports that the electricity meter is PIN-locked. 

Locked Meter Detection: Register a repair issue when the device reports the meter being locked 
Issue Cleanup: Remove the issue once the meter is reported as unlocked by the device



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr