### PR TITLE
Add support for updating and deleting CalDAV events

### DIFF
--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -183,15 +183,6 @@ async def async_setup_entry(
     )
 
 
-def _update_data(fields: dict[str, Any]) -> dict[str, Any]:
-    """Map the fields of an update, which replaces the event as a whole.
-
-    An absent rrule means the recurrence was removed, so it is passed on as
-    None rather than left out.
-    """
-    return {**_item_data(fields), "rrule": fields.get("rrule")}
-
-
 def _item_data(fields: dict[str, Any]) -> dict[str, Any]:
     """Map the Home Assistant event fields onto caldav keyword arguments."""
     item_data: dict[str, Any] = {
@@ -277,7 +268,7 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
                 update_event,
                 self.coordinator.calendar,
                 uid,
-                _update_data(event),
+                _item_data(event),
                 recurrence_id,
                 recurrence_range == RANGE_THIS_AND_FUTURE,
             ),

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -6,7 +6,7 @@ import logging
 from typing import Any, override
 
 import caldav
-from caldav.lib.error import DAVError
+from caldav.lib.error import DAVError, NotFoundError
 import requests
 import voluptuous as vol
 
@@ -38,8 +38,9 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import CalDavConfigEntry
 from .api import async_get_calendars
-from .const import TIMEOUT
+from .const import RANGE_THIS_AND_FUTURE, TIMEOUT
 from .coordinator import CalDavUpdateCoordinator
+from .recurrence import delete_event, update_event
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -182,10 +183,39 @@ async def async_setup_entry(
     )
 
 
+def _update_data(fields: dict[str, Any]) -> dict[str, Any]:
+    """Map the fields of an update, which replaces the event as a whole.
+
+    An absent rrule means the recurrence was removed, so it is passed on as
+    None rather than left out.
+    """
+    return {**_item_data(fields), "rrule": fields.get("rrule")}
+
+
+def _item_data(fields: dict[str, Any]) -> dict[str, Any]:
+    """Map the Home Assistant event fields onto caldav keyword arguments."""
+    item_data: dict[str, Any] = {
+        "summary": fields["summary"],
+        "dtstart": fields["dtstart"],
+        "dtend": fields["dtend"],
+    }
+    if description := fields.get("description"):
+        item_data["description"] = description
+    if location := fields.get("location"):
+        item_data["location"] = location
+    if rrule := fields.get("rrule"):
+        item_data["rrule"] = rrule
+    return item_data
+
+
 class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarEntity):
     """A device for getting the next Task from a WebDav Calendar."""
 
-    _attr_supported_features = CalendarEntityFeature.CREATE_EVENT
+    _attr_supported_features = (
+        CalendarEntityFeature.CREATE_EVENT
+        | CalendarEntityFeature.UPDATE_EVENT
+        | CalendarEntityFeature.DELETE_EVENT
+    )
 
     def __init__(
         self,
@@ -222,17 +252,7 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
         """Create a new event in the calendar."""
         _LOGGER.debug("Event: %s", kwargs)
 
-        item_data: dict[str, Any] = {
-            "summary": kwargs["summary"],
-            "dtstart": kwargs["dtstart"],
-            "dtend": kwargs["dtend"],
-        }
-        if description := kwargs.get("description"):
-            item_data["description"] = description
-        if location := kwargs.get("location"):
-            item_data["location"] = location
-        if rrule := kwargs.get("rrule"):
-            item_data["rrule"] = rrule
+        item_data = _item_data(kwargs)
 
         _LOGGER.debug("ICS data %s", item_data)
 
@@ -242,6 +262,60 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
             )
         except (requests.ConnectionError, requests.Timeout, DAVError) as err:
             raise HomeAssistantError(f"CalDAV save error: {err}") from err
+
+    @override
+    async def async_update_event(
+        self,
+        uid: str,
+        event: dict[str, Any],
+        recurrence_id: str | None = None,
+        recurrence_range: str | None = None,
+    ) -> None:
+        """Update an event on the calendar."""
+        await self._async_write(
+            partial(
+                update_event,
+                self.coordinator.calendar,
+                uid,
+                _update_data(event),
+                recurrence_id,
+                recurrence_range == RANGE_THIS_AND_FUTURE,
+            ),
+            "update",
+        )
+
+    @override
+    async def async_delete_event(
+        self,
+        uid: str,
+        recurrence_id: str | None = None,
+        recurrence_range: str | None = None,
+    ) -> None:
+        """Delete an event on the calendar."""
+        await self._async_write(
+            partial(
+                delete_event,
+                self.coordinator.calendar,
+                uid,
+                recurrence_id,
+                recurrence_range == RANGE_THIS_AND_FUTURE,
+            ),
+            "delete",
+        )
+
+    async def _async_write(self, job: partial[None], action: str) -> None:
+        try:
+            await self.hass.async_add_executor_job(job)
+        except NotFoundError as err:
+            raise HomeAssistantError(f"Event not found on the server: {err}") from err
+        except (
+            requests.ConnectionError,
+            requests.Timeout,
+            DAVError,
+            ValueError,
+        ) as err:
+            raise HomeAssistantError(f"CalDAV {action} error: {err}") from err
+        await self.coordinator.async_request_refresh()
 
     @callback
     @override

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -1,5 +1,6 @@
 """Support for WebDav Calendar."""
 
+import asyncio
 from datetime import datetime
 from functools import partial
 import logging
@@ -222,6 +223,7 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
             # Never modify events the filter hides from this entity.
             self._attr_supported_features = CalendarEntityFeature.CREATE_EVENT
         self.entity_id = entity_id
+        self._write_lock = asyncio.Lock()
         self._event: CalendarEvent | None = None
         self._attr_name = name
         if unique_id is not None:
@@ -298,6 +300,12 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
         )
 
     async def _async_write(self, job: partial[None], action: str) -> None:
+        # Concurrent read-modify-write cycles would drop each other's changes.
+        async with self._write_lock:
+            await self._async_run_write(job, action)
+        await self.coordinator.async_request_refresh()
+
+    async def _async_run_write(self, job: partial[None], action: str) -> None:
         try:
             await self.hass.async_add_executor_job(job)
         except NotFoundError as err:
@@ -309,7 +317,6 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
             ValueError,
         ) as err:
             raise HomeAssistantError(f"CalDAV {action} error: {err}") from err
-        await self.coordinator.async_request_refresh()
 
     @callback
     @override

--- a/homeassistant/components/caldav/calendar.py
+++ b/homeassistant/components/caldav/calendar.py
@@ -218,6 +218,9 @@ class WebDavCalendarEntity(CoordinatorEntity[CalDavUpdateCoordinator], CalendarE
     ) -> None:
         """Create the WebDav Calendar Event Device."""
         super().__init__(coordinator)
+        if coordinator.search is not None:
+            # Never modify events the filter hides from this entity.
+            self._attr_supported_features = CalendarEntityFeature.CREATE_EVENT
         self.entity_id = entity_id
         self._event: CalendarEvent | None = None
         self._attr_name = name

--- a/homeassistant/components/caldav/const.py
+++ b/homeassistant/components/caldav/const.py
@@ -4,3 +4,4 @@ from typing import Final
 
 DOMAIN: Final = "caldav"
 TIMEOUT: Final = 30
+RANGE_THIS_AND_FUTURE: Final = "THISANDFUTURE"

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -20,7 +20,13 @@ from typing import Any
 import caldav
 from caldav.lib.error import DAVError
 from dateutil.rrule import rrulestr
-from icalendar import Calendar as ICalCalendar, Event as ICalEvent, vDDDTypes, vRecur
+from icalendar import (
+    Calendar as ICalCalendar,
+    Event as ICalEvent,
+    vDDDLists,
+    vDDDTypes,
+    vRecur,
+)
 import requests
 
 from homeassistant.util import dt as dt_util
@@ -57,11 +63,17 @@ def update_event(
 
     if _utc(occurrence) <= _utc(master["DTSTART"].dt):
         _apply(master, data)
+        _drop_overrides(ical, occurrence, from_occurrence=True)
         _save(dav_event, ical, master)
         return
 
     if "RRULE" not in master and "RDATE" not in master:
         raise ValueError("Event is not a recurring series")
+
+    # A replayed command finds the head already capped and must not clone it
+    # over the valid tail.
+    if not _has_occurrences_from(master, occurrence):
+        return
 
     # RFC 4791 allows one UID per object; a derived UID makes retries
     # overwrite the tail instead of adding another one.
@@ -71,7 +83,15 @@ def update_event(
         _drop_overrides(ical, occurrence, from_occurrence=True)
         _save(dav_event, ical, master)
     except _WRITE_FAILURES:
-        _discard(tail)
+        # A timeout may hit after the server committed the capped head;
+        # deleting the tail then would drop every future occurrence.
+        if _head_uncapped(calendar, uid, occurrence):
+            _discard(tail)
+        else:
+            _LOGGER.warning(
+                "Keeping the split-off series; the head state could not be"
+                " verified after a failed update"
+            )
         raise
 
 
@@ -155,6 +175,9 @@ def _new_override(ical: Any, master: Any, occurrence: datetime | date) -> Any:
     override.add("UID", str(master["UID"]))
     override.add("DTSTAMP", dt_util.utcnow())
     override.add("RECURRENCE-ID", vDDDTypes(_align(master, occurrence)))
+    for key in ("DTSTART", "DTEND"):
+        if key in master:
+            override[key] = master[key]
     ical.add_component(override)
     return override
 
@@ -211,11 +234,11 @@ def _tail_uid(uid: str, occurrence: datetime | date) -> str:
 def _tail_rrule(master: Any, occurrence: datetime | date) -> vRecur | None:
     """Return the master's rule with COUNT reduced by the capped head."""
     rrule = master.get("RRULE")
-    if rrule is None:
+    if rrule is None or _ends_before(master, occurrence):
         return None
     recur = vRecur(dict(rrule))
     if count := recur.get("COUNT"):
-        recur["COUNT"] = [max(count[0] - _occurrences_before(master, occurrence), 1)]
+        recur["COUNT"] = [count[0] - _occurrences_before(master, occurrence)]
     return recur
 
 
@@ -227,6 +250,45 @@ def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
         target = datetime.combine(target, time.min)
     rule = rrulestr(master["RRULE"].to_ical().decode("utf-8"), dtstart=dtstart)
     return sum(1 for moment in rule if moment < target)
+
+
+def _ends_before(master: Any, occurrence: datetime | date) -> bool:
+    """Return whether the rule's own occurrences all lie before the cutoff."""
+    recur = master["RRULE"]
+    if until := recur.get("UNTIL"):
+        return _utc(until[0]) < _utc(_align(master, occurrence))
+    if count := recur.get("COUNT"):
+        return _occurrences_before(master, occurrence) >= count[0]
+    return False
+
+
+def _has_occurrences_from(master: Any, occurrence: datetime | date) -> bool:
+    if master.get("RRULE") is not None and not _ends_before(master, occurrence):
+        return True
+    return _has_dates_from(master, "RDATE", occurrence)
+
+
+def _has_dates_from(component: Any, key: str, occurrence: datetime | date) -> bool:
+    if key not in component:
+        return False
+    entries = component[key]
+    if not isinstance(entries, list):
+        entries = [entries]
+    target = _utc(occurrence)
+    return any(
+        _utc(_start_of(item.dt)) >= target for entry in entries for item in entry.dts
+    )
+
+
+def _head_uncapped(
+    calendar: caldav.Calendar, uid: str, occurrence: datetime | date
+) -> bool:
+    """Return whether the head still holds occurrences from the cutoff on."""
+    try:
+        ical = calendar.event_by_uid(uid).icalendar_instance
+    except requests.ConnectionError, requests.Timeout, DAVError:
+        return False
+    return _has_occurrences_from(_master(ical), occurrence)
 
 
 def _discard(tail: Any) -> None:
@@ -244,7 +306,9 @@ def _cap_series(master: Any, occurrence: datetime | date) -> None:
     rrule = master.get("RRULE")
     if rrule is None and "RDATE" not in master:
         raise ValueError("Event is not a recurring series")
-    if rrule is not None:
+    # A rule that already ends before the cutoff must stay as it is; an UNTIL
+    # at the cutoff would add occurrences instead of removing them.
+    if rrule is not None and not _ends_before(master, occurrence):
         recur = vRecur(dict(rrule))
         recur.pop("COUNT", None)
         recur["UNTIL"] = [_until(master, occurrence)]
@@ -256,22 +320,33 @@ def _cap_series(master: Any, occurrence: datetime | date) -> None:
 def _keep_dates(
     component: Any, key: str, occurrence: datetime | date, before: bool
 ) -> None:
-    """Keep the RDATE or EXDATE values on one side of the occurrence."""
+    """Keep the RDATE or EXDATE values on one side of the occurrence.
+
+    Property lines are filtered one by one: merging them would force every
+    value under a single TZID and shift the instants of the others.
+    """
     if key not in component:
         return
     entries = component[key]
     if not isinstance(entries, list):
         entries = [entries]
     target = _utc(occurrence)
-    kept = [
-        item.dt
-        for entry in entries
-        for item in entry.dts
-        if (_utc(_start_of(item.dt)) < target) == before
-    ]
+    kept_entries = []
+    for entry in entries:
+        kept = [
+            item.dt
+            for item in entry.dts
+            if (_utc(_start_of(item.dt)) < target) == before
+        ]
+        if len(kept) == len(entry.dts):
+            kept_entries.append(entry)
+        elif kept:
+            rebuilt = vDDDLists(kept)
+            rebuilt.params = entry.params
+            kept_entries.append(rebuilt)
     del component[key]
-    if kept:
-        component.add(key, kept)
+    if kept_entries:
+        component[key] = kept_entries if len(kept_entries) > 1 else kept_entries[0]
 
 
 def _start_of(value: Any) -> datetime | date:
@@ -290,17 +365,35 @@ def _until(master: Any, occurrence: datetime | date) -> datetime | date:
 def _apply(component: Any, data: dict[str, Any]) -> None:
     _replace(component, "summary", data.get("summary"))
     if "dtstart" in data:
-        _replace(component, "dtstart", data["dtstart"])
+        _set_time(component, "dtstart", data["dtstart"])
     if "dtend" in data:
         # RFC 5545 forbids DURATION alongside DTEND.
         _replace(component, "duration", None)
-        _replace(component, "dtend", data["dtend"])
+        _set_time(component, "dtend", data["dtend"])
     _replace(component, "description", data.get("description"))
     _replace(component, "location", data.get("location"))
     # The frontend never sees the rule (expand strips RRULE), so an absent
     # rrule must not remove the recurrence.
     if rrule := data.get("rrule"):
         _replace(component, "rrule", vRecur.from_ical(rrule))
+
+
+def _set_time(component: Any, key: str, value: Any) -> None:
+    """Write a time in the anchor the component already uses.
+
+    Home Assistant normalizes times to its own zone; writing them as received
+    would re-anchor a UTC, TZID or floating series on a summary-only edit and
+    shift future occurrences across DST boundaries.
+    """
+    old = component[key].dt if key in component else None
+    if isinstance(old, datetime) and isinstance(value, datetime):
+        if _utc(old) == _utc(value):
+            return
+        if old.tzinfo is None:
+            value = dt_util.as_local(value).replace(tzinfo=None)
+        else:
+            value = value.astimezone(old.tzinfo)
+    _replace(component, key, value)
 
 
 def _save(dav_event: caldav.CalendarObjectResource, ical: Any, touched: Any) -> None:

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -89,6 +89,16 @@ def update_event(
     if not _has_occurrences_from(master, occurrence):
         return
 
+    # Inheriting the rule onto an off-rule RDATE would re-anchor it there
+    # and reschedule every remaining rule occurrence.
+    if (
+        master.get("RRULE") is not None
+        and not data.get("rrule")
+        and not _ends_before(master, occurrence)
+        and not _on_rule(master, occurrence)
+    ):
+        raise ValueError("Splitting a series at an added date is not supported")
+
     # RFC 4791 allows one UID per object; a derived UID makes retries
     # overwrite the tail instead of adding another one.
     tail = calendar.save_event(_tail_ics(ical, master, data, occurrence))
@@ -312,6 +322,19 @@ def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
             break
         count += 1
     return count
+
+
+def _on_rule(master: Any, occurrence: datetime | date) -> bool:
+    dtstart = master["DTSTART"].dt
+    target = _align(master, occurrence)
+    if not isinstance(dtstart, datetime):
+        dtstart = datetime.combine(dtstart, time.min)
+        target = datetime.combine(target, time.min)
+    rule = rrulestr(master["RRULE"].to_ical().decode("utf-8"), dtstart=dtstart)
+    for moment in rule:
+        if moment >= target:
+            return moment == target
+    return False
 
 
 def _ends_before(master: Any, occurrence: datetime | date) -> bool:

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -49,7 +49,13 @@ def update_event(
     master = _master(ical)
 
     if recurrence_id is None:
+        old_start = _utc(master["DTSTART"].dt)
         _apply(master, data)
+        # A new rule or start invalidates the RECURRENCE-IDs of overrides.
+        if data.get("rrule") or _utc(master["DTSTART"].dt) != old_start:
+            _drop_overrides(
+                ical, master, old_start, from_occurrence=False, all_overrides=True
+            )
         _save(dav_event, ical, master)
         return
 
@@ -57,13 +63,13 @@ def update_event(
 
     if not this_and_future:
         target = _override(ical, occurrence) or _new_override(ical, master, occurrence)
-        _apply(target, data)
+        _apply(target, {**data, "rrule": None})
         _save(dav_event, ical, target)
         return
 
     if _utc(occurrence) <= _utc(master["DTSTART"].dt):
         _apply(master, data)
-        _drop_overrides(ical, occurrence, from_occurrence=True)
+        _drop_overrides(ical, master, occurrence, from_occurrence=True)
         _save(dav_event, ical, master)
         return
 
@@ -80,7 +86,7 @@ def update_event(
     tail = calendar.save_event(_tail_ics(ical, master, data, occurrence))
     try:
         _cap_series(master, occurrence)
-        _drop_overrides(ical, occurrence, from_occurrence=True)
+        _drop_overrides(ical, master, occurrence, from_occurrence=True)
         _save(dav_event, ical, master)
     except _WRITE_FAILURES:
         # A timeout may hit after the server committed the capped head;
@@ -118,10 +124,10 @@ def delete_event(
             dav_event.delete()
             return
         _cap_series(master, occurrence)
-        _drop_overrides(ical, occurrence, from_occurrence=True)
+        _drop_overrides(ical, master, occurrence, from_occurrence=True)
     else:
         _add_exdate(master, occurrence)
-        _drop_overrides(ical, occurrence, from_occurrence=False)
+        _drop_overrides(ical, master, occurrence, from_occurrence=False)
 
     _save(dav_event, ical, master)
 
@@ -171,24 +177,35 @@ def _override(ical: Any, occurrence: datetime | date) -> Any | None:
 
 
 def _new_override(ical: Any, master: Any, occurrence: datetime | date) -> Any:
-    override = ICalEvent()
-    override.add("UID", str(master["UID"]))
-    override.add("DTSTAMP", dt_util.utcnow())
+    override = ICalEvent.from_ical(master.to_ical())
+    for key in ("RRULE", "RDATE", "EXDATE"):
+        if key in override:
+            del override[key]
+    _replace(override, "dtstamp", dt_util.utcnow())
+    _replace(override, "sequence", None)
     override.add("RECURRENCE-ID", vDDDTypes(_align(master, occurrence)))
-    for key in ("DTSTART", "DTEND"):
-        if key in master:
-            override[key] = master[key]
     ical.add_component(override)
     return override
 
 
 def _drop_overrides(
-    ical: Any, occurrence: datetime | date, from_occurrence: bool
+    ical: Any,
+    master: Any,
+    occurrence: datetime | date,
+    from_occurrence: bool,
+    all_overrides: bool = False,
 ) -> None:
+    """Remove overrides, but never the component _master() returned.
+
+    On an orphan-override object every VEVENT carries a RECURRENCE-ID and the
+    first doubles as the master; removing it would save an empty resource.
+    """
     target = _utc(occurrence)
     for vevent in _overrides(ical):
+        if vevent is master:
+            continue
         moment = _utc(vevent["RECURRENCE-ID"].dt)
-        if moment >= target if from_occurrence else moment == target:
+        if all_overrides or (moment >= target if from_occurrence else moment == target):
             ical.subcomponents.remove(vevent)
 
 
@@ -215,7 +232,8 @@ def _tail_ics(
     tail = ICalCalendar.from_ical(ical.to_ical())
     vevent = _master(tail)
     for override in _overrides(tail):
-        tail.subcomponents.remove(override)
+        if override is not vevent:
+            tail.subcomponents.remove(override)
     _replace(vevent, "uid", _tail_uid(str(master["UID"]), occurrence))
     _replace(vevent, "dtstamp", dt_util.utcnow())
     _replace(vevent, "sequence", None)
@@ -386,6 +404,13 @@ def _set_time(component: Any, key: str, value: Any) -> None:
     shift future occurrences across DST boundaries.
     """
     old = component[key].dt if key in component else None
+    if (
+        old is not None
+        and isinstance(old, datetime) != isinstance(value, datetime)
+        and any(k in component for k in ("RRULE", "RDATE", "RECURRENCE-ID"))
+    ):
+        # UNTIL, RDATE, EXDATE and RECURRENCE-ID would keep the old value type.
+        raise ValueError("Cannot change a recurring event between all-day and timed")
     if isinstance(old, datetime) and isinstance(value, datetime):
         if _utc(old) == _utc(value):
             return

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -6,20 +6,28 @@ that occurrence and everything after it. CalDAV has no such call: the whole
 series lives in a single calendar object that has to be rewritten by hand.
 
 A single occurrence is dropped with an EXDATE and changed through an overriding
-VEVENT carrying a RECURRENCE-ID. "This and future" caps the RRULE with UNTIL.
-RFC 5545 requires EXDATE, RECURRENCE-ID and UNTIL to follow DTSTART: its value
-type, and its zone or lack of one. A floating DTSTART keeps them floating; a
-zoned one puts them in UTC.
+VEVENT carrying a RECURRENCE-ID. "This and future" caps the RRULE with UNTIL
+and drops later RDATEs; an update clones the resource into a second object
+holding the remaining occurrences. RFC 5545 requires EXDATE, RECURRENCE-ID and
+UNTIL to follow DTSTART: its value type, and its zone or lack of one. A
+floating DTSTART keeps them floating; a zoned one puts them in UTC.
 """
 
 from datetime import UTC, date, datetime, time, timedelta
+import logging
 from typing import Any
 
 import caldav
+from caldav.lib.error import DAVError
 from dateutil.rrule import rrulestr
-from icalendar import Event as ICalEvent, vDDDTypes, vRecur
+from icalendar import Calendar as ICalCalendar, Event as ICalEvent, vDDDTypes, vRecur
+import requests
 
 from homeassistant.util import dt as dt_util
+
+_LOGGER = logging.getLogger(__name__)
+
+_WRITE_FAILURES = (requests.ConnectionError, requests.Timeout, DAVError, ValueError)
 
 
 def update_event(
@@ -52,18 +60,19 @@ def update_event(
         _save(dav_event, ical, master)
         return
 
-    # RFC 4791 allows only one UID per object, so the tail needs its own.
-    tail = dict(data)
-    tail.setdefault("rrule", _tail_rrule(master, occurrence))
-    if tail["rrule"] is None:
-        del tail["rrule"]
+    if "RRULE" not in master and "RDATE" not in master:
+        raise ValueError("Event is not a recurring series")
 
-    # Creating the tail first costs a visible duplicate if capping then fails,
-    # where capping first would silently drop every occurrence from here on.
-    calendar.add_event(**tail)
-    _cap_series(master, occurrence)
-    _drop_overrides(ical, occurrence, from_occurrence=True)
-    _save(dav_event, ical, master)
+    # RFC 4791 allows one UID per object; a derived UID makes retries
+    # overwrite the tail instead of adding another one.
+    tail = calendar.save_event(_tail_ics(ical, master, data, occurrence))
+    try:
+        _cap_series(master, occurrence)
+        _drop_overrides(ical, occurrence, from_occurrence=True)
+        _save(dav_event, ical, master)
+    except _WRITE_FAILURES:
+        _discard(tail)
+        raise
 
 
 def delete_event(
@@ -176,15 +185,38 @@ def _add_exdate(master: Any, occurrence: datetime | date) -> None:
     master.add("EXDATE", vDDDTypes(_align(master, occurrence)))
 
 
-def _tail_rrule(master: Any, occurrence: datetime | date) -> str | None:
-    """Return the rule for the tail, with COUNT reduced by the capped head."""
+def _tail_ics(
+    ical: Any, master: Any, data: dict[str, Any], occurrence: datetime | date
+) -> str:
+    """Return the occurrences from the split onwards as their own object."""
+    tail = ICalCalendar.from_ical(ical.to_ical())
+    vevent = _master(tail)
+    for override in _overrides(tail):
+        tail.subcomponents.remove(override)
+    _replace(vevent, "uid", _tail_uid(str(master["UID"]), occurrence))
+    _replace(vevent, "dtstamp", dt_util.utcnow())
+    _replace(vevent, "sequence", None)
+    _apply(vevent, data)
+    if "rrule" not in data:
+        _replace(vevent, "rrule", _tail_rrule(master, occurrence))
+    _keep_dates(vevent, "RDATE", occurrence, before=False)
+    _keep_dates(vevent, "EXDATE", occurrence, before=False)
+    return tail.to_ical().decode("utf-8")
+
+
+def _tail_uid(uid: str, occurrence: datetime | date) -> str:
+    return f"{uid}-{_utc(occurrence).strftime('%Y%m%dT%H%M%SZ')}"
+
+
+def _tail_rrule(master: Any, occurrence: datetime | date) -> vRecur | None:
+    """Return the master's rule with COUNT reduced by the capped head."""
     rrule = master.get("RRULE")
     if rrule is None:
         return None
     recur = vRecur(dict(rrule))
     if count := recur.get("COUNT"):
         recur["COUNT"] = [max(count[0] - _occurrences_before(master, occurrence), 1)]
-    return recur.to_ical().decode("utf-8")
+    return recur
 
 
 def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
@@ -197,14 +229,54 @@ def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
     return sum(1 for moment in rule if moment < target)
 
 
+def _discard(tail: Any) -> None:
+    try:
+        tail.delete()
+    except (requests.ConnectionError, requests.Timeout, DAVError) as err:
+        _LOGGER.warning(
+            "The split-off series could not be removed after a failed update"
+            " and may show duplicate events until the update is retried: %s",
+            err,
+        )
+
+
 def _cap_series(master: Any, occurrence: datetime | date) -> None:
     rrule = master.get("RRULE")
-    if rrule is None:
+    if rrule is None and "RDATE" not in master:
         raise ValueError("Event is not a recurring series")
-    recur = vRecur(dict(rrule))
-    recur.pop("COUNT", None)
-    recur["UNTIL"] = [_until(master, occurrence)]
-    _replace(master, "rrule", recur)
+    if rrule is not None:
+        recur = vRecur(dict(rrule))
+        recur.pop("COUNT", None)
+        recur["UNTIL"] = [_until(master, occurrence)]
+        _replace(master, "rrule", recur)
+    _keep_dates(master, "RDATE", occurrence, before=True)
+    _keep_dates(master, "EXDATE", occurrence, before=True)
+
+
+def _keep_dates(
+    component: Any, key: str, occurrence: datetime | date, before: bool
+) -> None:
+    """Keep the RDATE or EXDATE values on one side of the occurrence."""
+    if key not in component:
+        return
+    entries = component[key]
+    if not isinstance(entries, list):
+        entries = [entries]
+    target = _utc(occurrence)
+    kept = [
+        item.dt
+        for entry in entries
+        for item in entry.dts
+        if (_utc(_start_of(item.dt)) < target) == before
+    ]
+    del component[key]
+    if kept:
+        component.add(key, kept)
+
+
+def _start_of(value: Any) -> datetime | date:
+    """Return the start of an RDATE value, which may be a period."""
+    return value[0] if isinstance(value, tuple) else value
 
 
 def _until(master: Any, occurrence: datetime | date) -> datetime | date:
@@ -225,9 +297,8 @@ def _apply(component: Any, data: dict[str, Any]) -> None:
         _replace(component, "dtend", data["dtend"])
     _replace(component, "description", data.get("description"))
     _replace(component, "location", data.get("location"))
-    # An absent rrule means "leave the recurrence alone": the coordinator
-    # expands series server side, so CalendarEvent.rrule is never populated and
-    # the frontend cannot echo the existing rule back.
+    # The frontend never sees the rule (expand strips RRULE), so an absent
+    # rrule must not remove the recurrence.
     if rrule := data.get("rrule"):
         _replace(component, "rrule", vRecur.from_ical(rrule))
 
@@ -236,10 +307,8 @@ def _save(dav_event: caldav.CalendarObjectResource, ical: Any, touched: Any) -> 
     _replace(touched, "last-modified", dt_util.utcnow())
     _replace(touched, "sequence", int(touched.get("sequence", 0)) + 1)
     dav_event.data = ical.to_ical().decode("utf-8")
-    # Defaults would bump SEQUENCE twice and, when an override comes first,
-    # merge back only that component, dropping the edits to the master.
-    # caldav.CalendarObjectResource types against a shim that predates
-    # only_this_recurrence; the runtime class accepts it.
+    # Defaults would bump SEQUENCE twice and merge back only the first
+    # component; the ignore covers a legacy shim without only_this_recurrence.
     dav_event.save(increase_seqno=False, only_this_recurrence=False)  # type: ignore[call-arg]
 
 

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -33,6 +33,7 @@ from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
+_MAX_OCCURRENCES = 10_000
 _NETWORK_FAILURES = (requests.ConnectionError, requests.Timeout, DAVError)
 _WRITE_FAILURES = (*_NETWORK_FAILURES, ValueError)
 
@@ -286,6 +287,8 @@ def _tail_ics(
         _clear_dates(vevent)
         return tail.to_ical().decode("utf-8")
     _replace(vevent, "rrule", _tail_rrule(master, occurrence))
+    if vevent.get("RRULE") is not None and not _self_anchored(vevent):
+        raise ValueError("The new start does not match the recurrence rule")
     _keep_dates(vevent, "RDATE", occurrence, before=False)
     _keep_dates(vevent, "EXDATE", occurrence, before=False)
     # A wall-clock delta keeps shifted values stable across DST changes.
@@ -325,6 +328,8 @@ def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
         if moment >= target:
             break
         count += 1
+        if count > _MAX_OCCURRENCES:
+            raise ValueError("The recurrence rule is too dense to process")
     return count
 
 
@@ -371,9 +376,11 @@ def _on_rule(master: Any, occurrence: datetime | date) -> bool:
         dtstart = datetime.combine(dtstart, time.min)
         target = datetime.combine(target, time.min)
     rule = rrulestr(master["RRULE"].to_ical().decode("utf-8"), dtstart=dtstart)
-    for moment in rule:
+    for count, moment in enumerate(rule):
         if moment >= target:
             return moment == target
+        if count > _MAX_OCCURRENCES:
+            raise ValueError("The recurrence rule is too dense to process")
     return False
 
 
@@ -557,13 +564,23 @@ def _set_time(component: Any, key: str, value: Any) -> None:
     ):
         # UNTIL, RDATE, EXDATE and RECURRENCE-ID would keep the old value type.
         raise ValueError("Cannot change a recurring event between all-day and timed")
-    if isinstance(old, datetime) and isinstance(value, datetime):
-        if _utc(old) == _utc(value):
-            return
-        if old.tzinfo is None:
+    if (
+        isinstance(old, datetime)
+        and isinstance(value, datetime)
+        and _utc(old) == _utc(value)
+    ):
+        return
+    # An event using DURATION has no stored end to anchor to.
+    anchor = (
+        old
+        if old is not None
+        else (component["DTSTART"].dt if "DTSTART" in component else None)
+    )
+    if isinstance(anchor, datetime) and isinstance(value, datetime):
+        if anchor.tzinfo is None:
             value = dt_util.as_local(value).replace(tzinfo=None)
         else:
-            value = value.astimezone(old.tzinfo)
+            value = value.astimezone(anchor.tzinfo)
     _replace(component, key, value)
 
 

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -1,0 +1,220 @@
+"""Write operations for CalDAV events.
+
+Home Assistant addresses an occurrence of a recurring event by the UID of the
+series plus a RECURRENCE-ID, and scopes a change to that occurrence alone or to
+that occurrence and everything after it. CalDAV has no such call: the whole
+series lives in a single calendar object that has to be rewritten by hand.
+
+A single occurrence is dropped with an EXDATE and changed through an overriding
+VEVENT carrying a RECURRENCE-ID. "This and future" caps the RRULE with UNTIL.
+RFC 5545 requires EXDATE and RECURRENCE-ID to use the value type of DTSTART,
+and UNTIL to be UTC whenever DTSTART is a datetime.
+"""
+
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Any
+
+import caldav
+from icalendar import Event as ICalEvent, vDDDTypes, vRecur
+
+from homeassistant.util import dt as dt_util
+
+
+def update_event(
+    calendar: caldav.Calendar,
+    uid: str,
+    data: dict[str, Any],
+    recurrence_id: str | None = None,
+    this_and_future: bool = False,
+) -> None:
+    """Update a whole series, a single occurrence, or an occurrence onwards."""
+    dav_event = calendar.event_by_uid(uid)
+    ical = dav_event.icalendar_instance
+    master = _master(ical)
+
+    if recurrence_id is None:
+        _apply(master, data)
+        _save(dav_event, ical, master)
+        return
+
+    occurrence = parse_recurrence_id(recurrence_id)
+
+    if not this_and_future:
+        target = _override(ical, occurrence) or _new_override(ical, master, occurrence)
+        _apply(target, data)
+        _save(dav_event, ical, target)
+        return
+
+    if _utc(occurrence) <= _utc(master["DTSTART"].dt):
+        _apply(master, data)
+        _save(dav_event, ical, master)
+        return
+
+    # RFC 4791 allows only one UID per object, so the tail needs its own.
+    tail = dict(data)
+    if tail.get("rrule") is None:
+        tail.pop("rrule", None)
+
+    _cap_series(master, occurrence)
+    _drop_overrides(ical, occurrence, from_occurrence=True)
+    _save(dav_event, ical, master)
+    calendar.add_event(**tail)
+
+
+def delete_event(
+    calendar: caldav.Calendar,
+    uid: str,
+    recurrence_id: str | None = None,
+    this_and_future: bool = False,
+) -> None:
+    """Delete a whole series, a single occurrence, or an occurrence onwards."""
+    dav_event = calendar.event_by_uid(uid)
+
+    if recurrence_id is None:
+        dav_event.delete()
+        return
+
+    ical = dav_event.icalendar_instance
+    master = _master(ical)
+    occurrence = parse_recurrence_id(recurrence_id)
+
+    if this_and_future:
+        # Capping before the first occurrence would leave an empty series.
+        if _utc(occurrence) <= _utc(master["DTSTART"].dt):
+            dav_event.delete()
+            return
+        _cap_series(master, occurrence)
+        _drop_overrides(ical, occurrence, from_occurrence=True)
+    else:
+        _add_exdate(master, occurrence)
+        _drop_overrides(ical, occurrence, from_occurrence=False)
+
+    _save(dav_event, ical, master)
+
+
+def parse_recurrence_id(value: str) -> datetime | date:
+    """Parse the recurrence id Home Assistant echoes back.
+
+    Dates are tried first: parse_datetime also accepts a date-only string and
+    would turn an all day occurrence into midnight, losing the value type that
+    EXDATE and UNTIL have to match.
+    """
+    parsed = dt_util.parse_date(value) or dt_util.parse_datetime(value)
+    if parsed is None:
+        raise ValueError(f"Unable to parse recurrence id: {value}")
+    return parsed
+
+
+def _utc(value: datetime | date) -> datetime:
+    """Normalize dates and floating times so comparisons never mix types."""
+    if not isinstance(value, datetime):
+        value = datetime.combine(value, time.min)
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=dt_util.get_default_time_zone())
+    return value.astimezone(UTC)
+
+
+def _master(ical: Any) -> Any:
+    vevents = list(ical.walk("VEVENT"))
+    if not vevents:
+        raise ValueError("Calendar object contains no event")
+    for vevent in vevents:
+        if "RECURRENCE-ID" not in vevent:
+            return vevent
+    return vevents[0]
+
+
+def _overrides(ical: Any) -> list[Any]:
+    return [vevent for vevent in ical.walk("VEVENT") if "RECURRENCE-ID" in vevent]
+
+
+def _override(ical: Any, occurrence: datetime | date) -> Any | None:
+    target = _utc(occurrence)
+    for vevent in _overrides(ical):
+        if _utc(vevent["RECURRENCE-ID"].dt) == target:
+            return vevent
+    return None
+
+
+def _new_override(ical: Any, master: Any, occurrence: datetime | date) -> Any:
+    override = ICalEvent()
+    override.add("UID", str(master["UID"]))
+    override.add("DTSTAMP", dt_util.utcnow())
+    override.add("RECURRENCE-ID", vDDDTypes(_match_type(master, occurrence)))
+    ical.add_component(override)
+    return override
+
+
+def _drop_overrides(
+    ical: Any, occurrence: datetime | date, from_occurrence: bool
+) -> None:
+    target = _utc(occurrence)
+    for vevent in _overrides(ical):
+        moment = _utc(vevent["RECURRENCE-ID"].dt)
+        if moment >= target if from_occurrence else moment == target:
+            ical.subcomponents.remove(vevent)
+
+
+def _match_type(master: Any, occurrence: datetime | date) -> datetime | date:
+    """Return the occurrence in the value type the master DTSTART uses."""
+    if isinstance(master["DTSTART"].dt, datetime):
+        return _utc(occurrence)
+    return occurrence.date() if isinstance(occurrence, datetime) else occurrence
+
+
+def _add_exdate(master: Any, occurrence: datetime | date) -> None:
+    master.add("EXDATE", vDDDTypes(_match_type(master, occurrence)))
+
+
+def _cap_series(master: Any, occurrence: datetime | date) -> None:
+    rrule = master.get("RRULE")
+    if rrule is None:
+        raise ValueError("Event is not a recurring series")
+    recur = vRecur(dict(rrule))
+    recur.pop("COUNT", None)
+    recur["UNTIL"] = [_until(master, occurrence)]
+    _replace(master, "rrule", recur)
+
+
+def _until(master: Any, occurrence: datetime | date) -> datetime | date:
+    """Return an UNTIL that stops the series before the occurrence."""
+    if isinstance(master["DTSTART"].dt, datetime):
+        return _utc(occurrence) - timedelta(seconds=1)
+    day = occurrence.date() if isinstance(occurrence, datetime) else occurrence
+    return day - timedelta(days=1)
+
+
+def _apply(component: Any, data: dict[str, Any]) -> None:
+    _replace(component, "summary", data.get("summary"))
+    if "dtstart" in data:
+        _replace(component, "dtstart", data["dtstart"])
+    if "dtend" in data:
+        # RFC 5545 forbids DURATION alongside DTEND.
+        _replace(component, "duration", None)
+        _replace(component, "dtend", data["dtend"])
+    _replace(component, "description", data.get("description"))
+    _replace(component, "location", data.get("location"))
+    if "rrule" in data:
+        _replace(
+            component,
+            "rrule",
+            vRecur.from_ical(data["rrule"]) if data["rrule"] else None,
+        )
+
+
+def _save(dav_event: caldav.CalendarObjectResource, ical: Any, touched: Any) -> None:
+    _replace(touched, "last-modified", dt_util.utcnow())
+    _replace(touched, "sequence", int(touched.get("sequence", 0)) + 1)
+    dav_event.data = ical.to_ical().decode("utf-8")
+    # Defaults would bump SEQUENCE twice and, when an override comes first,
+    # merge back only that component, dropping the edits to the master.
+    # caldav.CalendarObjectResource types against a shim that predates
+    # only_this_recurrence; the runtime class accepts it.
+    dav_event.save(increase_seqno=False, only_this_recurrence=False)  # type: ignore[call-arg]
+
+
+def _replace(component: Any, key: str, value: Any) -> None:
+    if key in component:
+        del component[key]
+    if value is not None:
+        component.add(key, value)

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -33,7 +33,8 @@ from homeassistant.util import dt as dt_util
 
 _LOGGER = logging.getLogger(__name__)
 
-_WRITE_FAILURES = (requests.ConnectionError, requests.Timeout, DAVError, ValueError)
+_NETWORK_FAILURES = (requests.ConnectionError, requests.Timeout, DAVError)
+_WRITE_FAILURES = (*_NETWORK_FAILURES, ValueError)
 
 
 def update_event(
@@ -125,6 +126,19 @@ def delete_event(
             return
         _cap_series(master, occurrence)
         _drop_overrides(ical, master, occurrence, from_occurrence=True)
+    elif "RECURRENCE-ID" in master:
+        # An object holding only overrides has no series to annotate; drop
+        # the matching component, or the resource when it is the last one.
+        target = _override(ical, occurrence)
+        if target is None:
+            raise ValueError(f"Occurrence not found: {recurrence_id}")
+        remaining = [v for v in _overrides(ical) if v is not target]
+        if not remaining:
+            dav_event.delete()
+            return
+        ical.subcomponents.remove(target)
+        _save(dav_event, ical, remaining[0])
+        return
     else:
         _add_exdate(master, occurrence)
         _drop_overrides(ical, master, occurrence, from_occurrence=False)
@@ -267,7 +281,12 @@ def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
         dtstart = datetime.combine(dtstart, time.min)
         target = datetime.combine(target, time.min)
     rule = rrulestr(master["RRULE"].to_ical().decode("utf-8"), dtstart=dtstart)
-    return sum(1 for moment in rule if moment < target)
+    count = 0
+    for moment in rule:
+        if moment >= target:
+            break
+        count += 1
+    return count
 
 
 def _ends_before(master: Any, occurrence: datetime | date) -> bool:
@@ -304,7 +323,7 @@ def _head_uncapped(
     """Return whether the head still holds occurrences from the cutoff on."""
     try:
         ical = calendar.event_by_uid(uid).icalendar_instance
-    except requests.ConnectionError, requests.Timeout, DAVError:
+    except _NETWORK_FAILURES:
         return False
     return _has_occurrences_from(_master(ical), occurrence)
 
@@ -312,7 +331,7 @@ def _head_uncapped(
 def _discard(tail: Any) -> None:
     try:
         tail.delete()
-    except (requests.ConnectionError, requests.Timeout, DAVError) as err:
+    except _NETWORK_FAILURES as err:
         _LOGGER.warning(
             "The split-off series could not be removed after a failed update"
             " and may show duplicate events until the update is retried: %s",

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -265,19 +265,22 @@ def _tail_ics(
     _replace(vevent, "sequence", None)
     _apply(vevent, {**data, "rrule": None})
     rule_changed = False
-    if (supplied := data.get("rrule")) and vRecur.from_ical(
-        supplied
-    ).to_ical() != master["RRULE"].to_ical():
+    if (supplied := data.get("rrule")) and (
+        "RRULE" not in master
+        or vRecur.from_ical(supplied).to_ical() != master["RRULE"].to_ical()
+    ):
         _replace(vevent, "rrule", vRecur.from_ical(supplied))
         rule_changed = True
     else:
         _replace(vevent, "rrule", _tail_rrule(master, occurrence))
-    # Dates anchored to the old schedule are meaningless on a moved tail.
-    if rule_changed or _utc(data["dtstart"]) != _utc(occurrence):
+    if rule_changed:
+        # Dates anchored to the replaced rule are meaningless on the tail.
         _clear_dates(vevent)
     else:
         _keep_dates(vevent, "RDATE", occurrence, before=False)
         _keep_dates(vevent, "EXDATE", occurrence, before=False)
+        if delta := _utc(data["dtstart"]) - _utc(occurrence):
+            _shift_dates(vevent, delta)
     return tail.to_ical().decode("utf-8")
 
 
@@ -374,6 +377,30 @@ def _cap_series(master: Any, occurrence: datetime | date) -> None:
         _replace(master, "rrule", recur)
     _keep_dates(master, "RDATE", occurrence, before=True)
     _keep_dates(master, "EXDATE", occurrence, before=True)
+
+
+def _shift_dates(component: Any, delta: timedelta) -> None:
+    """Move retained RDATE/EXDATE values along with a moved DTSTART."""
+    for key in ("RDATE", "EXDATE"):
+        if key not in component:
+            continue
+        entries = component[key]
+        if not isinstance(entries, list):
+            entries = [entries]
+        shifted = []
+        for entry in entries:
+            rebuilt = vDDDLists([_shifted(item.dt, delta) for item in entry.dts])
+            rebuilt.params = entry.params
+            shifted.append(rebuilt)
+        del component[key]
+        component[key] = shifted if len(shifted) > 1 else shifted[0]
+
+
+def _shifted(value: Any, delta: timedelta) -> Any:
+    if isinstance(value, tuple):
+        end = value[1] + delta if isinstance(value[1], datetime) else value[1]
+        return (value[0] + delta, end)
+    return value + delta
 
 
 def _clear_dates(component: Any) -> None:

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -59,9 +59,7 @@ def update_event(
             _drop_overrides(
                 ical, master, old_start, from_occurrence=False, all_overrides=True
             )
-            for key in ("EXDATE", "RDATE"):
-                if key in master:
-                    del master[key]
+            _clear_dates(master)
         _save(dav_event, ical, master)
         return
 
@@ -74,8 +72,12 @@ def update_event(
         return
 
     if _utc(occurrence) <= _utc(master["DTSTART"].dt):
+        old_start = _utc(master["DTSTART"].dt)
+        old_rule = _rule_string(master)
         _apply(master, data)
         _drop_overrides(ical, master, occurrence, from_occurrence=True)
+        if _rule_string(master) != old_rule or _utc(master["DTSTART"].dt) != old_start:
+            _clear_dates(master)
         _save(dav_event, ical, master)
         return
 
@@ -261,11 +263,21 @@ def _tail_ics(
     _replace(vevent, "uid", _tail_uid(str(master["UID"]), occurrence))
     _replace(vevent, "dtstamp", dt_util.utcnow())
     _replace(vevent, "sequence", None)
-    _apply(vevent, data)
-    if "rrule" not in data:
+    _apply(vevent, {**data, "rrule": None})
+    rule_changed = False
+    if (supplied := data.get("rrule")) and vRecur.from_ical(
+        supplied
+    ).to_ical() != master["RRULE"].to_ical():
+        _replace(vevent, "rrule", vRecur.from_ical(supplied))
+        rule_changed = True
+    else:
         _replace(vevent, "rrule", _tail_rrule(master, occurrence))
-    _keep_dates(vevent, "RDATE", occurrence, before=False)
-    _keep_dates(vevent, "EXDATE", occurrence, before=False)
+    # Dates anchored to the old schedule are meaningless on a moved tail.
+    if rule_changed or _utc(data["dtstart"]) != _utc(occurrence):
+        _clear_dates(vevent)
+    else:
+        _keep_dates(vevent, "RDATE", occurrence, before=False)
+        _keep_dates(vevent, "EXDATE", occurrence, before=False)
     return tail.to_ical().decode("utf-8")
 
 
@@ -362,6 +374,12 @@ def _cap_series(master: Any, occurrence: datetime | date) -> None:
         _replace(master, "rrule", recur)
     _keep_dates(master, "RDATE", occurrence, before=True)
     _keep_dates(master, "EXDATE", occurrence, before=True)
+
+
+def _clear_dates(component: Any) -> None:
+    for key in ("EXDATE", "RDATE"):
+        if key in component:
+            del component[key]
 
 
 def _keep_dates(

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -290,9 +290,11 @@ def _tail_ics(
     _keep_dates(vevent, "EXDATE", occurrence, before=False)
     # A wall-clock delta keeps shifted values stable across DST changes.
     if delta := _wall(master, data["dtstart"]) - _wall(master, occurrence):
-        _shift_dates(vevent, delta)
+        dtstart = master["DTSTART"].dt
+        zone = dtstart.tzinfo if isinstance(dtstart, datetime) else None
+        _shift_dates(vevent, delta, zone)
         if (recur := vevent.get("RRULE")) is not None and (until := recur.get("UNTIL")):
-            recur["UNTIL"] = [until[0] + delta]
+            recur["UNTIL"] = [_shifted(until[0], delta, zone)]
     return tail.to_ical().decode("utf-8")
 
 
@@ -440,7 +442,7 @@ def _cap_series(master: Any, occurrence: datetime | date) -> None:
     _keep_dates(master, "EXDATE", occurrence, before=True)
 
 
-def _shift_dates(component: Any, delta: timedelta) -> None:
+def _shift_dates(component: Any, delta: timedelta, zone: Any) -> None:
     """Move retained RDATE/EXDATE values along with a moved DTSTART."""
     for key in ("RDATE", "EXDATE"):
         if key not in component:
@@ -450,18 +452,27 @@ def _shift_dates(component: Any, delta: timedelta) -> None:
             entries = [entries]
         shifted = []
         for entry in entries:
-            rebuilt = vDDDLists([_shifted(item.dt, delta) for item in entry.dts])
+            rebuilt = vDDDLists([_shifted(item.dt, delta, zone) for item in entry.dts])
             rebuilt.params = entry.params
             shifted.append(rebuilt)
         del component[key]
         component[key] = shifted if len(shifted) > 1 else shifted[0]
 
 
-def _shifted(value: Any, delta: timedelta) -> Any:
+def _shifted(value: Any, delta: timedelta, zone: Any) -> Any:
+    """Shift in the series' wall clock, keeping the value's representation."""
     if isinstance(value, tuple):
-        end = value[1] + delta if isinstance(value[1], datetime) else value[1]
-        return (value[0] + delta, end)
-    return value + delta
+        end = (
+            _shifted(value[1], delta, zone)
+            if isinstance(value[1], datetime)
+            else value[1]
+        )
+        return (_shifted(value[0], delta, zone), end)
+    if not isinstance(value, datetime) or value.tzinfo is None:
+        return value + delta
+    anchor = zone or dt_util.get_default_time_zone()
+    wall = value.astimezone(anchor).replace(tzinfo=None) + delta
+    return wall.replace(tzinfo=anchor).astimezone(value.tzinfo)
 
 
 def _clear_dates(component: Any) -> None:

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -51,12 +51,17 @@ def update_event(
 
     if recurrence_id is None:
         old_start = _utc(master["DTSTART"].dt)
+        old_rule = _rule_string(master)
         _apply(master, data)
-        # A new rule or start invalidates the RECURRENCE-IDs of overrides.
-        if data.get("rrule") or _utc(master["DTSTART"].dt) != old_start:
+        # A changed rule or start invalidates everything anchored to the old
+        # schedule: overrides, exception dates and added dates alike.
+        if _rule_string(master) != old_rule or _utc(master["DTSTART"].dt) != old_start:
             _drop_overrides(
                 ical, master, old_start, from_occurrence=False, all_overrides=True
             )
+            for key in ("EXDATE", "RDATE"):
+                if key in master:
+                    del master[key]
         _save(dav_event, ical, master)
         return
 
@@ -176,6 +181,11 @@ def _master(ical: Any) -> Any:
         if "RECURRENCE-ID" not in vevent:
             return vevent
     return vevents[0]
+
+
+def _rule_string(master: Any) -> str | None:
+    rrule = master.get("RRULE")
+    return rrule.to_ical().decode("utf-8") if rrule is not None else None
 
 
 def _overrides(ical: Any) -> list[Any]:

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -57,9 +57,10 @@ def update_event(
         # A changed rule or start invalidates everything anchored to the old
         # schedule: overrides, exception dates and added dates alike.
         start_moved = _utc(master["DTSTART"].dt) != old_start
-        if start_moved and not data.get("rrule") and not _self_anchored(master):
+        rule_changed = _rule_string(master) != old_rule
+        if start_moved and not rule_changed and not _self_anchored(master):
             raise ValueError("The new start does not match the recurrence rule")
-        if _rule_string(master) != old_rule or start_moved:
+        if rule_changed or start_moved:
             _drop_overrides(
                 ical, master, old_start, from_occurrence=False, all_overrides=True
             )
@@ -68,6 +69,9 @@ def update_event(
         return
 
     occurrence = parse_recurrence_id(recurrence_id)
+
+    if this_and_future and "RECURRENCE-ID" in master:
+        raise ValueError("Event is not a recurring series")
 
     if not this_and_future:
         target = _override(ical, occurrence) or _new_override(ical, master, occurrence)
@@ -81,9 +85,10 @@ def update_event(
         _apply(master, data)
         _drop_overrides(ical, master, occurrence, from_occurrence=True)
         start_moved = _utc(master["DTSTART"].dt) != old_start
-        if start_moved and not data.get("rrule") and not _self_anchored(master):
+        rule_changed = _rule_string(master) != old_rule
+        if start_moved and not rule_changed and not _self_anchored(master):
             raise ValueError("The new start does not match the recurrence rule")
-        if _rule_string(master) != old_rule or start_moved:
+        if rule_changed or start_moved:
             _clear_dates(master)
         _save(dav_event, ical, master)
         return

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -7,14 +7,16 @@ series lives in a single calendar object that has to be rewritten by hand.
 
 A single occurrence is dropped with an EXDATE and changed through an overriding
 VEVENT carrying a RECURRENCE-ID. "This and future" caps the RRULE with UNTIL.
-RFC 5545 requires EXDATE and RECURRENCE-ID to use the value type of DTSTART,
-and UNTIL to be UTC whenever DTSTART is a datetime.
+RFC 5545 requires EXDATE, RECURRENCE-ID and UNTIL to follow DTSTART: its value
+type, and its zone or lack of one. A floating DTSTART keeps them floating; a
+zoned one puts them in UTC.
 """
 
 from datetime import UTC, date, datetime, time, timedelta
 from typing import Any
 
 import caldav
+from dateutil.rrule import rrulestr
 from icalendar import Event as ICalEvent, vDDDTypes, vRecur
 
 from homeassistant.util import dt as dt_util
@@ -52,13 +54,16 @@ def update_event(
 
     # RFC 4791 allows only one UID per object, so the tail needs its own.
     tail = dict(data)
-    if tail.get("rrule") is None:
-        tail.pop("rrule", None)
+    tail.setdefault("rrule", _tail_rrule(master, occurrence))
+    if tail["rrule"] is None:
+        del tail["rrule"]
 
+    # Creating the tail first costs a visible duplicate if capping then fails,
+    # where capping first would silently drop every occurrence from here on.
+    calendar.add_event(**tail)
     _cap_series(master, occurrence)
     _drop_overrides(ical, occurrence, from_occurrence=True)
     _save(dav_event, ical, master)
-    calendar.add_event(**tail)
 
 
 def delete_event(
@@ -140,7 +145,7 @@ def _new_override(ical: Any, master: Any, occurrence: datetime | date) -> Any:
     override = ICalEvent()
     override.add("UID", str(master["UID"]))
     override.add("DTSTAMP", dt_util.utcnow())
-    override.add("RECURRENCE-ID", vDDDTypes(_match_type(master, occurrence)))
+    override.add("RECURRENCE-ID", vDDDTypes(_align(master, occurrence)))
     ical.add_component(override)
     return override
 
@@ -155,15 +160,41 @@ def _drop_overrides(
             ical.subcomponents.remove(vevent)
 
 
-def _match_type(master: Any, occurrence: datetime | date) -> datetime | date:
-    """Return the occurrence in the value type the master DTSTART uses."""
-    if isinstance(master["DTSTART"].dt, datetime):
-        return _utc(occurrence)
-    return occurrence.date() if isinstance(occurrence, datetime) else occurrence
+def _align(master: Any, occurrence: datetime | date) -> datetime | date:
+    """Return the occurrence in the value type and zone the master DTSTART uses."""
+    dtstart = master["DTSTART"].dt
+    if not isinstance(dtstart, datetime):
+        return occurrence.date() if isinstance(occurrence, datetime) else occurrence
+    if not isinstance(occurrence, datetime):
+        occurrence = datetime.combine(occurrence, time.min)
+    if dtstart.tzinfo is None:
+        return occurrence.replace(tzinfo=None)
+    return _utc(occurrence)
 
 
 def _add_exdate(master: Any, occurrence: datetime | date) -> None:
-    master.add("EXDATE", vDDDTypes(_match_type(master, occurrence)))
+    master.add("EXDATE", vDDDTypes(_align(master, occurrence)))
+
+
+def _tail_rrule(master: Any, occurrence: datetime | date) -> str | None:
+    """Return the rule for the tail, with COUNT reduced by the capped head."""
+    rrule = master.get("RRULE")
+    if rrule is None:
+        return None
+    recur = vRecur(dict(rrule))
+    if count := recur.get("COUNT"):
+        recur["COUNT"] = [max(count[0] - _occurrences_before(master, occurrence), 1)]
+    return recur.to_ical().decode("utf-8")
+
+
+def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
+    dtstart = master["DTSTART"].dt
+    target = _align(master, occurrence)
+    if not isinstance(dtstart, datetime):
+        dtstart = datetime.combine(dtstart, time.min)
+        target = datetime.combine(target, time.min)
+    rule = rrulestr(master["RRULE"].to_ical().decode("utf-8"), dtstart=dtstart)
+    return sum(1 for moment in rule if moment < target)
 
 
 def _cap_series(master: Any, occurrence: datetime | date) -> None:
@@ -178,10 +209,10 @@ def _cap_series(master: Any, occurrence: datetime | date) -> None:
 
 def _until(master: Any, occurrence: datetime | date) -> datetime | date:
     """Return an UNTIL that stops the series before the occurrence."""
-    if isinstance(master["DTSTART"].dt, datetime):
-        return _utc(occurrence) - timedelta(seconds=1)
-    day = occurrence.date() if isinstance(occurrence, datetime) else occurrence
-    return day - timedelta(days=1)
+    aligned = _align(master, occurrence)
+    if isinstance(aligned, datetime):
+        return aligned - timedelta(seconds=1)
+    return aligned - timedelta(days=1)
 
 
 def _apply(component: Any, data: dict[str, Any]) -> None:
@@ -194,12 +225,11 @@ def _apply(component: Any, data: dict[str, Any]) -> None:
         _replace(component, "dtend", data["dtend"])
     _replace(component, "description", data.get("description"))
     _replace(component, "location", data.get("location"))
-    if "rrule" in data:
-        _replace(
-            component,
-            "rrule",
-            vRecur.from_ical(data["rrule"]) if data["rrule"] else None,
-        )
+    # An absent rrule means "leave the recurrence alone": the coordinator
+    # expands series server side, so CalendarEvent.rrule is never populated and
+    # the frontend cannot echo the existing rule back.
+    if rrule := data.get("rrule"):
+        _replace(component, "rrule", vRecur.from_ical(rrule))
 
 
 def _save(dav_event: caldav.CalendarObjectResource, ical: Any, touched: Any) -> None:

--- a/homeassistant/components/caldav/recurrence.py
+++ b/homeassistant/components/caldav/recurrence.py
@@ -55,7 +55,10 @@ def update_event(
         _apply(master, data)
         # A changed rule or start invalidates everything anchored to the old
         # schedule: overrides, exception dates and added dates alike.
-        if _rule_string(master) != old_rule or _utc(master["DTSTART"].dt) != old_start:
+        start_moved = _utc(master["DTSTART"].dt) != old_start
+        if start_moved and not data.get("rrule") and not _self_anchored(master):
+            raise ValueError("The new start does not match the recurrence rule")
+        if _rule_string(master) != old_rule or start_moved:
             _drop_overrides(
                 ical, master, old_start, from_occurrence=False, all_overrides=True
             )
@@ -76,7 +79,10 @@ def update_event(
         old_rule = _rule_string(master)
         _apply(master, data)
         _drop_overrides(ical, master, occurrence, from_occurrence=True)
-        if _rule_string(master) != old_rule or _utc(master["DTSTART"].dt) != old_start:
+        start_moved = _utc(master["DTSTART"].dt) != old_start
+        if start_moved and not data.get("rrule") and not _self_anchored(master):
+            raise ValueError("The new start does not match the recurrence rule")
+        if _rule_string(master) != old_rule or start_moved:
             _clear_dates(master)
         _save(dav_event, ical, master)
         return
@@ -93,7 +99,7 @@ def update_event(
     # and reschedule every remaining rule occurrence.
     if (
         master.get("RRULE") is not None
-        and not data.get("rrule")
+        and not _rule_replaced(master, data)
         and not _ends_before(master, occurrence)
         and not _on_rule(master, occurrence)
     ):
@@ -274,23 +280,19 @@ def _tail_ics(
     _replace(vevent, "dtstamp", dt_util.utcnow())
     _replace(vevent, "sequence", None)
     _apply(vevent, {**data, "rrule": None})
-    rule_changed = False
-    if (supplied := data.get("rrule")) and (
-        "RRULE" not in master
-        or vRecur.from_ical(supplied).to_ical() != master["RRULE"].to_ical()
-    ):
-        _replace(vevent, "rrule", vRecur.from_ical(supplied))
-        rule_changed = True
-    else:
-        _replace(vevent, "rrule", _tail_rrule(master, occurrence))
-    if rule_changed:
+    if _rule_replaced(master, data):
+        _replace(vevent, "rrule", vRecur.from_ical(data["rrule"]))
         # Dates anchored to the replaced rule are meaningless on the tail.
         _clear_dates(vevent)
-    else:
-        _keep_dates(vevent, "RDATE", occurrence, before=False)
-        _keep_dates(vevent, "EXDATE", occurrence, before=False)
-        if delta := _utc(data["dtstart"]) - _utc(occurrence):
-            _shift_dates(vevent, delta)
+        return tail.to_ical().decode("utf-8")
+    _replace(vevent, "rrule", _tail_rrule(master, occurrence))
+    _keep_dates(vevent, "RDATE", occurrence, before=False)
+    _keep_dates(vevent, "EXDATE", occurrence, before=False)
+    # A wall-clock delta keeps shifted values stable across DST changes.
+    if delta := _wall(master, data["dtstart"]) - _wall(master, occurrence):
+        _shift_dates(vevent, delta)
+        if (recur := vevent.get("RRULE")) is not None and (until := recur.get("UNTIL")):
+            recur["UNTIL"] = [until[0] + delta]
     return tail.to_ical().decode("utf-8")
 
 
@@ -322,6 +324,42 @@ def _occurrences_before(master: Any, occurrence: datetime | date) -> int:
             break
         count += 1
     return count
+
+
+def _rule_replaced(master: Any, data: dict[str, Any]) -> bool:
+    supplied = data.get("rrule")
+    if not supplied:
+        return False
+    return (
+        "RRULE" not in master
+        or vRecur.from_ical(supplied).to_ical() != master["RRULE"].to_ical()
+    )
+
+
+def _self_anchored(master: Any) -> bool:
+    """Return whether DTSTART is itself an occurrence of the rule."""
+    rrule = master.get("RRULE")
+    if rrule is None:
+        return True
+    dtstart = master["DTSTART"].dt
+    start = (
+        dtstart
+        if isinstance(dtstart, datetime)
+        else datetime.combine(dtstart, time.min)
+    )
+    rule = rrulestr(rrule.to_ical().decode("utf-8"), dtstart=start)
+    return next(iter(rule), None) == start
+
+
+def _wall(master: Any, value: datetime | date) -> datetime:
+    """Return the value as wall-clock time in the DTSTART anchor."""
+    dtstart = master["DTSTART"].dt
+    if not isinstance(dtstart, datetime):
+        aligned = _align(master, value)
+        return datetime.combine(aligned, time.min)
+    moment = _utc(value)
+    zone = dtstart.tzinfo or dt_util.get_default_time_zone()
+    return moment.astimezone(zone).replace(tzinfo=None)
 
 
 def _on_rule(master: Any, occurrence: datetime | date) -> bool:

--- a/tests/components/caldav/conftest.py
+++ b/tests/components/caldav/conftest.py
@@ -1,7 +1,10 @@
 """Test fixtures for caldav."""
 
+from collections.abc import Awaitable, Callable
+from typing import Any
 from unittest.mock import Mock, patch
 
+from aiohttp import ClientWebSocketResponse
 import pytest
 
 from homeassistant.components.caldav.const import DOMAIN
@@ -12,8 +15,10 @@ from homeassistant.const import (
     CONF_VERIFY_SSL,
     Platform,
 )
+from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
+from tests.typing import WebSocketGenerator
 
 TEST_URL = "https://example.com/url-1"
 TEST_USERNAME = "username-1"
@@ -63,3 +68,54 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_VERIFY_SSL: True,
         },
     )
+
+
+class Client:
+    """Test client with helper methods for the calendar websocket."""
+
+    def __init__(self, client: ClientWebSocketResponse) -> None:
+        """Initialize Client."""
+        self.client = client
+        self.id = 0
+
+    async def cmd(
+        self, cmd: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        """Send a command and receive the json result."""
+        self.id += 1
+        await self.client.send_json(
+            {
+                "id": self.id,
+                "type": f"calendar/event/{cmd}",
+                **(payload if payload is not None else {}),
+            }
+        )
+        resp = await self.client.receive_json()
+        assert resp.get("id") == self.id
+        return resp
+
+    async def cmd_result(
+        self, cmd: str, payload: dict[str, Any] | None = None
+    ) -> dict[str, Any] | None:
+        """Send a command and parse the result."""
+        resp = await self.cmd(cmd, payload)
+        assert resp.get("success")
+        assert resp.get("type") == "result"
+        return resp.get("result")
+
+
+type ClientFixture = Callable[[], Awaitable[Client]]
+
+
+@pytest.fixture
+async def ws_client(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> ClientFixture:
+    """Fixture for creating the test websocket client."""
+
+    async def create_client() -> Client:
+        ws_client = await hass_ws_client(hass)
+        return Client(ws_client)
+
+    return create_client

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -1637,7 +1637,11 @@ async def test_update_event_this_and_future(
             "uid": "rec-1",
             "recurrence_id": "2017-11-29 17:00:00+00:00",
             "recurrence_range": "THISANDFUTURE",
-            "event": UPDATED_EVENT,
+            "event": UPDATED_EVENT
+            | {
+                "dtstart": "2017-11-29T17:00:00+00:00",
+                "dtend": "2017-11-29T18:00:00+00:00",
+            },
         },
     )
 
@@ -1650,6 +1654,9 @@ async def test_update_event_this_and_future(
     tail = _saved_tail(calendars[0])
     assert tail["UID"] == "rec-1-20171129T170000Z"
     assert tail["SUMMARY"] == "Renamed standup"
+    assert tail["DTSTART"].dt == datetime.datetime(
+        2017, 11, 29, 17, 0, tzinfo=datetime.UTC
+    )
     # Two occurrences stay in the capped head, so three are left for the tail.
     assert tail["RRULE"]["COUNT"] == [3]
 
@@ -2600,3 +2607,169 @@ async def test_delete_event_this_and_future_keeps_exdate_zones(
     assert [item.dt for item in utc.dts] == [
         datetime.datetime(2017, 11, 29, 16, 0, tzinfo=datetime.UTC)
     ]
+
+
+async def test_update_event_new_rrule_drops_overrides(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that replacing the rule clears overrides of the old series."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OVERRIDDEN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": UPDATED_EVENT | {"rrule": "FREQ=WEEKLY"},
+        },
+    )
+
+    assert not _overrides(event)
+
+
+async def test_update_event_single_occurrence_ignores_rrule(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a rule in the payload cannot make an override recurring."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+            "event": UPDATED_EVENT | {"rrule": "FREQ=WEEKLY"},
+        },
+    )
+
+    (override,) = _overrides(event)
+    assert "RRULE" not in override
+    assert _master(event)["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"
+
+
+async def test_update_event_rejects_all_day_toggle(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a series cannot switch between timed and all day."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Renamed standup",
+                "dtstart": "2017-11-27",
+                "dtend": "2017-11-28",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "all-day" in resp["error"]["message"]
+    event.save.assert_not_called()
+
+
+async def test_update_event_single_occurrence_keeps_master_data(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a new override inherits what the edit cannot carry."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], RICH_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 16:00:00+00:00",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    (override,) = _overrides(event)
+    assert str(override["ATTENDEE"]) == "mailto:dev@example.com"
+    assert any(item.name == "VALARM" for item in override.subcomponents)
+    assert "RRULE" not in override
+
+
+ORPHAN_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+RECURRENCE-ID:20171128T170000Z
+DTSTART:20171128T190000Z
+DTEND:20171128T200000Z
+SUMMARY:Orphan override
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_orphan_override(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that editing an object holding only an override keeps it."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], ORPHAN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": UPDATED_EVENT
+            | {
+                "dtstart": "2017-11-28T20:00:00+00:00",
+                "dtend": "2017-11-28T21:00:00+00:00",
+            },
+        },
+    )
+
+    vevents = list(event.icalendar_instance.walk("VEVENT"))
+    assert len(vevents) == 1
+    assert vevents[0]["SUMMARY"] == "Renamed standup"
+
+
+async def test_delete_occurrence_of_orphan_override(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that cancelling the orphan's occurrence keeps the resource valid."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], ORPHAN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+        },
+    )
+
+    assert len(list(event.icalendar_instance.walk("VEVENT"))) == 1

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -8,7 +8,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 import zoneinfo
 
-from caldav.lib.error import NotFoundError
+from caldav.lib.error import DAVError, NotFoundError
 from caldav.objects import Event
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -1626,7 +1626,7 @@ async def test_update_event_this_and_future(
             "uid": "rec-1",
             "recurrence_id": "2017-11-29 17:00:00+00:00",
             "recurrence_range": "THISANDFUTURE",
-            "event": UPDATED_EVENT | {"rrule": "FREQ=DAILY;COUNT=5"},
+            "event": UPDATED_EVENT,
         },
     )
 
@@ -1639,7 +1639,8 @@ async def test_update_event_this_and_future(
     calendars[0].add_event.assert_called_once()
     tail = calendars[0].add_event.call_args[1]
     assert tail["summary"] == "Renamed standup"
-    assert tail["rrule"] == "FREQ=DAILY;COUNT=5"
+    # Two occurrences stay in the capped head, so three are left for the tail.
+    assert tail["rrule"] == "FREQ=DAILY;COUNT=3"
 
 
 async def test_update_event_not_found(
@@ -1709,49 +1710,6 @@ SUMMARY:One off
 END:VEVENT
 END:VCALENDAR
 """
-
-
-async def test_update_event_removes_recurrence(
-    setup_platform_cb: Callable[[], Awaitable[None]],
-    calendars: list[Mock],
-    ws_client: ClientFixture,
-) -> None:
-    """Test that a series updated without an rrule loses its recurrence."""
-    await setup_platform_cb()
-    event = _mock_dav_event(calendars[0])
-
-    client = await ws_client()
-    await client.cmd_result(
-        "update",
-        {"entity_id": TEST_ENTITY, "uid": "rec-1", "event": UPDATED_EVENT},
-    )
-
-    assert "RRULE" not in _master(event)
-
-
-async def test_update_event_this_and_future_removes_recurrence(
-    setup_platform_cb: Callable[[], Awaitable[None]],
-    calendars: list[Mock],
-    ws_client: ClientFixture,
-) -> None:
-    """Test that the split off tail does not inherit a removed recurrence."""
-    await setup_platform_cb()
-    _mock_dav_event(calendars[0])
-    calendars[0].add_event = MagicMock(return_value=[])
-
-    client = await ws_client()
-    await client.cmd_result(
-        "update",
-        {
-            "entity_id": TEST_ENTITY,
-            "uid": "rec-1",
-            "recurrence_id": "2017-11-29 17:00:00+00:00",
-            "recurrence_range": "THISANDFUTURE",
-            "event": UPDATED_EVENT,
-        },
-    )
-
-    assert "rrule" not in calendars[0].add_event.call_args[1]
 
 
 async def test_update_event_existing_override(
@@ -1906,7 +1864,7 @@ async def test_update_event_first_occurrence_and_future(
             "uid": "rec-1",
             "recurrence_id": "2017-11-27 17:00:00+00:00",
             "recurrence_range": "THISANDFUTURE",
-            "event": UPDATED_EVENT | {"rrule": "FREQ=DAILY;COUNT=5"},
+            "event": UPDATED_EVENT,
         },
     )
 
@@ -1914,3 +1872,118 @@ async def test_update_event_first_occurrence_and_future(
     master = _master(event)
     assert master["SUMMARY"] == "Renamed standup"
     assert master["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"
+
+
+FLOATING_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000
+DTEND:20171127T180000
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Floating standup
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_keeps_recurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that an update without an rrule leaves the series recurring.
+
+    The coordinator expands recurring events, so CalendarEvent.rrule is never
+    populated and the frontend cannot echo the rule back on an ordinary edit.
+    """
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {"entity_id": TEST_ENTITY, "uid": "rec-1", "event": UPDATED_EVENT},
+    )
+
+    master = _master(event)
+    assert master["SUMMARY"] == "Renamed standup"
+    assert master["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"
+
+
+async def test_update_event_this_and_future_creates_tail_first(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a failure to store the tail leaves the series untouched."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+    calendars[0].add_event = MagicMock(side_effect=DAVError("boom"))
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    event.save.assert_not_called()
+    assert _master(event)["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"
+
+
+async def test_delete_floating_event_single_occurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a floating series gets a floating EXDATE."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], FLOATING_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00",
+        },
+    )
+
+    exdate = _master(event)["EXDATE"].dts[0].dt
+    assert exdate == datetime.datetime(2017, 11, 28, 17, 0)
+    assert exdate.tzinfo is None
+
+
+async def test_delete_floating_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a floating series gets a floating UNTIL, as RFC 5545 requires."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], FLOATING_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    until = _master(event)["RRULE"]["UNTIL"][0]
+    assert until == datetime.datetime(2017, 11, 29, 16, 59, 59)
+    assert until.tzinfo is None

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2999,3 +2999,50 @@ async def test_update_moved_rdate_only_tail_shifts_dates(
         datetime.datetime(2017, 11, 29, 18, 0, tzinfo=datetime.UTC),
         datetime.datetime(2017, 12, 1, 18, 0, tzinfo=datetime.UTC),
     ]
+
+
+OFF_RULE_RDATE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=WEEKLY;COUNT=5
+RDATE:20171129T170000Z
+SUMMARY:Weekly with extra day
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_off_rule_rdate_split_rejected(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that splitting at an added date cannot re-anchor the rule."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OFF_RULE_RDATE_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed",
+                "dtstart": "2017-11-29T17:00:00+00:00",
+                "dtend": "2017-11-29T18:00:00+00:00",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "added date" in resp["error"]["message"]
+    calendars[0].save_event.assert_not_called()
+    event.save.assert_not_called()

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2102,6 +2102,8 @@ async def test_update_event_this_and_future_rolls_back_tail(
     """Test that a failure to cap the head removes the stored tail again."""
     await setup_platform_cb()
     event = _mock_dav_event(calendars[0])
+    fresh = Event(None, "rec-1.ics", RECURRING_ICS, calendars[0], "rec-1")
+    calendars[0].event_by_uid = MagicMock(side_effect=[event, fresh])
     tail = Mock()
     calendars[0].save_event = MagicMock(return_value=tail)
     event.save.side_effect = DAVError("boom")
@@ -2170,7 +2172,8 @@ async def test_delete_event_this_and_future_drops_future_rdates(
     )
 
     master = _master(event)
-    assert "UNTIL" in master["RRULE"]
+    # The rule ends before the cutoff; an UNTIL there would add occurrences.
+    assert master["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=3"
     assert [item.dt for item in master["RDATE"].dts] == [
         datetime.datetime(2017, 12, 1, 17, 0, tzinfo=datetime.UTC)
     ]
@@ -2360,6 +2363,8 @@ async def test_update_event_this_and_future_rollback_failure(
     """Test that a failing rollback still reports the original error."""
     await setup_platform_cb()
     event = _mock_dav_event(calendars[0])
+    fresh = Event(None, "rec-1.ics", RECURRING_ICS, calendars[0], "rec-1")
+    calendars[0].event_by_uid = MagicMock(side_effect=[event, fresh])
     tail = Mock()
     tail.delete.side_effect = DAVError("still down")
     calendars[0].save_event = MagicMock(return_value=tail)
@@ -2380,3 +2385,218 @@ async def test_update_event_this_and_future_rollback_failure(
     assert not resp["success"]
     assert "boom" in resp["error"]["message"]
     assert "could not be removed" in caplog.text
+
+
+CAPPED_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=DAILY;UNTIL=20171129T165959Z
+SUMMARY:Daily standup
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_keeps_start_anchor(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a summary-only edit does not re-anchor the start time."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], RICH_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Renamed standup",
+                "dtstart": "2017-11-27T16:00:00+00:00",
+                "dtend": "2017-11-27T17:00:00+00:00",
+            },
+        },
+    )
+
+    dtstart = _master(event)["DTSTART"]
+    assert dtstart.dt == datetime.datetime(
+        2017, 11, 27, 17, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Berlin")
+    )
+    assert str(dtstart.dt.tzinfo) == "Europe/Berlin"
+
+
+@pytest.mark.parametrize("tz", [UTC])
+async def test_update_event_moves_floating_start(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a moved time on a floating series stays floating."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], FLOATING_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Floating standup",
+                "dtstart": "2017-11-27T18:00:00+00:00",
+                "dtend": "2017-11-27T19:00:00+00:00",
+            },
+        },
+    )
+
+    dtstart = _master(event)["DTSTART"].dt
+    assert dtstart == datetime.datetime(2017, 11, 27, 18, 0)
+    assert dtstart.tzinfo is None
+
+
+async def test_update_event_this_and_future_replayed(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that replaying a finished split does not clone the capped head."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], CAPPED_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    calendars[0].save_event.assert_not_called()
+    event.save.assert_not_called()
+
+
+async def test_update_event_first_occurrence_drops_overrides(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that an edit of every future occurrence clears old overrides."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OVERRIDDEN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-27 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert _master(event)["SUMMARY"] == "Renamed standup"
+    assert not _overrides(event)
+
+
+async def test_update_event_this_and_future_ambiguous_failure(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that the tail survives when the head state cannot be verified."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+    calendars[0].event_by_uid = MagicMock(side_effect=[event, DAVError("down")])
+    tail = Mock()
+    calendars[0].save_event = MagicMock(return_value=tail)
+    event.save.side_effect = DAVError("boom")
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    tail.delete.assert_not_called()
+    assert "Keeping the split-off series" in caplog.text
+
+
+MIXED_TZ_EXDATE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:STANDARD
+DTSTART:19701025T030000
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART;TZID=Europe/Berlin:20171127T170000
+DTEND;TZID=Europe/Berlin:20171127T180000
+RRULE:FREQ=DAILY;COUNT=10
+EXDATE;TZID=Europe/Berlin:20171128T170000,20171204T170000
+EXDATE:20171129T160000Z
+SUMMARY:Daily standup
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_delete_event_this_and_future_keeps_exdate_zones(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that filtering EXDATEs does not merge lines with different zones."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], MIXED_TZ_EXDATE_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-01 16:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    entries = _master(event)["EXDATE"]
+    assert isinstance(entries, list)
+    berlin, utc = entries
+    assert berlin.params["TZID"] == "Europe/Berlin"
+    assert [item.dt for item in berlin.dts] == [
+        datetime.datetime(
+            2017, 11, 28, 17, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Berlin")
+        )
+    ]
+    assert [item.dt for item in utc.dts] == [
+        datetime.datetime(2017, 11, 29, 16, 0, tzinfo=datetime.UTC)
+    ]

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -3119,3 +3119,117 @@ async def test_update_event_off_rule_split_with_resubmitted_rule_rejected(
     assert not resp["success"]
     assert "added date" in resp["error"]["message"]
     event.save.assert_not_called()
+
+
+DURATION_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000
+DURATION:PT1H
+SUMMARY:Floating with duration
+END:VEVENT
+END:VCALENDAR
+"""
+
+SECONDLY_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=SECONDLY
+SUMMARY:Way too dense
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_tail_move_against_anchored_rule_rejected(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that moving a day-bound tail to another day needs a new rule."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], BYDAY_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-04 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Tuesday sync",
+                "dtstart": "2017-12-05T17:00:00+00:00",
+                "dtend": "2017-12-05T18:00:00+00:00",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "does not match the recurrence rule" in resp["error"]["message"]
+    calendars[0].save_event.assert_not_called()
+    event.save.assert_not_called()
+
+
+async def test_update_duration_event_keeps_floating_end(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a synthesized end follows the floating start."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], DURATION_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Renamed",
+                "dtstart": "2017-11-27T17:00:00+00:00",
+                "dtend": "2017-11-27T18:30:00+00:00",
+            },
+        },
+    )
+
+    master = _master(event)
+    assert "DURATION" not in master
+    assert master["DTEND"].dt.tzinfo is None
+    assert master["DTSTART"].dt.tzinfo is None
+
+
+async def test_update_dense_rule_rejected(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a secondly rule cannot tie up the executor."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], SECONDLY_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-27 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    assert "too dense" in resp["error"]["message"]
+    event.save.assert_not_called()

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -20,8 +20,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
+from .conftest import ClientFixture
+
 from tests.common import MockConfigEntry
 from tests.typing import ClientSessionGenerator
+
+SUPPORTED_FEATURES = (
+    CalendarEntityFeature.CREATE_EVENT
+    | CalendarEntityFeature.UPDATE_EVENT
+    | CalendarEntityFeature.DELETE_EVENT
+)
 
 EVENTS = [
     """BEGIN:VCALENDAR
@@ -460,7 +468,7 @@ async def test_ongoing_event(
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -485,7 +493,7 @@ async def test_just_ended_event(
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -510,7 +518,7 @@ async def test_ongoing_event_different_tz(
         "description": "Sunny day",
         "end_time": "2017-11-27 17:30:00",
         "location": "San Francisco",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -535,7 +543,7 @@ async def test_ongoing_floating_event_returned(
         "end_time": "2017-11-27 20:00:00",
         "location": "Hamburg",
         "description": "What a day",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -560,7 +568,7 @@ async def test_ongoing_event_with_offset(
         "end_time": "2017-11-27 11:00:00",
         "location": "Hamburg",
         "description": "Surprisingly shiny",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -601,7 +609,7 @@ async def test_matching_filter(
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -643,7 +651,7 @@ async def test_matching_filter_real_regexp(
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -676,7 +684,7 @@ async def test_filter_matching_past_event(
     assert dict(state.attributes) == {
         "friendly_name": CALENDAR_NAME,
         "offset_reached": False,
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -708,7 +716,7 @@ async def test_no_result_with_filtering(
     assert dict(state.attributes) == {
         "friendly_name": CALENDAR_NAME,
         "offset_reached": False,
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -766,7 +774,7 @@ async def test_all_day_event(
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
         "description": "What a beautiful day",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -791,7 +799,7 @@ async def test_event_rrule(
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
         "description": "Every day for a while",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -816,7 +824,7 @@ async def test_event_rrule_ongoing(
         "end_time": "2017-11-27 22:30:00",
         "location": "Hamburg",
         "description": "Every day for a while",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -841,7 +849,7 @@ async def test_event_rrule_duration(
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
         "description": "Every day for a while as well",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -866,7 +874,7 @@ async def test_event_rrule_duration_ongoing(
         "end_time": "2017-11-27 23:30:00",
         "location": "Hamburg",
         "description": "Every day for a while as well",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -891,7 +899,7 @@ async def test_event_rrule_endless(
         "end_time": "2017-11-27 23:59:59",
         "location": "Hamburg",
         "description": "Every day forever",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -951,7 +959,7 @@ async def test_event_rrule_all_day_early(
         "end_time": "2016-12-02 00:00:00",
         "location": "Hamburg",
         "description": "Groundhog Day",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -976,7 +984,7 @@ async def test_event_rrule_hourly_on_first(
         "end_time": "2015-11-27 00:30:00",
         "location": "Hamburg",
         "description": "The bell tolls for thee",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -1001,7 +1009,7 @@ async def test_event_rrule_hourly_on_last(
         "end_time": "2015-11-27 11:30:00",
         "location": "Hamburg",
         "description": "The bell tolls for thee",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -1188,7 +1196,7 @@ async def test_setup_config_entry(
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
         "description": "What a beautiful day",
-        "supported_features": CalendarEntityFeature.CREATE_EVENT,
+        "supported_features": SUPPORTED_FEATURES,
     }
 
 
@@ -1409,3 +1417,500 @@ async def test_missing_supported_components_not_assumed(
     caplog.clear()
     await async_get_calendars(hass, client, "VJOURNAL")
     assert warning_msg not in caplog.text
+
+
+RECURRING_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Daily standup
+END:VEVENT
+END:VCALENDAR
+"""
+
+UPDATED_EVENT = {
+    "summary": "Renamed standup",
+    "dtstart": "2017-11-27T17:00:00+00:00",
+    "dtend": "2017-11-27T18:00:00+00:00",
+}
+
+
+def _mock_dav_event(calendar: Mock, ics: str = RECURRING_ICS) -> Event:
+    """Return a real caldav Event whose writes are captured instead of sent."""
+    event = Event(None, "rec-1.ics", ics, calendar, "rec-1")
+    event.save = MagicMock()
+    event.delete = MagicMock()
+    calendar.event_by_uid = MagicMock(return_value=event)
+    return event
+
+
+def _master(event: Event) -> Any:
+    return next(
+        vevent
+        for vevent in event.icalendar_instance.walk("VEVENT")
+        if "RECURRENCE-ID" not in vevent
+    )
+
+
+def _overrides(event: Event) -> list[Any]:
+    return [
+        vevent
+        for vevent in event.icalendar_instance.walk("VEVENT")
+        if "RECURRENCE-ID" in vevent
+    ]
+
+
+async def test_delete_event(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test deleting a whole series."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result("delete", {"entity_id": TEST_ENTITY, "uid": "rec-1"})
+
+    event.delete.assert_called_once()
+
+
+async def test_delete_event_single_occurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test cancelling one occurrence leaves the series in place."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+        },
+    )
+
+    event.delete.assert_not_called()
+    master = _master(event)
+    assert master["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"
+    assert master["EXDATE"].dts[0].dt == datetime.datetime(
+        2017, 11, 28, 17, 0, tzinfo=datetime.UTC
+    )
+
+
+async def test_delete_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test deleting an occurrence onwards caps the series."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    event.delete.assert_not_called()
+    recur = _master(event)["RRULE"]
+    assert "COUNT" not in recur
+    assert recur["UNTIL"][0] == datetime.datetime(
+        2017, 11, 29, 16, 59, 59, tzinfo=datetime.UTC
+    )
+
+
+async def test_delete_event_first_occurrence_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that capping at the first occurrence removes the object instead."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-27 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    event.delete.assert_called_once()
+
+
+async def test_update_event(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test updating a whole series."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {"entity_id": TEST_ENTITY, "uid": "rec-1", "event": UPDATED_EVENT},
+    )
+
+    event.save.assert_called_once_with(increase_seqno=False, only_this_recurrence=False)
+    assert _master(event)["SUMMARY"] == "Renamed standup"
+    assert not _overrides(event)
+
+
+async def test_update_event_single_occurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test editing one occurrence adds an override and leaves the master."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert _master(event)["SUMMARY"] == "Daily standup"
+    overrides = _overrides(event)
+    assert len(overrides) == 1
+    assert overrides[0]["SUMMARY"] == "Renamed standup"
+    assert overrides[0]["RECURRENCE-ID"].dt == datetime.datetime(
+        2017, 11, 28, 17, 0, tzinfo=datetime.UTC
+    )
+    assert "RRULE" not in overrides[0]
+
+
+async def test_update_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test editing an occurrence onwards splits the series in two."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+    calendars[0].add_event = MagicMock(return_value=[])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT | {"rrule": "FREQ=DAILY;COUNT=5"},
+        },
+    )
+
+    recur = _master(event)["RRULE"]
+    assert recur["UNTIL"][0] == datetime.datetime(
+        2017, 11, 29, 16, 59, 59, tzinfo=datetime.UTC
+    )
+    assert _master(event)["SUMMARY"] == "Daily standup"
+
+    calendars[0].add_event.assert_called_once()
+    tail = calendars[0].add_event.call_args[1]
+    assert tail["summary"] == "Renamed standup"
+    assert tail["rrule"] == "FREQ=DAILY;COUNT=5"
+
+
+async def test_update_event_not_found(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test an event that is gone from the server surfaces an error."""
+    await setup_platform_cb()
+    calendars[0].event_by_uid = MagicMock(side_effect=NotFoundError("gone"))
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {"entity_id": TEST_ENTITY, "uid": "missing", "event": UPDATED_EVENT},
+    )
+
+    assert not resp["success"]
+    assert "Event not found on the server" in resp["error"]["message"]
+
+
+ALL_DAY_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART;VALUE=DATE:20171127
+DTEND;VALUE=DATE:20171128
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:All day standup
+END:VEVENT
+END:VCALENDAR
+"""
+
+OVERRIDDEN_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Daily standup
+END:VEVENT
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+RECURRENCE-ID:20171128T170000Z
+DTSTART:20171128T190000Z
+DTEND:20171128T200000Z
+SUMMARY:Moved standup
+END:VEVENT
+END:VCALENDAR
+"""
+
+NON_RECURRING_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+SUMMARY:One off
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_removes_recurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a series updated without an rrule loses its recurrence."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {"entity_id": TEST_ENTITY, "uid": "rec-1", "event": UPDATED_EVENT},
+    )
+
+    assert "RRULE" not in _master(event)
+
+
+async def test_update_event_this_and_future_removes_recurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that the split off tail does not inherit a removed recurrence."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0])
+    calendars[0].add_event = MagicMock(return_value=[])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert "rrule" not in calendars[0].add_event.call_args[1]
+
+
+async def test_update_event_existing_override(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test editing an occurrence that already has an override reuses it."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OVERRIDDEN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    overrides = _overrides(event)
+    assert len(overrides) == 1
+    assert overrides[0]["SUMMARY"] == "Renamed standup"
+
+
+async def test_delete_event_drops_stale_override(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that cancelling an occurrence removes its override too."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OVERRIDDEN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+        },
+    )
+
+    assert not _overrides(event)
+    assert _master(event)["EXDATE"].dts[0].dt == datetime.datetime(
+        2017, 11, 28, 17, 0, tzinfo=datetime.UTC
+    )
+
+
+async def test_delete_all_day_event_single_occurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that an all day EXDATE keeps the DATE value type of DTSTART."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], ALL_DAY_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {"entity_id": TEST_ENTITY, "uid": "rec-1", "recurrence_id": "2017-11-28"},
+    )
+
+    assert _master(event)["EXDATE"].dts[0].dt == datetime.date(2017, 11, 28)
+
+
+async def test_delete_all_day_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that an all day UNTIL is a date on the day before the occurrence."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], ALL_DAY_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    assert _master(event)["RRULE"]["UNTIL"][0] == datetime.date(2017, 11, 28)
+
+
+async def test_delete_event_not_recurring(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test scoping to future occurrences of an event that does not recur."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], NON_RECURRING_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    assert not resp["success"]
+    assert "not a recurring series" in resp["error"]["message"]
+
+
+async def test_delete_event_invalid_recurrence_id(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test a recurrence id that cannot be parsed."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "delete",
+        {"entity_id": TEST_ENTITY, "uid": "rec-1", "recurrence_id": "not-a-date"},
+    )
+
+    assert not resp["success"]
+    assert "Unable to parse recurrence id" in resp["error"]["message"]
+
+
+async def test_update_event_first_occurrence_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that scoping from the first occurrence edits the series in place."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+    calendars[0].add_event = MagicMock(return_value=[])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-27 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT | {"rrule": "FREQ=DAILY;COUNT=5"},
+        },
+    )
+
+    calendars[0].add_event.assert_not_called()
+    master = _master(event)
+    assert master["SUMMARY"] == "Renamed standup"
+    assert master["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -3233,3 +3233,89 @@ async def test_update_dense_rule_rejected(
     assert not resp["success"]
     assert "too dense" in resp["error"]["message"]
     event.save.assert_not_called()
+
+
+async def test_update_event_echoed_rule_does_not_bypass_anchor_check(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that resubmitting the rule does not allow an off-rule move."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], BYDAY_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Tuesday sync",
+                "dtstart": "2017-11-28T17:00:00+00:00",
+                "dtend": "2017-11-28T18:00:00+00:00",
+                "rrule": "FREQ=WEEKLY;BYDAY=MO;COUNT=5",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "does not match the recurrence rule" in resp["error"]["message"]
+    event.save.assert_not_called()
+
+
+async def test_update_first_occurrence_echoed_rule_anchor_check(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test the anchor check on the first-occurrence path with an echoed rule."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], BYDAY_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-27 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Tuesday sync",
+                "dtstart": "2017-11-28T17:00:00+00:00",
+                "dtend": "2017-11-28T18:00:00+00:00",
+                "rrule": "FREQ=WEEKLY;BYDAY=MO;COUNT=5",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "does not match the recurrence rule" in resp["error"]["message"]
+    event.save.assert_not_called()
+
+
+async def test_update_orphans_this_and_future_rejected(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a future-scoped edit cannot wipe sibling orphan overrides."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], TWO_ORPHANS_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    assert "not a recurring series" in resp["error"]["message"]
+    event.save.assert_not_called()

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -11,6 +11,7 @@ import zoneinfo
 from caldav.lib.error import DAVError, NotFoundError
 from caldav.objects import Event
 from freezegun.api import FrozenDateTimeFactory
+import icalendar
 import pytest
 
 from homeassistant.components.caldav.api import async_get_calendars
@@ -30,6 +31,7 @@ SUPPORTED_FEATURES = (
     | CalendarEntityFeature.UPDATE_EVENT
     | CalendarEntityFeature.DELETE_EVENT
 )
+FILTERED_FEATURES = CalendarEntityFeature.CREATE_EVENT
 
 EVENTS = [
     """BEGIN:VCALENDAR
@@ -609,7 +611,7 @@ async def test_matching_filter(
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
-        "supported_features": SUPPORTED_FEATURES,
+        "supported_features": FILTERED_FEATURES,
     }
 
 
@@ -651,7 +653,7 @@ async def test_matching_filter_real_regexp(
         "end_time": "2017-11-27 18:00:00",
         "location": "Hamburg",
         "description": "Surprisingly rainy",
-        "supported_features": SUPPORTED_FEATURES,
+        "supported_features": FILTERED_FEATURES,
     }
 
 
@@ -684,7 +686,7 @@ async def test_filter_matching_past_event(
     assert dict(state.attributes) == {
         "friendly_name": CALENDAR_NAME,
         "offset_reached": False,
-        "supported_features": SUPPORTED_FEATURES,
+        "supported_features": FILTERED_FEATURES,
     }
 
 
@@ -716,7 +718,7 @@ async def test_no_result_with_filtering(
     assert dict(state.attributes) == {
         "friendly_name": CALENDAR_NAME,
         "offset_reached": False,
-        "supported_features": SUPPORTED_FEATURES,
+        "supported_features": FILTERED_FEATURES,
     }
 
 
@@ -774,7 +776,7 @@ async def test_all_day_event(
         "end_time": "2017-11-28 00:00:00",
         "location": "Hamburg",
         "description": "What a beautiful day",
-        "supported_features": SUPPORTED_FEATURES,
+        "supported_features": FILTERED_FEATURES,
     }
 
 
@@ -959,7 +961,7 @@ async def test_event_rrule_all_day_early(
         "end_time": "2016-12-02 00:00:00",
         "location": "Hamburg",
         "description": "Groundhog Day",
-        "supported_features": SUPPORTED_FEATURES,
+        "supported_features": FILTERED_FEATURES,
     }
 
 
@@ -1465,6 +1467,15 @@ def _overrides(event: Event) -> list[Any]:
     ]
 
 
+def _saved_tail(calendar: Mock) -> Any:
+    """Return the master VEVENT of the object stored for the split-off tail."""
+    calendar.save_event.assert_called_once()
+    tail = icalendar.Calendar.from_ical(calendar.save_event.call_args[0][0])
+    return next(
+        vevent for vevent in tail.walk("VEVENT") if "RECURRENCE-ID" not in vevent
+    )
+
+
 async def test_delete_event(
     setup_platform_cb: Callable[[], Awaitable[None]],
     calendars: list[Mock],
@@ -1616,7 +1627,7 @@ async def test_update_event_this_and_future(
     """Test editing an occurrence onwards splits the series in two."""
     await setup_platform_cb()
     event = _mock_dav_event(calendars[0])
-    calendars[0].add_event = MagicMock(return_value=[])
+    calendars[0].save_event = MagicMock(return_value=Mock())
 
     client = await ws_client()
     await client.cmd_result(
@@ -1636,11 +1647,11 @@ async def test_update_event_this_and_future(
     )
     assert _master(event)["SUMMARY"] == "Daily standup"
 
-    calendars[0].add_event.assert_called_once()
-    tail = calendars[0].add_event.call_args[1]
-    assert tail["summary"] == "Renamed standup"
+    tail = _saved_tail(calendars[0])
+    assert tail["UID"] == "rec-1-20171129T170000Z"
+    assert tail["SUMMARY"] == "Renamed standup"
     # Two occurrences stay in the capped head, so three are left for the tail.
-    assert tail["rrule"] == "FREQ=DAILY;COUNT=3"
+    assert tail["RRULE"]["COUNT"] == [3]
 
 
 async def test_update_event_not_found(
@@ -1854,7 +1865,7 @@ async def test_update_event_first_occurrence_and_future(
     """Test that scoping from the first occurrence edits the series in place."""
     await setup_platform_cb()
     event = _mock_dav_event(calendars[0])
-    calendars[0].add_event = MagicMock(return_value=[])
+    calendars[0].save_event = MagicMock(return_value=Mock())
 
     client = await ws_client()
     await client.cmd_result(
@@ -1868,7 +1879,7 @@ async def test_update_event_first_occurrence_and_future(
         },
     )
 
-    calendars[0].add_event.assert_not_called()
+    calendars[0].save_event.assert_not_called()
     master = _master(event)
     assert master["SUMMARY"] == "Renamed standup"
     assert master["RRULE"].to_ical().decode() == "FREQ=DAILY;COUNT=5"
@@ -1921,7 +1932,7 @@ async def test_update_event_this_and_future_creates_tail_first(
     """Test that a failure to store the tail leaves the series untouched."""
     await setup_platform_cb()
     event = _mock_dav_event(calendars[0])
-    calendars[0].add_event = MagicMock(side_effect=DAVError("boom"))
+    calendars[0].save_event = MagicMock(side_effect=DAVError("boom"))
 
     client = await ws_client()
     resp = await client.cmd(
@@ -1987,3 +1998,385 @@ async def test_delete_floating_event_this_and_future(
     until = _master(event)["RRULE"]["UNTIL"][0]
     assert until == datetime.datetime(2017, 11, 29, 16, 59, 59)
     assert until.tzinfo is None
+
+
+RICH_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VTIMEZONE
+TZID:Europe/Berlin
+BEGIN:STANDARD
+DTSTART:19701025T030000
+TZOFFSETFROM:+0200
+TZOFFSETTO:+0100
+RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU
+END:STANDARD
+END:VTIMEZONE
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART;TZID=Europe/Berlin:20171127T170000
+DTEND;TZID=Europe/Berlin:20171127T180000
+RRULE:FREQ=DAILY;COUNT=5
+SUMMARY:Daily standup
+ORGANIZER:mailto:boss@example.com
+ATTENDEE:mailto:dev@example.com
+CATEGORIES:work
+X-CUSTOM-PROP:keep-me
+BEGIN:VALARM
+ACTION:DISPLAY
+TRIGGER:-PT10M
+END:VALARM
+END:VEVENT
+END:VCALENDAR
+"""
+
+MIXED_RDATE_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=DAILY;COUNT=3
+RDATE:20171201T170000Z,20171203T170000Z
+SUMMARY:Mixed series
+END:VEVENT
+END:VCALENDAR
+"""
+
+RDATE_ONLY_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RDATE:20171129T170000Z
+RDATE:20171201T170000Z
+SUMMARY:Extra sessions
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_this_and_future_preserves_master_data(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that the split-off tail keeps properties the edit cannot carry."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], RICH_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 16:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    stored = icalendar.Calendar.from_ical(calendars[0].save_event.call_args[0][0])
+    assert any(item.name == "VTIMEZONE" for item in stored.subcomponents)
+    tail = _saved_tail(calendars[0])
+    assert tail["SUMMARY"] == "Renamed standup"
+    assert str(tail["ORGANIZER"]) == "mailto:boss@example.com"
+    assert str(tail["ATTENDEE"]) == "mailto:dev@example.com"
+    assert tail["X-CUSTOM-PROP"] == "keep-me"
+    assert any(item.name == "VALARM" for item in tail.subcomponents)
+
+
+async def test_update_event_this_and_future_rolls_back_tail(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a failure to cap the head removes the stored tail again."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+    tail = Mock()
+    calendars[0].save_event = MagicMock(return_value=tail)
+    event.save.side_effect = DAVError("boom")
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    tail.delete.assert_called_once()
+
+
+async def test_update_event_not_recurring(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that scoping an update to future occurrences needs a series."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], NON_RECURRING_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    assert "not a recurring series" in resp["error"]["message"]
+    calendars[0].save_event.assert_not_called()
+    event.save.assert_not_called()
+
+
+async def test_delete_event_this_and_future_drops_future_rdates(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that the cutoff applies to RDATEs as well as the rule."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], MIXED_RDATE_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-03 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    master = _master(event)
+    assert "UNTIL" in master["RRULE"]
+    assert [item.dt for item in master["RDATE"].dts] == [
+        datetime.datetime(2017, 12, 1, 17, 0, tzinfo=datetime.UTC)
+    ]
+
+
+async def test_delete_rdate_only_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a series recurring only through RDATEs can be capped."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], RDATE_ONLY_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-01 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+        },
+    )
+
+    master = _master(event)
+    assert "RRULE" not in master
+    assert [item.dt for item in master["RDATE"].dts] == [
+        datetime.datetime(2017, 11, 29, 17, 0, tzinfo=datetime.UTC)
+    ]
+
+
+async def test_update_rdate_only_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that splitting a series recurring only through RDATEs works."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], RDATE_ONLY_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-01 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed session",
+                "dtstart": "2017-12-01T17:00:00+00:00",
+                "dtend": "2017-12-01T18:00:00+00:00",
+            },
+        },
+    )
+
+    tail = _saved_tail(calendars[0])
+    assert "RRULE" not in tail
+    assert [item.dt for item in tail["RDATE"].dts] == [
+        datetime.datetime(2017, 12, 1, 17, 0, tzinfo=datetime.UTC)
+    ]
+    assert [item.dt for item in _master(event)["RDATE"].dts] == [
+        datetime.datetime(2017, 11, 29, 17, 0, tzinfo=datetime.UTC)
+    ]
+
+
+@pytest.mark.parametrize(
+    ("tz", "config"),
+    [
+        (
+            UTC,
+            {
+                "custom_calendars": [
+                    {"name": CALENDAR_NAME, "calendar": CALENDAR_NAME, "search": ".*"}
+                ]
+            },
+        )
+    ],
+)
+async def test_filtered_entity_does_not_expose_writes(
+    hass: HomeAssistant,
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a filtered entity cannot reach events it never shows."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0])
+
+    state = hass.states.get("calendar.example_example")
+    assert state
+    assert state.attributes["supported_features"] == FILTERED_FEATURES
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "delete", {"entity_id": "calendar.example_example", "uid": "rec-1"}
+    )
+    assert not resp["success"]
+
+
+async def test_update_event_changes_recurrence(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a passed rrule replaces the rule of the series."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": UPDATED_EVENT | {"rrule": "FREQ=WEEKLY"},
+        },
+    )
+
+    assert _master(event)["RRULE"].to_ical().decode() == "FREQ=WEEKLY"
+
+
+async def test_update_all_day_event_this_and_future(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that an all day split reduces COUNT by the days the head keeps."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], ALL_DAY_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed standup",
+                "dtstart": "2017-11-29",
+                "dtend": "2017-11-30",
+            },
+        },
+    )
+
+    tail = _saved_tail(calendars[0])
+    assert tail["RRULE"]["COUNT"] == [3]
+
+
+async def test_update_event_this_and_future_drops_tail_overrides(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that the tail does not carry overrides of the old series."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], OVERRIDDEN_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    stored = icalendar.Calendar.from_ical(calendars[0].save_event.call_args[0][0])
+    assert len(list(stored.walk("VEVENT"))) == 1
+
+
+async def test_update_event_this_and_future_rollback_failure(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that a failing rollback still reports the original error."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0])
+    tail = Mock()
+    tail.delete.side_effect = DAVError("still down")
+    calendars[0].save_event = MagicMock(return_value=tail)
+    event.save.side_effect = DAVError("boom")
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": UPDATED_EVENT,
+        },
+    )
+
+    assert not resp["success"]
+    assert "boom" in resp["error"]["message"]
+    assert "could not be removed" in caplog.text

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2871,3 +2871,61 @@ async def test_update_event_new_rrule_drops_exdates(
     master = _master(event)
     assert "EXDATE" not in master
     assert master["RRULE"].to_ical().decode() == "FREQ=WEEKLY"
+
+
+async def test_update_event_first_occurrence_new_rule_drops_exdates(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that rescheduling every future occurrence clears old exceptions."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], MIXED_TZ_EXDATE_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-27 16:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed standup",
+                "dtstart": "2017-11-27T17:00:00+00:00",
+                "dtend": "2017-11-27T18:00:00+00:00",
+            },
+        },
+    )
+
+    assert "EXDATE" not in _master(event)
+
+
+async def test_update_event_moved_tail_drops_exdates(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a moved tail does not carry dates of the old schedule."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], MIXED_TZ_EXDATE_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-01 16:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed standup",
+                "dtstart": "2017-12-01T18:00:00+00:00",
+                "dtend": "2017-12-01T19:00:00+00:00",
+            },
+        },
+    )
+
+    tail = _saved_tail(calendars[0])
+    assert "EXDATE" not in tail

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2993,8 +2993,7 @@ async def test_update_moved_rdate_only_tail_shifts_dates(
 
     tail = _saved_tail(calendars[0])
     entries = tail["RDATE"]
-    if not isinstance(entries, list):
-        entries = [entries]
+    assert isinstance(entries, list)
     assert [item.dt for entry in entries for item in entry.dts] == [
         datetime.datetime(2017, 11, 29, 18, 0, tzinfo=datetime.UTC),
         datetime.datetime(2017, 12, 1, 18, 0, tzinfo=datetime.UTC),
@@ -3045,4 +3044,78 @@ async def test_update_event_off_rule_rdate_split_rejected(
     assert not resp["success"]
     assert "added date" in resp["error"]["message"]
     calendars[0].save_event.assert_not_called()
+    event.save.assert_not_called()
+
+
+BYDAY_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+DTSTART:20171127T170000Z
+DTEND:20171127T180000Z
+RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=5
+SUMMARY:Monday sync
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_update_event_move_against_anchored_rule_rejected(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that moving a day-bound series to another day needs a new rule."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], BYDAY_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Tuesday sync",
+                "dtstart": "2017-11-28T17:00:00+00:00",
+                "dtend": "2017-11-28T18:00:00+00:00",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "does not match the recurrence rule" in resp["error"]["message"]
+    event.save.assert_not_called()
+
+
+async def test_update_event_off_rule_split_with_resubmitted_rule_rejected(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that echoing the unchanged rule does not bypass the split guard."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OFF_RULE_RDATE_ICS)
+
+    client = await ws_client()
+    resp = await client.cmd(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed",
+                "dtstart": "2017-11-29T17:00:00+00:00",
+                "dtend": "2017-11-29T18:00:00+00:00",
+                "rrule": "FREQ=WEEKLY;COUNT=5",
+            },
+        },
+    )
+
+    assert not resp["success"]
+    assert "added date" in resp["error"]["message"]
     event.save.assert_not_called()

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2758,7 +2758,7 @@ async def test_delete_occurrence_of_orphan_override(
     calendars: list[Mock],
     ws_client: ClientFixture,
 ) -> None:
-    """Test that cancelling the orphan's occurrence keeps the resource valid."""
+    """Test that cancelling the orphan's only occurrence drops the resource."""
     await setup_platform_cb()
     event = _mock_dav_event(calendars[0], ORPHAN_ICS)
 
@@ -2772,4 +2772,51 @@ async def test_delete_occurrence_of_orphan_override(
         },
     )
 
-    assert len(list(event.icalendar_instance.walk("VEVENT"))) == 1
+    event.delete.assert_called_once()
+
+
+TWO_ORPHANS_ICS = """BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//E-Corp.//CalDAV Client//EN
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+RECURRENCE-ID:20171128T170000Z
+DTSTART:20171128T190000Z
+DTEND:20171128T200000Z
+SUMMARY:First orphan
+END:VEVENT
+BEGIN:VEVENT
+UID:rec-1
+DTSTAMP:20171125T000000Z
+RECURRENCE-ID:20171129T170000Z
+DTSTART:20171129T190000Z
+DTEND:20171129T200000Z
+SUMMARY:Second orphan
+END:VEVENT
+END:VCALENDAR
+"""
+
+
+async def test_delete_one_of_two_orphan_overrides(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that deleting one orphan occurrence keeps the other."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], TWO_ORPHANS_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "delete",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-28 17:00:00+00:00",
+        },
+    )
+
+    event.delete.assert_not_called()
+    vevents = list(event.icalendar_instance.walk("VEVENT"))
+    assert [vevent["SUMMARY"] for vevent in vevents] == ["Second orphan"]

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2820,3 +2820,54 @@ async def test_delete_one_of_two_orphan_overrides(
     event.delete.assert_not_called()
     vevents = list(event.icalendar_instance.walk("VEVENT"))
     assert [vevent["SUMMARY"] for vevent in vevents] == ["Second orphan"]
+
+
+async def test_update_event_same_rrule_keeps_overrides(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that resubmitting the unchanged rule keeps overrides."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], OVERRIDDEN_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": UPDATED_EVENT | {"rrule": "FREQ=DAILY;COUNT=5"},
+        },
+    )
+
+    assert len(_overrides(event)) == 1
+
+
+async def test_update_event_new_rrule_drops_exdates(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that a new rule clears dates anchored to the old schedule."""
+    await setup_platform_cb()
+    event = _mock_dav_event(calendars[0], MIXED_TZ_EXDATE_ICS)
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "event": {
+                "summary": "Renamed standup",
+                "dtstart": "2017-11-27T16:00:00+00:00",
+                "dtend": "2017-11-27T17:00:00+00:00",
+                "rrule": "FREQ=WEEKLY",
+            },
+        },
+    )
+
+    master = _master(event)
+    assert "EXDATE" not in master
+    assert master["RRULE"].to_ical().decode() == "FREQ=WEEKLY"

--- a/tests/components/caldav/test_calendar.py
+++ b/tests/components/caldav/test_calendar.py
@@ -2906,7 +2906,7 @@ async def test_update_event_moved_tail_drops_exdates(
     calendars: list[Mock],
     ws_client: ClientFixture,
 ) -> None:
-    """Test that a moved tail does not carry dates of the old schedule."""
+    """Test that a moved tail shifts retained dates along with it."""
     await setup_platform_cb()
     _mock_dav_event(calendars[0], MIXED_TZ_EXDATE_ICS)
     calendars[0].save_event = MagicMock(return_value=Mock())
@@ -2928,4 +2928,74 @@ async def test_update_event_moved_tail_drops_exdates(
     )
 
     tail = _saved_tail(calendars[0])
-    assert "EXDATE" not in tail
+    assert tail["EXDATE"].dts[0].dt == datetime.datetime(
+        2017, 12, 4, 19, 0, tzinfo=zoneinfo.ZoneInfo("Europe/Berlin")
+    )
+
+
+async def test_update_rdate_only_event_with_new_rule(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that supplying a rule to an RDATE-only series does not crash."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], RDATE_ONLY_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-12-01 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed session",
+                "dtstart": "2017-12-01T17:00:00+00:00",
+                "dtend": "2017-12-01T18:00:00+00:00",
+                "rrule": "FREQ=WEEKLY",
+            },
+        },
+    )
+
+    tail = _saved_tail(calendars[0])
+    assert tail["RRULE"].to_ical().decode() == "FREQ=WEEKLY"
+    assert "RDATE" not in tail
+
+
+async def test_update_moved_rdate_only_tail_shifts_dates(
+    setup_platform_cb: Callable[[], Awaitable[None]],
+    calendars: list[Mock],
+    ws_client: ClientFixture,
+) -> None:
+    """Test that moving an RDATE-only tail moves its dates too."""
+    await setup_platform_cb()
+    _mock_dav_event(calendars[0], RDATE_ONLY_ICS)
+    calendars[0].save_event = MagicMock(return_value=Mock())
+
+    client = await ws_client()
+    await client.cmd_result(
+        "update",
+        {
+            "entity_id": TEST_ENTITY,
+            "uid": "rec-1",
+            "recurrence_id": "2017-11-29 17:00:00+00:00",
+            "recurrence_range": "THISANDFUTURE",
+            "event": {
+                "summary": "Renamed session",
+                "dtstart": "2017-11-29T18:00:00+00:00",
+                "dtend": "2017-11-29T19:00:00+00:00",
+            },
+        },
+    )
+
+    tail = _saved_tail(calendars[0])
+    entries = tail["RDATE"]
+    if not isinstance(entries, list):
+        entries = [entries]
+    assert [item.dt for entry in entries for item in entry.dts] == [
+        datetime.datetime(2017, 11, 29, 18, 0, tzinfo=datetime.UTC),
+        datetime.datetime(2017, 12, 1, 18, 0, tzinfo=datetime.UTC),
+    ]


### PR DESCRIPTION
## Proposed change

Adds UPDATE_EVENT and DELETE_EVENT to the caldav calendar entity, so events can be
edited and deleted from the calendar panel. Works for single events, single
occurrences of a series and "this and future".

CalDAV has no API for editing occurrences, the whole calendar object has to be
rewritten: a cancelled occurrence becomes an EXDATE, an edited one an override with
RECURRENCE-ID, and "this and future" caps the rule with UNTIL and moves the rest
into a new object (RFC 4791 allows one UID per object). That logic lives in a new
recurrence.py. One caveat: the coordinator expands recurrences, so the frontend
never sees the rrule and an update without one keeps the existing rule. Exposing
the rule needs changes to the read path, planned as a follow-up.

Entities from custom_calendars filters keep create only, they should not touch
events they never expose.

Tested against Nextcloud 32, 33 and 34.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #159784
- This PR is related to issue: #170335 covers the same ground and reached review
  first. It is marked stale and its author noted he could not find a test pattern for
  update and delete, since neither is a service. They are websocket commands, so the
  tests here follow `local_calendar` and drive `calendar/event/update` and
  `calendar/event/delete` through a `ws_client` fixture. Happy to close this in favour
  of that PR if he would rather carry it forward.
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
