### PR TITLE
Fix Growatt V1 total output power

### DIFF
--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -38,8 +38,36 @@ if TYPE_CHECKING:
 type GrowattConfigEntry = ConfigEntry[GrowattRuntimeData]
 
 SCAN_INTERVAL = datetime.timedelta(minutes=5)
+_MAX_POWER_READING_AGE = datetime.timedelta(minutes=10)
 
 _LOGGER = logging.getLogger(__name__)
+
+
+def _latest_power_value(
+    power_overview: dict[str, Any], now: datetime.datetime
+) -> float | None:
+    """Return the newest recent power value from a plant power overview."""
+    latest_time: datetime.datetime | None = None
+    latest_power: float | None = None
+
+    for reading in power_overview.get("powers", []):
+        power = reading.get("power")
+        reading_time = dt_util.parse_datetime(reading.get("time", ""))
+        if power is None or reading_time is None:
+            continue
+        if reading_time.tzinfo is None:
+            reading_time = reading_time.replace(tzinfo=dt_util.get_default_time_zone())
+        if reading_time > now or now - reading_time > _MAX_POWER_READING_AGE:
+            continue
+        try:
+            power_value = float(power)
+        except TypeError, ValueError:
+            continue
+        if latest_time is None or reading_time > latest_time:
+            latest_time = reading_time
+            latest_power = power_value
+
+    return latest_power
 
 
 class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -201,8 +229,25 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     ) from err
                 total_info["todayEnergy"] = total_info["today_energy"]
                 total_info["totalEnergy"] = total_info["total_energy"]
-                # V1 API returns current_power in kW, convert to W
-                total_info["invTodayPpv"] = total_info["current_power"] * 1000
+                # The plant data endpoint can report zero while production continues.
+                current_power = total_info["current_power"] * 1000
+                now = dt_util.now()
+                try:
+                    power_overview = self.api.plant_power_overview(
+                        self.plant_id, now.date()
+                    )
+                except (growattServer.GrowattV1ApiError, RequestException) as err:
+                    _LOGGER.debug(
+                        "Failed to fetch plant power overview for %s: %s",
+                        self.plant_id,
+                        err,
+                    )
+                else:
+                    if (
+                        latest_power := _latest_power_value(power_overview, now)
+                    ) is not None:
+                        current_power = latest_power
+                total_info["invTodayPpv"] = current_power
             else:
                 # Classic API: use plant_info as before.
                 # Copy the response to avoid mutating the dict returned by the library

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -229,7 +229,9 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     ) from err
                 total_info["todayEnergy"] = total_info["today_energy"]
                 total_info["totalEnergy"] = total_info["total_energy"]
-                # The plant data endpoint can report zero while production continues.
+                # The plant power overview is authoritative for instantaneous power.
+                # Plant energy overview's current_power is only a fallback on error;
+                # it can report zero while production continues.
                 current_power = total_info["current_power"] * 1000
                 now = dt_util.now()
                 try:

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -3,6 +3,7 @@
 import datetime
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any, override
 
 import growattServer
@@ -52,8 +53,14 @@ def _latest_power_value(
 
     for reading in power_overview.get("powers", []):
         power = reading.get("power")
-        reading_time = dt_util.parse_datetime(reading.get("time", ""))
-        if power is None or reading_time is None:
+        timestamp = reading.get("time")
+        if power is None or not isinstance(timestamp, str):
+            continue
+        try:
+            reading_time = dt_util.parse_datetime(timestamp)
+        except ValueError:
+            continue
+        if reading_time is None:
             continue
         if reading_time.tzinfo is None:
             reading_time = reading_time.replace(tzinfo=dt_util.get_default_time_zone())
@@ -62,6 +69,8 @@ def _latest_power_value(
         try:
             power_value = float(power)
         except TypeError, ValueError:
+            continue
+        if not math.isfinite(power_value):
             continue
         if latest_time is None or reading_time > latest_time:
             latest_time = reading_time

--- a/tests/components/growatt_server/conftest.py
+++ b/tests/components/growatt_server/conftest.py
@@ -29,6 +29,7 @@ def mock_growatt_v1_api():
     Methods mocked for integration setup:
     - device_list: Called during async_setup_entry to discover devices
     - plant_energy_overview: Called by total coordinator during first refresh
+    - plant_power_overview: Called for the total coordinator's current power
 
     Methods mocked for MIN device coordinator refresh:
     - min_detail: Provides device state (e.g., acChargeEnable, chargePowerCommand)
@@ -144,6 +145,10 @@ def mock_growatt_v1_api():
             "today_energy": 12.5,
             "total_energy": 1250.0,
             "current_power": 2.5,
+        }
+        mock_v1_api.plant_power_overview.return_value = {
+            "count": 0,
+            "powers": [],
         }
 
         # Called by switch/number entities during turn_on/turn_off/set_value

--- a/tests/components/growatt_server/test_sensor.py
+++ b/tests/components/growatt_server/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for the Growatt Server sensor platform."""
 
-from datetime import timedelta
+from datetime import date, timedelta
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -181,6 +181,82 @@ async def test_sensor_coordinator_updates(
     state = hass.states.get("sensor.test_plant_total_energy_today")
     assert state is not None
     assert state.state == "25.0"
+
+
+@pytest.mark.parametrize(
+    ("powers", "expected_state"),
+    [
+        pytest.param(
+            [
+                {"time": "2026-07-14 18:50", "power": 1000.0},
+                {"time": "2026-07-14 19:05", "power": 700.0},
+                {"time": "invalid", "power": 900.0},
+                {"time": "2026-07-14 18:55", "power": 880.6},
+                {"time": "2026-07-14 18:57", "power": None},
+            ],
+            "880.6",
+            id="newest-valid-reading",
+        ),
+        pytest.param(
+            [{"time": "2026-07-14 18:55", "power": 0.0}],
+            "0.0",
+            id="nighttime-zero",
+        ),
+        pytest.param(
+            [{"time": "2026-07-14 18:45", "power": 900.0}],
+            "2500.0",
+            id="stale-reading",
+        ),
+        pytest.param([], "2500.0", id="missing-readings"),
+    ],
+)
+@pytest.mark.freeze_time("2026-07-14 17:00:00+00:00")
+async def test_v1_total_output_power_uses_recent_plant_power(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+    powers: list[dict[str, str | float | None]],
+    expected_state: str,
+) -> None:
+    """Test V1 total output power uses the newest recent plant power reading."""
+    await hass.config.async_set_time_zone("Europe/Amsterdam")
+    mock_growatt_v1_api.plant_power_overview.return_value = {
+        "count": len(powers),
+        "powers": powers,
+    }
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.test_plant_total_output_power")
+    assert state is not None
+    assert state.state == expected_state
+    mock_growatt_v1_api.plant_power_overview.assert_called_once_with(
+        "123456", date(2026, 7, 14)
+    )
+
+
+@pytest.mark.freeze_time("2026-07-14 17:00:00+00:00")
+async def test_v1_total_output_power_falls_back_on_power_api_error(
+    hass: HomeAssistant,
+    mock_growatt_v1_api,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test V1 total output power remains available when plant power fails."""
+    mock_growatt_v1_api.plant_power_overview.side_effect = (
+        growattServer.GrowattV1ApiError(
+            message="Rate limited",
+            error_code=growattServer.GrowattV1ApiErrorCode.RATE_LIMITED,
+            error_msg="Too many requests",
+        )
+    )
+
+    with patch("homeassistant.components.growatt_server.PLATFORMS", [Platform.SENSOR]):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("sensor.test_plant_total_output_power")
+    assert state is not None
+    assert state.state == "2500.0"
 
 
 async def test_sensor_unavailable_on_coordinator_error(

--- a/tests/components/growatt_server/test_sensor.py
+++ b/tests/components/growatt_server/test_sensor.py
@@ -1,7 +1,7 @@
 """Tests for the Growatt Server sensor platform."""
 
 from datetime import date, timedelta
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import growattServer
@@ -213,7 +213,7 @@ async def test_sensor_coordinator_updates(
 @pytest.mark.freeze_time("2026-07-14 17:00:00+00:00")
 async def test_v1_total_output_power_uses_recent_plant_power(
     hass: HomeAssistant,
-    mock_growatt_v1_api,
+    mock_growatt_v1_api: MagicMock,
     mock_config_entry: MockConfigEntry,
     powers: list[dict[str, str | float | None]],
     expected_state: str,
@@ -239,7 +239,7 @@ async def test_v1_total_output_power_uses_recent_plant_power(
 @pytest.mark.freeze_time("2026-07-14 17:00:00+00:00")
 async def test_v1_total_output_power_falls_back_on_power_api_error(
     hass: HomeAssistant,
-    mock_growatt_v1_api,
+    mock_growatt_v1_api: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test V1 total output power remains available when plant power fails."""

--- a/tests/components/growatt_server/test_sensor.py
+++ b/tests/components/growatt_server/test_sensor.py
@@ -207,6 +207,22 @@ async def test_sensor_coordinator_updates(
             "2500.0",
             id="stale-reading",
         ),
+        pytest.param(
+            [
+                {"time": None, "power": 900.0},
+                {"time": "2026-02-30 12:00", "power": 900.0},
+            ],
+            "2500.0",
+            id="invalid-timestamps",
+        ),
+        pytest.param(
+            [
+                {"time": "2026-07-14 18:55", "power": "nan"},
+                {"time": "2026-07-14 18:56", "power": "inf"},
+            ],
+            "2500.0",
+            id="non-finite-power",
+        ),
         pytest.param([], "2500.0", id="missing-readings"),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use the Growatt OpenAPI plant power series for the V1 plant-total output-power
sensor. Growatt's plant data overview can report `current_power: 0` while the
documented plant power endpoint and Growatt portal still report production.

The coordinator now selects the newest parseable, non-null plant power record
that is not in the future and is no more than ten minutes old. Ten minutes
allows one missed interval because Growatt documents and Home Assistant uses a
five-minute polling interval. If the power-series request fails or has no
recent valid value, the integration retains the existing plant-data value so
otherwise working total-energy entities remain available.

The tests reproduce the reported `880.6 W` discrepancy and cover unsorted,
future, invalid, null, zero, stale, missing, and rate-limited responses.

Validation:

- `uv run pytest tests/components/growatt_server -vv`: 154 passed, 717
  snapshots passed.
- Targeted `uv run prek run --files ...`: Ruff, codespell, Prettier, mypy,
  pylint, and applicable checks passed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176509
- This PR is related to issue: #120051, #173148
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
