### PR TITLE
Add timeout to user config flow in SMTP integration

### DIFF
--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -170,7 +170,7 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
             entry_data = user_input.copy()
             options = entry_data.pop(SECTION_OPTIONS)
             errors = await self.hass.async_add_executor_job(
-                validate_input, {**entry_data, **options}
+                validate_input, entry_data, options
             )
             if not errors:
                 return self.async_create_entry(
@@ -224,7 +224,7 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
                 }
             )
             errors = await self.hass.async_add_executor_job(
-                validate_input, {**user_input, **entry.options}
+                validate_input, user_input, dict(entry.options)
             )
             if not errors:
                 return self.async_update_and_abort(
@@ -256,7 +256,7 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             errors = await self.hass.async_add_executor_job(
-                validate_input, {**entry.data, **user_input, **entry.options}
+                validate_input, {**entry.data, **user_input}, dict(entry.options)
             )
             if not errors:
                 return self.async_update_and_abort(
@@ -279,7 +279,9 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
         options = {CONF_TIMEOUT: import_info.pop(CONF_TIMEOUT, DEFAULT_TIMEOUT)}
         self._async_abort_entries_match(import_info)
 
-        errors = await self.hass.async_add_executor_job(validate_input, import_info)
+        errors = await self.hass.async_add_executor_job(
+            validate_input, import_info, options
+        )
         if not errors:
             title = (
                 import_info.get(CONF_NAME)
@@ -304,7 +306,9 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_abort(reason=errors["base"])
 
 
-def validate_input(user_input: dict[str, Any]) -> dict[str, str]:
+def validate_input(
+    user_input: dict[str, Any], options: dict[str, Any]
+) -> dict[str, str]:
     """Validate the user input allows us to connect."""
     errors: dict[str, str] = {}
     ssl_context = create_client_context() if user_input[CONF_VERIFY_SSL] else None
@@ -314,14 +318,14 @@ def validate_input(user_input: dict[str, Any]) -> dict[str, str]:
             mail = SMTP_SSL(
                 user_input[CONF_SERVER],
                 user_input[CONF_PORT],
-                timeout=user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                timeout=options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
                 context=ssl_context,
             )
         else:
             mail = SMTP(
                 user_input[CONF_SERVER],
                 user_input[CONF_PORT],
-                timeout=user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
+                timeout=options.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             )
         mail.ehlo_or_helo_if_needed()
         if user_input[CONF_ENCRYPTION] == "starttls":

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -10,6 +10,7 @@ from typing import Any, override
 
 import voluptuous as vol
 
+from homeassistant import data_entry_flow
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.config_entries import (
     SOURCE_USER,
@@ -59,11 +60,28 @@ from .const import (
     DEFAULT_TIMEOUT,
     DOMAIN,
     ENCRYPTION_OPTIONS,
+    SECTION_OPTIONS,
     SUBENTRY_TYPE_RECIPIENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
+            NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=1800,
+                    step=1,
+                    unit_of_measurement=UnitOfTime.SECONDS,
+                    mode=NumberSelectorMode.BOX,
+                )
+            ),
+            vol.Coerce(int),
+        )
+    }
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -115,23 +133,6 @@ STEP_REAUTH_DATA_SCHEMA = vol.Schema(
     }
 )
 
-OPTIONS_SCHEMA = vol.Schema(
-    {
-        vol.Optional(CONF_TIMEOUT, default=DEFAULT_TIMEOUT): vol.All(
-            NumberSelector(
-                NumberSelectorConfig(
-                    min=1,
-                    max=1800,
-                    step=1,
-                    unit_of_measurement=UnitOfTime.SECONDS,
-                    mode=NumberSelectorMode.BOX,
-                )
-            ),
-            vol.Coerce(int),
-        )
-    }
-)
-
 
 class MailConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for SMTP."""
@@ -166,16 +167,28 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: user_input.get(CONF_USERNAME),
                 }
             )
-            errors = await self.hass.async_add_executor_job(validate_input, user_input)
+            options = user_input.pop(SECTION_OPTIONS)
+            errors = await self.hass.async_add_executor_job(
+                validate_input, {**user_input, **options}
+            )
             if not errors:
                 return self.async_create_entry(
                     title=user_input.get(CONF_SENDER_NAME, user_input[CONF_SENDER]),
                     data=user_input,
+                    options=options,
                 )
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
-                data_schema=STEP_USER_DATA_SCHEMA, suggested_values=user_input
+                data_schema=STEP_USER_DATA_SCHEMA.extend(
+                    {
+                        vol.Required(SECTION_OPTIONS): data_entry_flow.section(
+                            OPTIONS_SCHEMA,
+                            {"collapsed": True},
+                        ),
+                    }
+                ),
+                suggested_values=user_input,
             ),
             errors=errors,
         )
@@ -209,7 +222,9 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: user_input.get(CONF_USERNAME),
                 }
             )
-            errors = await self.hass.async_add_executor_job(validate_input, user_input)
+            errors = await self.hass.async_add_executor_job(
+                validate_input, {**user_input, **entry.options}
+            )
             if not errors:
                 return self.async_update_and_abort(
                     entry,
@@ -240,7 +255,7 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             errors = await self.hass.async_add_executor_job(
-                validate_input, {**entry.data, **user_input}
+                validate_input, {**entry.data, **user_input, **entry.options}
             )
             if not errors:
                 return self.async_update_and_abort(
@@ -298,12 +313,14 @@ def validate_input(user_input: dict[str, Any]) -> dict[str, str]:
             mail = SMTP_SSL(
                 user_input[CONF_SERVER],
                 user_input[CONF_PORT],
-                timeout=DEFAULT_TIMEOUT,
+                timeout=user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
                 context=ssl_context,
             )
         else:
             mail = SMTP(
-                user_input[CONF_SERVER], user_input[CONF_PORT], timeout=DEFAULT_TIMEOUT
+                user_input[CONF_SERVER],
+                user_input[CONF_PORT],
+                timeout=user_input.get(CONF_TIMEOUT, DEFAULT_TIMEOUT),
             )
         mail.ehlo_or_helo_if_needed()
         if user_input[CONF_ENCRYPTION] == "starttls":

--- a/homeassistant/components/smtp/config_flow.py
+++ b/homeassistant/components/smtp/config_flow.py
@@ -167,14 +167,15 @@ class MailConfigFlow(ConfigFlow, domain=DOMAIN):
                     CONF_USERNAME: user_input.get(CONF_USERNAME),
                 }
             )
-            options = user_input.pop(SECTION_OPTIONS)
+            entry_data = user_input.copy()
+            options = entry_data.pop(SECTION_OPTIONS)
             errors = await self.hass.async_add_executor_job(
-                validate_input, {**user_input, **options}
+                validate_input, {**entry_data, **options}
             )
             if not errors:
                 return self.async_create_entry(
-                    title=user_input.get(CONF_SENDER_NAME, user_input[CONF_SENDER]),
-                    data=user_input,
+                    title=entry_data.get(CONF_SENDER_NAME, entry_data[CONF_SENDER]),
+                    data=entry_data,
                     options=options,
                 )
         return self.async_show_form(

--- a/homeassistant/components/smtp/const.py
+++ b/homeassistant/components/smtp/const.py
@@ -11,6 +11,7 @@ ATTR_SENDER_NAME: Final = "sender_name"
 CONF_ENCRYPTION: Final = "encryption"
 CONF_SERVER: Final = "server"
 CONF_SENDER_NAME: Final = "sender_name"
+SECTION_OPTIONS: Final = "options"
 
 DEFAULT_HOST: Final = "localhost"
 DEFAULT_PORT: Final = 587

--- a/homeassistant/components/smtp/strings.json
+++ b/homeassistant/components/smtp/strings.json
@@ -67,6 +67,17 @@
           "server": "Hostname or IP address of the SMTP server. For example, `smtp.example.com`.",
           "username": "Username used to authenticate with the SMTP server.",
           "verify_ssl": "Enable certificate verification for secure SSL/TLS connections."
+        },
+        "sections": {
+          "options": {
+            "data": {
+              "timeout": "[%key:component::smtp::options::step::init::data::timeout%]"
+            },
+            "data_description": {
+              "timeout": "[%key:component::smtp::options::step::init::data_description::timeout%]"
+            },
+            "name": "Additional options"
+          }
         }
       }
     }

--- a/tests/components/smtp/conftest.py
+++ b/tests/components/smtp/conftest.py
@@ -51,11 +51,13 @@ def mock_smtp() -> Generator[MagicMock]:
 
     with (
         patch(
-            "homeassistant.components.smtp.helpers.smtplib.SMTP", autospec=True
+            "homeassistant.components.smtp.config_flow.SMTP_SSL", autospec=True
         ) as mock_client,
+        patch("homeassistant.components.smtp.helpers.smtplib.SMTP", new=mock_client),
         patch("homeassistant.components.smtp.config_flow.SMTP", new=mock_client),
     ):
         client = mock_client.return_value
+        client.cls = mock_client
         yield client
 
 
@@ -70,17 +72,6 @@ def mock_make_msgid() -> Generator[None]:
         yield
 
 
-@pytest.fixture(name="smtp_ssl")
-def mock_smtp_ssl() -> Generator[MagicMock]:
-    """Mock SMTP."""
-
-    with patch(
-        "homeassistant.components.smtp.config_flow.SMTP_SSL", autospec=True
-    ) as mock_client:
-        client = mock_client.return_value
-        yield client
-
-
 @pytest.fixture(name="config_entry")
 def mock_config_entry() -> MockConfigEntry:
     """Mock smtp configuration entry."""
@@ -89,7 +80,7 @@ def mock_config_entry() -> MockConfigEntry:
         title="Home Assistant",
         data=USER_INPUT,
         options={
-            CONF_TIMEOUT: 5,
+            CONF_TIMEOUT: 1312,
         },
         entry_id="123456789",
         subentries_data=[

--- a/tests/components/smtp/test_config_flow.py
+++ b/tests/components/smtp/test_config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.components.smtp.const import (
     CONF_ENCRYPTION,
     CONF_SENDER_NAME,
     DOMAIN,
+    SECTION_OPTIONS,
     SUBENTRY_TYPE_RECIPIENT,
 )
 from homeassistant.config_entries import (
@@ -37,10 +38,9 @@ from .conftest import USER_INPUT
 from tests.common import MockConfigEntry
 
 
-@pytest.mark.usefixtures("smtp", "smtp_ssl")
 @pytest.mark.parametrize("encryption", ["tls", "starttls"])
 async def test_form(
-    hass: HomeAssistant, mock_setup_entry: AsyncMock, encryption: str
+    hass: HomeAssistant, mock_setup_entry: AsyncMock, encryption: str, smtp: MagicMock
 ) -> None:
     """Test we get the form."""
     result = await hass.config_entries.flow.async_init(
@@ -54,6 +54,7 @@ async def test_form(
         {
             **USER_INPUT,
             CONF_ENCRYPTION: encryption,
+            SECTION_OPTIONS: {CONF_TIMEOUT: 60},
         },
     )
     await hass.async_block_till_done()
@@ -64,6 +65,7 @@ async def test_form(
         **USER_INPUT,
         CONF_ENCRYPTION: encryption,
     }
+    assert result["options"] == {CONF_TIMEOUT: 60}
     assert len(mock_setup_entry.mock_calls) == 1
 
     await hass.async_block_till_done(wait_background_tasks=True)
@@ -79,6 +81,8 @@ async def test_form(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Recipient"
     assert result["unique_id"] == "recipient@example.com"
+    assert smtp.cls.call_args[0] == ("mail.example.com", 587)
+    assert smtp.cls.call_args[1]["timeout"] == 60
 
 
 @pytest.mark.usefixtures("smtp")
@@ -98,7 +102,10 @@ async def test_form_already_configured(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        {
+            **USER_INPUT,
+            SECTION_OPTIONS: {CONF_TIMEOUT: 60},
+        },
     )
     await hass.async_block_till_done()
 
@@ -134,7 +141,10 @@ async def test_form_errors(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        {
+            **USER_INPUT,
+            SECTION_OPTIONS: {CONF_TIMEOUT: 60},
+        },
     )
 
     assert result["type"] is FlowResultType.FORM
@@ -144,13 +154,17 @@ async def test_form_errors(
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
-        USER_INPUT,
+        {
+            **USER_INPUT,
+            SECTION_OPTIONS: {CONF_TIMEOUT: 60},
+        },
     )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Home Assistant"
     assert result["data"] == USER_INPUT
+    assert result["options"] == {CONF_TIMEOUT: 60}
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -215,9 +229,8 @@ async def test_options_flow(
     }
 
 
-@pytest.mark.usefixtures("smtp")
 async def test_form_reconfigure(
-    hass: HomeAssistant, config_entry: MockConfigEntry
+    hass: HomeAssistant, config_entry: MockConfigEntry, smtp: MagicMock
 ) -> None:
     """Test reconfigure flow."""
 
@@ -250,6 +263,7 @@ async def test_form_reconfigure(
     }
 
     assert len(hass.config_entries.async_entries()) == 1
+    smtp.cls.assert_called_with("mail.example.com", 587, timeout=1312)
 
 
 @pytest.mark.usefixtures("smtp")
@@ -358,8 +372,9 @@ async def test_form_reconfigure_errors(
     assert len(hass.config_entries.async_entries()) == 1
 
 
-@pytest.mark.usefixtures("smtp")
-async def test_form_reauth(hass: HomeAssistant, config_entry: MockConfigEntry) -> None:
+async def test_form_reauth(
+    hass: HomeAssistant, config_entry: MockConfigEntry, smtp: MagicMock
+) -> None:
     """Test reauth flow."""
 
     config_entry.add_to_hass(hass)
@@ -388,6 +403,7 @@ async def test_form_reauth(hass: HomeAssistant, config_entry: MockConfigEntry) -
     }
 
     assert len(hass.config_entries.async_entries()) == 1
+    smtp.cls.assert_called_with("mail.example.com", 587, timeout=1312)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Allows setting timeout from the user config flow and use configured timeout in reconfigure and reauth flows.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176526
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
