### PR TITLE
Add Duco ventilation temperature sensors

### DIFF
--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -11,7 +11,13 @@ from duco_connectivity.exceptions import (
     DucoError,
     DucoResponseError,
 )
-from duco_connectivity.models import BoardInfo, Node, NodeListActionItemList, NodeName
+from duco_connectivity.models import (
+    BoardInfo,
+    Node,
+    NodeListActionItemList,
+    NodeName,
+    VentilationTemperatureInfo,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -26,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 type DucoConfigEntry = ConfigEntry[DucoCoordinator]
 
 
-@dataclass
+@dataclass(slots=True, kw_only=True)
 class DucoData:
     """Data returned by the Duco coordinator."""
 
@@ -34,6 +40,7 @@ class DucoData:
     node_actions: NodeListActionItemList
     rssi_wifi: int | None
     time_filter_remain: int | None
+    ventilation_temperatures: VentilationTemperatureInfo | None
 
 
 class DucoCoordinator(DataUpdateCoordinator[DucoData]):
@@ -42,6 +49,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
     config_entry: DucoConfigEntry
     board_info: BoardInfo
     _supports_time_filter_remain: bool
+    _supports_ventilation_temperatures: bool
     _configured_node_names: dict[int, str]
 
     def __init__(
@@ -61,6 +69,7 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
         self.client = client
         self._configured_node_names = {}
         self._supports_time_filter_remain = True
+        self._supports_ventilation_temperatures = True
 
     async def _async_load_node_names(self) -> None:
         """Load configured Duco node names during setup."""
@@ -175,9 +184,27 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 time_filter_remain = await self.client.async_get_time_filter_remaining()
                 self._supports_time_filter_remain = time_filter_remain is not None
 
+        ventilation_temperatures = (
+            self.data.ventilation_temperatures if self.data else None
+        )
+        if self._supports_ventilation_temperatures:
+            try:
+                ventilation_temperatures = (
+                    await self.client.async_get_ventilation_temperature_info()
+                )
+            except DucoError as err:
+                _LOGGER.debug(
+                    "Could not fetch Duco ventilation temperatures", exc_info=err
+                )
+            else:
+                self._supports_ventilation_temperatures = (
+                    ventilation_temperatures is not None
+                )
+
         return DucoData(
             nodes={node.node_id: node for node in nodes},
             node_actions=node_actions,
             rssi_wifi=rssi_wifi,
             time_filter_remain=time_filter_remain,
+            ventilation_temperatures=ventilation_temperatures,
         )

--- a/homeassistant/components/duco/coordinator.py
+++ b/homeassistant/components/duco/coordinator.py
@@ -10,6 +10,7 @@ from duco_connectivity.exceptions import (
     DucoConnectionError,
     DucoError,
     DucoResponseError,
+    DucoUnsupportedCapabilityError,
 )
 from duco_connectivity.models import (
     BoardInfo,
@@ -192,13 +193,12 @@ class DucoCoordinator(DataUpdateCoordinator[DucoData]):
                 ventilation_temperatures = (
                     await self.client.async_get_ventilation_temperature_info()
                 )
+            except DucoUnsupportedCapabilityError:
+                ventilation_temperatures = None
+                self._supports_ventilation_temperatures = False
             except DucoError as err:
                 _LOGGER.debug(
                     "Could not fetch Duco ventilation temperatures", exc_info=err
-                )
-            else:
-                self._supports_ventilation_temperatures = (
-                    ventilation_temperatures is not None
                 )
 
         return DucoData(

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     EntityCategory,
     UnitOfRatio,
+    UnitOfTemperature,
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -155,6 +156,70 @@ BOX_SENSOR_DESCRIPTIONS: tuple[DucoBoxSensorEntityDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
         value_fn=lambda coordinator: coordinator.data.rssi_wifi,
+    ),
+    DucoBoxSensorEntityDescription(
+        key="outdoor_air_temperature",
+        translation_key="outdoor_air_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        supported_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures is not None
+            and coordinator.data.ventilation_temperatures.temp_oda is not None
+        ),
+        value_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures.temp_oda
+            if coordinator.data.ventilation_temperatures
+            else None
+        ),
+    ),
+    DucoBoxSensorEntityDescription(
+        key="supply_air_temperature",
+        translation_key="supply_air_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        supported_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures is not None
+            and coordinator.data.ventilation_temperatures.temp_sup is not None
+        ),
+        value_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures.temp_sup
+            if coordinator.data.ventilation_temperatures
+            else None
+        ),
+    ),
+    DucoBoxSensorEntityDescription(
+        key="extract_air_temperature",
+        translation_key="extract_air_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        supported_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures is not None
+            and coordinator.data.ventilation_temperatures.temp_eta is not None
+        ),
+        value_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures.temp_eta
+            if coordinator.data.ventilation_temperatures
+            else None
+        ),
+    ),
+    DucoBoxSensorEntityDescription(
+        key="exhaust_air_temperature",
+        translation_key="exhaust_air_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        supported_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures is not None
+            and coordinator.data.ventilation_temperatures.temp_eha is not None
+        ),
+        value_fn=lambda coordinator: (
+            coordinator.data.ventilation_temperatures.temp_eha
+            if coordinator.data.ventilation_temperatures
+            else None
+        ),
     ),
 )
 

--- a/homeassistant/components/duco/strings.json
+++ b/homeassistant/components/duco/strings.json
@@ -73,6 +73,12 @@
       }
     },
     "sensor": {
+      "exhaust_air_temperature": {
+        "name": "Exhaust air temperature"
+      },
+      "extract_air_temperature": {
+        "name": "Extract air temperature"
+      },
       "filter_remaining": {
         "name": "Filter remaining"
       },
@@ -81,6 +87,12 @@
       },
       "iaq_rh": {
         "name": "Humidity air quality index"
+      },
+      "outdoor_air_temperature": {
+        "name": "Outdoor air temperature"
+      },
+      "supply_air_temperature": {
+        "name": "Supply air temperature"
       },
       "target_flow_level": {
         "name": "Target flow level"

--- a/tests/components/duco/conftest.py
+++ b/tests/components/duco/conftest.py
@@ -23,6 +23,7 @@ from duco_connectivity import (
     NodeMotorStateInfo,
     NodeSensorInfo,
     NodeVentilationInfo,
+    VentilationTemperatureInfo,
 )
 import pytest
 
@@ -179,6 +180,17 @@ def mock_lan_info() -> LanInfo:
 
 
 @pytest.fixture
+def mock_ventilation_temperature_info() -> VentilationTemperatureInfo:
+    """Return mock ventilation temperatures in Celsius."""
+    return VentilationTemperatureInfo(
+        temp_oda=5.5,
+        temp_sup=18.2,
+        temp_eta=21.4,
+        temp_eha=8.1,
+    )
+
+
+@pytest.fixture
 def mock_nodes() -> list[Node]:
     """Return a list of nodes covering all supported types."""
     return load_nodes_fixture("nodes.json")
@@ -235,6 +247,7 @@ def mock_duco_client(
     mock_lan_info: LanInfo,
     mock_nodes: list[Node],
     mock_node_actions: NodeListActionItemList,
+    mock_ventilation_temperature_info: VentilationTemperatureInfo,
 ) -> Generator[AsyncMock]:
     """Return a mocked DucoClient used by both the integration and config flow."""
     with (
@@ -255,6 +268,9 @@ def mock_duco_client(
         client.async_get_node_configs.return_value = node_configs_from_nodes(mock_nodes)
         client.async_get_node_actions.return_value = mock_node_actions
         client.async_get_time_filter_remaining.return_value = 180
+        client.async_get_ventilation_temperature_info.return_value = (
+            mock_ventilation_temperature_info
+        )
         client.async_get_diagnostics.return_value = [
             DiagComponent(component="Ventilation", status="Ok")
         ]

--- a/tests/components/duco/snapshots/test_sensor.ambr
+++ b/tests/components/duco/snapshots/test_sensor.ambr
@@ -835,6 +835,122 @@
     'state': '90',
   })
 # ---
+# name: test_sensor_entities_state[sensor.living_exhaust_air_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_exhaust_air_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Exhaust air temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Exhaust air temperature',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'exhaust_air_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_exhaust_air_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_exhaust_air_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Exhaust air temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_exhaust_air_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '8.1',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_extract_air_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_extract_air_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Extract air temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Extract air temperature',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'extract_air_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_extract_air_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_extract_air_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Extract air temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_extract_air_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '21.4',
+  })
+# ---
 # name: test_sensor_entities_state[sensor.living_filter_remaining-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -888,6 +1004,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '180',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_outdoor_air_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_outdoor_air_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Outdoor air temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Outdoor air temperature',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'outdoor_air_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_outdoor_air_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_outdoor_air_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Outdoor air temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_outdoor_air_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '5.5',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_signal_strength-entry]
@@ -994,6 +1168,64 @@
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_supply_air_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.living_supply_air_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Supply air temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Supply air temperature',
+    'platform': 'duco',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'supply_air_temperature',
+    'unique_id': 'aa:bb:cc:dd:ee:ff_1_supply_air_temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_state[sensor.living_supply_air_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Supply air temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.living_supply_air_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '18.2',
   })
 # ---
 # name: test_sensor_entities_state[sensor.living_target_flow_level-entry]

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -12,6 +12,7 @@ from duco_connectivity import (
     DucoConnectionError,
     DucoError,
     DucoResponseError,
+    DucoUnsupportedCapabilityError,
     LanInfo,
     Node,
     NodeListActionItemList,
@@ -203,7 +204,9 @@ async def test_unsupported_ventilation_temperature_capability_is_not_repolled(
     mock_duco_client: AsyncMock,
 ) -> None:
     """Test unavailable ventilation temperatures are not polled after setup."""
-    mock_duco_client.async_get_ventilation_temperature_info.return_value = None
+    mock_duco_client.async_get_ventilation_temperature_info.side_effect = (
+        DucoUnsupportedCapabilityError(400, "/info", '{"Code":3,"Result":"FAILED"}')
+    )
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -20,6 +20,7 @@ from duco_connectivity import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.duco.const import SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -160,33 +161,39 @@ async def test_setup_entry_ignores_lan_info_failures(
 
 
 @pytest.mark.parametrize(
-    "method",
-    [
-        pytest.param("async_get_ventilation_temperature_info", id="temperatures"),
-    ],
-)
-@pytest.mark.parametrize(
     "exception",
     [
         pytest.param(DucoError("API error"), id="duco_error"),
         pytest.param(DucoConnectionError("Connection refused"), id="connection_error"),
     ],
 )
-async def test_setup_entry_ignores_optional_temperature_capability_failures(
+async def test_setup_entry_recovers_from_optional_temperature_capability_failure(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
-    method: str,
     exception: Exception,
 ) -> None:
-    """Test setup succeeds when an optional temperature capability is unavailable."""
-    getattr(mock_duco_client, method).side_effect = exception
+    """Test an optional temperature capability is retried after a setup failure."""
+    mock_duco_client.async_get_ventilation_temperature_info.side_effect = [
+        exception,
+        VentilationTemperatureInfo(temp_oda=5.5),
+    ]
     mock_config_entry.add_to_hass(hass)
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert hass.states.get("sensor.living_outdoor_air_temperature") is None
+
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get("sensor.living_outdoor_air_temperature")
+    assert state is not None
+    assert state.state == "5.5"
 
 
 async def test_unsupported_ventilation_temperature_capability_is_not_repolled(

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -15,6 +15,7 @@ from duco_connectivity import (
     LanInfo,
     Node,
     NodeListActionItemList,
+    VentilationTemperatureInfo,
 )
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -158,6 +159,59 @@ async def test_setup_entry_ignores_lan_info_failures(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
 
+@pytest.mark.parametrize(
+    "method",
+    [
+        pytest.param("async_get_ventilation_temperature_info", id="temperatures"),
+    ],
+)
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(DucoError("API error"), id="duco_error"),
+        pytest.param(DucoConnectionError("Connection refused"), id="connection_error"),
+    ],
+)
+async def test_setup_entry_ignores_optional_temperature_capability_failures(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    method: str,
+    exception: Exception,
+) -> None:
+    """Test setup succeeds when an optional temperature capability is unavailable."""
+    getattr(mock_duco_client, method).side_effect = exception
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_unsupported_ventilation_temperature_capability_is_not_repolled(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test unavailable ventilation temperatures are not polled after setup."""
+    mock_duco_client.async_get_ventilation_temperature_info.return_value = None
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    mock_duco_client.async_get_ventilation_temperature_info.reset_mock()
+
+    freezer.tick(timedelta(days=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_duco_client.async_get_ventilation_temperature_info.assert_not_awaited()
+
+
 async def test_setup_entry_ignores_node_name_config_failures(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
@@ -280,6 +334,9 @@ async def test_setup_entry_creates_http_client(
         mock_client_class.return_value.async_get_node_actions.return_value = (
             mock_node_actions
         )
+        (
+            mock_client_class.return_value.async_get_ventilation_temperature_info.return_value
+        ) = VentilationTemperatureInfo()
         mock_client_class.return_value.async_get_diagnostics.return_value = [
             DiagComponent(component="Ventilation", status="Ok")
         ]

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -12,7 +12,6 @@ from duco_connectivity import (
     DucoConnectionError,
     DucoError,
     DucoResponseError,
-    DucoUnsupportedCapabilityError,
     LanInfo,
     Node,
     NodeListActionItemList,
@@ -195,31 +194,6 @@ async def test_setup_entry_recovers_from_optional_temperature_capability_failure
     state = hass.states.get("sensor.living_outdoor_air_temperature")
     assert state is not None
     assert state.state == "5.5"
-
-
-async def test_unsupported_ventilation_temperature_capability_is_not_repolled(
-    hass: HomeAssistant,
-    freezer: FrozenDateTimeFactory,
-    mock_config_entry: MockConfigEntry,
-    mock_duco_client: AsyncMock,
-) -> None:
-    """Test unavailable ventilation temperatures are not polled after setup."""
-    mock_duco_client.async_get_ventilation_temperature_info.side_effect = (
-        DucoUnsupportedCapabilityError(400, "/info", '{"Code":3,"Result":"FAILED"}')
-    )
-    mock_config_entry.add_to_hass(hass)
-
-    await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert mock_config_entry.state is ConfigEntryState.LOADED
-    mock_duco_client.async_get_ventilation_temperature_info.reset_mock()
-
-    freezer.tick(timedelta(days=1))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done(wait_background_tasks=True)
-
-    mock_duco_client.async_get_ventilation_temperature_info.assert_not_awaited()
 
 
 async def test_setup_entry_ignores_node_name_config_failures(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -28,6 +28,12 @@ from . import setup_platform_integration
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 FILTER_REMAINING_ENTITY_ID = "sensor.living_filter_remaining"
+VENTILATION_TEMPERATURE_ENTITY_IDS = (
+    "sensor.living_outdoor_air_temperature",
+    "sensor.living_supply_air_temperature",
+    "sensor.living_extract_air_temperature",
+    "sensor.living_exhaust_air_temperature",
+)
 
 
 @pytest.mark.parametrize(
@@ -221,6 +227,20 @@ async def test_time_filter_remaining_missing_skips_sensor_creation(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     assert hass.states.get(FILTER_REMAINING_ENTITY_ID) is None
+
+
+async def test_ventilation_temperatures_missing_skip_sensor_creation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test ventilation temperature sensors are not created when unsupported."""
+    mock_duco_client.async_get_ventilation_temperature_info.return_value = None
+
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
+
+    for entity_id in VENTILATION_TEMPERATURE_ENTITY_IDS:
+        assert hass.states.get(entity_id) is None
 
 
 async def test_time_filter_remaining_transient_failure_recovers_sensor_creation(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -13,6 +13,7 @@ from duco_connectivity import (
     NodeType,
     NodeVentilationInfo,
     VentilationState,
+    VentilationTemperatureInfo,
 )
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -241,6 +242,24 @@ async def test_ventilation_temperatures_missing_skip_sensor_creation(
 
     for entity_id in VENTILATION_TEMPERATURE_ENTITY_IDS:
         assert hass.states.get(entity_id) is None
+
+
+async def test_partial_ventilation_temperatures_create_available_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+) -> None:
+    """Test only reported ventilation temperatures create sensor entities."""
+    mock_duco_client.async_get_ventilation_temperature_info.return_value = (
+        VentilationTemperatureInfo(temp_oda=5.5, temp_eta=21.4)
+    )
+
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
+
+    assert hass.states.get("sensor.living_outdoor_air_temperature") is not None
+    assert hass.states.get("sensor.living_extract_air_temperature") is not None
+    assert hass.states.get("sensor.living_supply_air_temperature") is None
+    assert hass.states.get("sensor.living_exhaust_air_temperature") is None
 
 
 async def test_time_filter_remaining_transient_failure_recovers_sensor_creation(

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -235,32 +235,47 @@ async def test_ventilation_temperatures_missing_skip_sensor_creation(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test ventilation temperature sensors are not created when unsupported."""
-    mock_duco_client.async_get_ventilation_temperature_info.side_effect = (
-        DucoUnsupportedCapabilityError(400, "/info", '{"Code":3,"Result":"FAILED"}')
-    )
+    """Test unsupported ventilation temperatures never expose temperature states."""
+    mock_duco_client.async_get_ventilation_temperature_info.side_effect = [
+        DucoUnsupportedCapabilityError(400, "/info", '{"Code":3,"Result":"FAILED"}'),
+        VentilationTemperatureInfo(temp_oda=5.5),
+    ]
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
 
     for entity_id in VENTILATION_TEMPERATURE_ENTITY_IDS:
         assert hass.states.get(entity_id) is None
 
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
 
-async def test_partial_ventilation_temperatures_create_available_sensors(
+    for entity_id in VENTILATION_TEMPERATURE_ENTITY_IDS:
+        assert hass.states.get(entity_id) is None
+
+
+async def test_partial_ventilation_temperatures_only_expose_available_sensor_values(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_duco_client: AsyncMock,
 ) -> None:
-    """Test only reported ventilation temperatures create sensor entities."""
+    """Test only populated ventilation temperature fields are exposed as states."""
     mock_duco_client.async_get_ventilation_temperature_info.return_value = (
         VentilationTemperatureInfo(temp_oda=5.5, temp_eta=21.4)
     )
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
 
-    assert hass.states.get("sensor.living_outdoor_air_temperature") is not None
-    assert hass.states.get("sensor.living_extract_air_temperature") is not None
+    state = hass.states.get("sensor.living_outdoor_air_temperature")
+    assert state is not None
+    assert state.state == "5.5"
+
+    state = hass.states.get("sensor.living_extract_air_temperature")
+    assert state is not None
+    assert state.state == "21.4"
+
     assert hass.states.get("sensor.living_supply_air_temperature") is None
     assert hass.states.get("sensor.living_exhaust_air_temperature") is None
 

--- a/tests/components/duco/test_sensor.py
+++ b/tests/components/duco/test_sensor.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 from duco_connectivity import (
     DucoConnectionError,
     DucoError,
+    DucoUnsupportedCapabilityError,
     Node,
     NodeGeneralInfo,
     NodeSensorInfo,
@@ -236,7 +237,9 @@ async def test_ventilation_temperatures_missing_skip_sensor_creation(
     mock_duco_client: AsyncMock,
 ) -> None:
     """Test ventilation temperature sensors are not created when unsupported."""
-    mock_duco_client.async_get_ventilation_temperature_info.return_value = None
+    mock_duco_client.async_get_ventilation_temperature_info.side_effect = (
+        DucoUnsupportedCapabilityError(400, "/info", '{"Code":3,"Result":"FAILED"}')
+    )
 
     await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add optional outdoor, supply, extract, and exhaust air temperature sensors for supported Duco ventilation boxes.

This is the first of two planned pull requests for the requested Duco temperature functionality. Follow-up pull requests will add bypass target controls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Feature request discussion: https://github.com/orgs/home-assistant/discussions/4276
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46890
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr