### PR TITLE
Bump pyairnow to 1.4.0 for AirNow 2026 API endpoints

### DIFF
--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -38,11 +38,10 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> bool:
 
     lat = data[CONF_LATITUDE]
     lng = data[CONF_LONGITUDE]
-    distance = data[CONF_RADIUS]
 
     # Check that the provided latitude/longitude provide a response
     try:
-        test_data = await client.observations.latLong(lat, lng, distance=distance)
+        test_data = await client.observations.latLong(lat, lng)
 
     except InvalidKeyError as exc:
         raise InvalidAuth from exc

--- a/homeassistant/components/airnow/coordinator.py
+++ b/homeassistant/components/airnow/coordinator.py
@@ -77,7 +77,6 @@ class AirNowDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             obs = await self.airnow.observations.latLong(
                 self.latitude,
                 self.longitude,
-                distance=self.distance,
             )
 
         except (AirNowError, ClientConnectorError, InvalidJsonError) as error:

--- a/homeassistant/components/airnow/manifest.json
+++ b/homeassistant/components/airnow/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["pyairnow"],
-  "requirements": ["pyairnow==1.3.1"]
+  "requirements": ["pyairnow==1.4.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2021,7 +2021,7 @@ pyaehw4a1==0.3.9
 pyaftership==21.11.0
 
 # homeassistant.components.airnow
-pyairnow==1.3.1
+pyairnow==1.4.0
 
 # homeassistant.components.airobot
 pyairobotrest==0.4.0

--- a/tests/components/airnow/fixtures/response.json
+++ b/tests/components/airnow/fixtures/response.json
@@ -1,47 +1,47 @@
 [
   {
-    "DateObserved": "2020-12-20",
-    "HourObserved": 15,
-    "LocalTimeZone": "PST",
-    "ReportingArea": "Central LA CO",
-    "StateCode": "CA",
-    "Latitude": 34.0663,
-    "Longitude": -118.2266,
-    "ParameterName": "O3",
-    "AQI": 44,
-    "Category": {
-      "Number": 1,
-      "Name": "Good"
-    }
+    "dateObserved": "2020-12-20",
+    "hourObserved": "15:00",
+    "localTimeZone": "PST",
+    "reportingAreaName": "Central LA CO",
+    "siteID": "060371103",
+    "siteName": "Los Angeles - N. Main Street",
+    "parameterName": "OZONE",
+    "nowcastAQI": 44,
+    "aqiCategoryName": "Good",
+    "reportingAgency": "South Coast AQMD",
+    "lookupBehavior": "Closest Reading By Pollutant",
+    "consideredMonitors": "All",
+    "lookupBoundary": "50 Miles"
   },
   {
-    "DateObserved": "2020-12-20",
-    "HourObserved": 15,
-    "LocalTimeZone": "PST",
-    "ReportingArea": "Central LA CO",
-    "StateCode": "CA",
-    "Latitude": 34.0663,
-    "Longitude": -118.2266,
-    "ParameterName": "PM2.5",
-    "AQI": 37,
-    "Category": {
-      "Number": 1,
-      "Name": "Good"
-    }
+    "dateObserved": "2020-12-20",
+    "hourObserved": "15:00",
+    "localTimeZone": "PST",
+    "reportingAreaName": "Central LA CO",
+    "siteID": "060371103",
+    "siteName": "Los Angeles - N. Main Street",
+    "parameterName": "PM2.5",
+    "nowcastAQI": 37,
+    "aqiCategoryName": "Good",
+    "reportingAgency": "South Coast AQMD",
+    "lookupBehavior": "Closest Reading By Pollutant",
+    "consideredMonitors": "All",
+    "lookupBoundary": "50 Miles"
   },
   {
-    "DateObserved": "2020-12-20",
-    "HourObserved": 15,
-    "LocalTimeZone": "PST",
-    "ReportingArea": "Central LA CO",
-    "StateCode": "CA",
-    "Latitude": 34.0663,
-    "Longitude": -118.2266,
-    "ParameterName": "PM10",
-    "AQI": 11,
-    "Category": {
-      "Number": 1,
-      "Name": "Good"
-    }
+    "dateObserved": "2020-12-20",
+    "hourObserved": "15:00",
+    "localTimeZone": "PST",
+    "reportingAreaName": "Central LA CO",
+    "siteID": "060371103",
+    "siteName": "Los Angeles - N. Main Street",
+    "parameterName": "PM10",
+    "nowcastAQI": 11,
+    "aqiCategoryName": "Good",
+    "reportingAgency": "South Coast AQMD",
+    "lookupBehavior": "Closest Reading By Pollutant",
+    "consideredMonitors": "All",
+    "lookupBoundary": "50 Miles"
   }
 ]

--- a/tests/components/airnow/snapshots/test_diagnostics.ambr
+++ b/tests/components/airnow/snapshots/test_diagnostics.ambr
@@ -7,15 +7,15 @@
       'Category.Number': 1,
       'DateObserved': '2020-12-20',
       'HourObserved': 15,
-      'Latitude': '**REDACTED**',
+      'Latitude': None,
       'LocalTimeZone': 'PST',
-      'Longitude': '**REDACTED**',
+      'Longitude': None,
       'O3': 0.048,
       'PM10': 12,
       'PM2.5': 6.7,
       'Pollutant': 'O3',
       'ReportingArea': '**REDACTED**',
-      'StateCode': '**REDACTED**',
+      'StateCode': '',
     }),
     'entry': dict({
       'data': dict({


### PR DESCRIPTION
## Proposed change

The EPA is retiring the AirNow endpoints this integration depends on through
`pyairnow` on September 30, 2026, per the
[June 2026 API update notice](https://docs.airnowapi.org/docs/AirNowAPIUpdates2026June.pdf).
`aq/observation/latLong/current` is one of the six services being turned down.

`pyairnow` 1.4.0 (asymworks/pyairnow#18, closing asymworks/pyairnow#17) moves to the
replacement `aq/observation/current/ziplatlong` endpoint and normalizes the response
back to the legacy field layout, so the coordinator itself needs no changes. This bumps
the requirement and updates the tests to match the new API contract.

Verified against the live AirNow API on 1.4.0: AQI, category and pollutant
concentrations are unchanged.

### Dependency diff: pyairnow 1.3.1 to 1.4.0

- Compare: https://github.com/asymworks/pyairnow/compare/v1.3.1...v1.4.0
- Release: https://github.com/asymworks/pyairnow/releases/tag/v1.4.0
- Changelog: https://github.com/asymworks/pyairnow/blob/v1.4.0/CHANGELOG.md
- PyPI: https://pypi.org/project/pyairnow/1.4.0/

Library changes are the endpoint migration (`aq/observation/{zipCode,latLong}/current`
to `aq/observation/current/ziplatlong`, and `aq/forecast/{zipCode,latLong}` to
`aq/forecast/current`), response normalization back to the legacy field layout, a
`DeprecationWarning` on the now-ignored `distance` parameter, and dropping Python 3.9.

The upstream change is a single PR, asymworks/pyairnow#18, if that is an easier read
than the compare view.

### Test fixture

The fixture is updated to the new response format. The suite patches
`pyairnow.WebServiceAPI._get`, so the fixture stands in for the raw API payload and the
library's normalization runs during tests. Left as-is, the tests would assert against a
response shape AirNow no longer returns, and the stale payload normalizes to an empty
observation (`AQI: -1`), which fails setup with `AQI must be greater than 0`.

The fixture mirrors a real response from the new endpoint, keeping the existing
reporting area and AQI values so sensor expectations are unchanged. Note `OZONE` is the
new parameter name and pyairnow maps it back to `O3`.

### Radius option

The new endpoint has no distance parameter and pyairnow 1.4.0 emits a
`DeprecationWarning` when one is passed, on every config flow attempt and every update.
Passing it is dropped from both call sites.

This does mean the radius option no longer affects lookups. Checked against the live
API, `distance=5` and `distance=150` return identical results with `lookupBoundary`
fixed at 50 miles, so the option is inert regardless of whether it is sent. It is left
in place here rather than removed, since deprecating a user-facing option seems worth
handling separately from the endpoint migration. Happy to follow up with a removal and
entry migration if that is preferred.

### Station attributes

The new response does not include `stateCode`, `latitude` or `longitude`. pyairnow maps
those fields but they are absent upstream, so they normalize to `''`/`None` and the
station attributes lose that data. This shows in the diagnostics snapshot. Confirmed
against the live API, which returns `siteID`/`siteName` in their place. AQI and
concentrations are unaffected.

Together with the inert radius option, this is user-visible behaviour change driven by
the upstream API rather than by this change. It is filed as a dependency upgrade since
that is the underlying cause, but happy to reclassify if a breaking-change note for the
release notes would be preferred.

Two related upstream notes, in case they are useful:

- The `stateCode`/`latitude`/`longitude` mappings in `_normalize_observation` are
  unreachable against the current API.
- A null `nowcastAQI` normalizes to `AQI: None`, and an absent one to `-1`. Either
  reaches `aqi_to_concentration` and the `> max_aqi` comparison, raising `TypeError` or
  `ValueError`. Not seen in practice across the locations checked, and not addressed
  here to keep this focused on the endpoint migration.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

