### PR TITLE
Fix Forecast.Solar entity ID naming

### DIFF
--- a/homeassistant/components/forecast_solar/sensor.py
+++ b/homeassistant/components/forecast_solar/sensor.py
@@ -8,7 +8,6 @@ from typing import Any, override
 from forecast_solar.models import Estimate
 
 from homeassistant.components.sensor import (
-    DOMAIN as SENSOR_DOMAIN,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -168,7 +167,6 @@ class ForecastSolarSensorEntity(
         """Initialize Forecast.Solar sensor."""
         super().__init__(coordinator=coordinator)
         self.entity_description = entity_description
-        self.entity_id = f"{SENSOR_DOMAIN}.{entity_description.key}"
         self._attr_unique_id = f"{entry_id}_{entity_description.key}"
 
         self._attr_device_info = DeviceInfo(
@@ -179,6 +177,12 @@ class ForecastSolarSensorEntity(
             name="Solar production forecast",
             configuration_url="https://forecast.solar",
         )
+
+    @property
+    @override
+    def suggested_object_id(self) -> str | None:
+        """Base the entity ID on the key, prefixed with the device name."""
+        return self.entity_description.key
 
     @property
     @override

--- a/tests/components/forecast_solar/test_sensor.py
+++ b/tests/components/forecast_solar/test_sensor.py
@@ -34,8 +34,10 @@ async def test_sensors(
     """Test the Forecast.Solar sensors."""
     entry_id = init_integration.entry_id
 
-    state = hass.states.get("sensor.energy_production_today")
-    entry = entity_registry.async_get("sensor.energy_production_today")
+    state = hass.states.get("sensor.solar_production_forecast_energy_production_today")
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_energy_production_today"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_production_today"
@@ -49,8 +51,12 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.energy_production_today_remaining")
-    entry = entity_registry.async_get("sensor.energy_production_today_remaining")
+    state = hass.states.get(
+        "sensor.solar_production_forecast_energy_production_today_remaining"
+    )
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_energy_production_today_remaining"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_production_today_remaining"
@@ -64,8 +70,12 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.energy_production_tomorrow")
-    entry = entity_registry.async_get("sensor.energy_production_tomorrow")
+    state = hass.states.get(
+        "sensor.solar_production_forecast_energy_production_tomorrow"
+    )
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_energy_production_tomorrow"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_production_tomorrow"
@@ -79,8 +89,12 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.power_highest_peak_time_today")
-    entry = entity_registry.async_get("sensor.power_highest_peak_time_today")
+    state = hass.states.get(
+        "sensor.solar_production_forecast_power_highest_peak_time_today"
+    )
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_power_highest_peak_time_today"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_power_highest_peak_time_today"
@@ -94,8 +108,12 @@ async def test_sensors(
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.power_highest_peak_time_tomorrow")
-    entry = entity_registry.async_get("sensor.power_highest_peak_time_tomorrow")
+    state = hass.states.get(
+        "sensor.solar_production_forecast_power_highest_peak_time_tomorrow"
+    )
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_power_highest_peak_time_tomorrow"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_power_highest_peak_time_tomorrow"
@@ -109,8 +127,10 @@ async def test_sensors(
     assert ATTR_UNIT_OF_MEASUREMENT not in state.attributes
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.power_production_now")
-    entry = entity_registry.async_get("sensor.power_production_now")
+    state = hass.states.get("sensor.solar_production_forecast_power_production_now")
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_power_production_now"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_power_production_now"
@@ -124,8 +144,10 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.POWER
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.energy_current_hour")
-    entry = entity_registry.async_get("sensor.energy_current_hour")
+    state = hass.states.get("sensor.solar_production_forecast_energy_current_hour")
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_energy_current_hour"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_current_hour"
@@ -139,8 +161,10 @@ async def test_sensors(
     assert state.attributes.get(ATTR_DEVICE_CLASS) == SensorDeviceClass.ENERGY
     assert ATTR_ICON not in state.attributes
 
-    state = hass.states.get("sensor.energy_next_hour")
-    entry = entity_registry.async_get("sensor.energy_next_hour")
+    state = hass.states.get("sensor.solar_production_forecast_energy_next_hour")
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_energy_next_hour"
+    )
     assert entry
     assert state
     assert entry.unique_id == f"{entry_id}_energy_next_hour"
@@ -165,12 +189,81 @@ async def test_sensors(
     assert not device_entry.sw_version
 
 
+async def test_recreate_entity_id_respects_device_rename(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test regenerating an entity ID follows the device name."""
+    entry = entity_registry.async_get(
+        "sensor.solar_production_forecast_energy_production_today"
+    )
+    assert entry
+    assert entry.object_id_base == "energy_production_today"
+    assert entry.suggested_object_id is None
+
+    assert entry.device_id
+    device_registry.async_update_device(entry.device_id, name_by_user="Solar Roof")
+    assert (
+        entity_registry.async_regenerate_entity_id(entry)
+        == "sensor.solar_roof_energy_production_today"
+    )
+
+
+async def test_existing_entity_id_preserved_and_migrated(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_forecast_solar: MagicMock,
+) -> None:
+    """Test the upgrade path from the legacy hardcoded entity ID.
+
+    An existing entity keeps its un-prefixed entity ID, while the stored
+    suggested_object_id is migrated to object_id_base so that regenerating the
+    entity ID now follows the device name.
+    """
+    entry_id = mock_config_entry.entry_id
+    key = "energy_production_today"
+
+    # Simulate an entity created by the old hardcoded entity_id: a
+    # suggested_object_id (used verbatim, no device prefix) and no
+    # object_id_base.
+    legacy = entity_registry.async_get_or_create(
+        SENSOR_DOMAIN,
+        DOMAIN,
+        f"{entry_id}_{key}",
+        suggested_object_id=key,
+        has_entity_name=True,
+    )
+    assert legacy.entity_id == f"{SENSOR_DOMAIN}.{key}"
+    assert legacy.suggested_object_id == key
+    assert legacy.object_id_base is None
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry = entity_registry.async_get(f"{SENSOR_DOMAIN}.{key}")
+    assert entry
+    # The existing entity ID is preserved on upgrade.
+    assert entry.unique_id == f"{entry_id}_{key}"
+    # The stored object id fields are migrated, so regeneration now follows the
+    # device name instead of reproducing the un-prefixed id.
+    assert entry.object_id_base == key
+    assert entry.suggested_object_id is None
+    assert (
+        entity_registry.async_regenerate_entity_id(entry)
+        == f"{SENSOR_DOMAIN}.solar_production_forecast_{key}"
+    )
+
+
 @pytest.mark.parametrize(
     "entity_id",
     [
-        "sensor.power_production_next_12hours",
-        "sensor.power_production_next_24hours",
-        "sensor.power_production_next_hour",
+        "sensor.solar_production_forecast_power_production_next_12hours",
+        "sensor.solar_production_forecast_power_production_next_24hours",
+        "sensor.solar_production_forecast_power_production_next_hour",
     ],
 )
 async def test_disabled_by_default(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`ForecastSolarSensorEntity` sets `_attr_has_entity_name = True` but hardcoded its own entity ID:

```python
self.entity_id = f"{SENSOR_DOMAIN}.{entity_description.key}"
```

Assigning `entity_id` directly makes the entity platform store the value as the entity's
`suggested_object_id`. Per `EntityRegistry._async_generate_entity_id`, a `suggested_object_id` is
**never prefixed with the device name** and is used verbatim when regenerating automatic entity IDs.
So despite `has_entity_name = True`:

1. Generated entity IDs had **no device prefix** (`sensor.energy_production_today` instead of
   `sensor.solar_production_forecast_energy_production_today`).
2. The device page **"recreate entity IDs"** action reverted a user's manual rename, because it
   regenerates from the stored `suggested_object_id` (the hardcoded value), ignoring the device name.

Fix: replace the hardcoded `entity_id` with a `suggested_object_id` property returning
`entity_description.key` (same approach as `aosmith`). The object ID stays clean and key-based, but is
now routed through `object_id_base`, so it is prefixed with the device name and reproduced from it —
including a user's `name_by_user` — on regeneration. A user with multiple arrays can now rename each
device and get clean, distinct IDs via "recreate entity IDs", which previously reverted to the generic
un-prefixed form.

### Upgrade impact

This is non-breaking. Entity IDs are preserved (the entity registry keys entities by `unique_id`,
which is unchanged), and the device name is untouched, so device names and friendly names do not
change for anyone. On upgrade the stored `suggested_object_id` is migrated to `object_id_base`, which
only changes what "recreate entity IDs" produces (opt-in) — it does not rename existing entities. Only
newly created entities get the device-name prefix. A test covers this upgrade path.

### Note / question for maintainers

The device name is still hardcoded (`"Solar production forecast"`), so multiple instances share the
same default device name and their entity IDs collide into `_2` until the user renames a device
(after which "recreate entity IDs" now produces clean `sensor.<device>_*` IDs). I looked at deriving
the device name from the config entry title instead, but dropped it: `async_step_user` creates entries
with `title=""` (the name field was removed in #168922 per `hass-config-flow-name-field`), so a title
only exists if the user set one, and using it would change the device/friendly names of existing
titled entries — a breaking change for a marginal benefit.

There's also a related rough edge, not addressed here: when a device is named, only the **enabled**
entities' IDs are updated to follow it (core's device-name handler skips `has_entity_name` entities, so
the frontend does the update over the visible/enabled entities). The 3 disabled-by-default
`power_production_next_*` sensors keep the default prefix and collide across instances. Reproduced by
adding a second instance and clicking "Skip and finish" (no rename):

```
sensor.solar_production_forecast_energy_production_today            # enabled  — clean
sensor.solar_production_forecast_power_production_next_hour_2       # disabled — collides -> _2
sensor.solar_production_forecast_power_production_next_12hours_2    # disabled — collides -> _2
sensor.solar_production_forecast_power_production_next_24hours_2    # disabled — collides -> _2
```

This is generic `has_entity_name` behaviour, not specific to this integration. Would you prefer the
config flow to set a distinct default title, and/or a separate core/frontend fix so naming a device
updates disabled entities' IDs too? Happy to follow up.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
