### PR TITLE
Update syrupy to 5.5.1

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -38,7 +38,7 @@ pytest==9.0.3
 requests==2.34.2
 requests-mock==1.12.1
 respx==0.23.1
-syrupy==5.3.4
+syrupy==5.5.1
 tqdm==4.67.1
 types-aiofiles==24.1.0.20250822
 types-atomicwrites==1.4.5.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,7 +40,6 @@ import pytest_socket
 import requests_mock
 import respx
 from syrupy.assertion import SnapshotAssertion
-from syrupy.session import SnapshotSession
 
 # Setup patching of JSON functions before any other Home Assistant imports
 from . import patch_json  # isort:skip
@@ -108,7 +107,7 @@ from homeassistant.util.async_ import create_eager_task, get_scheduled_timer_han
 from homeassistant.util.json import json_loads
 
 from .ignore_uncaught_exceptions import IGNORE_UNCAUGHT_EXCEPTIONS
-from .syrupy import HomeAssistantSnapshotExtension, override_syrupy_finish
+from .syrupy import HomeAssistantSnapshotExtension
 from .typing import (
     ClientSessionGenerator,
     MockHAClientWebSocket,
@@ -172,11 +171,6 @@ def pytest_configure(config: pytest.Config) -> None:
     )
     if config.getoption("verbose") > 0:
         logging.getLogger().setLevel(logging.DEBUG)
-
-    # Override default finish to detect unused snapshots despite xdist
-    # Temporary workaround until it is finalised inside syrupy
-    # See https://github.com/syrupy-project/syrupy/pull/901
-    SnapshotSession.finish = override_syrupy_finish
 
 
 class HASocketBlockedError(pytest_socket.SocketBlockedError):

--- a/tests/syrupy.py
+++ b/tests/syrupy.py
@@ -3,22 +3,14 @@
 from contextlib import suppress
 import dataclasses
 from enum import IntFlag
-import json
-import os
 from pathlib import Path
 from typing import Any
 
 import attr
 import attrs
-import pytest
-from syrupy.constants import EXIT_STATUS_FAIL_UNUSED
-from syrupy.data import Snapshot, SnapshotCollection, SnapshotCollections
 from syrupy.extensions.amber import AmberDataSerializer, AmberSnapshotExtension
 from syrupy.location import PyTestLocation
-from syrupy.report import SnapshotReport
-from syrupy.session import ItemStatus, SnapshotSession
 from syrupy.types import PropertyFilter, PropertyMatcher, PropertyPath, SerializableData
-from syrupy.utils import is_xdist_controller, is_xdist_worker
 import voluptuous as vol
 import voluptuous_serialize
 
@@ -272,164 +264,3 @@ class HomeAssistantSnapshotExtension(AmberSnapshotExtension):
         """
         test_dir = Path(test_location.filepath).parent
         return str(test_dir.joinpath("snapshots"))
-
-
-# Classes and Methods to override default finish behavior in syrupy
-# This is needed to handle the xdist plugin in pytest
-# The default implementation does not handle the xdist plugin
-# and will not work correctly when running tests in parallel
-# with pytest-xdist.
-# Temporary workaround until it is finalised inside syrupy
-# See https://github.com/syrupy-project/syrupy/pull/901
-
-
-class _FakePytestObject:
-    """Fake object."""
-
-    def __init__(self, collected_item: dict[str, str]) -> None:
-        """Initialise fake object."""
-        self.__module__ = collected_item["modulename"]
-        self.__name__ = collected_item["methodname"]
-
-
-class _FakePytestItem:
-    """Fake pytest.Item object."""
-
-    def __init__(self, collected_item: dict[str, str]) -> None:
-        """Initialise fake pytest.Item object."""
-        self.nodeid = collected_item["nodeid"]
-        self.name = collected_item["name"]
-        self.path = Path(collected_item["path"])
-        self.obj = _FakePytestObject(collected_item)
-
-
-def _serialize_collections(collections: SnapshotCollections) -> dict[str, Any]:
-    return {
-        k: [c.name for c in v] for k, v in collections._snapshot_collections.items()
-    }
-
-
-def _serialize_report(
-    report: SnapshotReport,
-    collected_items: set[pytest.Item],
-    selected_items: dict[str, ItemStatus],
-) -> dict[str, Any]:
-    return {
-        "discovered": _serialize_collections(report.discovered),
-        "created": _serialize_collections(report.created),
-        "failed": _serialize_collections(report.failed),
-        "matched": _serialize_collections(report.matched),
-        "updated": _serialize_collections(report.updated),
-        "used": _serialize_collections(report.used),
-        "_collected_items": [
-            {
-                "nodeid": c.nodeid,
-                "name": c.name,
-                "path": str(c.path),
-                "modulename": c.obj.__module__,
-                "methodname": c.obj.__name__,
-            }
-            for c in list(collected_items)
-        ],
-        "_selected_items": {
-            key: status.value for key, status in selected_items.items()
-        },
-    }
-
-
-def _merge_serialized_collections(
-    collections: SnapshotCollections, json_data: dict[str, list[str]]
-) -> None:
-    if not json_data:
-        return
-    for location, names in json_data.items():
-        snapshot_collection = SnapshotCollection(location=location)
-        for name in names:
-            snapshot_collection.add(Snapshot(name))
-        collections.update(snapshot_collection)
-
-
-def _merge_serialized_report(report: SnapshotReport, json_data: dict[str, Any]) -> None:
-    _merge_serialized_collections(report.discovered, json_data["discovered"])
-    _merge_serialized_collections(report.created, json_data["created"])
-    _merge_serialized_collections(report.failed, json_data["failed"])
-    _merge_serialized_collections(report.matched, json_data["matched"])
-    _merge_serialized_collections(report.updated, json_data["updated"])
-    _merge_serialized_collections(report.used, json_data["used"])
-    for collected_item in json_data["_collected_items"]:
-        custom_item = _FakePytestItem(collected_item)
-        if not any(
-            t.nodeid == custom_item.nodeid and t.name == custom_item.nodeid
-            for t in report.collected_items
-        ):
-            report.collected_items.add(custom_item)
-    for key, selected_item in json_data["_selected_items"].items():
-        if key in report.selected_items:
-            status = ItemStatus(selected_item)
-            if status is not ItemStatus.NOT_RUN:
-                report.selected_items[key] = status
-        else:
-            report.selected_items[key] = ItemStatus(selected_item)
-
-
-def override_syrupy_finish(self: SnapshotSession) -> int:
-    """Override the finish method to allow for custom handling."""
-    exitstatus = 0
-    self.flush_snapshot_write_queue()
-    self.report = SnapshotReport(
-        base_dir=self.pytest_session.config.rootpath,
-        collected_items=self._collected_items,
-        selected_items=self._selected_items,
-        assertions=self._assertions,
-        options=self.pytest_session.config.option,
-    )
-
-    needs_xdist_merge = self.update_snapshots or bool(
-        self.pytest_session.config.option.include_snapshot_details
-    )
-
-    if is_xdist_worker():
-        if not needs_xdist_merge:
-            return exitstatus
-        with open(".pytest_syrupy_worker_count", "w", encoding="utf-8") as f:
-            f.write(os.getenv("PYTEST_XDIST_WORKER_COUNT"))
-        with open(
-            f".pytest_syrupy_{os.getenv('PYTEST_XDIST_WORKER')}_result",
-            "w",
-            encoding="utf-8",
-        ) as f:
-            json.dump(
-                _serialize_report(
-                    self.report, self._collected_items, self._selected_items
-                ),
-                f,
-                indent=2,
-            )
-        return exitstatus
-    if is_xdist_controller():
-        return exitstatus
-
-    if needs_xdist_merge:
-        worker_count = None
-        try:
-            with open(".pytest_syrupy_worker_count", encoding="utf-8") as f:
-                worker_count = f.read()
-            os.remove(".pytest_syrupy_worker_count")
-        except FileNotFoundError:
-            pass
-
-        if worker_count:
-            for i in range(int(worker_count)):
-                with open(f".pytest_syrupy_gw{i}_result", encoding="utf-8") as f:
-                    _merge_serialized_report(self.report, json.load(f))
-                os.remove(f".pytest_syrupy_gw{i}_result")
-
-    if self.report.num_unused:
-        if self.update_snapshots:
-            self.remove_unused_snapshots(
-                unused_snapshot_collections=self.report.unused,
-                used_snapshot_collections=self.report.used,
-            )
-        elif not self.warn_unused_snapshots:
-            exitstatus |= EXIT_STATUS_FAIL_UNUSED
-    return exitstatus


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Alternative to #176257. Updates syrupy from 5.3.4 to 5.5.1 ([changelog](https://github.com/syrupy-project/syrupy/blob/main/CHANGELOG.md), [compare](https://github.com/syrupy-project/syrupy/compare/v5.3.4...v5.5.1)).

Syrupy 5.4.0 ships native pytest-xdist support: workers publish their snapshot reports via `config.workeroutput` and the controller merges them before the unused-snapshot check. Implemented in syrupy-project/syrupy#1132, which our `override_syrupy_finish` workaround in `tests/syrupy.py` was a stopgap for, so the workaround (and its monkeypatch in `tests/conftest.py`) is removed. The plain Renovate bump (#176257) fails CI because syrupy 5.4.0 also removed `syrupy.utils.is_xdist_controller`, which the workaround imported, breaking test collection.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
