### PR TITLE
Retry KNX telegram store init on timeout instead of disabling it

### DIFF
--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -63,8 +63,9 @@ STORE_INIT_TIMEOUT = 10
 
 # When store initialization times out during startup (busy event loop, cold or large
 # database on low-power hardware), the failure is usually transient. Instead of giving
-# up until the next reload, retry in the background with a capped backoff. The store is
-# only disabled after this many consecutive timeouts.
+# up until the next reload, retry in the background with a capped backoff. This many
+# retries are allowed on top of the initial attempt, i.e. the store is only disabled
+# after STORE_INIT_MAX_RETRIES + 1 consecutive timeouts.
 STORE_INIT_RETRY_BACKOFF = (15, 30, 60, 120, 300, 300)
 STORE_INIT_MAX_RETRIES = len(STORE_INIT_RETRY_BACKOFF)
 
@@ -119,6 +120,7 @@ class Telegrams:
         ) = None
         self._evict_expired_unsub: CALLBACK_TYPE | None = None
         self._store_init_retry_unsub: CALLBACK_TYPE | None = None
+        self._store_init_retry_task: asyncio.Task[None] | None = None
         self._store_init_attempts = 0
 
         if self.backend == KNX_TELEGRAM_BACKEND_POSTGRES:
@@ -197,7 +199,6 @@ class Telegrams:
                 self._store_init_attempts,
                 delay,
             )
-            async_create_telegram_storage_issue(self.hass)
             self._store_init_retry_unsub = async_call_later(
                 self.hass, delay, self._async_retry_load_history
             )
@@ -255,7 +256,11 @@ class Telegrams:
     async def _async_retry_load_history(self, now: datetime) -> None:
         """Retry telegram store initialization after a transient timeout."""
         self._store_init_retry_unsub = None
-        await self.load_history()
+        self._store_init_retry_task = asyncio.current_task()
+        try:
+            await self.load_history()
+        finally:
+            self._store_init_retry_task = None
 
     async def _abort_store_init(self) -> None:
         """Create a repair issue and tear down a store that failed to init."""
@@ -281,6 +286,14 @@ class Telegrams:
         if self._store_init_retry_unsub is not None:
             self._store_init_retry_unsub()
             self._store_init_retry_unsub = None
+        if self._store_init_retry_task is not None:
+            self._store_init_retry_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._store_init_retry_task
+        if self._uninitialized_store is not None:
+            with contextlib.suppress(Exception):
+                await self._uninitialized_store.close()
+            self._uninitialized_store = None
         if self._evict_expired_unsub is not None:
             self._evict_expired_unsub()
             self._evict_expired_unsub = None

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -177,6 +177,8 @@ class Telegrams:
                 "Successfully initialized KNX telegram storage backend '%s'",
                 self.backend,
             )
+        except asyncio.CancelledError:
+            raise
         except TimeoutError:
             self._store_init_attempts += 1
             if self._store_init_attempts > STORE_INIT_MAX_RETRIES:
@@ -199,6 +201,10 @@ class Telegrams:
                 self._store_init_attempts,
                 delay,
             )
+            # No repair issue here: a single timeout is expected to self-heal via the
+            # retry above. Raising one on every transient blip would be alarming and
+            # not user-actionable; _abort_store_init() raises it once retries are
+            # actually exhausted.
             self._store_init_retry_unsub = async_call_later(
                 self.hass, delay, self._async_retry_load_history
             )
@@ -256,6 +262,10 @@ class Telegrams:
     async def _async_retry_load_history(self, now: datetime) -> None:
         """Retry telegram store initialization after a transient timeout."""
         self._store_init_retry_unsub = None
+        # asyncio.current_task() is safe here only because HassJob coroutine
+        # functions are scheduled via create_eager_task(), which runs the task
+        # synchronously up to its first suspension point - so by the time this
+        # line executes, the Task object already exists and is "current".
         self._store_init_retry_task = asyncio.current_task()
         try:
             await self.load_history()

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -262,10 +262,7 @@ class Telegrams:
     async def _async_retry_load_history(self, now: datetime) -> None:
         """Retry telegram store initialization after a transient timeout."""
         self._store_init_retry_unsub = None
-        # asyncio.current_task() is safe here only because HassJob coroutine
-        # functions are scheduled via create_eager_task(), which runs the task
-        # synchronously up to its first suspension point - so by the time this
-        # line executes, the Task object already exists and is "current".
+        # Relies on eager task start so this task is already "current" here.
         self._store_init_retry_task = asyncio.current_task()
         try:
             await self.load_history()

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -65,8 +65,8 @@ STORE_INIT_TIMEOUT = 10
 # database on low-power hardware), the failure is usually transient. Instead of giving
 # up until the next reload, retry in the background with a capped backoff. The store is
 # only disabled after this many consecutive timeouts.
-STORE_INIT_MAX_RETRIES = 6
 STORE_INIT_RETRY_BACKOFF = (15, 30, 60, 120, 300, 300)
+STORE_INIT_MAX_RETRIES = len(STORE_INIT_RETRY_BACKOFF)
 
 
 class DecodedTelegramPayload(TypedDict):

--- a/homeassistant/components/knx/telegrams.py
+++ b/homeassistant/components/knx/telegrams.py
@@ -22,7 +22,7 @@ from xknx.telegram.apci import GroupValueResponse, GroupValueWrite
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
-from homeassistant.helpers.event import async_track_time_change
+from homeassistant.helpers.event import async_call_later, async_track_time_change
 from homeassistant.helpers.storage import STORAGE_DIR, Store
 from homeassistant.util import dt as dt_util
 
@@ -60,6 +60,13 @@ MAX_BUFFER_TELEGRAMS = FLUSH_INTERVAL_SECONDS * 50
 # Timeout for the migration probe and store initialization, so an unreachable
 # database cannot block KNX setup until the driver/OS connection timeout expires.
 STORE_INIT_TIMEOUT = 10
+
+# When store initialization times out during startup (busy event loop, cold or large
+# database on low-power hardware), the failure is usually transient. Instead of giving
+# up until the next reload, retry in the background with a capped backoff. The store is
+# only disabled after this many consecutive timeouts.
+STORE_INIT_MAX_RETRIES = 6
+STORE_INIT_RETRY_BACKOFF = (15, 30, 60, 120, 300, 300)
 
 
 class DecodedTelegramPayload(TypedDict):
@@ -111,6 +118,8 @@ class Telegrams:
             BufferedSqliteStore | BufferedPostgresStore | None
         ) = None
         self._evict_expired_unsub: CALLBACK_TYPE | None = None
+        self._store_init_retry_unsub: CALLBACK_TYPE | None = None
+        self._store_init_attempts = 0
 
         if self.backend == KNX_TELEGRAM_BACKEND_POSTGRES:
             self._uninitialized_store = BufferedPostgresStore(
@@ -167,11 +176,31 @@ class Telegrams:
                 self.backend,
             )
         except TimeoutError:
-            _LOGGER.error(
-                "Timeout initializing KNX telegram storage backend '%s'",
+            self._store_init_attempts += 1
+            if self._store_init_attempts > STORE_INIT_MAX_RETRIES:
+                _LOGGER.error(
+                    "Timeout initializing KNX telegram storage backend '%s' after "
+                    "%s attempts; giving up until the next reload",
+                    self.backend,
+                    self._store_init_attempts,
+                )
+                await self._abort_store_init()
+                return
+            delay = STORE_INIT_RETRY_BACKOFF[
+                min(self._store_init_attempts - 1, len(STORE_INIT_RETRY_BACKOFF) - 1)
+            ]
+            _LOGGER.warning(
+                "Timeout initializing KNX telegram storage backend '%s' (attempt %s); "
+                "retrying in %s s. Telegram history is temporarily unavailable; the "
+                "KNX connection is unaffected",
                 self.backend,
+                self._store_init_attempts,
+                delay,
             )
-            await self._abort_store_init()
+            async_create_telegram_storage_issue(self.hass)
+            self._store_init_retry_unsub = async_call_later(
+                self.hass, delay, self._async_retry_load_history
+            )
             return
         except KnxTelegramStoreException as err:
             _LOGGER.error(
@@ -190,6 +219,7 @@ class Telegrams:
             await self._abort_store_init()
             return
         async_delete_telegram_storage_issue(self.hass)
+        self._store_init_attempts = 0
         self.store = self._uninitialized_store
         self.store.start()
         self._uninitialized_store = None
@@ -222,6 +252,11 @@ class Telegrams:
                 self.last_ga_telegrams[t_dict["destination"]] = t_dict
         _LOGGER.debug("Hydrated %d unique telegrams from store", len(result))
 
+    async def _async_retry_load_history(self, now: datetime) -> None:
+        """Retry telegram store initialization after a transient timeout."""
+        self._store_init_retry_unsub = None
+        await self.load_history()
+
     async def _abort_store_init(self) -> None:
         """Create a repair issue and tear down a store that failed to init."""
         async_create_telegram_storage_issue(self.hass)
@@ -243,6 +278,9 @@ class Telegrams:
 
     async def stop(self) -> None:
         """Stop history store."""
+        if self._store_init_retry_unsub is not None:
+            self._store_init_retry_unsub()
+            self._store_init_retry_unsub = None
         if self._evict_expired_unsub is not None:
             self._evict_expired_unsub()
             self._evict_expired_unsub = None

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -278,22 +278,15 @@ async def test_stop_cancels_pending_retry_timer(
         side_effect=TimeoutError(),
     ):
         await knx.setup_integration()
+        assert hass.data[KNX_MODULE_KEY].telegrams.store is None
 
-        telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
-        assert telegrams_module.store is None
-        assert telegrams_module._store_init_retry_unsub is not None
-        assert telegrams_module._uninitialized_store is not None
-
-        await telegrams_module.stop()
-
-        assert telegrams_module._store_init_retry_unsub is None
-        assert telegrams_module._uninitialized_store is None
+        assert await hass.config_entries.async_unload(knx.mock_config_entry.entry_id)
+        assert KNX_MODULE_KEY not in hass.data
 
         # The cancelled timer must not fire later and try to (re)initialize.
         freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
-        assert telegrams_module.store is None
 
 
 async def test_stop_cancels_in_flight_retry_task(
@@ -303,31 +296,29 @@ async def test_stop_cancels_in_flight_retry_task(
 ) -> None:
     """Unloading while a retry attempt is actively running cancels it cleanly."""
     freezer.move_to("2024-01-01 12:00:00+00:00")
+    attempts = 0
 
-    async def hanging_initialize() -> None:
+    async def initialize_side_effect() -> None:
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise TimeoutError()
         await asyncio.Event().wait()
 
     with patch(
         "knx_telegram_store.BufferedSqliteStore.initialize",
-        side_effect=[TimeoutError(), hanging_initialize],
+        side_effect=initialize_side_effect,
     ):
         await knx.setup_integration()
-
-        telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
-        assert telegrams_module._store_init_retry_unsub is not None
 
         freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
         async_fire_time_changed(hass)
 
         # The retry fired and is now suspended inside the hanging initialize()
-        # call (eager task start runs synchronously up to that point).
-        assert telegrams_module._store_init_retry_task is not None
-        assert not telegrams_module._store_init_retry_task.done()
-
-        await telegrams_module.stop()
-
-        assert telegrams_module._store_init_retry_task is None
-        assert telegrams_module._uninitialized_store is None
+        # call (eager task start runs synchronously up to that point) - unload
+        # must cancel it instead of hanging or leaking the task.
+        assert await hass.config_entries.async_unload(knx.mock_config_entry.entry_id)
+        assert KNX_MODULE_KEY not in hass.data
 
 
 async def test_migrate_telegrams_from_json(

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -302,7 +302,7 @@ async def test_stop_cancels_in_flight_retry_task(
         nonlocal attempts
         attempts += 1
         if attempts == 1:
-            raise TimeoutError()
+            raise TimeoutError
         await asyncio.Event().wait()
 
     with patch(

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -213,20 +213,16 @@ async def test_store_init_timeout_retries_and_succeeds(
         telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
         issue_registry = ir.async_get(hass)
 
-        # First attempt timed out: no store yet and a repair issue is raised,
-        # but init is not abandoned - a background retry is scheduled.
         assert telegrams_module.store is None
         assert (
             issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
-            is not None
+            is None
         )
 
-        # Advance past the first backoff so the scheduled retry fires.
         freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()
 
-        # Retry succeeded: store initialized and the repair issue cleared.
         assert telegrams_module.store is not None
         assert (
             issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
@@ -253,15 +249,12 @@ async def test_store_init_timeout_exhausts_retries_and_aborts(
         telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
         issue_registry = ir.async_get(hass)
 
-        # First timeout: retry scheduled, repair raised, no store yet.
         assert telegrams_module.store is None
         assert (
             issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
-            is not None
+            is None
         )
 
-        # Fire the retry; it times out again and, the budget being spent,
-        # the store is abandoned.
         freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
         async_fire_time_changed(hass)
         await hass.async_block_till_done()

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -20,7 +20,10 @@ from homeassistant.components.knx.const import (
     KNX_TELEGRAM_BACKEND_POSTGRES,
     REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR,
 )
-from homeassistant.components.knx.telegrams import TelegramDict
+from homeassistant.components.knx.telegrams import (
+    STORE_INIT_RETRY_BACKOFF,
+    TelegramDict,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.util import dt as dt_util
@@ -135,7 +138,6 @@ async def test_store_telegram_history_sqlite(
     "side_effect",
     [
         pytest.param(KnxTelegramStoreException("DB init failure"), id="db_error"),
-        pytest.param(TimeoutError(), id="timeout"),
         pytest.param(ValueError("unexpected"), id="generic_error"),
     ],
 )
@@ -164,7 +166,7 @@ async def test_store_telegram_history_needs_migration_timeout(
     hass: HomeAssistant,
     knx: KNXTestKit,
 ) -> None:
-    """Test that store initialization is aborted when needs_migration times out."""
+    """Test store init aborts when needs_migration times out and retries are off."""
 
     async def hanging_probe() -> bool:
         await asyncio.Event().wait()
@@ -172,6 +174,7 @@ async def test_store_telegram_history_needs_migration_timeout(
 
     with (
         patch("homeassistant.components.knx.telegrams.STORE_INIT_TIMEOUT", 0.05),
+        patch("homeassistant.components.knx.telegrams.STORE_INIT_MAX_RETRIES", 0),
         patch(
             "knx_telegram_store.BufferedSqliteStore.needs_migration",
             side_effect=hanging_probe,
@@ -186,6 +189,88 @@ async def test_store_telegram_history_needs_migration_timeout(
     issue_registry = ir.async_get(hass)
     issue = issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
     assert issue is not None
+
+
+async def test_store_init_timeout_retries_and_succeeds(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A transient init timeout is retried in the background and then succeeds."""
+    freezer.move_to("2024-01-01 12:00:00+00:00")
+    with (
+        patch(
+            "knx_telegram_store.BufferedSqliteStore.initialize",
+            side_effect=[TimeoutError(), None],
+        ),
+        patch(
+            "knx_telegram_store.BufferedSqliteStore.get_last_unique_telegrams",
+            return_value=[],
+        ),
+    ):
+        await knx.setup_integration()
+
+        telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+        issue_registry = ir.async_get(hass)
+
+        # First attempt timed out: no store yet and a repair issue is raised,
+        # but init is not abandoned - a background retry is scheduled.
+        assert telegrams_module.store is None
+        assert (
+            issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
+            is not None
+        )
+
+        # Advance past the first backoff so the scheduled retry fires.
+        freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+        # Retry succeeded: store initialized and the repair issue cleared.
+        assert telegrams_module.store is not None
+        assert (
+            issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
+            is None
+        )
+
+
+async def test_store_init_timeout_exhausts_retries_and_aborts(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A persistent init timeout disables the store once the retry budget is spent."""
+    freezer.move_to("2024-01-01 12:00:00+00:00")
+    with (
+        patch("homeassistant.components.knx.telegrams.STORE_INIT_MAX_RETRIES", 1),
+        patch(
+            "knx_telegram_store.BufferedSqliteStore.initialize",
+            side_effect=TimeoutError(),
+        ),
+    ):
+        await knx.setup_integration()
+
+        telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+        issue_registry = ir.async_get(hass)
+
+        # First timeout: retry scheduled, repair raised, no store yet.
+        assert telegrams_module.store is None
+        assert (
+            issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
+            is not None
+        )
+
+        # Fire the retry; it times out again and, the budget being spent,
+        # the store is abandoned.
+        freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+
+    assert telegrams_module.store is None
+    assert (
+        issue_registry.async_get_issue(DOMAIN, REPAIR_ISSUE_TELEGRAM_BACKEND_ERROR)
+        is not None
+    )
 
 
 async def test_migrate_telegrams_from_json(

--- a/tests/components/knx/test_telegrams.py
+++ b/tests/components/knx/test_telegrams.py
@@ -266,6 +266,70 @@ async def test_store_init_timeout_exhausts_retries_and_aborts(
     )
 
 
+async def test_stop_cancels_pending_retry_timer(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Unloading while a retry timer is scheduled (not yet fired) tears down cleanly."""
+    freezer.move_to("2024-01-01 12:00:00+00:00")
+    with patch(
+        "knx_telegram_store.BufferedSqliteStore.initialize",
+        side_effect=TimeoutError(),
+    ):
+        await knx.setup_integration()
+
+        telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+        assert telegrams_module.store is None
+        assert telegrams_module._store_init_retry_unsub is not None
+        assert telegrams_module._uninitialized_store is not None
+
+        await telegrams_module.stop()
+
+        assert telegrams_module._store_init_retry_unsub is None
+        assert telegrams_module._uninitialized_store is None
+
+        # The cancelled timer must not fire later and try to (re)initialize.
+        freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert telegrams_module.store is None
+
+
+async def test_stop_cancels_in_flight_retry_task(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Unloading while a retry attempt is actively running cancels it cleanly."""
+    freezer.move_to("2024-01-01 12:00:00+00:00")
+
+    async def hanging_initialize() -> None:
+        await asyncio.Event().wait()
+
+    with patch(
+        "knx_telegram_store.BufferedSqliteStore.initialize",
+        side_effect=[TimeoutError(), hanging_initialize],
+    ):
+        await knx.setup_integration()
+
+        telegrams_module = hass.data[KNX_MODULE_KEY].telegrams
+        assert telegrams_module._store_init_retry_unsub is not None
+
+        freezer.tick(STORE_INIT_RETRY_BACKOFF[0] + 1)
+        async_fire_time_changed(hass)
+
+        # The retry fired and is now suspended inside the hanging initialize()
+        # call (eager task start runs synchronously up to that point).
+        assert telegrams_module._store_init_retry_task is not None
+        assert not telegrams_module._store_init_retry_task.done()
+
+        await telegrams_module.stop()
+
+        assert telegrams_module._store_init_retry_task is None
+        assert telegrams_module._uninitialized_store is None
+
+
 async def test_migrate_telegrams_from_json(
     hass: HomeAssistant,
     knx: KNXTestKit,


### PR DESCRIPTION
## Proposed change

On many installations the KNX telegram store — a local SQLite store kept under
`.storage/knx/`, separate from the recorder database — is initialized during config
entry setup in `Telegrams.load_history()`. In the non-migration path that
initialization is wrapped in a fixed `asyncio.timeout(10)`.

There are several reasons why this initialization can legitimately take longer than
10 seconds, especially during startup:

- Home Assistant startup is a busy phase: the event loop is under heavy load while
  many integrations set up at once, so an executor/disk-bound task such as opening and
  preparing a SQLite store does not get its wall-clock time uninterrupted.
- Other integrations do their own disk-heavy work at startup (database migrations,
  cleanup/eviction, cache warming) and compete for the same I/O and CPU.
- Home Assistant is very often run on low-power appliances (Home Assistant Green/Yellow,
  Raspberry Pi, small NUC-class devices) that are optimized for low power draw rather
  than raw speed, so cold disk I/O on a non-trivially sized database is slow.
- The telegram store itself can be sizeable on an active KNX bus (on my installation
  ~510k rows / ~68 MB at 10-day retention), on top of an already large overall database.

Under those conditions store initialization occasionally exceeds the 10 s timeout.
Currently a `TimeoutError` calls `_abort_store_init()`, which tears the store down and
permanently disables telegram history (raising a repair issue) until the config entry
is reloaded or Home Assistant is restarted.

The timeout is almost always transient: once startup contention is over, initialization
completes in well under a second, so a manual reload fixes it immediately. On
installations that restart frequently this recurs and forces the user to intervene
every time.

This PR changes the `TimeoutError` path to keep the (still uninitialized) store and
retry initialization in the background with a bounded backoff, instead of giving up.
The short timeout is deliberately kept so that a slow store init never delays the KNX
connection itself. Genuine database errors and other exceptions keep their existing
abort behaviour. The repair issue is only raised once the retry budget is exhausted and
the store is disabled — a transient timeout that resolves via retry never surfaces one.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
