### PR TITLE
Bump oralb-ble to 1.1.1

### DIFF
--- a/homeassistant/components/oralb/icons.json
+++ b/homeassistant/components/oralb/icons.json
@@ -37,8 +37,7 @@
           "sector_1": "mdi:circle-slice-2",
           "sector_2": "mdi:circle-slice-4",
           "sector_3": "mdi:circle-slice-6",
-          "sector_4": "mdi:circle-slice-8",
-          "success": "mdi:check-circle-outline"
+          "sector_4": "mdi:circle-slice-8"
         }
       },
       "toothbrush_state": {

--- a/homeassistant/components/oralb/manifest.json
+++ b/homeassistant/components/oralb/manifest.json
@@ -13,5 +13,5 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["oralb_ble"],
-  "requirements": ["oralb-ble==1.1.0"]
+  "requirements": ["oralb-ble==1.1.1"]
 }

--- a/homeassistant/components/oralb/sensor.py
+++ b/homeassistant/components/oralb/sensor.py
@@ -3,13 +3,7 @@
 from typing import override
 
 from oralb_ble import OralBSensor, SensorUpdate
-from oralb_ble.parser import (
-    IO_SERIES_MODES,
-    PRESSURE,
-    SECTOR_MAP,
-    SMART_SERIES_MODES,
-    STATES,
-)
+from oralb_ble.parser import IO_SERIES_MODES, PRESSURE, SMART_SERIES_MODES, STATES
 
 from homeassistant.components.bluetooth.passive_update_processor import (
     PassiveBluetoothDataProcessor,
@@ -46,7 +40,7 @@ SENSOR_DESCRIPTIONS: dict[str, SensorEntityDescription] = {
         key=OralBSensor.SECTOR,
         translation_key="sector",
         entity_category=EntityCategory.DIAGNOSTIC,
-        options=[v.replace(" ", "_") for v in set(SECTOR_MAP.values()) | {"no_sector"}],
+        options=["no_sector", *(f"sector_{sector}" for sector in range(1, 8))],
         device_class=SensorDeviceClass.ENUM,
     ),
     OralBSensor.NUMBER_OF_SECTORS: SensorEntityDescription(

--- a/homeassistant/components/oralb/strings.json
+++ b/homeassistant/components/oralb/strings.json
@@ -60,7 +60,9 @@
           "sector_2": "Sector 2",
           "sector_3": "Sector 3",
           "sector_4": "Sector 4",
-          "success": "Success"
+          "sector_5": "Sector 5",
+          "sector_6": "Sector 6",
+          "sector_7": "Sector 7"
         }
       },
       "sector_timer": {

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1804,7 +1804,7 @@ openwrt-ubus-rpc==0.0.3
 opower==0.18.6
 
 # homeassistant.components.oralb
-oralb-ble==1.1.0
+oralb-ble==1.1.1
 
 # homeassistant.components.oru
 oru==0.1.11

--- a/tests/components/oralb/__init__.py
+++ b/tests/components/oralb/__init__.py
@@ -37,6 +37,28 @@ ORALB_IO_SERIES_4_SERVICE_INFO = BluetoothServiceInfo(
     source="local",
 )
 
+ORALB_IO_SIX_SECTORS_SECTOR_5_SERVICE_INFO = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    # running, 6 sectors, currently in sector 5
+    manufacturer_data={220: b"\x062\x0c\x03\x00\x00\x1e\x00\x05\x0a\x06"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+
+ORALB_IO_SIX_SECTORS_LAST_SECTOR_SERVICE_INFO = BluetoothServiceInfo(
+    name="Oral-B Toothbrush",
+    address="78:DB:2F:C2:48:BE",
+    rssi=-63,
+    # running, 6 sectors, "last sector" sentinel (7) resolves to sector 6
+    manufacturer_data={220: b"\x062\x0c\x03\x00\x00\x28\x00\x07\x0a\x06"},
+    service_uuids=[],
+    service_data={},
+    source="local",
+)
+
 ORALB_IO_SERIES_6_SERVICE_INFO = BluetoothServiceInfoBleak(
     name="Oral-B Toothbrush",
     address="B0:D2:78:20:1D:CF",

--- a/tests/components/oralb/test_sensor.py
+++ b/tests/components/oralb/test_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.bluetooth import (
     async_address_present,
 )
 from homeassistant.components.oralb.const import DOMAIN
+from homeassistant.components.sensor import ATTR_OPTIONS
 from homeassistant.const import ATTR_ASSUMED_STATE, ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -17,6 +18,8 @@ from homeassistant.util import dt as dt_util
 from . import (
     ORALB_IO_SERIES_4_SERVICE_INFO,
     ORALB_IO_SERIES_6_SERVICE_INFO,
+    ORALB_IO_SIX_SECTORS_LAST_SECTOR_SERVICE_INFO,
+    ORALB_IO_SIX_SECTORS_SECTOR_5_SERVICE_INFO,
     ORALB_SERVICE_INFO,
 )
 
@@ -136,6 +139,50 @@ async def test_sensors_io_series_4(hass: HomeAssistant) -> None:
     assert toothbrush_sensor.state == "gum_care"
     toothbrush_sensor_attrs = toothbrush_sensor.attributes
     assert toothbrush_sensor_attrs[ATTR_ASSUMED_STATE] is True
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sector_sensor_six_sectors(hass: HomeAssistant) -> None:
+    """Test the sector sensor while brushing with a six sector routine."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ORALB_IO_SIX_SECTORS_SECTOR_5_SERVICE_INFO.address,
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    inject_bluetooth_service_info(hass, ORALB_IO_SIX_SECTORS_SECTOR_5_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    sector_sensor = hass.states.get("sensor.io_series_48be_sector")
+    assert sector_sensor.state == "sector_5"
+    assert sector_sensor.attributes[ATTR_OPTIONS] == [
+        "no_sector",
+        "sector_1",
+        "sector_2",
+        "sector_3",
+        "sector_4",
+        "sector_5",
+        "sector_6",
+        "sector_7",
+    ]
+
+    number_of_sectors_sensor = hass.states.get(
+        "sensor.io_series_48be_number_of_sectors"
+    )
+    assert number_of_sectors_sensor.state == "6"
+
+    # The "last sector" sentinel resolves to the sector count (sector 6)
+    inject_bluetooth_service_info(hass, ORALB_IO_SIX_SECTORS_LAST_SECTOR_SERVICE_INFO)
+    await hass.async_block_till_done()
+
+    sector_sensor = hass.states.get("sensor.io_series_48be_sector")
+    assert sector_sensor.state == "sector_6"
 
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump oralb-ble to 1.1.1.

changelog: https://github.com/Bluetooth-Devices/oralb-ble/compare/v1.1.0...v1.1.1

The library no longer exposes `SECTOR_MAP` (sector decoding is handled internally since v1.1.1 and now covers sectors 5–7), so the enum options for the sector sensor are now listed explicitly. The former `success` value is no longer emitted by the library and was removed from the options, translations and state icons; `sector_5`–`sector_7` were added. A regression test covers a six-sector brushing session (sector 5 and the "last sector" sentinel resolving to sector 6).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

