### PR TITLE
Retry rympro setup on OperationError instead of failing permanently

### DIFF
--- a/homeassistant/components/rympro/__init__.py
+++ b/homeassistant/components/rympro/__init__.py
@@ -29,6 +29,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: RymProConfigEntry) -> bo
             token = await rympro.login(data[CONF_EMAIL], data[CONF_PASSWORD], "ha")
         except UnauthorizedError as error:
             raise ConfigEntryAuthFailed from error
+        except CannotConnectError as error:
+            raise ConfigEntryNotReady from error
         hass.config_entries.async_update_entry(
             entry,
             data={**data, CONF_TOKEN: token},

--- a/homeassistant/components/rympro/__init__.py
+++ b/homeassistant/components/rympro/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from pyrympro import CannotConnectError, RymPro, UnauthorizedError
+from pyrympro import CannotConnectError, OperationError, RymPro, UnauthorizedError
 
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TOKEN, Platform
 from homeassistant.core import HomeAssistant
@@ -22,7 +22,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RymProConfigEntry) -> bo
     rympro.set_token(data[CONF_TOKEN])
     try:
         await rympro.account_info()
-    except CannotConnectError as error:
+    except (CannotConnectError, OperationError) as error:
         raise ConfigEntryNotReady from error
     except UnauthorizedError:
         try:

--- a/tests/components/rympro/test_init.py
+++ b/tests/components/rympro/test_init.py
@@ -1,0 +1,69 @@
+"""Test the Read Your Meter Pro integration setup."""
+
+from unittest.mock import patch
+
+from pyrympro import CannotConnectError, OperationError, UnauthorizedError
+import pytest
+
+from homeassistant.components.rympro.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD, CONF_TOKEN, CONF_UNIQUE_ID
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+TEST_DATA = {
+    CONF_EMAIL: "test-email",
+    CONF_PASSWORD: "test-password",
+    CONF_TOKEN: "test-token",
+    CONF_UNIQUE_ID: "test-account-number",
+}
+
+
+@pytest.fixture
+def config_entry(hass: HomeAssistant) -> MockConfigEntry:
+    """Create a mock config entry."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=TEST_DATA,
+        unique_id=TEST_DATA[CONF_UNIQUE_ID],
+    )
+    config_entry.add_to_hass(hass)
+    return config_entry
+
+
+@pytest.mark.parametrize("exception", [CannotConnectError, OperationError])
+async def test_account_info_error_retries_setup(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    exception: type[Exception],
+) -> None:
+    """Test that a transient account_info error schedules a setup retry."""
+    with patch(
+        "homeassistant.components.rympro.RymPro.account_info",
+        side_effect=exception,
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_relogin_cannot_connect_error_retries_setup(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test that a connection error while re-authenticating retries setup."""
+    with (
+        patch(
+            "homeassistant.components.rympro.RymPro.account_info",
+            side_effect=UnauthorizedError,
+        ),
+        patch(
+            "homeassistant.components.rympro.RymPro.login",
+            side_effect=CannotConnectError,
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
## Proposed change

`async_setup_entry()` only caught `CannotConnectError` around `account_info()`. An `OperationError` (e.g. a 429 from the vendor's API) propagated unhandled instead, which Home Assistant treats as a hard setup failure (`setup_error`) rather than a retryable one — the config entry then never recovers on its own and needs a manual reload.

This is what turns a transient upstream hiccup (a day-rollover indexing bug in the `pyrympro` library, see [OnFreund/pyrympro#7](https://github.com/OnFreund/pyrympro/pull/7)) into a permanent failure: repeated retries during first-refresh call `account_info()` again each time, and if the vendor rate-limits that burst, the resulting `OperationError` isn't caught and kills the entry outright.

The same gap existed on the re-login path: if `account_info()` raises `UnauthorizedError` and the subsequent `login()` call itself fails with `CannotConnectError` (e.g. the same kind of transient vendor hiccup happening during a token refresh instead), that was also left uncaught.

This PR:
- Catches `OperationError` alongside `CannotConnectError` around `account_info()` and raises `ConfigEntryNotReady`, so setup retries automatically with HA's built-in backoff instead of requiring a manual reload.
- Catches `CannotConnectError` around the `login()` re-auth call the same way.
- Adds tests covering both retry paths.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This PR is related to issue:
- Companion fix in the underlying library: [OnFreund/pyrympro#7](https://github.com/OnFreund/pyrympro/pull/7)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] There is no commented out code in this PR.
- [x] Tests have been added to verify that the new code works.