### PR TITLE
Add restore to lock template entities

### DIFF
--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -142,17 +142,20 @@ class LockExtraStoredData(ExtraStoredData):
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self:
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         """Initialize a stored lock state from a dict."""
-        return cls(
-            code_format=restored["code_format"],
-            is_locked=restored["is_locked"],
-            is_locking=restored["is_locking"],
-            is_open=restored["is_open"],
-            is_opening=restored["is_opening"],
-            is_unlocking=restored["is_unlocking"],
-            is_jammed=restored["is_jammed"],
-        )
+        try:
+            return cls(
+                code_format=restored["code_format"],
+                is_locked=restored["is_locked"],
+                is_locking=restored["is_locking"],
+                is_open=restored["is_open"],
+                is_opening=restored["is_opening"],
+                is_unlocking=restored["is_unlocking"],
+                is_jammed=restored["is_jammed"],
+            )
+        except KeyError:
+            return None
 
 
 class AbstractTemplateLock(AbstractTemplateEntity, LockEntity, RestoreEntity):

--- a/homeassistant/components/template/lock.py
+++ b/homeassistant/components/template/lock.py
@@ -1,6 +1,7 @@
 """Support for locks which integrates with other components."""
 
-from typing import TYPE_CHECKING, Any, override
+from dataclasses import asdict, dataclass
+from typing import TYPE_CHECKING, Any, Self, override
 
 import voluptuous as vol
 
@@ -20,6 +21,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import validators as template_validators
@@ -122,12 +124,45 @@ def async_create_preview_lock(
     )
 
 
-class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
+@dataclass(kw_only=True)
+class LockExtraStoredData(ExtraStoredData):
+    """Holds extra stored data for template lock entities."""
+
+    code_format: str | None
+    is_locked: bool | None
+    is_locking: bool | None
+    is_open: bool | None
+    is_opening: bool | None
+    is_unlocking: bool | None
+    is_jammed: bool | None
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the lock data."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self:
+        """Initialize a stored lock state from a dict."""
+        return cls(
+            code_format=restored["code_format"],
+            is_locked=restored["is_locked"],
+            is_locking=restored["is_locking"],
+            is_open=restored["is_open"],
+            is_opening=restored["is_opening"],
+            is_unlocking=restored["is_unlocking"],
+            is_jammed=restored["is_jammed"],
+        )
+
+
+class AbstractTemplateLock(AbstractTemplateEntity, LockEntity, RestoreEntity):
     """Representation of a template lock features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
     _state_option = CONF_STATE
+    _restore_state_extra_data = LockExtraStoredData
+    _restore_state_properties = ("_attr_is_locked",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -259,6 +294,31 @@ class AbstractTemplateLock(AbstractTemplateEntity, LockEntity):
                     "cause": str(self._code_format_template_error),
                 },
             )
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> LockExtraStoredData:
+        """Return lock specific state data to be restored."""
+        return LockExtraStoredData(
+            code_format=self._attr_code_format,
+            is_locked=self._attr_is_locked,
+            is_locking=self._attr_is_locking,
+            is_open=self._attr_is_open,
+            is_opening=self._attr_is_opening,
+            is_unlocking=self._attr_is_unlocking,
+            is_jammed=self._attr_is_jammed,
+        )
+
+    @override
+    def restore_extra_data(self, extra_data: LockExtraStoredData) -> None:
+        """Restore the extra data."""
+        self._attr_code_format = extra_data.code_format
+        self._attr_is_locked = extra_data.is_locked
+        self._attr_is_locking = extra_data.is_locking
+        self._attr_is_open = extra_data.is_open
+        self._attr_is_opening = extra_data.is_opening
+        self._attr_is_unlocking = extra_data.is_unlocking
+        self._attr_is_jammed = extra_data.is_jammed
 
 
 class StateLockEntity(TemplateEntity, AbstractTemplateLock):

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -1031,6 +1031,21 @@ async def test_flow_preview(
             },
         ),
         (
+            LockState.JAMMED,
+            {
+                "code_format": ".+",
+                "is_locked": False,
+                "is_locking": False,
+                "is_opening": False,
+                "is_unlocking": False,
+                "is_jammed": True,
+            },
+            STATE_UNKNOWN,
+            {
+                "code_format": None,
+            },
+        ),
+        (
             STATE_UNAVAILABLE,
             {
                 "code_format": ".+",
@@ -1072,7 +1087,7 @@ async def test_restore_state(
     initial_state: LockState | str,
     initial_attributes: ConfigType,
 ) -> None:
-    """Test restoring trigger template weather."""
+    """Test restoring state."""
 
     setup_mock_template_entity_restore_state(
         hass,

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -1119,4 +1119,7 @@ async def test_restore_state(
         {"lock_state": LockState.UNLOCKED, "code_format": "\\\\d+"},
     )
 
-    assert_state_and_attributes(hass, TEST_LOCK, LockState.UNLOCKED, {})
+    # The first trigger should replace the restored code_format attribute
+    assert_state_and_attributes(
+        hass, TEST_LOCK, LockState.UNLOCKED, {"code_format": "\\\\d+"}
+    )

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -1031,6 +1031,38 @@ async def test_flow_preview(
             },
         ),
         (
+            LockState.LOCKED,
+            {
+                "code_format": ".+",
+                "is_locked": True,
+                "is_locking": False,
+                "is_open": False,
+                "is_opening": False,
+                "is_unlocking": False,
+                "is_jammed": False,
+            },
+            LockState.LOCKED,
+            {
+                "code_format": ".+",
+            },
+        ),
+        (
+            LockState.LOCKING,
+            {
+                "code_format": ".+",
+                "is_locked": False,
+                "is_locking": True,
+                "is_open": False,
+                "is_opening": False,
+                "is_unlocking": False,
+                "is_jammed": False,
+            },
+            LockState.LOCKING,
+            {
+                "code_format": ".+",
+            },
+        ),
+        (
             LockState.JAMMED,
             {
                 "code_format": ".+",

--- a/tests/components/template/test_lock.py
+++ b/tests/components/template/test_lock.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.typing import ConfigType
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -31,6 +32,8 @@ from .conftest import (
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
 from tests.common import MockConfigEntry
@@ -998,3 +1001,107 @@ async def test_flow_preview(
     )
 
     assert state["state"] == LockState.LOCKED
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+    ),
+    [
+        (
+            LockState.JAMMED,
+            {
+                "code_format": ".+",
+                "is_locked": False,
+                "is_locking": False,
+                "is_open": False,
+                "is_opening": False,
+                "is_unlocking": False,
+                "is_jammed": True,
+            },
+            LockState.JAMMED,
+            {
+                "code_format": ".+",
+            },
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "code_format": ".+",
+                "is_locked": False,
+                "is_locking": False,
+                "is_open": False,
+                "is_opening": False,
+                "is_unlocking": False,
+                "is_jammed": True,
+            },
+            STATE_UNKNOWN,
+            {
+                "code_format": None,
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "code_format": ".+",
+                "is_locked": False,
+                "is_locking": False,
+                "is_open": False,
+                "is_opening": False,
+                "is_unlocking": False,
+                "is_jammed": True,
+            },
+            STATE_UNKNOWN,
+            {
+                "code_format": None,
+            },
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    saved_state: LockState | str,
+    saved_extra_data: dict | None,
+    initial_state: LockState | str,
+    initial_attributes: ConfigType,
+) -> None:
+    """Test restoring trigger template weather."""
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_LOCK,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_LOCK,
+        style,
+        {
+            "code_format": "{{ state_attr('sensor.test_state', 'code_format') }}",
+            "state": "{{ state_attr('sensor.test_state', 'lock_state') }}",
+            "lock": [],
+            "open": [],
+            "unlock": [],
+        },
+        "is_state_attr('sensor.test_state', 'lock_state', 'unlocked')",
+    )
+
+    assert_state_and_attributes(hass, TEST_LOCK, initial_state, initial_attributes)
+
+    await async_trigger(
+        hass,
+        "sensor.test_state",
+        "anything",
+        {"lock_state": LockState.UNLOCKED, "code_format": "\\\\d+"},
+    )
+
+    assert_state_and_attributes(hass, TEST_LOCK, LockState.UNLOCKED, {})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to lock template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
