### PR TITLE
Add Google Health calories, floors, and body fat sensors

### DIFF
--- a/homeassistant/components/google_health/coordinator.py
+++ b/homeassistant/components/google_health/coordinator.py
@@ -1,5 +1,6 @@
 """Coordinators for Google Health."""
 
+import asyncio
 from dataclasses import dataclass
 from datetime import timedelta
 import logging
@@ -12,9 +13,13 @@ from google_health_api.exceptions import (
     HealthAuthException,
 )
 from google_health_api.model import (
+    ActiveEnergyBurnedRollupValue,
+    BodyFat,
     DailyRestingHeartRate,
     DistanceRollupValue,
+    FloorsRollupValue,
     StepsRollupValue,
+    TotalCaloriesRollupValue,
     Weight,
 )
 
@@ -40,6 +45,9 @@ class GoogleHealthActivityData:
 
     steps: StepsRollupValue | None = None
     distance: DistanceRollupValue | None = None
+    active_energy_burned: ActiveEnergyBurnedRollupValue | None = None
+    total_calories: TotalCaloriesRollupValue | None = None
+    floors: FloorsRollupValue | None = None
 
 
 @dataclass
@@ -48,6 +56,7 @@ class GoogleHealthBodyData:
 
     weight: Weight | None = None
     resting_heart_rate: DailyRestingHeartRate | None = None
+    body_fat: BodyFat | None = None
 
 
 class GoogleHealthDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
@@ -116,20 +125,42 @@ class GoogleHealthActivityCoordinator(
 
     @override
     async def _async_fetch_data(self) -> GoogleHealthActivityData:
-        """Fetch steps and distance rollup for today.
+        """Fetch activity rollups for today.
 
-        Queries the daily rollup endpoints using Home Assistant's local time zone
-        to aggregate step and distance counts over the current civil day. If no
-        data points exist for today yet, the API returns None, which the sensors
-        default to 0.
+        Queries the daily rollup endpoints in parallel using Home Assistant's
+        local time zone to aggregate steps, distance, active calories, total
+        calories, and floors. If no data points exist for today yet, the API
+        returns None, which the sensors default to 0.
         """
-        steps_rollup = await self.api.steps.today(self.hass.config.time_zone)
-        distance_rollup = await self.api.distance.today(self.hass.config.time_zone)
+        (
+            steps_rollup,
+            distance_rollup,
+            active_energy_rollup,
+            total_calories_rollup,
+            floors_rollup,
+        ) = await asyncio.gather(
+            self.api.steps.today(self.hass.config.time_zone),
+            self.api.distance.today(self.hass.config.time_zone),
+            self.api.active_energy_burned.today(self.hass.config.time_zone),
+            self.api.total_calories.today(self.hass.config.time_zone),
+            self.api.floors.today(self.hass.config.time_zone),
+        )
 
         steps = steps_rollup.data if steps_rollup else None
         distance = distance_rollup.data if distance_rollup else None
+        active_energy_burned = (
+            active_energy_rollup.data if active_energy_rollup else None
+        )
+        total_calories = total_calories_rollup.data if total_calories_rollup else None
+        floors = floors_rollup.data if floors_rollup else None
 
-        return GoogleHealthActivityData(steps=steps, distance=distance)
+        return GoogleHealthActivityData(
+            steps=steps,
+            distance=distance,
+            active_energy_burned=active_energy_burned,
+            total_calories=total_calories,
+            floors=floors,
+        )
 
 
 class GoogleHealthBodyCoordinator(
@@ -155,13 +186,14 @@ class GoogleHealthBodyCoordinator(
 
     @override
     async def _async_fetch_data(self) -> GoogleHealthBodyData:
-        """Fetch latest body weight and resting heart rate."""
+        """Fetch latest body weight, resting heart rate, and body fat in parallel."""
         # The Google Health API returns data points sorted by interval start time
         # in descending order (newest first). Querying with page_size=1 and grabbing
         # the first element is sufficient to fetch the most recent measurement.
-        weight_result = await self.api.weight.list(page_size=DEFAULT_PAGE_SIZE)
-        hr_result = await self.api.daily_resting_heart_rate.list(
-            page_size=DEFAULT_PAGE_SIZE
+        weight_result, hr_result, body_fat_result = await asyncio.gather(
+            self.api.weight.list(page_size=DEFAULT_PAGE_SIZE),
+            self.api.daily_resting_heart_rate.list(page_size=DEFAULT_PAGE_SIZE),
+            self.api.body_fat.list(page_size=DEFAULT_PAGE_SIZE),
         )
 
         weight = (
@@ -170,7 +202,12 @@ class GoogleHealthBodyCoordinator(
         resting_heart_rate = (
             hr_result.data_points[0].data if hr_result.data_points else None
         )
+        body_fat = (
+            body_fat_result.data_points[0].data if body_fat_result.data_points else None
+        )
 
         return GoogleHealthBodyData(
-            weight=weight, resting_heart_rate=resting_heart_rate
+            weight=weight,
+            resting_heart_rate=resting_heart_rate,
+            body_fat=body_fat,
         )

--- a/homeassistant/components/google_health/sensor.py
+++ b/homeassistant/components/google_health/sensor.py
@@ -10,7 +10,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import UnitOfLength, UnitOfMass
+from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfLength, UnitOfMass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -56,6 +56,32 @@ ACTIVITY_SENSORS: list[
             data.distance.millimeters_sum / 1000.0 if data and data.distance else 0.0
         ),
     ),
+    GoogleHealthSensorEntityDescription[GoogleHealthActivityCoordinator, float](
+        key="active_calories",
+        translation_key="active_calories",
+        native_unit_of_measurement=UnitOfEnergy.KILO_CALORIE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: (
+            data.active_energy_burned.kcal_sum
+            if data and data.active_energy_burned
+            else 0.0
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthActivityCoordinator, float](
+        key="total_calories",
+        translation_key="total_calories",
+        native_unit_of_measurement=UnitOfEnergy.KILO_CALORIE,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: (
+            data.total_calories.kcal_sum if data and data.total_calories else 0.0
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthActivityCoordinator, int](
+        key="floors",
+        translation_key="floors",
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        value_fn=lambda data: data.floors.count_sum if data and data.floors else 0,
+    ),
 ]
 
 BODY_SENSORS: list[
@@ -79,6 +105,15 @@ BODY_SENSORS: list[
             data.resting_heart_rate.beats_per_minute
             if data and data.resting_heart_rate
             else None
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthBodyCoordinator, float | None](
+        key="body_fat",
+        translation_key="body_fat",
+        native_unit_of_measurement=PERCENTAGE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.body_fat.percentage if data and data.body_fat else None
         ),
     ),
 ]

--- a/homeassistant/components/google_health/strings.json
+++ b/homeassistant/components/google_health/strings.json
@@ -35,12 +35,24 @@
   },
   "entity": {
     "sensor": {
+      "active_calories": {
+        "name": "Active calories"
+      },
+      "body_fat": {
+        "name": "Body fat"
+      },
+      "floors": {
+        "name": "Floors"
+      },
       "resting_heart_rate": {
         "name": "Resting heart rate"
       },
       "steps": {
         "name": "Steps",
         "unit_of_measurement": "steps"
+      },
+      "total_calories": {
+        "name": "Total calories"
       }
     }
   },

--- a/tests/components/google_health/conftest.py
+++ b/tests/components/google_health/conftest.py
@@ -6,15 +6,19 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from google_health_api.model import (
+    BODY_FAT,
     DAILY_RESTING_HEART_RATE,
     WEIGHT,
+    ActiveEnergyBurnedRollupValue,
     DailyRollupDataPoint,
     DataPoint,
     DataType,
     DistanceRollupValue,
+    FloorsRollupValue,
     Identity,
     ListDataPointResult,
     StepsRollupValue,
+    TotalCaloriesRollupValue,
     UserInfo,
     _ListDataPointsModel,
 )
@@ -129,6 +133,20 @@ def mock_google_health_client() -> Generator[AsyncMock]:
         client.distance.today.return_value = _rollup_fixture(
             "distance.json", DistanceRollupValue, "distance"
         )
+        client.active_energy_burned = AsyncMock()
+        client.active_energy_burned.today.return_value = _rollup_fixture(
+            "active_energy_burned.json",
+            ActiveEnergyBurnedRollupValue,
+            "activeEnergyBurned",
+        )
+        client.total_calories = AsyncMock()
+        client.total_calories.today.return_value = _rollup_fixture(
+            "total_calories.json", TotalCaloriesRollupValue, "totalCalories"
+        )
+        client.floors = AsyncMock()
+        client.floors.today.return_value = _rollup_fixture(
+            "floors.json", FloorsRollupValue, "floors"
+        )
         client.weight = AsyncMock()
         client.weight.list.return_value = _list_fixture("weight.json", WEIGHT)
         client.weight.required_read_scopes = [
@@ -138,6 +156,8 @@ def mock_google_health_client() -> Generator[AsyncMock]:
         client.daily_resting_heart_rate.list.return_value = _list_fixture(
             "resting_heart_rate.json", DAILY_RESTING_HEART_RATE
         )
+        client.body_fat = AsyncMock()
+        client.body_fat.list.return_value = _list_fixture("body_fat.json", BODY_FAT)
         client.get_identity.return_value = Identity.from_dict(
             load_json_object_fixture("identity.json", DOMAIN)
         )

--- a/tests/components/google_health/fixtures/active_energy_burned.json
+++ b/tests/components/google_health/fixtures/active_energy_burned.json
@@ -1,0 +1,23 @@
+{
+  "rollupDataPoints": [
+    {
+      "activeEnergyBurned": {
+        "kcalSum": 350.5
+      },
+      "civilStartTime": {
+        "date": {
+          "year": 2026,
+          "month": 6,
+          "day": 28
+        }
+      },
+      "civilEndTime": {
+        "date": {
+          "year": 2026,
+          "month": 6,
+          "day": 29
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/google_health/fixtures/body_fat.json
+++ b/tests/components/google_health/fixtures/body_fat.json
@@ -1,0 +1,12 @@
+{
+  "dataPoints": [
+    {
+      "bodyFat": {
+        "percentage": 18.5,
+        "sampleTime": {
+          "physicalTime": "2026-06-29T00:00:00Z"
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/google_health/fixtures/floors.json
+++ b/tests/components/google_health/fixtures/floors.json
@@ -1,0 +1,23 @@
+{
+  "rollupDataPoints": [
+    {
+      "floors": {
+        "countSum": 5
+      },
+      "civilStartTime": {
+        "date": {
+          "year": 2026,
+          "month": 6,
+          "day": 28
+        }
+      },
+      "civilEndTime": {
+        "date": {
+          "year": 2026,
+          "month": 6,
+          "day": 29
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/google_health/fixtures/total_calories.json
+++ b/tests/components/google_health/fixtures/total_calories.json
@@ -1,0 +1,23 @@
+{
+  "rollupDataPoints": [
+    {
+      "totalCalories": {
+        "kcalSum": 2100.2
+      },
+      "civilStartTime": {
+        "date": {
+          "year": 2026,
+          "month": 6,
+          "day": 28
+        }
+      },
+      "civilEndTime": {
+        "date": {
+          "year": 2026,
+          "month": 6,
+          "day": 29
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/google_health/snapshots/test_sensor.ambr
+++ b/tests/components/google_health/snapshots/test_sensor.ambr
@@ -1,4 +1,112 @@
 # serializer version: 1
+# name: test_all_entities[sensor.google_health_active_calories-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_active_calories',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Active calories',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Active calories',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'active_calories',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_active_calories',
+    'unit_of_measurement': <UnitOfEnergy.KILO_CALORIE: 'kcal'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_active_calories-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Active calories',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_CALORIE: 'kcal'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_active_calories',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '350.5',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_body_fat-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_body_fat',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Body fat',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Body fat',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'body_fat',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_body_fat',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_body_fat-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Body fat',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_body_fat',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '18.5',
+  })
+# ---
 # name: test_all_entities[sensor.google_health_distance-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -55,6 +163,59 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '5000.0',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_floors-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_floors',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Floors',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Floors',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'floors',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_floors',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_floors-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Floors',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_floors',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5',
   })
 # ---
 # name: test_all_entities[sensor.google_health_resting_heart_rate-entry]
@@ -163,6 +324,60 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '10500',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_total_calories-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_total_calories',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Total calories',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Total calories',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'total_calories',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_total_calories',
+    'unit_of_measurement': <UnitOfEnergy.KILO_CALORIE: 'kcal'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_total_calories-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Total calories',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfEnergy.KILO_CALORIE: 'kcal'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_total_calories',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2100.2',
   })
 # ---
 # name: test_all_entities[sensor.google_health_weight-entry]

--- a/tests/components/google_health/test_init.py
+++ b/tests/components/google_health/test_init.py
@@ -1,5 +1,6 @@
 """Tests for Google Health integration lifecycle (init/unloading)."""
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
@@ -189,6 +190,8 @@ async def test_runtime_auth_error(
         hass,
         dt_util.utcnow() + POLLING_INTERVAL + timedelta(seconds=1),
     )
+    await hass.async_block_till_done()
+    await asyncio.sleep(0)
     await hass.async_block_till_done()
 
     # Verify that the flow was initiated

--- a/tests/components/google_health/test_init.py
+++ b/tests/components/google_health/test_init.py
@@ -111,9 +111,13 @@ async def test_setup_missing_activity_scope(
 
     assert hass.states.get("sensor.google_health_steps") is None
     assert hass.states.get("sensor.google_health_distance") is None
+    assert hass.states.get("sensor.google_health_active_calories") is None
+    assert hass.states.get("sensor.google_health_total_calories") is None
+    assert hass.states.get("sensor.google_health_floors") is None
 
     assert hass.states.get("sensor.google_health_weight") is not None
     assert hass.states.get("sensor.google_health_resting_heart_rate") is not None
+    assert hass.states.get("sensor.google_health_body_fat") is not None
 
 
 @pytest.mark.usefixtures("mock_google_health_client")
@@ -137,9 +141,13 @@ async def test_setup_missing_measurements_scope(
 
     assert hass.states.get("sensor.google_health_weight") is None
     assert hass.states.get("sensor.google_health_resting_heart_rate") is None
+    assert hass.states.get("sensor.google_health_body_fat") is None
 
     assert hass.states.get("sensor.google_health_steps") is not None
     assert hass.states.get("sensor.google_health_distance") is not None
+    assert hass.states.get("sensor.google_health_active_calories") is not None
+    assert hass.states.get("sensor.google_health_total_calories") is not None
+    assert hass.states.get("sensor.google_health_floors") is not None
 
 
 async def test_setup_oauth_implementation_unavailable(

--- a/tests/components/google_health/test_init.py
+++ b/tests/components/google_health/test_init.py
@@ -191,6 +191,7 @@ async def test_runtime_auth_error(
         dt_util.utcnow() + POLLING_INTERVAL + timedelta(seconds=1),
     )
     await hass.async_block_till_done()
+    # Yield to let untracked asyncio.gather tasks run
     await asyncio.sleep(0)
     await hass.async_block_till_done()
 

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -33,9 +33,12 @@ async def test_sensor_empty_rollup(
     mock_google_health_client: AsyncMock,
     integration_setup: Callable[[], Awaitable[bool]],
 ) -> None:
-    """Test steps and distance sensors when the rollup endpoint returns no data."""
+    """Test rollup sensors when the rollup endpoints return no data."""
     mock_google_health_client.steps.today.return_value = None
     mock_google_health_client.distance.today.return_value = None
+    mock_google_health_client.active_energy_burned.today.return_value = None
+    mock_google_health_client.total_calories.today.return_value = None
+    mock_google_health_client.floors.today.return_value = None
 
     assert await integration_setup()
 
@@ -46,3 +49,15 @@ async def test_sensor_empty_rollup(
     distance_state = hass.states.get("sensor.google_health_distance")
     assert distance_state is not None
     assert distance_state.state == "0.0"
+
+    active_calories_state = hass.states.get("sensor.google_health_active_calories")
+    assert active_calories_state is not None
+    assert active_calories_state.state == "0.0"
+
+    total_calories_state = hass.states.get("sensor.google_health_total_calories")
+    assert total_calories_state is not None
+    assert total_calories_state.state == "0.0"
+
+    floors_state = hass.states.get("sensor.google_health_floors")
+    assert floors_state is not None
+    assert floors_state.state == "0"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds more sensors to the recently introduced **Google Health** integration:
* **Active Calories** (`sensor.google_health_active_calories`): Daily active energy burned rollup (in kcal).
* **Total Calories** (`sensor.google_health_total_calories`): Daily total energy burned rollup (in kcal).
* **Floors** (`sensor.google_health_floors`): Daily floors climbed rollup count.
* **Body Fat** (`sensor.google_health_body_fat`): Latest body fat percentage measurement.

To support these additional endpoints cleanly and efficiently, this PR also updates the update coordinators (`GoogleHealthActivityCoordinator` and `GoogleHealthBodyCoordinator`) to fetch their respective API data points concurrently using `asyncio.gather`.

Additionally, a test suite adjustment was made to `test_runtime_auth_error` to yield execution to the event loop (`await asyncio.sleep(0)`) to allow the parallel `asyncio.gather` tasks to complete and raise exceptions prior to asserting the re-authentication flow.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
