### PR TITLE
Add Airzone Aidoo swing mode support

### DIFF
--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -46,10 +46,10 @@ from homeassistant.components.climate import (
     FAN_HIGH,
     FAN_LOW,
     FAN_MEDIUM,
-    ClimateEntity,
-    ClimateEntityFeature,
     SWING_OFF,
     SWING_VERTICAL,
+    ClimateEntity,
+    ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )

--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -48,6 +48,8 @@ from homeassistant.components.climate import (
     FAN_MEDIUM,
     ClimateEntity,
     ClimateEntityFeature,
+    SWING_OFF,
+    SWING_VERTICAL,
     HVACAction,
     HVACMode,
 )
@@ -113,11 +115,9 @@ HVAC_MODE_HASS_TO_LIB: Final[dict[HVACMode, OperationMode]] = {
     HVACMode.DRY: OperationMode.DRY,
     HVACMode.HEAT_COOL: OperationMode.AUTO,
 }
-SWING_MODE_OFF: Final[str] = "Off"
-SWING_MODE_VERTICAL: Final[str] = "Vertical"
 SLATS_AIRZONE_TO_HASS: Final[dict[str, str]] = {
-    "fixed": SWING_MODE_OFF,
-    "swing": SWING_MODE_VERTICAL,
+    "fixed": SWING_OFF,
+    "swing": SWING_VERTICAL,
 }
 SLATS_HASS_TO_AIRZONE: Final[dict[str, str]] = {
     value: key for key, value in SLATS_AIRZONE_TO_HASS.items()

--- a/homeassistant/components/airzone_cloud/climate.py
+++ b/homeassistant/components/airzone_cloud/climate.py
@@ -56,6 +56,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import API_SLATS_V_CONF, AZD_SLATS_V_CONF, AZD_SLATS_V_VALUES
 from .coordinator import AirzoneCloudConfigEntry, AirzoneUpdateCoordinator
 from .entity import (
     AirzoneAidooEntity,
@@ -111,6 +112,15 @@ HVAC_MODE_HASS_TO_LIB: Final[dict[HVACMode, OperationMode]] = {
     HVACMode.FAN_ONLY: OperationMode.VENTILATION,
     HVACMode.DRY: OperationMode.DRY,
     HVACMode.HEAT_COOL: OperationMode.AUTO,
+}
+SWING_MODE_OFF: Final[str] = "Off"
+SWING_MODE_VERTICAL: Final[str] = "Vertical"
+SLATS_AIRZONE_TO_HASS: Final[dict[str, str]] = {
+    "fixed": SWING_MODE_OFF,
+    "swing": SWING_MODE_VERTICAL,
+}
+SLATS_HASS_TO_AIRZONE: Final[dict[str, str]] = {
+    value: key for key, value in SLATS_AIRZONE_TO_HASS.items()
 }
 
 
@@ -426,6 +436,41 @@ class AirzoneAidooClimate(AirzoneAidooEntity, AirzoneDeviceClimate):
         self._init_attributes()
 
         self._async_update_attrs()
+
+    @override
+    def _init_attributes(self) -> None:
+        """Init Aidoo climate attributes."""
+        super()._init_attributes()
+
+        if slat_values := self.get_airzone_value(AZD_SLATS_V_VALUES):
+            swing_modes = [
+                SLATS_AIRZONE_TO_HASS[value]
+                for value in slat_values
+                if value in SLATS_AIRZONE_TO_HASS
+            ]
+            if swing_modes:
+                self._attr_swing_modes = swing_modes
+                self._attr_supported_features |= ClimateEntityFeature.SWING_MODE
+
+    @callback
+    @override
+    def _async_update_attrs(self) -> None:
+        """Update Aidoo climate attributes."""
+        super()._async_update_attrs()
+        if self.supported_features & ClimateEntityFeature.SWING_MODE:
+            self._attr_swing_mode = SLATS_AIRZONE_TO_HASS.get(
+                self.get_airzone_value(AZD_SLATS_V_CONF)
+            )
+
+    @override
+    async def async_set_swing_mode(self, swing_mode: str) -> None:
+        """Set Aidoo vertical swing mode."""
+        params: dict[str, Any] = {
+            API_SLATS_V_CONF: {
+                API_VALUE: SLATS_HASS_TO_AIRZONE[swing_mode],
+            }
+        }
+        await self._async_update_params(params)
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/homeassistant/components/airzone_cloud/const.py
+++ b/homeassistant/components/airzone_cloud/const.py
@@ -6,3 +6,11 @@ DOMAIN: Final[str] = "airzone_cloud"
 MANUFACTURER: Final[str] = "Airzone"
 
 AIOAIRZONE_CLOUD_TIMEOUT_SEC: Final[int] = 30
+
+AZD_SLATS_H_VALUES: Final[str] = "slats-h-values"
+AZD_SLATS_V_CONF: Final[str] = "slats-v-conf"
+AZD_SLATS_V_VALUES: Final[str] = "slats-v-values"
+
+API_SLATS_H_VALUES: Final[str] = "slats_h_values"
+API_SLATS_V_CONF: Final[str] = "slats_v_conf"
+API_SLATS_V_VALUES: Final[str] = "slats_v_values"

--- a/homeassistant/components/airzone_cloud/coordinator.py
+++ b/homeassistant/components/airzone_cloud/coordinator.py
@@ -10,7 +10,7 @@ from aioairzone_cloud.const import AZD_AIDOOS, RAW_DEVICES_CONFIG
 from aioairzone_cloud.exceptions import AirzoneCloudError
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
@@ -44,7 +44,7 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     ) -> None:
         """Initialize."""
         self.airzone = airzone
-        self.airzone.set_update_callback(self.async_set_updated_data)
+        self.airzone.set_update_callback(self._async_set_updated_data)
 
         super().__init__(
             hass,
@@ -64,9 +64,15 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 raise UpdateFailed(error) from error
             return self.data_with_slats()
 
-    def data_with_slats(self) -> dict[str, Any]:
+    @callback
+    def _async_set_updated_data(self, data: dict[str, Any]) -> None:
+        """Enrich Airzone callback data before publishing it."""
+        self.async_set_updated_data(self.data_with_slats(data))
+
+    def data_with_slats(self, data: dict[str, Any] | None = None) -> dict[str, Any]:
         """Return Airzone data with Aidoo slat fields from raw API config."""
-        data = self.airzone.data()
+        if data is None:
+            data = self.airzone.data()
         aidoos = data.get(AZD_AIDOOS, {})
         raw_config = self.airzone.raw_data().get(RAW_DEVICES_CONFIG, {})
 

--- a/homeassistant/components/airzone_cloud/coordinator.py
+++ b/homeassistant/components/airzone_cloud/coordinator.py
@@ -6,13 +6,23 @@ import logging
 from typing import Any, override
 
 from aioairzone_cloud.cloudapi import AirzoneCloudApi
+from aioairzone_cloud.const import AZD_AIDOOS, RAW_DEVICES_CONFIG
 from aioairzone_cloud.exceptions import AirzoneCloudError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import AIOAIRZONE_CLOUD_TIMEOUT_SEC, DOMAIN
+from .const import (
+    AIOAIRZONE_CLOUD_TIMEOUT_SEC,
+    API_SLATS_H_VALUES,
+    API_SLATS_V_CONF,
+    API_SLATS_V_VALUES,
+    AZD_SLATS_H_VALUES,
+    AZD_SLATS_V_CONF,
+    AZD_SLATS_V_VALUES,
+    DOMAIN,
+)
 
 SCAN_INTERVAL = timedelta(seconds=60)
 
@@ -52,4 +62,22 @@ class AirzoneUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 await self.airzone.update()
             except AirzoneCloudError as error:
                 raise UpdateFailed(error) from error
-            return self.airzone.data()
+            return self.data_with_slats()
+
+    def data_with_slats(self) -> dict[str, Any]:
+        """Return Airzone data with Aidoo slat fields from raw API config."""
+        data = self.airzone.data()
+        aidoos = data.get(AZD_AIDOOS, {})
+        raw_config = self.airzone.raw_data().get(RAW_DEVICES_CONFIG, {})
+
+        for aidoo_id, aidoo_data in aidoos.items():
+            if not (config := raw_config.get(aidoo_id)):
+                continue
+            if API_SLATS_V_CONF in config:
+                aidoo_data[AZD_SLATS_V_CONF] = config[API_SLATS_V_CONF]
+            if API_SLATS_V_VALUES in config:
+                aidoo_data[AZD_SLATS_V_VALUES] = config[API_SLATS_V_VALUES]
+            if API_SLATS_H_VALUES in config:
+                aidoo_data[AZD_SLATS_H_VALUES] = config[API_SLATS_H_VALUES]
+
+        return data

--- a/homeassistant/components/airzone_cloud/entity.py
+++ b/homeassistant/components/airzone_cloud/entity.py
@@ -5,6 +5,7 @@ import logging
 from typing import Any, override
 
 from aioairzone_cloud.const import (
+    API_VALUE,
     AZD_AIDOOS,
     AZD_AVAILABLE,
     AZD_FIRMWARE,
@@ -20,6 +21,7 @@ from aioairzone_cloud.const import (
     AZD_WEBSERVER,
     AZD_WEBSERVERS,
     AZD_ZONES,
+    RAW_DEVICES_CONFIG,
 )
 from aioairzone_cloud.exceptions import AirzoneCloudError
 
@@ -28,7 +30,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN, MANUFACTURER
+from .const import API_SLATS_V_CONF, DOMAIN, MANUFACTURER
 from .coordinator import AirzoneUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -97,7 +99,13 @@ class AirzoneAidooEntity(AirzoneEntity):
                 f"Failed to set {self.entity_id} params: {error}"
             ) from error
 
-        self.coordinator.async_set_updated_data(self.coordinator.airzone.data())
+        raw_config = self.coordinator.airzone.raw_data().get(RAW_DEVICES_CONFIG, {})
+        if aidoo_config := raw_config.get(self.aidoo_id):
+            for param, data in params.items():
+                if param == API_SLATS_V_CONF:
+                    aidoo_config[param] = data[API_VALUE]
+
+        self.coordinator.async_set_updated_data(self.coordinator.data_with_slats())
 
 
 class AirzoneGroupEntity(AirzoneEntity):

--- a/homeassistant/components/airzone_cloud/entity.py
+++ b/homeassistant/components/airzone_cloud/entity.py
@@ -21,7 +21,6 @@ from aioairzone_cloud.const import (
     AZD_WEBSERVER,
     AZD_WEBSERVERS,
     AZD_ZONES,
-    RAW_DEVICES_CONFIG,
 )
 from aioairzone_cloud.exceptions import AirzoneCloudError
 
@@ -30,7 +29,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import API_SLATS_V_CONF, DOMAIN, MANUFACTURER
+from .const import API_SLATS_V_CONF, AZD_SLATS_V_CONF, DOMAIN, MANUFACTURER
 from .coordinator import AirzoneUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -99,13 +98,13 @@ class AirzoneAidooEntity(AirzoneEntity):
                 f"Failed to set {self.entity_id} params: {error}"
             ) from error
 
-        raw_config = self.coordinator.airzone.raw_data().get(RAW_DEVICES_CONFIG, {})
-        if aidoo_config := raw_config.get(self.aidoo_id):
+        updated_data = self.coordinator.data_with_slats()
+        if aidoo_config := updated_data.get(AZD_AIDOOS, {}).get(self.aidoo_id):
             for param, data in params.items():
                 if param == API_SLATS_V_CONF:
-                    aidoo_config[param] = data[API_VALUE]
+                    aidoo_config[AZD_SLATS_V_CONF] = data[API_VALUE]
 
-        self.coordinator.async_set_updated_data(self.coordinator.data_with_slats())
+        self.coordinator.async_set_updated_data(updated_data)
 
 
 class AirzoneGroupEntity(AirzoneEntity):

--- a/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
+++ b/tests/components/airzone_cloud/snapshots/test_diagnostics.ambr
@@ -129,6 +129,11 @@
           'name': 'Bron',
           'power': False,
           'problems': False,
+          'slats-v-conf': 'fixed',
+          'slats-v-values': list([
+            'swing',
+            'fixed',
+          ]),
           'speed': 6,
           'speed-type': 0,
           'speeds': dict({
@@ -182,6 +187,11 @@
           'outdoor-temperature': 29.0,
           'power': True,
           'problems': False,
+          'slats-v-conf': 'swing',
+          'slats-v-values': list([
+            'swing',
+            'fixed',
+          ]),
           'speed': 3,
           'speed-type': 0,
           'speeds': dict({

--- a/tests/components/airzone_cloud/test_climate.py
+++ b/tests/components/airzone_cloud/test_climate.py
@@ -2,10 +2,16 @@
 
 from unittest.mock import patch
 
-from aioairzone_cloud.const import API_DEFAULT_TEMP_STEP
+from aioairzone_cloud.const import (
+    API_DEFAULT_TEMP_STEP,
+    API_INSTALLATION_ID,
+    API_PARAM,
+    API_VALUE,
+)
 from aioairzone_cloud.exceptions import AirzoneCloudError
 import pytest
 
+from homeassistant.components.airzone_cloud.const import API_SLATS_V_CONF
 from homeassistant.components.climate import (
     ATTR_CURRENT_HUMIDITY,
     ATTR_CURRENT_TEMPERATURE,
@@ -30,6 +36,8 @@ from homeassistant.components.climate import (
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_SWING_MODE,
     SERVICE_SET_TEMPERATURE,
+    SWING_OFF,
+    SWING_VERTICAL,
     HVACAction,
     HVACMode,
 )
@@ -72,8 +80,8 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     ]
     assert state.attributes[ATTR_MAX_TEMP] == 30
     assert state.attributes[ATTR_MIN_TEMP] == 15
-    assert state.attributes[ATTR_SWING_MODE] == "Off"
-    assert state.attributes[ATTR_SWING_MODES] == ["Vertical", "Off"]
+    assert state.attributes[ATTR_SWING_MODE] == SWING_OFF
+    assert state.attributes[ATTR_SWING_MODES] == [SWING_VERTICAL, SWING_OFF]
     assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_DEFAULT_TEMP_STEP
     assert state.attributes[ATTR_TEMPERATURE] == 22.0
 
@@ -101,8 +109,8 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     ]
     assert state.attributes[ATTR_MAX_TEMP] == 30
     assert state.attributes[ATTR_MIN_TEMP] == 15
-    assert state.attributes[ATTR_SWING_MODE] == "Vertical"
-    assert state.attributes[ATTR_SWING_MODES] == ["Vertical", "Off"]
+    assert state.attributes[ATTR_SWING_MODE] == SWING_VERTICAL
+    assert state.attributes[ATTR_SWING_MODES] == [SWING_VERTICAL, SWING_OFF]
     assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_DEFAULT_TEMP_STEP
     assert state.attributes.get(ATTR_TEMPERATURE) == 22.0
 
@@ -358,19 +366,36 @@ async def test_airzone_climate_set_swing_mode(hass: HomeAssistant) -> None:
     with patch(
         "homeassistant.components.airzone_cloud.AirzoneCloudApi.api_patch_device",
         return_value=None,
-    ):
+    ) as patch_device:
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_SWING_MODE,
             {
                 ATTR_ENTITY_ID: "climate.bron",
-                ATTR_SWING_MODE: "Vertical",
+                ATTR_SWING_MODE: SWING_VERTICAL,
             },
             blocking=True,
         )
 
+    patch_device.assert_called_once()
+    assert patch_device.call_args.args[1] == {
+        API_PARAM: API_SLATS_V_CONF,
+        API_VALUE: "swing",
+        API_INSTALLATION_ID: "inst1",
+    }
+
     state = hass.states.get("climate.bron")
-    assert state.attributes[ATTR_SWING_MODE] == "Vertical"
+    assert state.attributes[ATTR_SWING_MODE] == SWING_VERTICAL
+
+
+async def test_airzone_climate_without_swing_modes(hass: HomeAssistant) -> None:
+    """Test Aidoo climate without slat values does not expose swing mode."""
+
+    await async_init_integration(hass, aidoo1_slats_supported=False)
+
+    state = hass.states.get("climate.bron")
+    assert ATTR_SWING_MODE not in state.attributes
+    assert ATTR_SWING_MODES not in state.attributes
 
 
 async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:

--- a/tests/components/airzone_cloud/test_climate.py
+++ b/tests/components/airzone_cloud/test_climate.py
@@ -16,6 +16,8 @@ from homeassistant.components.climate import (
     ATTR_HVAC_MODES,
     ATTR_MAX_TEMP,
     ATTR_MIN_TEMP,
+    ATTR_SWING_MODE,
+    ATTR_SWING_MODES,
     ATTR_TARGET_TEMP_HIGH,
     ATTR_TARGET_TEMP_LOW,
     ATTR_TARGET_TEMP_STEP,
@@ -26,6 +28,7 @@ from homeassistant.components.climate import (
     FAN_MEDIUM,
     SERVICE_SET_FAN_MODE,
     SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_SWING_MODE,
     SERVICE_SET_TEMPERATURE,
     HVACAction,
     HVACMode,
@@ -69,6 +72,8 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     ]
     assert state.attributes[ATTR_MAX_TEMP] == 30
     assert state.attributes[ATTR_MIN_TEMP] == 15
+    assert state.attributes[ATTR_SWING_MODE] == "Off"
+    assert state.attributes[ATTR_SWING_MODES] == ["Vertical", "Off"]
     assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_DEFAULT_TEMP_STEP
     assert state.attributes[ATTR_TEMPERATURE] == 22.0
 
@@ -96,6 +101,8 @@ async def test_airzone_create_climates(hass: HomeAssistant) -> None:
     ]
     assert state.attributes[ATTR_MAX_TEMP] == 30
     assert state.attributes[ATTR_MIN_TEMP] == 15
+    assert state.attributes[ATTR_SWING_MODE] == "Vertical"
+    assert state.attributes[ATTR_SWING_MODES] == ["Vertical", "Off"]
     assert state.attributes[ATTR_TARGET_TEMP_STEP] == API_DEFAULT_TEMP_STEP
     assert state.attributes.get(ATTR_TEMPERATURE) == 22.0
 
@@ -341,6 +348,29 @@ async def test_airzone_climate_set_fan_mode(hass: HomeAssistant) -> None:
 
     state = hass.states.get("climate.bron_pro")
     assert state.attributes[ATTR_FAN_MODE] == FAN_AUTO
+
+
+async def test_airzone_climate_set_swing_mode(hass: HomeAssistant) -> None:
+    """Test setting the swing mode."""
+
+    await async_init_integration(hass)
+
+    with patch(
+        "homeassistant.components.airzone_cloud.AirzoneCloudApi.api_patch_device",
+        return_value=None,
+    ):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_SWING_MODE,
+            {
+                ATTR_ENTITY_ID: "climate.bron",
+                ATTR_SWING_MODE: "Vertical",
+            },
+            blocking=True,
+        )
+
+    state = hass.states.get("climate.bron")
+    assert state.attributes[ATTR_SWING_MODE] == "Vertical"
 
 
 async def test_airzone_climate_set_hvac_mode(hass: HomeAssistant) -> None:

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -110,6 +110,7 @@ from aioairzone_cloud.const import (
     API_WS_IDS,
     API_WS_TYPE,
     API_ZONE_NUMBER,
+    RAW_DEVICES_CONFIG,
 )
 from aioairzone_cloud.device import Device
 from aioairzone_cloud.webserver import WebServer
@@ -551,6 +552,19 @@ async def async_init_integration(
     )
     config_entry.add_to_hass(hass)
 
+    raw_data = {
+        RAW_DEVICES_CONFIG: {
+            "aidoo1": {
+                API_SLATS_V_CONF: "fixed",
+                API_SLATS_V_VALUES: ["swing", "fixed"],
+            },
+            "aidoo_pro": {
+                API_SLATS_V_CONF: "swing",
+                API_SLATS_V_VALUES: ["swing", "fixed"],
+            },
+        },
+    }
+
     with (
         patch(
             "homeassistant.components.airzone_cloud.AirzoneCloudApi.api_get_device_config",
@@ -575,6 +589,10 @@ async def async_init_integration(
         patch(
             "homeassistant.components.airzone_cloud.AirzoneCloudApi.login",
             return_value=None,
+        ),
+        patch(
+            "homeassistant.components.airzone_cloud.AirzoneCloudApi.raw_data",
+            return_value=raw_data,
         ),
     ):
         await hass.config_entries.async_setup(config_entry.entry_id)

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -114,7 +114,11 @@ from aioairzone_cloud.const import (
 from aioairzone_cloud.device import Device
 from aioairzone_cloud.webserver import WebServer
 
-from homeassistant.components.airzone_cloud.const import DOMAIN
+from homeassistant.components.airzone_cloud.const import (
+    API_SLATS_V_CONF,
+    API_SLATS_V_VALUES,
+    DOMAIN,
+)
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 
@@ -297,7 +301,14 @@ def mock_get_device_config(device: Device) -> dict[str, Any]:
             API_PC_UE: 0.15,
             API_PE_UE: 0.02,
             API_RETURN_TEMP: {API_CELSIUS: 26, API_FAH: 79},
+            API_SLATS_V_CONF: "swing",
+            API_SLATS_V_VALUES: ["swing", "fixed"],
             API_WORK_TEMP: {API_CELSIUS: 25, API_FAH: 77},
+        }
+    if device.get_id() == "aidoo1":
+        return {
+            API_SLATS_V_CONF: "fixed",
+            API_SLATS_V_VALUES: ["swing", "fixed"],
         }
     if device.get_id() == "system1":
         return {

--- a/tests/components/airzone_cloud/util.py
+++ b/tests/components/airzone_cloud/util.py
@@ -541,6 +541,7 @@ def mock_get_webserver(webserver: WebServer, devices: bool) -> dict[str, Any]:
 
 async def async_init_integration(
     hass: HomeAssistant,
+    aidoo1_slats_supported: bool = True,
 ) -> None:
     """Set up the Airzone integration in Home Assistant."""
 
@@ -556,7 +557,6 @@ async def async_init_integration(
         RAW_DEVICES_CONFIG: {
             "aidoo1": {
                 API_SLATS_V_CONF: "fixed",
-                API_SLATS_V_VALUES: ["swing", "fixed"],
             },
             "aidoo_pro": {
                 API_SLATS_V_CONF: "swing",
@@ -564,6 +564,11 @@ async def async_init_integration(
             },
         },
     }
+    if aidoo1_slats_supported:
+        raw_data[RAW_DEVICES_CONFIG]["aidoo1"][API_SLATS_V_VALUES] = [
+            "swing",
+            "fixed",
+        ]
 
     with (
         patch(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if
  you write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add vertical swing mode support for Airzone Cloud Aidoo climate entities.

Airzone Cloud exposes Aidoo vertical slat support in the raw device config as:

- `slats_v_conf`
- `slats_v_values`

This maps the supported Airzone values to Home Assistant climate swing modes:

- `fixed` -> `off`
- `swing` -> `vertical`

Devices that do not report `slats_v_values` do not expose swing mode.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Validated locally with:

- `python3 -m py_compile` on changed Airzone integration and test files.
- Live Airzone Cloud Aidoo install using a local custom component override on Home Assistant 2026.7.1.

The targeted pytest run was not executed locally because this checkout requires Python 3.14.5, which is not installed in the local environment.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr