### PR TITLE
Bump knx-telegram-store to 0.10.1

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -14,7 +14,7 @@
     "xknx==3.16.0",
     "xknxproject==3.9.0",
     "knx-frontend==2026.6.23.203726",
-    "knx-telegram-store[sqlite,postgres]==0.9.1"
+    "knx-telegram-store[sqlite,postgres]==0.10.1"
   ],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1438,7 +1438,7 @@ knocki==0.4.2
 knx-frontend==2026.6.23.203726
 
 # homeassistant.components.knx
-knx-telegram-store[sqlite,postgres]==0.9.1
+knx-telegram-store[sqlite,postgres]==0.10.1
 
 # homeassistant.components.kraken
 krakenex==2.2.2


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `knx-telegram-store` from 0.9.1 to 0.10.1.

Full diff: https://github.com/XKNX/knx-telegram-store/compare/v0.9.1...v0.10.1

Notable changes for the KNX integration's telegram history store:

- **Fix (0.10.1):** `initialize()` no longer fails on TimescaleDB-backed Postgres stores once the compression policy has compressed older chunks. The legacy-data backfills of the schema upgrade now run in their own transaction, only when rows actually need fixing, lift TimescaleDB's per-transaction tuple decompression limit for that transaction, and degrade to a logged warning instead of failing startup. The compression `ALTER TABLE` is skipped when compression is already configured (older TimescaleDB rejects re-running it once chunks are compressed).
- **Feature (0.10.0):** `TelegramQuery` supports exact sub-DPT `(main, sub)` pair filtering via the new `dpts` field.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
