### PR TITLE
Add diagnostics support to energieleser

### DIFF
--- a/homeassistant/components/energieleser/diagnostics.py
+++ b/homeassistant/components/energieleser/diagnostics.py
@@ -1,0 +1,28 @@
+"""Diagnostics support for energieleser."""
+
+import dataclasses
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_DEVICE_ID, CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from .coordinator import EnergieleserConfigEntry
+
+TO_REDACT = {CONF_DEVICE_ID, CONF_HOST, "fabrication_number"}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: EnergieleserConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+
+    device_data = coordinator.data
+
+    device_data_dict = dataclasses.asdict(device_data)
+
+    return {
+        "info": async_redact_data(entry.data, TO_REDACT),
+        "data": async_redact_data(device_data_dict, TO_REDACT),
+    }

--- a/homeassistant/components/energieleser/diagnostics.py
+++ b/homeassistant/components/energieleser/diagnostics.py
@@ -4,12 +4,12 @@ import dataclasses
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_DEVICE_ID, CONF_HOST
+from homeassistant.const import CONF_DEVICE_ID
 from homeassistant.core import HomeAssistant
 
 from .coordinator import EnergieleserConfigEntry
 
-TO_REDACT = {CONF_DEVICE_ID, CONF_HOST, "fabrication_number"}
+TO_REDACT = {CONF_DEVICE_ID, "fabrication_number"}
 
 
 async def async_get_config_entry_diagnostics(
@@ -22,7 +22,4 @@ async def async_get_config_entry_diagnostics(
 
     device_data_dict = dataclasses.asdict(device_data)
 
-    return {
-        "info": async_redact_data(entry.data, TO_REDACT),
-        "data": async_redact_data(device_data_dict, TO_REDACT),
-    }
+    return async_redact_data(device_data_dict, TO_REDACT)

--- a/homeassistant/components/energieleser/quality_scale.yaml
+++ b/homeassistant/components/energieleser/quality_scale.yaml
@@ -49,7 +49,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: done
   discovery: done
   docs-data-update: todo

--- a/tests/components/energieleser/snapshots/test_diagnostics.ambr
+++ b/tests/components/energieleser/snapshots/test_diagnostics.ambr
@@ -1,149 +1,125 @@
 # serializer version: 1
-# name: test_entry_diagnostics[stromleser]
-  dict({
-    'data': dict({
-      'device_id': '**REDACTED**',
-      'device_type': 'stromleser',
-      'energy_export': dict({
-        'unit': 'Wh',
-        'value': 26561.0,
-      }),
-      'energy_export_tariff_1': None,
-      'energy_export_tariff_2': None,
-      'energy_export_tariff_3': None,
-      'energy_export_tariff_4': None,
-      'energy_import': dict({
-        'unit': 'Wh',
-        'value': 12345.0,
-      }),
-      'energy_import_tariff_1': None,
-      'energy_import_tariff_2': None,
-      'energy_import_tariff_3': None,
-      'energy_import_tariff_4': None,
-      'pin_locked': False,
-      'power_absolute': None,
-      'power_active': dict({
-        'unit': 'W',
-        'value': 8.16,
-      }),
-      'power_export': None,
-      'power_import': None,
-      'power_l1': dict({
-        'unit': 'W',
-        'value': 0.0,
-      }),
-      'power_l2': dict({
-        'unit': 'W',
-        'value': 0.0,
-      }),
-      'power_l3': dict({
-        'unit': 'W',
-        'value': 8.16,
-      }),
-      'signal_strength_dbm': -51.0,
-      'timestamp': 1776178480,
-    }),
-    'info': dict({
-      'device_id': '**REDACTED**',
-      'host': '**REDACTED**',
-    }),
-  })
-# ---
 # name: test_entry_diagnostics[gasleser]
   dict({
-    'data': dict({
-      'count': 603,
-      'current_flow_rate': 0.01,
-      'device_id': '**REDACTED**',
-      'device_type': 'gasleser',
-      'signal_strength_dbm': -51.0,
-      'timestamp': 1776179005,
-      'total_consumption': 37030.67,
+    'count': 603,
+    'current_flow_rate': 0.01,
+    'device_id': '**REDACTED**',
+    'device_type': 'gasleser',
+    'signal_strength_dbm': -51.0,
+    'timestamp': 1776179005,
+    'total_consumption': 37030.67,
+  })
+# ---
+# name: test_entry_diagnostics[stromleser]
+  dict({
+    'device_id': '**REDACTED**',
+    'device_type': 'stromleser',
+    'energy_export': dict({
+      'unit': 'Wh',
+      'value': 26561.0,
     }),
-    'info': dict({
-      'device_id': '**REDACTED**',
-      'host': '**REDACTED**',
+    'energy_export_tariff_1': None,
+    'energy_export_tariff_2': None,
+    'energy_export_tariff_3': None,
+    'energy_export_tariff_4': None,
+    'energy_import': dict({
+      'unit': 'Wh',
+      'value': 12345.0,
     }),
+    'energy_import_tariff_1': None,
+    'energy_import_tariff_2': None,
+    'energy_import_tariff_3': None,
+    'energy_import_tariff_4': None,
+    'pin_locked': False,
+    'power_absolute': None,
+    'power_active': dict({
+      'unit': 'W',
+      'value': 8.16,
+    }),
+    'power_export': None,
+    'power_import': None,
+    'power_l1': dict({
+      'unit': 'W',
+      'value': 0.0,
+    }),
+    'power_l2': dict({
+      'unit': 'W',
+      'value': 0.0,
+    }),
+    'power_l3': dict({
+      'unit': 'W',
+      'value': 8.16,
+    }),
+    'signal_strength_dbm': -51.0,
+    'timestamp': 1776178480,
   })
 # ---
 # name: test_entry_diagnostics[waermeleser]
   dict({
-    'data': dict({
-      'device_id': '**REDACTED**',
-      'device_type': 'waermeleser',
-      'fabrication_number': '**REDACTED**',
-      'flow_temperature': dict({
-        'unit': '°C',
-        'value': 16.9,
-      }),
-      'power': dict({
-        'unit': 'kW',
-        'value': 2.31,
-      }),
-      'return_temperature': dict({
-        'unit': '°C',
-        'value': 19.6,
-      }),
-      'signal_strength_dbm': -51.0,
-      'temperature_difference': dict({
-        'unit': 'K',
-        'value': 2.68,
-      }),
-      'timestamp': 1747285200,
-      'total_energy_t1': dict({
-        'unit': 'MWh',
-        'value': 34.09,
-      }),
-      'total_energy_t2': dict({
-        'unit': 'MWh',
-        'value': 12.45,
-      }),
-      'total_energy_t3': dict({
-        'unit': 'MWh',
-        'value': 5.67,
-      }),
-      'total_volume': dict({
-        'unit': 'm³',
-        'value': 3561.23,
-      }),
-      'volume_flow': dict({
-        'unit': 'l/h',
-        'value': 1.23,
-      }),
+    'device_id': '**REDACTED**',
+    'device_type': 'waermeleser',
+    'fabrication_number': '**REDACTED**',
+    'flow_temperature': dict({
+      'unit': '°C',
+      'value': 16.9,
     }),
-    'info': dict({
-      'device_id': '**REDACTED**',
-      'host': '**REDACTED**',
+    'power': dict({
+      'unit': 'kW',
+      'value': 2.31,
+    }),
+    'return_temperature': dict({
+      'unit': '°C',
+      'value': 19.6,
+    }),
+    'signal_strength_dbm': -51.0,
+    'temperature_difference': dict({
+      'unit': 'K',
+      'value': 2.68,
+    }),
+    'timestamp': 1747285200,
+    'total_energy_t1': dict({
+      'unit': 'MWh',
+      'value': 34.09,
+    }),
+    'total_energy_t2': dict({
+      'unit': 'MWh',
+      'value': 12.45,
+    }),
+    'total_energy_t3': dict({
+      'unit': 'MWh',
+      'value': 5.67,
+    }),
+    'total_volume': dict({
+      'unit': 'm³',
+      'value': 3561.23,
+    }),
+    'volume_flow': dict({
+      'unit': 'l/h',
+      'value': 1.23,
     }),
   })
 # ---
 # name: test_entry_diagnostics[wasserleser]
   dict({
-    'data': dict({
-      'current_flow_rate': dict({
-        'unit': 'l/h',
-        'value': 0.0,
-      }),
-      'current_flow_rate_m3': dict({
-        'unit': 'm3/h',
-        'value': 0.0,
-      }),
-      'device_id': '**REDACTED**',
-      'device_type': 'wasserleser',
-      'signal_strength_dbm': -49.0,
-      'timestamp': 1779276532,
-      'today_consumption': dict({
-        'unit': 'm3',
-        'value': 0.0,
-      }),
-      'total_consumption': dict({
-        'unit': 'm3',
-        'value': 123.755,
-      }),
+    'current_flow_rate': dict({
+      'unit': 'l/h',
+      'value': 0.0,
     }),
-    'info': dict({
-      'device_id': '**REDACTED**',
-      'host': '**REDACTED**',
+    'current_flow_rate_m3': dict({
+      'unit': 'm3/h',
+      'value': 0.0,
+    }),
+    'device_id': '**REDACTED**',
+    'device_type': 'wasserleser',
+    'signal_strength_dbm': -49.0,
+    'timestamp': 1779276532,
+    'today_consumption': dict({
+      'unit': 'm3',
+      'value': 0.0,
+    }),
+    'total_consumption': dict({
+      'unit': 'm3',
+      'value': 123.755,
     }),
   })
 # ---

--- a/tests/components/energieleser/snapshots/test_diagnostics.ambr
+++ b/tests/components/energieleser/snapshots/test_diagnostics.ambr
@@ -1,0 +1,149 @@
+# serializer version: 1
+# name: test_entry_diagnostics[stromleser]
+  dict({
+    'data': dict({
+      'device_id': '**REDACTED**',
+      'device_type': 'stromleser',
+      'energy_export': dict({
+        'unit': 'Wh',
+        'value': 26561.0,
+      }),
+      'energy_export_tariff_1': None,
+      'energy_export_tariff_2': None,
+      'energy_export_tariff_3': None,
+      'energy_export_tariff_4': None,
+      'energy_import': dict({
+        'unit': 'Wh',
+        'value': 12345.0,
+      }),
+      'energy_import_tariff_1': None,
+      'energy_import_tariff_2': None,
+      'energy_import_tariff_3': None,
+      'energy_import_tariff_4': None,
+      'pin_locked': False,
+      'power_absolute': None,
+      'power_active': dict({
+        'unit': 'W',
+        'value': 8.16,
+      }),
+      'power_export': None,
+      'power_import': None,
+      'power_l1': dict({
+        'unit': 'W',
+        'value': 0.0,
+      }),
+      'power_l2': dict({
+        'unit': 'W',
+        'value': 0.0,
+      }),
+      'power_l3': dict({
+        'unit': 'W',
+        'value': 8.16,
+      }),
+      'signal_strength_dbm': -51.0,
+      'timestamp': 1776178480,
+    }),
+    'info': dict({
+      'device_id': '**REDACTED**',
+      'host': '**REDACTED**',
+    }),
+  })
+# ---
+# name: test_entry_diagnostics[gasleser]
+  dict({
+    'data': dict({
+      'count': 603,
+      'current_flow_rate': 0.01,
+      'device_id': '**REDACTED**',
+      'device_type': 'gasleser',
+      'signal_strength_dbm': -51.0,
+      'timestamp': 1776179005,
+      'total_consumption': 37030.67,
+    }),
+    'info': dict({
+      'device_id': '**REDACTED**',
+      'host': '**REDACTED**',
+    }),
+  })
+# ---
+# name: test_entry_diagnostics[waermeleser]
+  dict({
+    'data': dict({
+      'device_id': '**REDACTED**',
+      'device_type': 'waermeleser',
+      'fabrication_number': '**REDACTED**',
+      'flow_temperature': dict({
+        'unit': '°C',
+        'value': 16.9,
+      }),
+      'power': dict({
+        'unit': 'kW',
+        'value': 2.31,
+      }),
+      'return_temperature': dict({
+        'unit': '°C',
+        'value': 19.6,
+      }),
+      'signal_strength_dbm': -51.0,
+      'temperature_difference': dict({
+        'unit': 'K',
+        'value': 2.68,
+      }),
+      'timestamp': 1747285200,
+      'total_energy_t1': dict({
+        'unit': 'MWh',
+        'value': 34.09,
+      }),
+      'total_energy_t2': dict({
+        'unit': 'MWh',
+        'value': 12.45,
+      }),
+      'total_energy_t3': dict({
+        'unit': 'MWh',
+        'value': 5.67,
+      }),
+      'total_volume': dict({
+        'unit': 'm³',
+        'value': 3561.23,
+      }),
+      'volume_flow': dict({
+        'unit': 'l/h',
+        'value': 1.23,
+      }),
+    }),
+    'info': dict({
+      'device_id': '**REDACTED**',
+      'host': '**REDACTED**',
+    }),
+  })
+# ---
+# name: test_entry_diagnostics[wasserleser]
+  dict({
+    'data': dict({
+      'current_flow_rate': dict({
+        'unit': 'l/h',
+        'value': 0.0,
+      }),
+      'current_flow_rate_m3': dict({
+        'unit': 'm3/h',
+        'value': 0.0,
+      }),
+      'device_id': '**REDACTED**',
+      'device_type': 'wasserleser',
+      'signal_strength_dbm': -49.0,
+      'timestamp': 1779276532,
+      'today_consumption': dict({
+        'unit': 'm3',
+        'value': 0.0,
+      }),
+      'total_consumption': dict({
+        'unit': 'm3',
+        'value': 123.755,
+      }),
+    }),
+    'info': dict({
+      'device_id': '**REDACTED**',
+      'host': '**REDACTED**',
+    }),
+  })
+# ---

--- a/tests/components/energieleser/test_diagnostics.py
+++ b/tests/components/energieleser/test_diagnostics.py
@@ -1,0 +1,55 @@
+"""Test energieleser diagnostics."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+@pytest.mark.parametrize(
+    ("device_fixture", "config_entry_fixture"),
+    [
+        pytest.param(
+            "mock_stromleser_device", "mock_stromleser_config_entry", id="stromleser"
+        ),
+        pytest.param(
+            "mock_gasleser_device", "mock_gasleser_config_entry", id="gasleser"
+        ),
+        pytest.param(
+            "mock_waermeleser_device",
+            "mock_waermeleser_config_entry",
+            id="waermeleser",
+        ),
+        pytest.param(
+            "mock_wasserleser_device",
+            "mock_wasserleser_config_entry",
+            id="wasserleser",
+        ),
+    ],
+)
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_energieleser_client: AsyncMock,
+    device_fixture: str,
+    config_entry_fixture: str,
+    request: pytest.FixtureRequest,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+    device = request.getfixturevalue(device_fixture)
+    config_entry = request.getfixturevalue(config_entry_fixture)
+
+    mock_energieleser_client.get_device.return_value = device
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await get_diagnostics_for_config_entry(hass, hass_client, config_entry)
+
+    assert result == snapshot


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds diagnostics support to the `energieleser` integration along with tests while redacting revealing info

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr