### PR TITLE
Catch PynoboConnectionError at nobo_hub connection sites

### DIFF
--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from pynobo import nobo
+from pynobo import PynoboConnectionError, nobo
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -53,7 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
 
     try:
         hub = await _connect(stored_ip)
-    except OSError as err:
+    except PynoboConnectionError as err:
         # Stored IP may be stale - try UDP rediscovery to pick up a new
         # DHCP lease (or a hub that's been moved).
         discovered = await nobo.async_discover_hubs(serial=serial)
@@ -66,7 +66,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
         new_ip, _ = next(iter(discovered))
         try:
             hub = await _connect(new_ip)
-        except OSError as rediscover_err:
+        except PynoboConnectionError as rediscover_err:
             raise ConfigEntryNotReady(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",

--- a/homeassistant/components/nobo_hub/config_flow.py
+++ b/homeassistant/components/nobo_hub/config_flow.py
@@ -3,7 +3,7 @@
 import ipaddress
 from typing import TYPE_CHECKING, Any, override
 
-from pynobo import nobo
+from pynobo import PynoboConnectionError, nobo
 import voluptuous as vol
 
 from homeassistant.config_entries import (
@@ -313,14 +313,14 @@ class NoboHubConfigFlow(ConfigFlow, domain=DOMAIN):
             raise NoboHubConnectError("invalid_ip") from err
         hub = nobo(serial=serial, ip=ip_address, discover=False, synchronous=False)
         # pynobo distinguishes the two failure modes: TCP-level errors
-        # (wrong IP, hub offline, port closed) raise OSError, while a
-        # successful TCP connection followed by a handshake REJECT
+        # (wrong IP, hub offline, port closed) raise PynoboConnectionError,
+        # while a successful TCP connection followed by a handshake REJECT
         # (serial mismatch) returns False.
         try:
             if not await hub.async_connect_hub(ip_address, serial):
                 raise NoboHubConnectError("cannot_connect")
             return hub.hub_info["name"]
-        except OSError as err:
+        except PynoboConnectionError as err:
             raise NoboHubConnectError("cannot_connect_ip") from err
         finally:
             await hub.close()

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -1,8 +1,8 @@
 """Test the Nobø Ecohub config flow."""
 
-import errno
 from unittest.mock import AsyncMock, PropertyMock, patch
 
+from pynobo import PynoboConnectionError
 import pytest
 
 from homeassistant import config_entries
@@ -407,7 +407,10 @@ async def test_configure_invalid_ip_address(
     ("connect_outcome", "expected_error"),
     [
         ({"return_value": False}, "cannot_connect"),
-        ({"side_effect": ConnectionRefusedError(61, "")}, "cannot_connect_ip"),
+        (
+            {"side_effect": PynoboConnectionError("Failed to connect")},
+            "cannot_connect_ip",
+        ),
     ],
     ids=["serial_mismatch", "tcp_failure"],
 )
@@ -420,10 +423,10 @@ async def test_configure_cannot_connect(
     """Connect failures map to distinct error keys; retry recovers.
 
     pynobo's async_connect_hub returns False on a successful TCP connect
-    followed by a handshake REJECT (serial mismatch) and raises OSError
-    on TCP-level failure (wrong IP / hub offline). We surface these as
-    cannot_connect ("check serial number") and cannot_connect_ip
-    ("check IP address") respectively.
+    followed by a handshake REJECT (serial mismatch) and raises
+    PynoboConnectionError on TCP-level failure (wrong IP / hub offline).
+    We surface these as cannot_connect ("check serial number") and
+    cannot_connect_ip ("check IP address") respectively.
     """
     with patch(
         "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
@@ -818,7 +821,7 @@ async def test_reconfigure_flow_changes_ip(
     [
         (
             "192.168.1.200",
-            {"side_effect": ConnectionRefusedError(errno.ECONNREFUSED, "")},
+            {"side_effect": PynoboConnectionError("Failed to connect")},
             "cannot_connect_ip",
             1,
         ),

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -475,6 +475,37 @@ async def test_configure_cannot_connect(
     mock_setup_entry.assert_awaited_once()
 
 
+async def test_configure_plain_os_error_not_caught(
+    hass: HomeAssistant,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """A plain OSError is not mapped to cannot_connect_ip; only PynoboConnectionError is."""
+    with patch(
+        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
+        return_value=[("1.1.1.1", "123456789")],
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"device": "1.1.1.1"},
+    )
+
+    with (
+        patch(
+            "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
+            side_effect=OSError("boom"),
+        ),
+        pytest.raises(OSError, match="boom"),
+    ):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"serial_suffix": "012"},
+        )
+
+
 async def test_dhcp_discovery_new_hub(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,

--- a/tests/components/nobo_hub/test_config_flow.py
+++ b/tests/components/nobo_hub/test_config_flow.py
@@ -475,37 +475,6 @@ async def test_configure_cannot_connect(
     mock_setup_entry.assert_awaited_once()
 
 
-async def test_configure_plain_os_error_not_caught(
-    hass: HomeAssistant,
-    mock_setup_entry: AsyncMock,
-) -> None:
-    """A plain OSError is not mapped to cannot_connect_ip; only PynoboConnectionError is."""
-    with patch(
-        "homeassistant.components.nobo_hub.config_flow.nobo.async_discover_hubs",
-        return_value=[("1.1.1.1", "123456789")],
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"],
-        {"device": "1.1.1.1"},
-    )
-
-    with (
-        patch(
-            "homeassistant.components.nobo_hub.config_flow.nobo.async_connect_hub",
-            side_effect=OSError("boom"),
-        ),
-        pytest.raises(OSError, match="boom"),
-    ):
-        await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {"serial_suffix": "012"},
-        )
-
-
 async def test_dhcp_discovery_new_hub(
     hass: HomeAssistant,
     mock_setup_entry: AsyncMock,

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -123,6 +123,45 @@ async def test_setup_retries_when_rediscovered_ip_also_fails(
     }
 
 
+async def test_setup_does_not_catch_plain_os_error_on_stored_ip(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nobo_class: MagicMock,
+) -> None:
+    """A plain OSError (not PynoboConnectionError) is not caught; no rediscovery."""
+    mock_config_entry.add_to_hass(hass)
+    failing_hub = MagicMock(spec=pynobo_nobo)
+    failing_hub.connect.side_effect = OSError("boom")
+    mock_nobo_class.side_effect = [failing_hub]
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    mock_nobo_class.async_discover_hubs.assert_not_called()
+
+
+async def test_setup_does_not_catch_plain_os_error_on_rediscovered_ip(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_nobo_class: MagicMock,
+) -> None:
+    """A plain OSError from the rediscovered IP is not caught by the fallback."""
+    mock_config_entry.add_to_hass(hass)
+    first_failing_hub = MagicMock(spec=pynobo_nobo)
+    first_failing_hub.connect.side_effect = PynoboConnectionError("Unreachable")
+    second_failing_hub = MagicMock(spec=pynobo_nobo)
+    second_failing_hub.connect.side_effect = OSError("boom")
+    mock_nobo_class.side_effect = [first_failing_hub, second_failing_hub]
+    mock_nobo_class.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_nobo_class.call_count == 2
+
+
 @pytest.mark.parametrize(
     ("stored_options", "expected_options"),
     [

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -123,24 +123,6 @@ async def test_setup_retries_when_rediscovered_ip_also_fails(
     }
 
 
-async def test_setup_does_not_catch_plain_os_error_on_stored_ip(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_nobo_class: MagicMock,
-) -> None:
-    """A plain OSError (not PynoboConnectionError) is not caught; no rediscovery."""
-    mock_config_entry.add_to_hass(hass)
-    failing_hub = MagicMock(spec=pynobo_nobo)
-    failing_hub.connect.side_effect = OSError("boom")
-    mock_nobo_class.side_effect = [failing_hub]
-
-    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
-    mock_nobo_class.async_discover_hubs.assert_not_called()
-
-
 async def test_setup_does_not_catch_plain_os_error_on_rediscovered_ip(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -3,7 +3,7 @@
 import logging
 from unittest.mock import MagicMock
 
-from pynobo import nobo as pynobo_nobo
+from pynobo import PynoboConnectionError, nobo as pynobo_nobo
 import pytest
 
 from homeassistant.components.nobo_hub.const import (
@@ -61,7 +61,7 @@ async def test_setup_rediscovery_updates_ip(
     """A failed direct connect falls back to rediscovery and persists the new IP."""
     mock_config_entry.add_to_hass(hass)
     failing_hub = MagicMock(spec=pynobo_nobo)
-    failing_hub.connect.side_effect = OSError("Unreachable")
+    failing_hub.connect.side_effect = PynoboConnectionError("Unreachable")
     mock_nobo_class.side_effect = [failing_hub, mock_nobo_class.return_value]
     mock_nobo_class.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
 
@@ -83,7 +83,7 @@ async def test_setup_retries_when_rediscovery_finds_nothing(
     """Setup retries when stored IP fails and rediscovery is empty."""
     mock_config_entry.add_to_hass(hass)
     failing_hub = MagicMock(spec=pynobo_nobo)
-    failing_hub.connect.side_effect = OSError("Unreachable")
+    failing_hub.connect.side_effect = PynoboConnectionError("Unreachable")
     mock_nobo_class.side_effect = [failing_hub]
     mock_nobo_class.async_discover_hubs.return_value = set()
 
@@ -106,9 +106,9 @@ async def test_setup_retries_when_rediscovered_ip_also_fails(
     """Setup retries when both stored and rediscovered IPs fail."""
     mock_config_entry.add_to_hass(hass)
     first_failing_hub = MagicMock(spec=pynobo_nobo)
-    first_failing_hub.connect.side_effect = OSError("Unreachable")
+    first_failing_hub.connect.side_effect = PynoboConnectionError("Unreachable")
     second_failing_hub = MagicMock(spec=pynobo_nobo)
-    second_failing_hub.connect.side_effect = OSError("Unreachable")
+    second_failing_hub.connect.side_effect = PynoboConnectionError("Unreachable")
     mock_nobo_class.side_effect = [first_failing_hub, second_failing_hub]
     mock_nobo_class.async_discover_hubs.return_value = {(NEW_IP, SERIAL)}
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

`pynobo` raises `PynoboConnectionError` (a subclass of `OSError`) on TCP-level connection failures. Catch that specific type instead of the broad `OSError` at the hub-connect sites in `async_setup_entry` and the config flow's `_test_connection`, so unrelated `OSError`s are no longer swallowed.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
