### PR TITLE
Fix samsungtv entity unique_id storing entry_id as fallback

### DIFF
--- a/homeassistant/components/samsungtv/entity.py
+++ b/homeassistant/components/samsungtv/entity.py
@@ -39,7 +39,7 @@ class SamsungTVEntity(CoordinatorEntity[SamsungTVDataUpdateCoordinator], Entity)
         self._host: str | None = config_entry.data.get(CONF_HOST)
         # Fallback for legacy models that doesn't have a API
         # to retrieve MAC or SerialNumber
-        self._attr_unique_id = config_entry.unique_id or config_entry.entry_id
+        self._attr_unique_id = config_entry.unique_id
         self._attr_device_info = DeviceInfo(
             manufacturer=config_entry.data.get(CONF_MANUFACTURER),
             model_id=config_entry.data.get(CONF_MODEL),

--- a/tests/components/samsungtv/__init__.py
+++ b/tests/components/samsungtv/__init__.py
@@ -3,9 +3,8 @@
 from collections.abc import Mapping
 from typing import Any
 
-from homeassistant.components.samsungtv.const import DOMAIN, METHOD_LEGACY
+from homeassistant.components.samsungtv.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_METHOD
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -19,11 +18,7 @@ async def setup_samsungtv_entry(
         domain=DOMAIN,
         data=data,
         entry_id="123456",
-        unique_id=(
-            None
-            if data[CONF_METHOD] == METHOD_LEGACY
-            else "be9554b9-c9fb-41f4-8920-22da015376a4"
-        ),
+        unique_id="be9554b9-c9fb-41f4-8920-22da015376a4",
     )
     entry.add_to_hass(hass)
 

--- a/tests/components/samsungtv/snapshots/test_init.ambr
+++ b/tests/components/samsungtv/snapshots/test_init.ambr
@@ -52,7 +52,7 @@
       'identifiers': set({
         tuple(
           'samsungtv',
-          '123456',
+          'be9554b9-c9fb-41f4-8920-22da015376a4',
         ),
       }),
       'labels': set({

--- a/tests/components/samsungtv/test_media_player.py
+++ b/tests/components/samsungtv/test_media_player.py
@@ -159,6 +159,7 @@ async def test_setup_websocket_2(
     entry = MockConfigEntry(
         domain=DOMAIN,
         data=MOCK_ENTRY_WS,
+        unique_id="be9554b9-c9fb-41f4-8920-22da015376a4",
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The SamsungTVEntity `__init__` fell back to `config_entry.entry_id` when `config_entry.unique_id` was not set. This caused two problems:

1. pylint W0125: `if self.unique_id:` was always truthy (`entry_id` is always a non-empty string), making the guard a constant test.

2. The entity registry received a non-stable `unique_id` (`entry_id` changes across imports/reconfigures).

Fix by removing the `entry_id` fallback. When `unique_id` is not set, `_attr_unique_id` remains `None` and the registry guard is properly skipped.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176453 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

This PR replaces #176453. After review feedback, the approach changed: instead of removing the always-true guard (which was a symptom), the root cause (the `entry_id` fallback in unique_id) is fixed.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
