### PR TITLE
[Overseerr] feat: implement searching and request media

### DIFF
--- a/homeassistant/components/overseerr/config_flow.py
+++ b/homeassistant/components/overseerr/config_flow.py
@@ -1,5 +1,4 @@
 """Config flow for Overseerr."""
-
 from collections.abc import Mapping
 from typing import Any, override
 

--- a/homeassistant/components/overseerr/config_flow.py
+++ b/homeassistant/components/overseerr/config_flow.py
@@ -1,4 +1,5 @@
 """Config flow for Overseerr."""
+
 from collections.abc import Mapping
 from typing import Any, override
 

--- a/homeassistant/components/overseerr/const.py
+++ b/homeassistant/components/overseerr/const.py
@@ -9,9 +9,15 @@ LOGGER = logging.getLogger(__package__)
 
 REQUESTS = "requests"
 
+ATTR_LIMIT = "limit"
+ATTR_MEDIA_TYPE = "media_type"
+ATTR_QUERY = "query"
+ATTR_REQUESTED_BY = "requested_by"
+ATTR_SEASONS = "seasons"
 ATTR_STATUS = "status"
 ATTR_SORT_ORDER = "sort_order"
-ATTR_REQUESTED_BY = "requested_by"
+ATTR_TMDB_ID = "tmdb_id"
+
 
 EVENT_KEY = f"{DOMAIN}_event"
 

--- a/homeassistant/components/overseerr/const.py
+++ b/homeassistant/components/overseerr/const.py
@@ -15,7 +15,7 @@ ATTR_REQUESTED_BY = "requested_by"
 ATTR_SEASONS = "seasons"
 ATTR_STATUS = "status"
 ATTR_SORT_ORDER = "sort_order"
-ATTR_TMDB_ID = "tmdb_id"
+ATTR_MEDIA_ID = "media_id"
 
 
 EVENT_KEY = f"{DOMAIN}_event"

--- a/homeassistant/components/overseerr/const.py
+++ b/homeassistant/components/overseerr/const.py
@@ -9,7 +9,6 @@ LOGGER = logging.getLogger(__package__)
 
 REQUESTS = "requests"
 
-ATTR_LIMIT = "limit"
 ATTR_MEDIA_TYPE = "media_type"
 ATTR_QUERY = "query"
 ATTR_REQUESTED_BY = "requested_by"

--- a/homeassistant/components/overseerr/icons.json
+++ b/homeassistant/components/overseerr/icons.json
@@ -32,6 +32,15 @@
   "services": {
     "get_requests": {
       "service": "mdi:multimedia"
+    },
+    "request_media": {
+      "service": "mdi:download"
+    },
+    "search_and_request": {
+      "service": "mdi:download"
+    },
+    "search_media": {
+      "service": "mdi:magnify"
     }
   }
 }

--- a/homeassistant/components/overseerr/icons.json
+++ b/homeassistant/components/overseerr/icons.json
@@ -36,9 +36,6 @@
     "request_media": {
       "service": "mdi:download"
     },
-    "search_and_request": {
-      "service": "mdi:download"
-    },
     "search_media": {
       "service": "mdi:magnify"
     }

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -2,6 +2,7 @@
 
 from dataclasses import asdict
 from typing import Any, cast
+from urllib.parse import quote
 
 from python_overseerr import OverseerrClient, OverseerrConnectionError
 import voluptuous as vol
@@ -21,7 +22,12 @@ from homeassistant.util.json import JsonValueType
 from .const import ATTR_REQUESTED_BY, ATTR_SORT_ORDER, ATTR_STATUS, DOMAIN, LOGGER
 from .coordinator import OverseerrConfigEntry
 
+ATTR_QUERY = "query"
+ATTR_LIMIT = "limit"
+
 SERVICE_GET_REQUESTS = "get_requests"
+SERVICE_SEARCH_MEDIA = "search_media"
+
 SERVICE_GET_REQUESTS_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
@@ -30,6 +36,14 @@ SERVICE_GET_REQUESTS_SCHEMA = vol.Schema(
         ),
         vol.Optional(ATTR_SORT_ORDER): vol.In(["added", "modified"]),
         vol.Optional(ATTR_REQUESTED_BY): int,
+    }
+)
+
+SERVICE_SEARCH_MEDIA_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): str,
+        vol.Required(ATTR_QUERY): str,
+        vol.Optional(ATTR_LIMIT): vol.Coerce(int),
     }
 )
 
@@ -92,6 +106,30 @@ async def _async_get_requests(call: ServiceCall) -> ServiceResponse:
     return {"requests": cast(list[JsonValueType], result)}
 
 
+async def _async_search_media(call: ServiceCall) -> ServiceResponse:
+    """Search for media in Overseerr."""
+    entry = _async_get_entry(call.hass, call.data[ATTR_CONFIG_ENTRY_ID])
+    client = entry.runtime_data.client
+    query = call.data[ATTR_QUERY]
+    limit = call.data.get(ATTR_LIMIT)
+    try:
+        LOGGER.debug("Searching for '%s'", query)
+        # URL encode the query to handle spaces and special characters
+        search_results = await client.search(quote(query))
+    except OverseerrConnectionError as err:
+        LOGGER.error("Error searching for '%s': %s", query, str(err))
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="connection_error",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    if limit is not None and limit > 0:
+        search_results = search_results[:limit]
+
+    return {"results": cast(list[JsonValueType], [asdict(result) for result in search_results])}
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up the services for the Overseerr integration."""
@@ -101,5 +139,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_GET_REQUESTS,
         _async_get_requests,
         schema=SERVICE_GET_REQUESTS_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SEARCH_MEDIA,
+        _async_search_media,
+        schema=SERVICE_SEARCH_MEDIA_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -24,9 +24,13 @@ from .coordinator import OverseerrConfigEntry
 
 ATTR_QUERY = "query"
 ATTR_LIMIT = "limit"
+ATTR_MEDIA_TYPE = "media_type"
+ATTR_TMDB_ID = "tmdb_id"
+ATTR_SEASONS = "seasons"
 
 SERVICE_GET_REQUESTS = "get_requests"
 SERVICE_SEARCH_MEDIA = "search_media"
+SERVICE_REQUEST_MEDIA = "request_media"
 
 SERVICE_GET_REQUESTS_SCHEMA = vol.Schema(
     {
@@ -44,6 +48,19 @@ SERVICE_SEARCH_MEDIA_SCHEMA = vol.Schema(
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_QUERY): str,
         vol.Optional(ATTR_LIMIT): vol.Coerce(int),
+    }
+)
+
+SERVICE_REQUEST_MEDIA_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_CONFIG_ENTRY_ID): str,
+        vol.Required(ATTR_MEDIA_TYPE): vol.In(["movie", "tv"]),
+        vol.Required(ATTR_TMDB_ID): vol.Coerce(int),
+        vol.Optional(ATTR_SEASONS): vol.Any(
+            vol.Coerce(int),
+            [vol.Coerce(int)],
+            "all",
+        ),
     }
 )
 
@@ -130,6 +147,42 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
     return {"results": cast(list[JsonValueType], [asdict(result) for result in search_results])}
 
 
+async def _async_request_media(call: ServiceCall) -> ServiceResponse:
+    """Request media in Overseerr."""
+    entry = _async_get_entry(call.hass, call.data[ATTR_CONFIG_ENTRY_ID])
+    client = entry.runtime_data.client
+    media_type = call.data[ATTR_MEDIA_TYPE]
+    tmdb_id = call.data[ATTR_TMDB_ID]
+    seasons = call.data.get(ATTR_SEASONS)
+
+    # Convert single integer to list for seasons
+    if isinstance(seasons, int):
+        seasons = [seasons]
+
+    try:
+        LOGGER.debug(
+            "Requesting %s with TMDB ID %s (seasons: %s)",
+            media_type,
+            tmdb_id,
+            seasons if seasons else "none",
+        )
+        request = await client.create_request(media_type, tmdb_id, seasons)
+    except OverseerrConnectionError as err:
+        LOGGER.error(
+            "Error requesting %s with TMDB ID %s: %s",
+            media_type,
+            tmdb_id,
+            str(err),
+        )
+        raise HomeAssistantError(
+            translation_domain=DOMAIN,
+            translation_key="connection_error",
+            translation_placeholders={"error": str(err)},
+        ) from err
+
+    return {"request": cast(JsonValueType, asdict(request))}
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up the services for the Overseerr integration."""
@@ -147,5 +200,13 @@ def async_setup_services(hass: HomeAssistant) -> None:
         SERVICE_SEARCH_MEDIA,
         _async_search_media,
         schema=SERVICE_SEARCH_MEDIA_SCHEMA,
+        supports_response=SupportsResponse.ONLY,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REQUEST_MEDIA,
+        _async_request_media,
+        schema=SERVICE_REQUEST_MEDIA_SCHEMA,
         supports_response=SupportsResponse.ONLY,
     )

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -18,14 +18,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import service
 from homeassistant.util.json import JsonValueType
 
-from .const import ATTR_REQUESTED_BY, ATTR_SORT_ORDER, ATTR_STATUS, DOMAIN, LOGGER
+from .const import ATTR_LIMIT, ATTR_MEDIA_TYPE, ATTR_QUERY, ATTR_REQUESTED_BY, ATTR_SEASONS, ATTR_SORT_ORDER, \
+    ATTR_STATUS, \
+    ATTR_TMDB_ID, DOMAIN, \
+    LOGGER
 from .coordinator import OverseerrConfigEntry
 
-ATTR_QUERY = "query"
-ATTR_LIMIT = "limit"
-ATTR_MEDIA_TYPE = "media_type"
-ATTR_TMDB_ID = "tmdb_id"
-ATTR_SEASONS = "seasons"
+
 
 SERVICE_GET_REQUESTS = "get_requests"
 SERVICE_SEARCH_MEDIA = "search_media"

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -88,7 +88,7 @@ async def _get_media(
 
 
 async def _async_get_requests(call: ServiceCall) -> ServiceResponse:
-    """Get requests made to Overseerr."""
+    """Get requests made to Seerr."""
     entry: OverseerrConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
@@ -129,7 +129,7 @@ async def _async_get_requests(call: ServiceCall) -> ServiceResponse:
 
 
 async def _async_search_media(call: ServiceCall) -> ServiceResponse:
-    """Search for media in Overseerr."""
+    """Search for media in Seerr."""
     entry: OverseerrConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
@@ -158,7 +158,7 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
 
 
 async def _async_request_media(call: ServiceCall) -> ServiceResponse:
-    """Request media in Overseerr."""
+    """Request media in Seerr."""
     entry: OverseerrConfigEntry = service.async_get_config_entry(
         call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
     )
@@ -210,7 +210,7 @@ def parse_seasons_input(seasons_input: Any | None) -> Literal["all"] | list[int]
 
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
-    """Set up the services for the Overseerr integration."""
+    """Set up the services for the Seerr integration."""
 
     hass.services.async_register(
         DOMAIN,

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -193,17 +193,20 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
 
 def parse_seasons_input(seasons_input: Any | None) -> Literal["all"] | list[int]:
     """Parse all possible inputs to "all" or a list of integers."""
-    seasons_input = str(seasons_input).strip()
-    if seasons_input == "":
+    if seasons_input is None:
+        return "all"
+
+    seasons_str = str(seasons_input).strip()
+    if seasons_str == "":
         return "all"
 
     try:
-        parsed = ast.literal_eval(seasons_input)
+        parsed = ast.literal_eval(seasons_str)
         if isinstance(parsed, int):
             return [parsed]
         return list(parsed)
-    except ValueError, SyntaxError:
-        LOGGER.error("Unable to cast input to a list '%s'", seasons_input)
+    except (ValueError, SyntaxError, TypeError):
+        LOGGER.error("Unable to cast input to a list '%s'", seasons_str)
         return "all"
 
 

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -20,13 +20,13 @@ from homeassistant.helpers import service
 from homeassistant.util.json import JsonValueType
 
 from .const import (
+    ATTR_MEDIA_ID,
     ATTR_MEDIA_TYPE,
     ATTR_QUERY,
     ATTR_REQUESTED_BY,
     ATTR_SEASONS,
     ATTR_SORT_ORDER,
     ATTR_STATUS,
-    ATTR_TMDB_ID,
     DOMAIN,
     LOGGER,
 )
@@ -58,7 +58,7 @@ SERVICE_REQUEST_MEDIA_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_MEDIA_TYPE): vol.In(["movie", "tv"]),
-        vol.Required(ATTR_TMDB_ID): vol.Coerce(int),
+        vol.Required(ATTR_MEDIA_ID): vol.Coerce(int),
         vol.Optional(ATTR_SEASONS): vol.Any(
             vol.Coerce(int),
             [vol.Coerce(int)],
@@ -158,18 +158,18 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
     )
     client = entry.runtime_data.client
     media_type = call.data[ATTR_MEDIA_TYPE]
-    tmdb_id = call.data[ATTR_TMDB_ID]
+    media_id = call.data[ATTR_MEDIA_ID]
     seasons = parse_seasons_input(call.data.get(ATTR_SEASONS))
 
     LOGGER.debug(
-        "Requesting %s with TMDB ID %s (seasons: %s)",
+        "Requesting %s with media ID %s (seasons: %s)",
         media_type,
-        tmdb_id,
+        media_id,
         seasons or "none",
     )
     try:
         # We can always pass in the seasons, they will be ignored if the media type isn't TV
-        request = await client.create_request(media_type, tmdb_id, seasons)
+        request = await client.create_request(media_type, media_id, seasons)
     except OverseerrConnectionError as err:
         raise HomeAssistantError(
             translation_domain=DOMAIN,

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -133,8 +133,9 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
     )
     client = entry.runtime_data.client
     query = call.data[ATTR_QUERY]
+
+    LOGGER.debug("Searching for '%s'", query)
     try:
-        LOGGER.debug("Searching for '%s'", query)
         search_results = await client.search(query)
     except OverseerrConnectionError as err:
         raise HomeAssistantError(
@@ -160,13 +161,13 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
     tmdb_id = call.data[ATTR_TMDB_ID]
     seasons = parse_seasons_input(call.data.get(ATTR_SEASONS))
 
+    LOGGER.debug(
+        "Requesting %s with TMDB ID %s (seasons: %s)",
+        media_type,
+        tmdb_id,
+        seasons or "none",
+    )
     try:
-        LOGGER.debug(
-            "Requesting %s with TMDB ID %s (seasons: %s)",
-            media_type,
-            tmdb_id,
-            seasons or "none",
-        )
         # We can always pass in the seasons, they will be ignored if the media type isn't TV
         request = await client.create_request(media_type, tmdb_id, seasons)
     except OverseerrConnectionError as err:

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -2,7 +2,6 @@
 
 from dataclasses import asdict
 from typing import Any, cast
-from urllib.parse import quote
 
 from python_overseerr import OverseerrClient, OverseerrConnectionError
 import voluptuous as vol
@@ -125,14 +124,16 @@ async def _async_get_requests(call: ServiceCall) -> ServiceResponse:
 
 async def _async_search_media(call: ServiceCall) -> ServiceResponse:
     """Search for media in Overseerr."""
-    entry = _async_get_entry(call.hass, call.data[ATTR_CONFIG_ENTRY_ID])
+    entry: OverseerrConfigEntry = service.async_get_config_entry(
+        call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
+    )
     client = entry.runtime_data.client
     query = call.data[ATTR_QUERY]
     limit = call.data.get(ATTR_LIMIT)
     try:
         LOGGER.debug("Searching for '%s'", query)
         # URL encode the query to handle spaces and special characters
-        search_results = await client.search(quote(query))
+        search_results = await client.search(query)
     except OverseerrConnectionError as err:
         LOGGER.error("Error searching for '%s': %s", query, str(err))
         raise HomeAssistantError(
@@ -144,12 +145,18 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
     if limit is not None and limit > 0:
         search_results = search_results[:limit]
 
-    return {"results": cast(list[JsonValueType], [asdict(result) for result in search_results])}
+    return {
+        "results": cast(
+            list[JsonValueType], [asdict(result) for result in search_results]
+        )
+    }
 
 
 async def _async_request_media(call: ServiceCall) -> ServiceResponse:
     """Request media in Overseerr."""
-    entry = _async_get_entry(call.hass, call.data[ATTR_CONFIG_ENTRY_ID])
+    entry: OverseerrConfigEntry = service.async_get_config_entry(
+        call.hass, DOMAIN, call.data[ATTR_CONFIG_ENTRY_ID]
+    )
     client = entry.runtime_data.client
     media_type = call.data[ATTR_MEDIA_TYPE]
     tmdb_id = call.data[ATTR_TMDB_ID]
@@ -164,7 +171,7 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
             "Requesting %s with TMDB ID %s (seasons: %s)",
             media_type,
             tmdb_id,
-            seasons if seasons else "none",
+            seasons or "none",
         )
         request = await client.create_request(media_type, tmdb_id, seasons)
     except OverseerrConnectionError as err:

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -18,13 +18,19 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import service
 from homeassistant.util.json import JsonValueType
 
-from .const import ATTR_LIMIT, ATTR_MEDIA_TYPE, ATTR_QUERY, ATTR_REQUESTED_BY, ATTR_SEASONS, ATTR_SORT_ORDER, \
-    ATTR_STATUS, \
-    ATTR_TMDB_ID, DOMAIN, \
-    LOGGER
+from .const import (
+    ATTR_LIMIT,
+    ATTR_MEDIA_TYPE,
+    ATTR_QUERY,
+    ATTR_REQUESTED_BY,
+    ATTR_SEASONS,
+    ATTR_SORT_ORDER,
+    ATTR_STATUS,
+    ATTR_TMDB_ID,
+    DOMAIN,
+    LOGGER,
+)
 from .coordinator import OverseerrConfigEntry
-
-
 
 SERVICE_GET_REQUESTS = "get_requests"
 SERVICE_SEARCH_MEDIA = "search_media"
@@ -45,7 +51,7 @@ SERVICE_SEARCH_MEDIA_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_QUERY): str,
-        vol.Optional(ATTR_LIMIT): vol.All(vol.Coerce(int), vol.Range(min=1))
+        vol.Optional(ATTR_LIMIT): vol.All(vol.Coerce(int), vol.Range(min=1)),
     }
 )
 
@@ -134,7 +140,7 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
         # URL encode the query to handle spaces and special characters
         search_results = await client.search(query)
     except OverseerrConnectionError as err:
-        LOGGER.error("Error searching for '%s': %s", query, str(err))
+        LOGGER.info("Error searching for '%s': %s", query, str(err))
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="connection_error",

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -1,7 +1,8 @@
 """Define services for the Overseerr integration."""
 
+import ast
 from dataclasses import asdict
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 from python_overseerr import OverseerrClient, OverseerrConnectionError
 import voluptuous as vol
@@ -137,7 +138,6 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
     limit = call.data.get(ATTR_LIMIT)
     try:
         LOGGER.debug("Searching for '%s'", query)
-        # URL encode the query to handle spaces and special characters
         search_results = await client.search(query)
     except OverseerrConnectionError as err:
         LOGGER.info("Error searching for '%s': %s", query, str(err))
@@ -165,11 +165,7 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
     client = entry.runtime_data.client
     media_type = call.data[ATTR_MEDIA_TYPE]
     tmdb_id = call.data[ATTR_TMDB_ID]
-    seasons = call.data.get(ATTR_SEASONS)
-
-    # Convert single integer to list for seasons
-    if isinstance(seasons, int):
-        seasons = [seasons]
+    seasons = parse_seasons_input(call.data.get(ATTR_SEASONS))
 
     try:
         LOGGER.debug(
@@ -178,6 +174,7 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
             tmdb_id,
             seasons or "none",
         )
+        # We can always pass in the seasons, they will be ignored if the media type isn't TV
         request = await client.create_request(media_type, tmdb_id, seasons)
     except OverseerrConnectionError as err:
         LOGGER.error(
@@ -193,6 +190,22 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
         ) from err
 
     return {"request": cast(JsonValueType, asdict(request))}
+
+
+def parse_seasons_input(seasons_input: Any | None) -> Literal["all"] | list[int]:
+    """Parse all possible inputs to "all" or a list of integers."""
+    seasons_input = str(seasons_input).strip()
+    if seasons_input == "":
+        return "all"
+
+    try:
+        parsed = ast.literal_eval(seasons_input)
+        if isinstance(parsed, int):
+            return [parsed]
+        return list(parsed)
+    except ValueError, SyntaxError:
+        LOGGER.error("Unable to cast input to a list '%s'", seasons_input)
+        return "all"
 
 
 @callback

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -58,7 +58,10 @@ SERVICE_REQUEST_MEDIA_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_MEDIA_TYPE): vol.In(["movie", "tv"]),
-        vol.Required(ATTR_MEDIA_ID): vol.Coerce(int),
+        vol.Required(ATTR_MEDIA_ID): vol.All(
+            vol.Coerce(int),
+            vol.Range(min=1),
+        ),
         vol.Optional(ATTR_SEASONS): vol.Any(
             vol.Coerce(int),
             [vol.Coerce(int)],

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -46,7 +46,7 @@ SERVICE_SEARCH_MEDIA_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_QUERY): str,
-        vol.Optional(ATTR_LIMIT): vol.Coerce(int),
+        vol.Optional(ATTR_LIMIT): vol.All(vol.Coerce(int), vol.Range(min=1))
     }
 )
 

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -140,7 +140,6 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
         LOGGER.debug("Searching for '%s'", query)
         search_results = await client.search(query)
     except OverseerrConnectionError as err:
-        LOGGER.info("Error searching for '%s': %s", query, str(err))
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="connection_error",

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -20,7 +20,6 @@ from homeassistant.helpers import service
 from homeassistant.util.json import JsonValueType
 
 from .const import (
-    ATTR_LIMIT,
     ATTR_MEDIA_TYPE,
     ATTR_QUERY,
     ATTR_REQUESTED_BY,
@@ -52,7 +51,6 @@ SERVICE_SEARCH_MEDIA_SCHEMA = vol.Schema(
     {
         vol.Required(ATTR_CONFIG_ENTRY_ID): str,
         vol.Required(ATTR_QUERY): str,
-        vol.Optional(ATTR_LIMIT): vol.All(vol.Coerce(int), vol.Range(min=1)),
     }
 )
 
@@ -135,7 +133,6 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
     )
     client = entry.runtime_data.client
     query = call.data[ATTR_QUERY]
-    limit = call.data.get(ATTR_LIMIT)
     try:
         LOGGER.debug("Searching for '%s'", query)
         search_results = await client.search(query)
@@ -145,9 +142,6 @@ async def _async_search_media(call: ServiceCall) -> ServiceResponse:
             translation_key="connection_error",
             translation_placeholders={"error": str(err)},
         ) from err
-
-    if limit is not None and limit > 0:
-        search_results = search_results[:limit]
 
     return {
         "results": cast(

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -187,11 +187,8 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
 
 def parse_seasons_input(seasons_input: Any | None) -> Literal["all"] | list[int]:
     """Parse all possible inputs to "all" or a list of integers."""
-    if seasons_input is None:
-        return "all"
-
     seasons_str = str(seasons_input).strip()
-    if seasons_str == "":
+    if seasons_str == "" or seasons_input is None:
         return "all"
 
     try:

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -176,12 +176,6 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
         # We can always pass in the seasons, they will be ignored if the media type isn't TV
         request = await client.create_request(media_type, tmdb_id, seasons)
     except OverseerrConnectionError as err:
-        LOGGER.error(
-            "Error requesting %s with TMDB ID %s: %s",
-            media_type,
-            tmdb_id,
-            str(err),
-        )
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key="connection_error",
@@ -205,8 +199,8 @@ def parse_seasons_input(seasons_input: Any | None) -> Literal["all"] | list[int]
         if isinstance(parsed, int):
             return [parsed]
         return list(parsed)
-    except (ValueError, SyntaxError, TypeError):
-        LOGGER.error("Unable to cast input to a list '%s'", seasons_str)
+    except ValueError, SyntaxError, TypeError:
+        LOGGER.error("Unable to cast input to a list '%s'", seasons_input)
         return "all"
 
 

--- a/homeassistant/components/overseerr/services.py
+++ b/homeassistant/components/overseerr/services.py
@@ -65,7 +65,7 @@ SERVICE_REQUEST_MEDIA_SCHEMA = vol.Schema(
         vol.Optional(ATTR_SEASONS): vol.Any(
             vol.Coerce(int),
             [vol.Coerce(int)],
-            "all",
+            str,
         ),
     }
 )
@@ -186,14 +186,14 @@ async def _async_request_media(call: ServiceCall) -> ServiceResponse:
 def parse_seasons_input(seasons_input: Any | None) -> Literal["all"] | list[int]:
     """Parse all possible inputs to "all" or a list of integers."""
     seasons_str = str(seasons_input).strip()
-    if seasons_str == "" or seasons_input is None:
+    if seasons_input is None or seasons_str in ("", "all"):
         return "all"
 
     try:
         parsed = ast.literal_eval(seasons_str)
         if isinstance(parsed, int):
             return [parsed]
-        return list(parsed)
+        return [int(season) for season in parsed]
     except ValueError, SyntaxError, TypeError:
         LOGGER.error("Unable to cast input to a list '%s'", seasons_input)
         return "all"

--- a/homeassistant/components/overseerr/services.yaml
+++ b/homeassistant/components/overseerr/services.yaml
@@ -47,3 +47,32 @@ search_media:
           min: 1
           mode: box
       description: "Maximum number of results to return"
+
+request_media:
+  description: "Request media"
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: overseerr
+    media_type:
+      required: true
+      selector:
+        select:
+          options:
+            - movie
+            - tv
+          translation_key: media_type
+      description: "The type of media to request (movie or tv)"
+    tmdb_id:
+      required: true
+      selector:
+        number:
+          min: 1
+          mode: box
+      description: "The TMDB ID of the media to request"
+    seasons:
+      selector:
+        text:
+      description: "For TV shows, the seasons to request. Can be a single season number (e.g. 2), a list of season numbers (e.g. 1,2), or 'all' for all seasons"

--- a/homeassistant/components/overseerr/services.yaml
+++ b/homeassistant/components/overseerr/services.yaml
@@ -28,3 +28,22 @@ get_requests:
         number:
           min: 0
           mode: box
+
+search_media:
+  fields:
+    config_entry_id:
+      required: true
+      selector:
+        config_entry:
+          integration: overseerr
+    query:
+      required: true
+      selector:
+        text:
+      description: "The search query"
+    limit:
+      selector:
+        number:
+          min: 1
+          mode: box
+      description: "Maximum number of results to return"

--- a/homeassistant/components/overseerr/services.yaml
+++ b/homeassistant/components/overseerr/services.yaml
@@ -56,7 +56,7 @@ request_media:
             - movie
             - tv
           translation_key: request_media_type
-    tmdb_id:
+    media_id:
       required: true
       selector:
         number:

--- a/homeassistant/components/overseerr/services.yaml
+++ b/homeassistant/components/overseerr/services.yaml
@@ -40,11 +40,6 @@ search_media:
       required: true
       selector:
         text:
-    limit:
-      selector:
-        number:
-          min: 1
-          mode: box
 
 request_media:
   fields:

--- a/homeassistant/components/overseerr/services.yaml
+++ b/homeassistant/components/overseerr/services.yaml
@@ -60,7 +60,7 @@ request_media:
           options:
             - movie
             - tv
-          translation_key: media_type
+          translation_key: request_media_type
     tmdb_id:
       required: true
       selector:

--- a/homeassistant/components/overseerr/services.yaml
+++ b/homeassistant/components/overseerr/services.yaml
@@ -40,16 +40,13 @@ search_media:
       required: true
       selector:
         text:
-      description: "The search query"
     limit:
       selector:
         number:
           min: 1
           mode: box
-      description: "Maximum number of results to return"
 
 request_media:
-  description: "Request media"
   fields:
     config_entry_id:
       required: true
@@ -64,15 +61,12 @@ request_media:
             - movie
             - tv
           translation_key: media_type
-      description: "The type of media to request (movie or tv)"
     tmdb_id:
       required: true
       selector:
         number:
           min: 1
           mode: box
-      description: "The TMDB ID of the media to request"
     seasons:
       selector:
         text:
-      description: "For TV shows, the seasons to request. Can be a single season number (e.g. 2), a list of season numbers (e.g. 1,2), or 'all' for all seasons"

--- a/homeassistant/components/overseerr/strings.json
+++ b/homeassistant/components/overseerr/strings.json
@@ -171,6 +171,10 @@
           "description": "The Seerr instance to create the request on.",
           "name": "Seerr instance"
         },
+        "media_id": {
+          "description": "The TMDB ID or TVDB ID of the media to request.",
+          "name": "Media ID"
+        },
         "media_type": {
           "description": "Type of media to request.",
           "name": "Media type"
@@ -178,10 +182,6 @@
         "seasons": {
           "description": "For TV requests: seasons to request. Optional list of integers (e.g., [1, 2, 4]). If omitted, all seasons will be requested.",
           "name": "Seasons"
-        },
-        "tmdb_id": {
-          "description": "The TMDB ID of the media to request.",
-          "name": "TMDB ID"
         }
       },
       "name": "Request media"

--- a/homeassistant/components/overseerr/strings.json
+++ b/homeassistant/components/overseerr/strings.json
@@ -118,6 +118,12 @@
     }
   },
   "selector": {
+    "request_media_type": {
+      "options": {
+        "movie": "Movie",
+        "tv": "TV"
+      }
+    },
     "request_sort_order": {
       "options": {
         "added": "Added",

--- a/homeassistant/components/overseerr/strings.json
+++ b/homeassistant/components/overseerr/strings.json
@@ -159,11 +159,11 @@
       "name": "Get requests"
     },
     "request_media": {
-      "description": "Creates a media request in Overseerr.",
+      "description": "Creates a media request in Seerr.",
       "fields": {
         "config_entry_id": {
-          "description": "The Overseerr instance to create the request on.",
-          "name": "Overseerr instance"
+          "description": "The Seerr instance to create the request on.",
+          "name": "Seerr instance"
         },
         "media_type": {
           "description": "Type of media to request.",
@@ -181,11 +181,11 @@
       "name": "Request media"
     },
     "search_media": {
-      "description": "Searches for media in Overseerr.",
+      "description": "Searches for media in Seerr.",
       "fields": {
         "config_entry_id": {
-          "description": "The Overseerr instance to search.",
-          "name": "Overseerr instance"
+          "description": "The Seerr instance to search.",
+          "name": "Seerr instance"
         },
         "limit": {
           "description": "Maximum number of results to return.",

--- a/homeassistant/components/overseerr/strings.json
+++ b/homeassistant/components/overseerr/strings.json
@@ -170,7 +170,7 @@
           "name": "Media type"
         },
         "seasons": {
-          "description": "For TV requests: seasons to request. Provide a number, a list of numbers, or 'all'.",
+          "description": "For TV requests: seasons to request. Optional list of integers (e.g., [1, 2, 4]). If omitted, all seasons will be requested.",
           "name": "Seasons"
         },
         "tmdb_id": {
@@ -179,24 +179,6 @@
         }
       },
       "name": "Request media"
-    },
-    "search_and_request": {
-      "description": "Searches for media and creates a request for the best match.",
-      "fields": {
-        "config_entry_id": {
-          "description": "The Overseerr instance to use.",
-          "name": "Overseerr instance"
-        },
-        "query": {
-          "description": "The search query.",
-          "name": "Query"
-        },
-        "seasons": {
-          "description": "For TV requests: seasons to request. Provide a number, a list of numbers, or 'all'.",
-          "name": "Seasons"
-        }
-      },
-      "name": "Search and request"
     },
     "search_media": {
       "description": "Searches for media in Overseerr.",

--- a/homeassistant/components/overseerr/strings.json
+++ b/homeassistant/components/overseerr/strings.json
@@ -193,10 +193,6 @@
           "description": "The Seerr instance to search.",
           "name": "Seerr instance"
         },
-        "limit": {
-          "description": "Maximum number of results to return.",
-          "name": "Limit"
-        },
         "query": {
           "description": "The search query.",
           "name": "Query"

--- a/homeassistant/components/overseerr/strings.json
+++ b/homeassistant/components/overseerr/strings.json
@@ -157,6 +157,64 @@
         }
       },
       "name": "Get requests"
+    },
+    "request_media": {
+      "description": "Creates a media request in Overseerr.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The Overseerr instance to create the request on.",
+          "name": "Overseerr instance"
+        },
+        "media_type": {
+          "description": "Type of media to request.",
+          "name": "Media type"
+        },
+        "seasons": {
+          "description": "For TV requests: seasons to request. Provide a number, a list of numbers, or 'all'.",
+          "name": "Seasons"
+        },
+        "tmdb_id": {
+          "description": "The TMDB ID of the media to request.",
+          "name": "TMDB ID"
+        }
+      },
+      "name": "Request media"
+    },
+    "search_and_request": {
+      "description": "Searches for media and creates a request for the best match.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The Overseerr instance to use.",
+          "name": "Overseerr instance"
+        },
+        "query": {
+          "description": "The search query.",
+          "name": "Query"
+        },
+        "seasons": {
+          "description": "For TV requests: seasons to request. Provide a number, a list of numbers, or 'all'.",
+          "name": "Seasons"
+        }
+      },
+      "name": "Search and request"
+    },
+    "search_media": {
+      "description": "Searches for media in Overseerr.",
+      "fields": {
+        "config_entry_id": {
+          "description": "The Overseerr instance to search.",
+          "name": "Overseerr instance"
+        },
+        "limit": {
+          "description": "Maximum number of results to return.",
+          "name": "Limit"
+        },
+        "query": {
+          "description": "The search query.",
+          "name": "Query"
+        }
+      },
+      "name": "Search media"
     }
   }
 }

--- a/tests/components/overseerr/conftest.py
+++ b/tests/components/overseerr/conftest.py
@@ -67,6 +67,7 @@ def mock_overseerr_client() -> Generator[AsyncMock]:
         client.get_tv_details.return_value = TVDetails.from_json(
             load_fixture("tv.json", DOMAIN)
         )
+        client.search.return_value = []
         yield client
 
 

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -12,7 +12,11 @@ from homeassistant.components.overseerr.const import (
     ATTR_STATUS,
     DOMAIN,
 )
-from homeassistant.components.overseerr.services import SERVICE_GET_REQUESTS
+from homeassistant.components.overseerr.services import (
+    ATTR_QUERY,
+    SERVICE_GET_REQUESTS,
+    SERVICE_SEARCH_MEDIA,
+)
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
@@ -75,6 +79,49 @@ async def test_service_get_requests_no_meta(
         assert request["media"] == {}
 
 
+async def test_service_search_media(
+    hass: HomeAssistant,
+    mock_overseerr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the search_media service."""
+    # Mock the search method
+    mock_overseerr_client.search.return_value = []
+
+    await setup_integration(hass, mock_config_entry)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SEARCH_MEDIA,
+        {
+            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+            ATTR_QUERY: "test",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert response == {"results": []}
+    mock_overseerr_client.search.assert_called_once_with("test")
+
+    # Reset mock
+    mock_overseerr_client.search.reset_mock()
+
+    # Test with a query containing spaces
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SEARCH_MEDIA,
+        {
+            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+            ATTR_QUERY: "test query with spaces",
+        },
+        blocking=True,
+        return_response=True,
+    )
+    assert response == {"results": []}
+    mock_overseerr_client.search.assert_called_once_with("test%20query%20with%20spaces")
+
+
 @pytest.mark.parametrize(
     ("service", "payload", "function", "exception", "raised_exception", "message"),
     [
@@ -82,6 +129,14 @@ async def test_service_get_requests_no_meta(
             SERVICE_GET_REQUESTS,
             {},
             "get_requests",
+            OverseerrConnectionError("Timeout"),
+            HomeAssistantError,
+            "Error connecting to the Seerr instance: Timeout",
+        ),
+        (
+            SERVICE_SEARCH_MEDIA,
+            {ATTR_QUERY: "test"},
+            "search",
             OverseerrConnectionError("Timeout"),
             HomeAssistantError,
             "Error connecting to the Seerr instance: Timeout",
@@ -119,6 +174,7 @@ async def test_services_connection_error(
     ("service", "payload"),
     [
         (SERVICE_GET_REQUESTS, {}),
+        (SERVICE_SEARCH_MEDIA, {ATTR_QUERY: "test"}),
     ],
 )
 async def test_service_entry_availability(

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -298,6 +298,7 @@ async def test_service_entry_availability(
         ("[  1  , 2 ,    3]", [1, 2, 3]),
         ("", "all"),
         ("  ", "all"),
+        (None, "all"),
         ("Not a valid input", "all"),
         ("-", "all"),
     ],

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -9,13 +9,13 @@ from python_overseerr.models import MediaType
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.overseerr.const import (
+    ATTR_MEDIA_ID,
     ATTR_MEDIA_TYPE,
     ATTR_QUERY,
     ATTR_REQUESTED_BY,
     ATTR_SEASONS,
     ATTR_SORT_ORDER,
     ATTR_STATUS,
-    ATTR_TMDB_ID,
     DOMAIN,
 )
 from homeassistant.components.overseerr.services import (
@@ -137,7 +137,7 @@ async def test_service_request_media(
         {
             ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
             ATTR_MEDIA_TYPE: "tv",
-            ATTR_TMDB_ID: "123456789",
+            ATTR_MEDIA_ID: "123456789",
             ATTR_SEASONS: "1",
         },
         blocking=True,
@@ -168,7 +168,7 @@ async def test_service_request_media(
         ),
         (
             SERVICE_REQUEST_MEDIA,
-            {ATTR_MEDIA_TYPE: "tv", ATTR_TMDB_ID: "123456789", ATTR_SEASONS: "1"},
+            {ATTR_MEDIA_TYPE: "tv", ATTR_MEDIA_ID: "123456789", ATTR_SEASONS: "1"},
             "create_request",
             OverseerrConnectionError("Timeout"),
             HomeAssistantError,
@@ -210,7 +210,7 @@ async def test_services_connection_error(
         (SERVICE_SEARCH_MEDIA, {ATTR_QUERY: "test"}),
         (
             SERVICE_REQUEST_MEDIA,
-            {ATTR_MEDIA_TYPE: "tv", ATTR_TMDB_ID: "123456789", ATTR_SEASONS: "1"},
+            {ATTR_MEDIA_TYPE: "tv", ATTR_MEDIA_ID: "123456789", ATTR_SEASONS: "1"},
         ),
     ],
 )

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -1,20 +1,27 @@
 """Tests for the Overseerr services."""
 
+import dataclasses
 from unittest.mock import AsyncMock
 
 import pytest
 from python_overseerr import OverseerrConnectionError
+from python_overseerr.models import MediaType
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.overseerr.const import (
+    ATTR_LIMIT,
+    ATTR_MEDIA_TYPE,
     ATTR_REQUESTED_BY,
+    ATTR_SEASONS,
     ATTR_SORT_ORDER,
     ATTR_STATUS,
+    ATTR_TMDB_ID,
     DOMAIN,
 )
 from homeassistant.components.overseerr.services import (
     ATTR_QUERY,
     SERVICE_GET_REQUESTS,
+    SERVICE_REQUEST_MEDIA,
     SERVICE_SEARCH_MEDIA,
     parse_seasons_input,
 )
@@ -92,22 +99,6 @@ async def test_service_search_media(
 
     await setup_integration(hass, mock_config_entry)
 
-    response = await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SEARCH_MEDIA,
-        {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
-            ATTR_QUERY: "test",
-        },
-        blocking=True,
-        return_response=True,
-    )
-    assert response == {"results": []}
-    mock_overseerr_client.search.assert_called_once_with("test")
-
-    # Reset mock
-    mock_overseerr_client.search.reset_mock()
-
     # Test with a query containing spaces
     response = await hass.services.async_call(
         DOMAIN,
@@ -121,6 +112,75 @@ async def test_service_search_media(
     )
     assert response == {"results": []}
     mock_overseerr_client.search.assert_called_once_with("test query with spaces")
+
+
+async def test_service_search_media_with_limit(
+    hass: HomeAssistant,
+    mock_overseerr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the "limit" function of the search_media service."""
+
+    @dataclasses.dataclass
+    class SearchResultMock:
+        name: str
+
+    mock_overseerr_client.search.return_value = [
+        SearchResultMock(name="Result 1"),
+        SearchResultMock(name="Result 2"),
+        SearchResultMock(name="Result 3"),
+    ]
+
+    await setup_integration(hass, mock_config_entry)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SEARCH_MEDIA,
+        {
+            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+            ATTR_QUERY: "test",
+            ATTR_LIMIT: 2,
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {"results": [{"name": "Result 1"}, {"name": "Result 2"}]}
+
+
+async def test_service_request_media(
+    hass: HomeAssistant,
+    mock_overseerr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the request_media service."""
+
+    # Mock the create request method
+    @dataclasses.dataclass
+    class RequestWithMediaMock:
+        tmdb_id: str = "123456789"
+        media_type: MediaType = MediaType.TV
+
+    mock_overseerr_client.create_request.return_value = RequestWithMediaMock()
+
+    await setup_integration(hass, mock_config_entry)
+
+    response = await hass.services.async_call(
+        DOMAIN,
+        SERVICE_REQUEST_MEDIA,
+        {
+            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
+            ATTR_MEDIA_TYPE: "tv",
+            ATTR_TMDB_ID: "123456789",
+            ATTR_SEASONS: "1",
+        },
+        blocking=True,
+        return_response=True,
+    )
+
+    assert response == {"request": {"media_type": MediaType.TV, "tmdb_id": "123456789"}}
 
 
 @pytest.mark.parametrize(
@@ -138,6 +198,14 @@ async def test_service_search_media(
             SERVICE_SEARCH_MEDIA,
             {ATTR_QUERY: "test"},
             "search",
+            OverseerrConnectionError("Timeout"),
+            HomeAssistantError,
+            "Error connecting to the Seerr instance: Timeout",
+        ),
+        (
+            SERVICE_REQUEST_MEDIA,
+            {ATTR_MEDIA_TYPE: "tv", ATTR_TMDB_ID: "123456789", ATTR_SEASONS: "1"},
+            "create_request",
             OverseerrConnectionError("Timeout"),
             HomeAssistantError,
             "Error connecting to the Seerr instance: Timeout",
@@ -175,7 +243,11 @@ async def test_services_connection_error(
     ("service", "payload"),
     [
         (SERVICE_GET_REQUESTS, {}),
-        (SERVICE_SEARCH_MEDIA, {ATTR_QUERY: "test"}),
+        (SERVICE_SEARCH_MEDIA, {ATTR_QUERY: "test", ATTR_LIMIT: 3}),
+        (
+            SERVICE_REQUEST_MEDIA,
+            {ATTR_MEDIA_TYPE: "tv", ATTR_TMDB_ID: "123456789", ATTR_SEASONS: "1"},
+        ),
     ],
 )
 async def test_service_entry_availability(
@@ -217,6 +289,7 @@ async def test_service_entry_availability(
     ("seasons_input", "expected_seasons"),
     [
         ("1", [1]),
+        ("1,", [1]),
         ("1,2,3", [1, 2, 3]),
         ("1, 2, 3", [1, 2, 3]),
         (" 1 ,     2,  3    ", [1, 2, 3]),

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -9,7 +9,6 @@ from python_overseerr.models import MediaType
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.overseerr.const import (
-    ATTR_LIMIT,
     ATTR_MEDIA_TYPE,
     ATTR_QUERY,
     ATTR_REQUESTED_BY,
@@ -114,41 +113,6 @@ async def test_service_search_media(
     mock_overseerr_client.search.assert_called_once_with("test query with spaces")
 
 
-async def test_service_search_media_with_limit(
-    hass: HomeAssistant,
-    mock_overseerr_client: AsyncMock,
-    mock_config_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
-) -> None:
-    """Test the "limit" function of the search_media service."""
-
-    @dataclasses.dataclass
-    class SearchResultMock:
-        name: str
-
-    mock_overseerr_client.search.return_value = [
-        SearchResultMock(name="Result 1"),
-        SearchResultMock(name="Result 2"),
-        SearchResultMock(name="Result 3"),
-    ]
-
-    await setup_integration(hass, mock_config_entry)
-
-    response = await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SEARCH_MEDIA,
-        {
-            ATTR_CONFIG_ENTRY_ID: mock_config_entry.entry_id,
-            ATTR_QUERY: "test",
-            ATTR_LIMIT: 2,
-        },
-        blocking=True,
-        return_response=True,
-    )
-
-    assert response == {"results": [{"name": "Result 1"}, {"name": "Result 2"}]}
-
-
 async def test_service_request_media(
     hass: HomeAssistant,
     mock_overseerr_client: AsyncMock,
@@ -243,7 +207,7 @@ async def test_services_connection_error(
     ("service", "payload"),
     [
         (SERVICE_GET_REQUESTS, {}),
-        (SERVICE_SEARCH_MEDIA, {ATTR_QUERY: "test", ATTR_LIMIT: 3}),
+        (SERVICE_SEARCH_MEDIA, {ATTR_QUERY: "test"}),
         (
             SERVICE_REQUEST_MEDIA,
             {ATTR_MEDIA_TYPE: "tv", ATTR_TMDB_ID: "123456789", ATTR_SEASONS: "1"},

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -11,6 +11,7 @@ from syrupy.assertion import SnapshotAssertion
 from homeassistant.components.overseerr.const import (
     ATTR_LIMIT,
     ATTR_MEDIA_TYPE,
+    ATTR_QUERY,
     ATTR_REQUESTED_BY,
     ATTR_SEASONS,
     ATTR_SORT_ORDER,
@@ -19,7 +20,6 @@ from homeassistant.components.overseerr.const import (
     DOMAIN,
 )
 from homeassistant.components.overseerr.services import (
-    ATTR_QUERY,
     SERVICE_GET_REQUESTS,
     SERVICE_REQUEST_MEDIA,
     SERVICE_SEARCH_MEDIA,

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -16,6 +16,7 @@ from homeassistant.components.overseerr.services import (
     ATTR_QUERY,
     SERVICE_GET_REQUESTS,
     SERVICE_SEARCH_MEDIA,
+    parse_seasons_input,
 )
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID
 from homeassistant.core import HomeAssistant
@@ -119,7 +120,7 @@ async def test_service_search_media(
         return_response=True,
     )
     assert response == {"results": []}
-    mock_overseerr_client.search.assert_called_once_with("test%20query%20with%20spaces")
+    mock_overseerr_client.search.assert_called_once_with("test query with spaces")
 
 
 @pytest.mark.parametrize(
@@ -140,7 +141,7 @@ async def test_service_search_media(
             OverseerrConnectionError("Timeout"),
             HomeAssistantError,
             "Error connecting to the Seerr instance: Timeout",
-        )
+        ),
     ],
 )
 async def test_services_connection_error(
@@ -210,3 +211,24 @@ async def test_service_entry_availability(
             return_response=True,
         )
     assert err.value.translation_key == "service_config_entry_not_found"
+
+
+@pytest.mark.parametrize(
+    ("seasons_input", "expected_seasons"),
+    [
+        ("1", [1]),
+        ("1,2,3", [1, 2, 3]),
+        ("1, 2, 3", [1, 2, 3]),
+        (" 1 ,     2,  3    ", [1, 2, 3]),
+        ("[1]", [1]),
+        ("[1,2,3]", [1, 2, 3]),
+        ("[  1  , 2 ,    3]", [1, 2, 3]),
+        ("", "all"),
+        ("  ", "all"),
+        ("Not a valid input", "all"),
+        ("-", "all"),
+    ],
+)
+def test_parse_seasons_input(seasons_input, expected_seasons) -> None:
+    """Test that all inputs are parsed correctly."""
+    assert expected_seasons == parse_seasons_input(seasons_input)

--- a/tests/components/overseerr/test_services.py
+++ b/tests/components/overseerr/test_services.py
@@ -90,7 +90,6 @@ async def test_service_search_media(
     hass: HomeAssistant,
     mock_overseerr_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the search_media service."""
     # Mock the search method
@@ -117,7 +116,6 @@ async def test_service_request_media(
     hass: HomeAssistant,
     mock_overseerr_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    snapshot: SnapshotAssertion,
 ) -> None:
     """Test the request_media service."""
 
@@ -263,10 +261,13 @@ async def test_service_entry_availability(
         ("", "all"),
         ("  ", "all"),
         (None, "all"),
+        ("all", "all"),
         ("Not a valid input", "all"),
         ("-", "all"),
     ],
 )
-def test_parse_seasons_input(seasons_input, expected_seasons) -> None:
+def test_parse_seasons_input(
+    seasons_input: str | None, expected_seasons: list[int] | str
+) -> None:
     """Test that all inputs are parsed correctly."""
     assert expected_seasons == parse_seasons_input(seasons_input)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This PR enhances the functionality of the Seerr integration: It allows the user to:

* search for media
  - search by name

* request media
  - request by tmdb id (can be obtained by the action above)



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [X] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
