### PR TITLE
Do not refresh OAuth token during Tibber unload

### DIFF
--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -3,6 +3,7 @@
 import asyncio
 from dataclasses import dataclass, field
 import logging
+from typing import Final
 
 import aiohttp
 from aiohttp.client_exceptions import ClientError
@@ -36,6 +37,8 @@ from .coordinator import (
 from .services import async_setup_services
 
 PLATFORMS = [Platform.BINARY_SENSOR, Platform.NOTIFY, Platform.SENSOR]
+
+DISCONNECT_TIMEOUT: Final = 10
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -88,7 +91,7 @@ async def _async_disconnect_client(client: tibber.Tibber | None) -> None:
     if client is None:
         return
     try:
-        async with asyncio.timeout(10):
+        async with asyncio.timeout(DISCONNECT_TIMEOUT):
             await client.rt_disconnect()
     except Exception:  # noqa: BLE001
         _LOGGER.warning(

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -1,5 +1,6 @@
 """Support for Tibber."""
 
+import asyncio
 from dataclasses import dataclass, field
 import logging
 
@@ -52,6 +53,11 @@ class TibberRuntimeData:
     price_coordinator: TibberPriceCoordinator | None = field(default=None)
     _client: tibber.Tibber | None = None
 
+    @property
+    def client(self) -> tibber.Tibber | None:
+        """Return the cached Tibber client, if any."""
+        return self._client
+
     async def _async_get_access_token(self) -> str:
         """Return a valid Tibber access token."""
         await self.session.async_ensure_token_valid()
@@ -75,6 +81,19 @@ class TibberRuntimeData:
         else:
             await self._client.set_access_token(access_token)
         return self._client
+
+
+async def _async_disconnect_client(client: tibber.Tibber | None) -> None:
+    """Disconnect the realtime connection without raising."""
+    if client is None:
+        return
+    try:
+        async with asyncio.timeout(10):
+            await client.rt_disconnect()
+    except Exception:  # noqa: BLE001
+        _LOGGER.warning(
+            "Error disconnecting the Tibber realtime connection", exc_info=True
+        )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -123,7 +142,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TibberConfigEntry) -> bo
     tibber_connection = await entry.runtime_data.async_get_client(hass)
 
     async def _close(event: Event) -> None:
-        await tibber_connection.rt_disconnect()
+        await _async_disconnect_client(tibber_connection)
 
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
 
@@ -168,6 +187,5 @@ async def async_unload_entry(
     if unload_ok := await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     ):
-        tibber_connection = await config_entry.runtime_data.async_get_client(hass)
-        await tibber_connection.rt_disconnect()
+        await _async_disconnect_client(config_entry.runtime_data.client)
     return unload_ok

--- a/homeassistant/components/tibber/__init__.py
+++ b/homeassistant/components/tibber/__init__.py
@@ -56,11 +56,6 @@ class TibberRuntimeData:
     price_coordinator: TibberPriceCoordinator | None = field(default=None)
     _client: tibber.Tibber | None = None
 
-    @property
-    def client(self) -> tibber.Tibber | None:
-        """Return the cached Tibber client, if any."""
-        return self._client
-
     async def _async_get_access_token(self) -> str:
         """Return a valid Tibber access token."""
         await self.session.async_ensure_token_valid()
@@ -85,18 +80,17 @@ class TibberRuntimeData:
             await self._client.set_access_token(access_token)
         return self._client
 
-
-async def _async_disconnect_client(client: tibber.Tibber | None) -> None:
-    """Disconnect the realtime connection without raising."""
-    if client is None:
-        return
-    try:
-        async with asyncio.timeout(DISCONNECT_TIMEOUT):
-            await client.rt_disconnect()
-    except Exception:  # noqa: BLE001
-        _LOGGER.warning(
-            "Error disconnecting the Tibber realtime connection", exc_info=True
-        )
+    async def async_disconnect(self) -> None:
+        """Disconnect the cached realtime connection without raising."""
+        if self._client is None:
+            return
+        try:
+            async with asyncio.timeout(DISCONNECT_TIMEOUT):
+                await self._client.rt_disconnect()
+        except Exception:  # noqa: BLE001
+            _LOGGER.warning(
+                "Error disconnecting the Tibber realtime connection", exc_info=True
+            )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -145,7 +139,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TibberConfigEntry) -> bo
     tibber_connection = await entry.runtime_data.async_get_client(hass)
 
     async def _close(event: Event) -> None:
-        await _async_disconnect_client(tibber_connection)
+        await entry.runtime_data.async_disconnect()
 
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _close))
 
@@ -190,5 +184,5 @@ async def async_unload_entry(
     if unload_ok := await hass.config_entries.async_unload_platforms(
         config_entry, PLATFORMS
     ):
-        await _async_disconnect_client(config_entry.runtime_data.client)
+        await config_entry.runtime_data.async_disconnect()
     return unload_ok

--- a/tests/components/tibber/conftest.py
+++ b/tests/components/tibber/conftest.py
@@ -220,8 +220,8 @@ def config_entry(hass: HomeAssistant) -> MockConfigEntry:
 
 
 @pytest.fixture
-def tibber_mock() -> AsyncGenerator[MagicMock]:
-    """Patch the Tibber libraries used by the integration."""
+def tibber_client_cls() -> AsyncGenerator[MagicMock]:
+    """Patch the Tibber class used by the integration."""
     unique_user_id = "unique_user_id"
     title = "title"
 
@@ -246,7 +246,13 @@ def tibber_mock() -> AsyncGenerator[MagicMock]:
         data_api_mock.get_userinfo = AsyncMock()
         tibber_mock.data_api = data_api_mock
 
-        yield tibber_mock
+        yield mock_tibber
+
+
+@pytest.fixture
+def tibber_mock(tibber_client_cls: MagicMock) -> MagicMock:
+    """Return the patched Tibber client instance."""
+    return tibber_client_cls.return_value
 
 
 @pytest.fixture

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -106,6 +106,38 @@ async def test_data_api_runtime_creates_client(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("recorder_mock")
+async def test_async_get_client_propagates_rotated_token(hass: HomeAssistant) -> None:
+    """Ensure a rotated OAuth token is pushed to the cached client on next fetch."""
+    session = MagicMock()
+    session.async_ensure_token_valid = AsyncMock()
+    session.token = {CONF_ACCESS_TOKEN: "token-1"}
+
+    runtime = TibberRuntimeData(
+        session=session,
+    )
+
+    with patch("homeassistant.components.tibber.tibber.Tibber") as mock_client_cls:
+        mock_client = MagicMock()
+        mock_client.set_access_token = AsyncMock()
+        mock_client_cls.return_value = mock_client
+
+        await runtime.async_get_client(hass)
+        mock_client_cls.assert_called_once_with(
+            access_token="token-1",
+            websession=ANY,
+            time_zone=ANY,
+            ssl=ANY,
+            refresh_access_token=ANY,
+        )
+
+        session.token = {CONF_ACCESS_TOKEN: "token-2"}
+        await runtime.async_get_client(hass)
+
+        mock_client_cls.assert_called_once()
+        mock_client.set_access_token.assert_awaited_once_with("token-2")
+
+
+@pytest.mark.usefixtures("recorder_mock")
 async def test_data_api_runtime_missing_token_raises(hass: HomeAssistant) -> None:
     """Ensure missing tokens trigger reauthentication."""
     session = MagicMock()

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -1,5 +1,7 @@
 """Test loading of the Tibber config entry."""
 
+import asyncio
+from collections.abc import Awaitable, Callable
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
@@ -29,10 +31,15 @@ async def test_entry_unload(
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
+async def _hang_forever() -> None:
+    """Simulate a realtime disconnect that never completes."""
+    await asyncio.Event().wait()
+
+
 @pytest.mark.parametrize(
     "side_effect",
     [
-        pytest.param(TimeoutError(), id="timeout"),
+        pytest.param(_hang_forever, id="timeout"),
         pytest.param(Exception("Disconnect failed"), id="exception"),
     ],
 )
@@ -40,14 +47,15 @@ async def test_entry_unload_rt_disconnect_error(
     recorder_mock: Recorder,
     hass: HomeAssistant,
     mock_tibber_setup: MagicMock,
-    side_effect: Exception,
+    side_effect: Exception | Callable[[], Awaitable[None]],
 ) -> None:
     """Test the entry unloads even if disconnecting the client fails."""
     entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "tibber")
     assert entry.state is ConfigEntryState.LOADED
 
     mock_tibber_setup.rt_disconnect.side_effect = side_effect
-    await hass.config_entries.async_unload(entry.entry_id)
+    with patch("homeassistant.components.tibber.DISCONNECT_TIMEOUT", 0.05):
+        await hass.config_entries.async_unload(entry.entry_id)
     mock_tibber_setup.rt_disconnect.assert_called_once()
     await hass.async_block_till_done(wait_background_tasks=True)
     assert entry.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -21,6 +21,32 @@ async def test_entry_unload(
     entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "tibber")
     assert entry.state is ConfigEntryState.LOADED
 
+    mock_tibber_setup.set_access_token.reset_mock()
+    await hass.config_entries.async_unload(entry.entry_id)
+    mock_tibber_setup.rt_disconnect.assert_called_once()
+    mock_tibber_setup.set_access_token.assert_not_called()
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(TimeoutError(), id="timeout"),
+        pytest.param(Exception("Disconnect failed"), id="exception"),
+    ],
+)
+async def test_entry_unload_rt_disconnect_error(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_tibber_setup: MagicMock,
+    side_effect: Exception,
+) -> None:
+    """Test the entry unloads even if disconnecting the client fails."""
+    entry = hass.config_entries.async_entry_for_domain_unique_id(DOMAIN, "tibber")
+    assert entry.state is ConfigEntryState.LOADED
+
+    mock_tibber_setup.rt_disconnect.side_effect = side_effect
     await hass.config_entries.async_unload(entry.entry_id)
     mock_tibber_setup.rt_disconnect.assert_called_once()
     await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/tibber/test_init.py
+++ b/tests/components/tibber/test_init.py
@@ -2,16 +2,17 @@
 
 import asyncio
 from collections.abc import Awaitable, Callable
-from unittest.mock import ANY, AsyncMock, MagicMock, patch
+import time
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
 
 from homeassistant.components.recorder import Recorder
-from homeassistant.components.tibber import DOMAIN, TibberRuntimeData
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.tibber import DOMAIN
+from homeassistant.components.tibber.const import AUTH_IMPLEMENTATION
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed
 
 from tests.common import MockConfigEntry
 
@@ -61,96 +62,90 @@ async def test_entry_unload_rt_disconnect_error(
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.usefixtures("recorder_mock")
-async def test_data_api_runtime_creates_client(hass: HomeAssistant) -> None:
-    """Ensure the data API runtime creates and caches the client."""
-    session = MagicMock()
-    session.async_ensure_token_valid = AsyncMock()
-    session.token = {CONF_ACCESS_TOKEN: "access-token"}
-
-    runtime = TibberRuntimeData(
-        session=session,
+async def _async_trigger_client_fetch(hass: HomeAssistant) -> None:
+    """Make the integration fetch its client through a public entity action."""
+    await hass.services.async_call(
+        "notify",
+        "send_message",
+        {"entity_id": "notify.tibber", "message": "message"},
+        blocking=True,
     )
 
-    with patch("homeassistant.components.tibber.tibber.Tibber") as mock_client_cls:
-        mock_client = MagicMock()
-        mock_client.set_access_token = AsyncMock()
-        mock_client_cls.return_value = mock_client
 
-        client = await runtime.async_get_client(hass)
-
-        mock_client_cls.assert_called_once_with(
-            access_token="access-token",
-            websession=ANY,
-            time_zone=ANY,
-            ssl=ANY,
-            refresh_access_token=ANY,
-        )
-        session.async_ensure_token_valid.assert_awaited_once()
-        mock_client.set_access_token.assert_not_awaited()
-        assert client is mock_client
-
-        refresh_access_token = mock_client_cls.call_args.kwargs["refresh_access_token"]
-        session.async_ensure_token_valid.reset_mock()
-        assert await refresh_access_token() == "access-token"
-        session.async_ensure_token_valid.assert_awaited_once()
-
-        session.async_ensure_token_valid.reset_mock()
-
-        cached_client = await runtime.async_get_client(hass)
-
-        mock_client_cls.assert_called_once()
-        session.async_ensure_token_valid.assert_awaited_once()
-        mock_client.set_access_token.assert_awaited_once_with("access-token")
-        assert cached_client is client
-
-
-@pytest.mark.usefixtures("recorder_mock")
-async def test_async_get_client_propagates_rotated_token(hass: HomeAssistant) -> None:
-    """Ensure a rotated OAuth token is pushed to the cached client on next fetch."""
-    session = MagicMock()
-    session.async_ensure_token_valid = AsyncMock()
-    session.token = {CONF_ACCESS_TOKEN: "token-1"}
-
-    runtime = TibberRuntimeData(
-        session=session,
+@pytest.mark.usefixtures("recorder_mock", "mock_tibber_setup")
+async def test_client_created_once_and_reused(
+    hass: HomeAssistant,
+    tibber_client_cls: MagicMock,
+    tibber_mock: MagicMock,
+) -> None:
+    """Ensure setup builds one authenticated client that later fetches reuse."""
+    tibber_client_cls.assert_called_once_with(
+        access_token="test-token",
+        websession=ANY,
+        time_zone=ANY,
+        ssl=ANY,
+        refresh_access_token=ANY,
     )
 
-    with patch("homeassistant.components.tibber.tibber.Tibber") as mock_client_cls:
-        mock_client = MagicMock()
-        mock_client.set_access_token = AsyncMock()
-        mock_client_cls.return_value = mock_client
+    # The library refreshes its own realtime token through this callback.
+    refresh_access_token = tibber_client_cls.call_args.kwargs["refresh_access_token"]
+    assert await refresh_access_token() == "test-token"
 
-        await runtime.async_get_client(hass)
-        mock_client_cls.assert_called_once_with(
-            access_token="token-1",
-            websession=ANY,
-            time_zone=ANY,
-            ssl=ANY,
-            refresh_access_token=ANY,
-        )
+    tibber_mock.set_access_token.reset_mock()
+    await _async_trigger_client_fetch(hass)
 
-        session.token = {CONF_ACCESS_TOKEN: "token-2"}
-        await runtime.async_get_client(hass)
-
-        mock_client_cls.assert_called_once()
-        mock_client.set_access_token.assert_awaited_once_with("token-2")
+    tibber_client_cls.assert_called_once()
+    tibber_mock.set_access_token.assert_awaited_once_with("test-token")
 
 
-@pytest.mark.usefixtures("recorder_mock")
-async def test_data_api_runtime_missing_token_raises(hass: HomeAssistant) -> None:
-    """Ensure missing tokens trigger reauthentication."""
-    session = MagicMock()
-    session.async_ensure_token_valid = AsyncMock()
-    session.token = {}
-
-    runtime = TibberRuntimeData(
-        session=session,
+@pytest.mark.usefixtures("recorder_mock", "mock_tibber_setup")
+async def test_rotated_token_pushed_to_cached_client(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    tibber_client_cls: MagicMock,
+    tibber_mock: MagicMock,
+) -> None:
+    """Ensure a rotated OAuth token reaches the cached client on the next fetch."""
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            "token": {**config_entry.data["token"], CONF_ACCESS_TOKEN: "token-2"},
+        },
     )
 
-    with pytest.raises(ConfigEntryAuthFailed):
-        await runtime.async_get_client(hass)
-    session.async_ensure_token_valid.assert_awaited_once()
+    tibber_mock.set_access_token.reset_mock()
+    await _async_trigger_client_fetch(hass)
+
+    tibber_client_cls.assert_called_once()
+    tibber_mock.set_access_token.assert_awaited_once_with("token-2")
+
+
+@pytest.mark.usefixtures("recorder_mock", "tibber_mock", "setup_credentials")
+async def test_setup_missing_access_token_triggers_reauth(
+    hass: HomeAssistant,
+) -> None:
+    """Ensure an OAuth token without an access token triggers reauthentication."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            AUTH_IMPLEMENTATION: DOMAIN,
+            "token": {
+                "refresh_token": "refresh-token",
+                "token_type": "Bearer",
+                "expires_at": time.time() + 3600,
+            },
+        },
+        unique_id="tibber",
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["context"]["source"] == SOURCE_REAUTH
 
 
 async def test_setup_requires_data_api_reauth(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`async_unload_entry` currently obtains the client via `runtime_data.async_get_client(hass)` — solely to disconnect it. That call performs a network OAuth token refresh (`OAuth2Session.async_ensure_token_valid()`), and when the token has rotated it calls `Tibber.set_access_token()`, which does a full realtime websocket reset, reconnect and resubscribe — all in the middle of tearing the entry down. Any exception escaping here (flaky Tibber API, auth failure), or a hang in the unbounded `rt_disconnect()` close path on a half-dead websocket, wedges the entry into the non-recoverable `FAILED_UNLOAD` state, from which only a Home Assistant restart recovers.

This change:
- keeps a single way to obtain the client, `async_get_client()`, which is always authenticated, and adds an `async_disconnect()` action on `TibberRuntimeData` for teardown,
- makes `async_unload_entry` disconnect the cached client directly (no network round-trip, no token refresh, no websocket rebuild during teardown),
- bounds the disconnect with `asyncio.timeout` and logs instead of raising, so a dead websocket that won't close politely cannot fail the unload,
- applies the same bounded disconnect to the `EVENT_HOMEASSISTANT_STOP` handler.

Real-world reports of reloads wedging into `FAILED_UNLOAD` with this integration: #168480 (several comments), #166228 (March comment with the full traceback chain), #176268 (the realtime-drop scenario in which users attempt the reload).

Test evidence: `pytest tests/components/tibber/` → 93 passed. The new and changed tests fail against unpatched code, verified by reverting the component and re-running: `test_entry_unload` asserts `set_access_token` is **not** called during unload, a parametrised `test_entry_unload_rt_disconnect_error` asserts the entry reaches `NOT_LOADED` even when `rt_disconnect` hangs past the deadline or raises, and `test_rotated_token_pushed_to_cached_client` asserts a rotated OAuth token reaches the cached client without rebuilding it. The runtime-data tests now drive the integration through its config entry rather than constructing `TibberRuntimeData` directly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #168480, #166228, #176268, #176593
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

