### PR TITLE
Bump PyViCare to 2.61.0

### DIFF
--- a/homeassistant/components/vicare/manifest.json
+++ b/homeassistant/components/vicare/manifest.json
@@ -13,5 +13,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["PyViCare"],
-  "requirements": ["PyViCare==2.60.2"]
+  "requirements": ["PyViCare==2.61.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -99,7 +99,7 @@ PyTransportNSW==0.1.1
 PyTurboJPEG==1.8.3
 
 # homeassistant.components.vicare
-PyViCare==2.60.2
+PyViCare==2.61.0
 
 # homeassistant.components.xiaomi_aqara
 PyXiaomiGateway==0.14.3

--- a/tests/components/vicare/conftest.py
+++ b/tests/components/vicare/conftest.py
@@ -38,33 +38,37 @@ class MockPyViCare:
         """Init a single device from json dump."""
         self.devices = []
         for idx, fixture in enumerate(fixtures):
+            service = MockViCareService(
+                f"installation{idx}", f"gateway{idx}", f"deviceId{idx}", fixture
+            )
             self.devices.append(
                 PyViCareDeviceConfig(
-                    MockViCareService(
-                        f"installation{idx}", f"gateway{idx}", f"device{idx}", fixture
-                    ),
-                    f"deviceId{idx}",
+                    service.accessor,
+                    service,
                     "Vitovalor"
                     if fixture.data_file.endswith("VitoValor.json")
                     else f"model{idx}",
                     "Online",
+                    roles=list(fixture.roles),
                 )
             )
         # Simulate a device with an unsupported deviceType that PyViCare's
         # `devices` filter would drop but should still appear in `all_devices`
         # (used by diagnostics).
+        unsupported_service = MockViCareService(
+            "installation_unsupported",
+            "gateway_unsupported",
+            "deviceId_unsupported",
+            Fixture(set(), "vicare/dummy-device-no-serial.json"),
+        )
         self.all_devices = [
             *self.devices,
             PyViCareDeviceConfig(
-                MockViCareService(
-                    "installation_unsupported",
-                    "gateway_unsupported",
-                    "device_unsupported",
-                    Fixture(set(), "vicare/dummy-device-no-serial.json"),
-                ),
-                "deviceId_unsupported",
+                unsupported_service.accessor,
+                unsupported_service,
                 "unsupported_model",
                 "Online",
+                roles=[],
             ),
         ]
 
@@ -88,6 +92,7 @@ class MockViCareService:
         """Initialize the mock from a json dump."""
         self._test_data = load_json_object_fixture(fixture.data_file)
         self.fetch_all_features = Mock(return_value=self._test_data)
+        self.setProperty = Mock()
         self.roles = fixture.roles
         self.accessor = ViCareDeviceAccessor(installation_id, gateway_id, device_id)
 
@@ -95,7 +100,7 @@ class MockViCareService:
         """Return true if requested roles are assigned."""
         return requested_roles and set(requested_roles).issubset(self.roles)
 
-    def getProperty(self, property_name: str):
+    def getProperty(self, accessor: ViCareDeviceAccessor, property_name: str):
         """Read a property from json dump."""
         return readFeature(self._test_data["data"], property_name)
 

--- a/tests/components/vicare/snapshots/test_diagnostics.ambr
+++ b/tests/components/vicare/snapshots/test_diagnostics.ambr
@@ -4715,6 +4715,7 @@
           'id': 'deviceId0',
           'modelId': 'model0',
           'roles': list([
+            'type:boiler',
           ]),
           'status': 'Online',
           'type': None,


### PR DESCRIPTION
## Proposed change

Bump PyViCare from 2.60.2 to 2.61.0.

Release notes: https://github.com/openviess/PyViCare/releases/tag/2.61.0
Diff: https://github.com/openviess/PyViCare/compare/2.60.2...2.61.0

2.61.0 passes the device accessor per call
(`PyViCareDeviceConfig(accessor, service, …)`, `service.getProperty(accessor, …)`).
The integration uses the high-level device API and is unchanged; the test
doubles in conftest.py are updated to match.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Related to #176163.

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
