### PR TITLE
Switchbot Cloud：enable webhook for the Fan  series.

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -216,20 +216,6 @@ async def make_device_data(
         devices_data.sensors.append((device, coordinator))
 
     if isinstance(device, Device) and device.device_type in [
-        "Battery Circulator Fan",
-        "Standing Fan",
-    ]:
-        coordinator = await coordinator_for_device(
-            hass, entry, api, device, coordinators_by_id
-        )
-        devices_data.fans.append((device, coordinator))
-        devices_data.sensors.append((device, coordinator))
-    if isinstance(device, Device) and device.device_type == "Circulator Fan":
-        coordinator = await coordinator_for_device(
-            hass, entry, api, device, coordinators_by_id
-        )
-        devices_data.fans.append((device, coordinator))
-    if isinstance(device, Device) and device.device_type in [
         "Curtain",
         "Curtain3",
         "Roller Shade",

--- a/homeassistant/components/switchbot_cloud/const.py
+++ b/homeassistant/components/switchbot_cloud/const.py
@@ -155,4 +155,14 @@ DEVICE_SUPPORT_MAP: Final[dict[str, SwitchbotCloudDeviceConfig]] = {
     "AI Art Frame": SwitchbotCloudDeviceConfig(
         True, entity_config=(Platform.SENSOR, Platform.BUTTON, Platform.IMAGE)
     ),
+    "Circulator Fan": SwitchbotCloudDeviceConfig(True, entity_config=(Platform.FAN,)),
+    "Standing Fan": SwitchbotCloudDeviceConfig(
+        True, entity_config=(Platform.SENSOR, Platform.FAN)
+    ),
+    "Battery Circulator Fan": SwitchbotCloudDeviceConfig(
+        True, entity_config=(Platform.SENSOR, Platform.FAN)
+    ),
+    "Battery Circulator Fan 2 Pro": SwitchbotCloudDeviceConfig(
+        True, entity_config=(Platform.SENSOR, Platform.FAN)
+    ),
 }

--- a/homeassistant/components/switchbot_cloud/fan.py
+++ b/homeassistant/components/switchbot_cloud/fan.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import logging
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from switchbot_api import (
     AirPurifierCommands,
@@ -69,10 +69,14 @@ class SwitchBotCloudFan(SwitchBotCloudEntity, FanEntity):
         if self.coordinator.data is None:
             return
 
-        power: str = self.coordinator.data["power"]
+        power: str | None = self.coordinator.data.get(
+            "power"
+        ) or self.coordinator.data.get("powerState")
         mode: str = self.coordinator.data["mode"]
         fan_speed: str = self.coordinator.data["fanSpeed"]
-        self._attr_is_on = power == "on"
+        if TYPE_CHECKING:
+            assert power is not None
+        self._attr_is_on = power.lower() == "on"
         self._attr_preset_mode = mode
         self._attr_percentage = int(fan_speed)
         self._attr_supported_features = (

--- a/homeassistant/components/switchbot_cloud/sensor.py
+++ b/homeassistant/components/switchbot_cloud/sensor.py
@@ -185,6 +185,7 @@ SENSOR_DESCRIPTIONS_BY_DEVICE_TYPES = {
     "Bot": (BATTERY_DESCRIPTION,),
     "Battery Circulator Fan": (BATTERY_DESCRIPTION,),
     "Standing Fan": (BATTERY_DESCRIPTION,),
+    "Battery Circulator Fan 2 Pro": (BATTERY_DESCRIPTION,),
     "Meter": (
         TEMPERATURE_DESCRIPTION,
         HUMIDITY_DESCRIPTION,

--- a/tests/components/switchbot_cloud/__init__.py
+++ b/tests/components/switchbot_cloud/__init__.py
@@ -57,6 +57,14 @@ STANDING_FAN_INFO = Device(
     hubDeviceId="test-hub-id",
 )
 
+BATTERY_CIRCULATOR_FAN_2_PRO_INFO = Device(
+    version="V1.0",
+    deviceId="device-id-1",
+    deviceName="device-1",
+    deviceType="Battery Circulator Fan 2 Pro",
+    hubDeviceId="test-hub-id",
+)
+
 
 METER_INFO = Device(
     version="V1.0",

--- a/tests/components/switchbot_cloud/fixtures/sensor_status.json
+++ b/tests/components/switchbot_cloud/fixtures/sensor_status.json
@@ -31,7 +31,21 @@
     "nightStatus": "off",
     "oscillation": "on",
     "verticalOscillation": "on",
-    "fanSpeed": 3
+    "fanSpeed": 3,
+    "battery": 22
+  },
+  {
+    "deviceId": "A1C3E5F7D9B0",
+    "deviceType": "Battery Circulator Fan 2 Pro",
+    "hubDeviceId": "FFFFFFFFFFF",
+    "mode": "direct",
+    "version": "V6.3",
+    "power": "on",
+    "nightStatus": "off",
+    "oscillation": "on",
+    "verticalOscillation": "on",
+    "fanSpeed": 3,
+    "battery": 22
   },
   {
     "deviceId": "9B0D2F4A6C8E",

--- a/tests/components/switchbot_cloud/snapshots/test_sensor.ambr
+++ b/tests/components/switchbot_cloud/snapshots/test_sensor.ambr
@@ -54,6 +54,61 @@
     'state': '0',
   })
 # ---
+# name: test_coordinator_data[Battery Circulator Fan 2 Pro][sensor.test_device_name_1_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_device_name_1_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'switchbot_cloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test-device-id-1_battery',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_coordinator_data[Battery Circulator Fan 2 Pro][sensor.test_device_name_1_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test-device-name-1 Battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_device_name_1_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '22',
+  })
+# ---
 # name: test_coordinator_data[Battery Circulator Fan][sensor.test_device_name_1_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -3263,7 +3318,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '22',
   })
 # ---
 # name: test_coordinator_data[Water Detector][sensor.test_device_name_1_battery-entry]
@@ -3697,6 +3752,61 @@
   })
 # ---
 # name: test_no_coordinator_data[AI Art Frame][sensor.test_device_name_1_battery-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test-device-name-1 Battery',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfRatio.PERCENTAGE: '%'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.test_device_name_1_battery',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_no_coordinator_data[Battery Circulator Fan 2 Pro][sensor.test_device_name_1_battery-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.test_device_name_1_battery',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Battery',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.BATTERY: 'battery'>,
+    'original_icon': None,
+    'original_name': 'Battery',
+    'platform': 'switchbot_cloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'test-device-id-1_battery',
+    'unit_of_measurement': <UnitOfRatio.PERCENTAGE: '%'>,
+  })
+# ---
+# name: test_no_coordinator_data[Battery Circulator Fan 2 Pro][sensor.test_device_name_1_battery-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery',

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -260,7 +260,7 @@ async def test_power_state(
     device_info: Device,
     entry_id: str,
 ) -> None:
-    """Test set preset mode."""
+    """Test handling of powerState in status payloads."""
     mock_list_devices.return_value = [
         device_info,
     ]

--- a/tests/components/switchbot_cloud/test_fan.py
+++ b/tests/components/switchbot_cloud/test_fan.py
@@ -1,6 +1,6 @@
 """Test for the Switchbot (Battery) Circulator Fan."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import switchbot_api
@@ -30,6 +30,7 @@ from homeassistant.helpers import entity_registry as er
 
 from . import (
     AIR_PURIFIER_INFO,
+    BATTERY_CIRCULATOR_FAN_2_PRO_INFO,
     BATTERY_CIRCULATOR_FAN_INFO,
     CIRCULATOR_FAN_INFO,
     STANDING_FAN_INFO,
@@ -45,12 +46,14 @@ from tests.common import async_load_json_object_fixture, snapshot_platform
         (AIR_PURIFIER_INFO, "fan.air_purifier_1"),
         (CIRCULATOR_FAN_INFO, "fan.fan_1"),
         (BATTERY_CIRCULATOR_FAN_INFO, "fan.battery_fan_1"),
+        (STANDING_FAN_INFO, "fan.standing_fan_1"),
+        (BATTERY_CIRCULATOR_FAN_2_PRO_INFO, "fan.device_1"),
     ],
 )
 async def test_coordinator_data_is_none(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
     device_info: Device,
     entry_id: str,
 ) -> None:
@@ -71,12 +74,13 @@ async def test_coordinator_data_is_none(
         (CIRCULATOR_FAN_INFO, "fan.fan_1"),
         (BATTERY_CIRCULATOR_FAN_INFO, "fan.battery_fan_1"),
         (STANDING_FAN_INFO, "fan.standing_fan_1"),
+        (BATTERY_CIRCULATOR_FAN_2_PRO_INFO, "fan.device_1"),
     ],
 )
 async def test_turn_on(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
     device_info: Device,
     entry_id: str,
 ) -> None:
@@ -113,12 +117,14 @@ async def test_turn_on(
     [
         (CIRCULATOR_FAN_INFO, "fan.fan_1"),
         (BATTERY_CIRCULATOR_FAN_INFO, "fan.battery_fan_1"),
+        (STANDING_FAN_INFO, "fan.standing_fan_1"),
+        (BATTERY_CIRCULATOR_FAN_2_PRO_INFO, "fan.device_1"),
     ],
 )
 async def test_turn_off(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
     device_info: Device,
     entry_id: str,
 ) -> None:
@@ -156,12 +162,13 @@ async def test_turn_off(
         (CIRCULATOR_FAN_INFO, "fan.fan_1"),
         (BATTERY_CIRCULATOR_FAN_INFO, "fan.battery_fan_1"),
         (STANDING_FAN_INFO, "fan.standing_fan_1"),
+        (BATTERY_CIRCULATOR_FAN_2_PRO_INFO, "fan.device_1"),
     ],
 )
 async def test_set_percentage(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
     device_info: Device,
     entry_id: str,
 ) -> None:
@@ -199,12 +206,13 @@ async def test_set_percentage(
         (CIRCULATOR_FAN_INFO, "fan.fan_1"),
         (BATTERY_CIRCULATOR_FAN_INFO, "fan.battery_fan_1"),
         (STANDING_FAN_INFO, "fan.standing_fan_1"),
+        (BATTERY_CIRCULATOR_FAN_2_PRO_INFO, "fan.device_1"),
     ],
 )
 async def test_set_preset_mode(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
     device_info: Device,
     entry_id: str,
 ) -> None:
@@ -236,12 +244,56 @@ async def test_set_preset_mode(
     mock_send_command.assert_called_once()
 
 
+@pytest.mark.parametrize(
+    ("device_info", "entry_id"),
+    [
+        (CIRCULATOR_FAN_INFO, "fan.fan_1"),
+        (BATTERY_CIRCULATOR_FAN_INFO, "fan.battery_fan_1"),
+        (STANDING_FAN_INFO, "fan.standing_fan_1"),
+        (BATTERY_CIRCULATOR_FAN_2_PRO_INFO, "fan.device_1"),
+    ],
+)
+async def test_power_state(
+    hass: HomeAssistant,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
+    device_info: Device,
+    entry_id: str,
+) -> None:
+    """Test set preset mode."""
+    mock_list_devices.return_value = [
+        device_info,
+    ]
+    mock_get_status.side_effect = [
+        {"powerState": "On", "mode": "direct", "fanSpeed": "0"},
+        {"powerState": "On", "mode": "direct", "fanSpeed": "0"},
+        {"powerState": "On", "mode": "baby", "fanSpeed": "0"},
+    ]
+    entry = await configure_integration(hass)
+    assert entry.state is ConfigEntryState.LOADED
+    entity_id = entry_id
+    state = hass.states.get(entity_id)
+
+    assert state.state == STATE_ON
+
+    with (
+        patch.object(SwitchBotAPI, "send_command") as mock_send_command,
+    ):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PRESET_MODE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PRESET_MODE: "baby"},
+            blocking=True,
+        )
+    mock_send_command.assert_called_once()
+
+
 async def test_air_purifier(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
 ) -> None:
     """Test air purifier."""
 
@@ -293,8 +345,8 @@ async def test_air_purifier(
 )
 async def test_air_purifier_controller(
     hass: HomeAssistant,
-    mock_list_devices,
-    mock_get_status,
+    mock_list_devices: AsyncMock,
+    mock_get_status: AsyncMock,
     service: str,
     service_data: dict,
     expected_call_args: tuple,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Enable webhook for blow devices:

1. Battery Circulator Fan
2. Circulator Fan
3. Standing Fan
4. Battery Circulator Fan 2 Pro

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
