### PR TITLE
Tolerate unloading a never-loaded config entry in EntityComponent

### DIFF
--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -198,7 +198,18 @@ class EntityComponent[_EntityT: entity.Entity = entity.Entity]:
         key = config_entry.entry_id
 
         if (platform := self._platforms.pop(key, None)) is None:
-            raise ValueError("Config entry was never loaded!")
+            self.logger.warning(
+                (
+                    "Config entry %s (%s) for %s.%s was never loaded, "
+                    "possibly because its platform setup failed earlier; "
+                    "there is nothing to unload"
+                ),
+                config_entry.title,
+                key,
+                config_entry.domain,
+                self.domain,
+            )
+            return True
 
         await platform.async_reset()
         return True

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -201,7 +201,7 @@ class EntityComponent[_EntityT: entity.Entity = entity.Entity]:
             self.logger.warning(
                 (
                     "Config entry %s (%s) for %s.%s was never loaded, "
-                    "possibly because its platform setup failed earlier; "
+                    "possibly because its platform setup never completed; "
                     "there is nothing to unload"
                 ),
                 config_entry.title,

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -200,9 +200,9 @@ class EntityComponent[_EntityT: entity.Entity = entity.Entity]:
         if (platform := self._platforms.pop(key, None)) is None:
             self.logger.warning(
                 (
-                    "Config entry %s (%s) for %s.%s was never loaded, "
-                    "possibly because its platform setup never completed; "
-                    "there is nothing to unload"
+                    "Ignored unload request for config entry %s (%s) in %s.%s; "
+                    "no platform is loaded, it was never set up "               
+                    "or has already been unloaded"                              
                 ),
                 config_entry.title,
                 key,

--- a/homeassistant/helpers/entity_component.py
+++ b/homeassistant/helpers/entity_component.py
@@ -201,8 +201,8 @@ class EntityComponent[_EntityT: entity.Entity = entity.Entity]:
             self.logger.warning(
                 (
                     "Ignored unload request for config entry %s (%s) in %s.%s; "
-                    "no platform is loaded, it was never set up "               
-                    "or has already been unloaded"                              
+                    "no platform is loaded, it was never set up "
+                    "or has already been unloaded"
                 ),
                 config_entry.title,
                 key,

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -418,13 +418,18 @@ async def test_unload_entry_resets_platform(hass: HomeAssistant) -> None:
     assert len(hass.states.async_entity_ids()) == 0
 
 
-async def test_unload_entry_fails_if_never_loaded(hass: HomeAssistant) -> None:
-    """."""
+async def test_unload_entry_tolerates_never_loaded(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test unloading an entry that was never loaded succeeds with a warning."""
     component = EntityComponent(_LOGGER, DOMAIN, hass)
     entry = MockConfigEntry(domain="entry_domain")
 
-    with pytest.raises(ValueError):
-        await component.async_unload_entry(entry)
+    assert await component.async_unload_entry(entry)
+    assert (
+        f"Config entry Mock Title ({entry.entry_id}) for "
+        f"entry_domain.{DOMAIN} was never loaded"
+    ) in caplog.text
 
 
 async def test_update_entity(hass: HomeAssistant) -> None:

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -428,8 +428,8 @@ async def test_unload_entry_tolerates_never_loaded(
     assert await component.async_unload_entry(entry)
     assert (
         f"Ignored unload request for config entry Mock Title ({entry.entry_id}) "
-        f"in entry_domain.{DOMAIN}; no platform is loaded, it was never set up " 
-        "or has already been unloaded"                                           
+        f"in entry_domain.{DOMAIN}; no platform is loaded, it was never set up "
+        "or has already been unloaded"
     ) in caplog.text
 
 

--- a/tests/helpers/test_entity_component.py
+++ b/tests/helpers/test_entity_component.py
@@ -427,8 +427,9 @@ async def test_unload_entry_tolerates_never_loaded(
 
     assert await component.async_unload_entry(entry)
     assert (
-        f"Config entry Mock Title ({entry.entry_id}) for "
-        f"entry_domain.{DOMAIN} was never loaded"
+        f"Ignored unload request for config entry Mock Title ({entry.entry_id}) "
+        f"in entry_domain.{DOMAIN}; no platform is loaded, it was never set up " 
+        "or has already been unloaded"                                           
     ) in caplog.text
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`EntityComponent.async_unload_entry` raises `ValueError("Config entry was never loaded!")` when the entry is not in `self._platforms`. In practice this situation arises when a forwarded platform's setup silently failed earlier: `_async_forward_entry_setups_locked` gathers per-platform setup tasks and discards their results, so an integration's entry can be `LOADED` while one of its platforms (e.g. `notify`) was never registered with the corresponding `EntityComponent`.

The *next* unload of that entry then hits the `ValueError`, which `config_entries` converts into a failed unload — wedging the whole entry into the non-recoverable `FAILED_UNLOAD` state. The user's only way out is a full Home Assistant restart, for a situation where there was **nothing to unload in the first place**.

Real-world reports of exactly this chain:
- #166228 — tibber: `Error unloading entry Tibber for notify` → `ValueError: Config entry was never loaded!` → `FAILED_UNLOAD` → restart required
- #159949 — esphome `assist_satellite`, same `ValueError`; the reporter explicitly identified this method as not handling already-/never-loaded entries
- #90180 — tibber `sensor` platform, same failure in 2023.3

This change makes `async_unload_entry` log a warning (naming the entry and domain, and pointing at a possible earlier platform setup failure) and return `True` when the entry was never registered — there is no `EntityPlatform` state to reset, so treating it as already-unloaded is accurate and lets the entry unload/reload normally instead of requiring a restart. The `async_setup_entry` side (including its "has already been setup" guard) is unchanged.

Test evidence: `pytest tests/helpers/test_entity_component.py` → 30 passed (the previous `test_unload_entry_fails_if_never_loaded` is replaced by `test_unload_entry_tolerates_never_loaded`, asserting `True` plus the warning in caplog; the new test fails with the old `ValueError` when the helper is reverted). Sanity run of `tests/components/tibber/` on this branch: 92 passed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176593
- This PR is related to issue: #166228, #159949, #90180
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
