### PR TITLE
Redact serial from unknown component model name in diagnostics

### DIFF
--- a/homeassistant/components/nobo_hub/diagnostics.py
+++ b/homeassistant/components/nobo_hub/diagnostics.py
@@ -26,13 +26,12 @@ _MODEL_FIELDS = (
 
 
 def _component_to_dict(component: ComponentInfo) -> dict[str, Any]:
-    formatted = dict(component)
-    if (model := formatted.get("model")) is not None:
-        model_dict = {field: getattr(model, field, None) for field in _MODEL_FIELDS}
-        if getattr(model, "type", None) == nobo.Model.UNKNOWN:
-            # Unknown models carry the serial number in the name.
-            model_dict["name"] = REDACTED
-        formatted["model"] = model_dict
+    model = component["model"]
+    formatted: dict[str, Any] = dict(component)
+    formatted["model"] = {field: getattr(model, field, None) for field in _MODEL_FIELDS}
+    if model.type == nobo.Model.UNKNOWN:
+        # Unknown models carry the serial number in the name.
+        formatted["model"]["name"] = REDACTED
     return formatted
 
 

--- a/homeassistant/components/nobo_hub/diagnostics.py
+++ b/homeassistant/components/nobo_hub/diagnostics.py
@@ -2,9 +2,9 @@
 
 from typing import Any
 
-from pynobo import ComponentInfo
+from pynobo import ComponentInfo, nobo
 
-from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.components.diagnostics import REDACTED, async_redact_data
 from homeassistant.const import CONF_IP_ADDRESS, CONF_MAC
 from homeassistant.core import HomeAssistant
 
@@ -28,9 +28,11 @@ _MODEL_FIELDS = (
 def _component_to_dict(component: ComponentInfo) -> dict[str, Any]:
     formatted = dict(component)
     if (model := formatted.get("model")) is not None:
-        formatted["model"] = {
-            field: getattr(model, field, None) for field in _MODEL_FIELDS
-        }
+        model_dict = {field: getattr(model, field, None) for field in _MODEL_FIELDS}
+        if getattr(model, "type", None) == nobo.Model.UNKNOWN:
+            # Unknown models carry the serial number in the name.
+            model_dict["name"] = REDACTED
+        formatted["model"] = model_dict
     return formatted
 
 

--- a/tests/components/nobo_hub/test_diagnostics.py
+++ b/tests/components/nobo_hub/test_diagnostics.py
@@ -1,7 +1,11 @@
 """Tests for the Nobø Ecohub diagnostics."""
 
+from unittest.mock import MagicMock
+
+from pynobo import nobo as pynobo_nobo
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.diagnostics import REDACTED
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -19,3 +23,31 @@ async def test_entry_diagnostics(
     result = await get_diagnostics_for_config_entry(hass, hass_client, init_integration)
 
     assert result == snapshot
+
+
+async def test_entry_diagnostics_redacts_unknown_model_name(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    init_integration: MockConfigEntry,
+    mock_nobo_hub: MagicMock,
+) -> None:
+    """An unknown model's name embeds the serial, so it is dropped; model_id is kept."""
+    mock_nobo_hub.components = {
+        "999000012345": {
+            "serial": "999000012345",
+            "name": "Mystery device",
+            "zone_id": "1",
+            "model": pynobo_nobo.Model(
+                model_id="999",
+                type=pynobo_nobo.Model.UNKNOWN,
+                name="Unknown (serial number: 999 000 012 345)",
+            ),
+        },
+    }
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, init_integration)
+
+    component = result["components"][0]
+    assert component["serial"] == REDACTED
+    assert component["model"]["model_id"] == "999"
+    assert component["model"]["name"] == REDACTED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

pynobo builds an unknown component model's name as "Unknown (serial number: …)", embedding the full serial. The diagnostics only redact keys named "serial", so that name leaked the serial for any unsupported component. Redact the name for UNKNOWN-type models; model_id (the first 3 serial digits) already identifies the model.

Reported in https://github.com/home-assistant/core/pull/176514#discussion_r3581618180

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
