### PR TITLE
Fix open/close for RTSGeneric covers in Overkiz

### DIFF
--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -352,7 +352,6 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
     ),
     # Needs override to support this Generic device (rts:GenericRTSComponent)
     # uiClass is Generic (not mapped to cover as this is a Generic device class)
-    # Only exposes the raw one-way RTS commands (up/down/stop), not open/close
     OverkizCoverDescription(
         key=UIWidget.RTS_GENERIC,
         open_command=OverkizCommand.UP,

--- a/homeassistant/components/overkiz/cover.py
+++ b/homeassistant/components/overkiz/cover.py
@@ -352,10 +352,11 @@ COVER_DESCRIPTIONS: list[OverkizCoverDescription] = [
     ),
     # Needs override to support this Generic device (rts:GenericRTSComponent)
     # uiClass is Generic (not mapped to cover as this is a Generic device class)
+    # Only exposes the raw one-way RTS commands (up/down/stop), not open/close
     OverkizCoverDescription(
         key=UIWidget.RTS_GENERIC,
-        open_command=OverkizCommand.OPEN,
-        close_command=OverkizCommand.CLOSE,
+        open_command=OverkizCommand.UP,
+        close_command=OverkizCommand.DOWN,
         stop_command=OverkizCommand.STOP,
     ),
     ##

--- a/tests/components/overkiz/fixtures/setup/cloud_somfy_connexoon_rts_asia.json
+++ b/tests/components/overkiz/fixtures/setup/cloud_somfy_connexoon_rts_asia.json
@@ -544,6 +544,73 @@
       "type": 1,
       "oid": "c198bcdd-8b8b-4dc6-a2b0-f86f7dc7c001",
       "uiClass": "VenetianBlind"
+    },
+    {
+      "creationTime": 1613676720000,
+      "lastUpdateTime": 1613676720000,
+      "label": "Living Room Screen",
+      "deviceURL": "rts://1234-1234-6362/16718220",
+      "shortcut": false,
+      "controllableName": "rts:GenericRTSComponent",
+      "definition": {
+        "commands": [
+          {
+            "commandName": "down",
+            "nparams": 1
+          },
+          {
+            "commandName": "identify",
+            "nparams": 0
+          },
+          {
+            "commandName": "rest",
+            "nparams": 1
+          },
+          {
+            "commandName": "stop",
+            "nparams": 1
+          },
+          {
+            "commandName": "test",
+            "nparams": 0
+          },
+          {
+            "commandName": "up",
+            "nparams": 1
+          },
+          {
+            "commandName": "openConfiguration",
+            "nparams": 1
+          }
+        ],
+        "states": [],
+        "dataProperties": [
+          {
+            "value": "0",
+            "qualifiedName": "core:identifyInterval"
+          }
+        ],
+        "widgetName": "RTSGeneric",
+        "uiProfiles": ["UpDown"],
+        "uiClass": "Generic",
+        "qualifiedName": "rts:GenericRTSComponent",
+        "type": "ACTUATOR"
+      },
+      "states": [],
+      "attributes": [
+        {
+          "name": "rts:diy",
+          "type": 6,
+          "value": true
+        }
+      ],
+      "available": true,
+      "enabled": true,
+      "placeOID": "6133b4a0-f514-4553-b635-d1b7beb7e7b2",
+      "widget": "RTSGeneric",
+      "type": 1,
+      "oid": "97f85fd1-53f7-4cdf-8c73-9b2c172dbd62",
+      "uiClass": "Generic"
     }
   ],
   "zones": [],

--- a/tests/components/overkiz/snapshots/test_cover.ambr
+++ b/tests/components/overkiz/snapshots/test_cover.ambr
@@ -485,6 +485,59 @@
     'state': 'unknown',
   })
 # ---
+# name: test_cover_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][cover.palm_court_living_room_screen-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'cover',
+    'entity_category': None,
+    'entity_id': 'cover.palm_court_living_room_screen',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'overkiz',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <CoverEntityFeature: 11>,
+    'translation_key': None,
+    'unique_id': 'rts://1234-1234-6362/16718220',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_cover_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][cover.palm_court_living_room_screen-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.ASSUMED_STATE: 'assumed_state'>: True,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living Room Screen',
+      <CoverEntityStateAttribute.IS_CLOSED: 'is_closed'>: None,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <CoverEntityFeature: 11>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'cover.palm_court_living_room_screen',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
 # name: test_cover_entities_snapshot[cloud_somfy_connexoon_rts_asia.json][cover.palm_court_office_venetian_blind-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/overkiz/test_cover.py
+++ b/tests/components/overkiz/test_cover.py
@@ -122,6 +122,12 @@ UP_DOWN_SHEER_SCREEN = FixtureDevice(
     "rts://1234-1234-6362/16753206",
     "cover.palm_court_kitchen_sheer_screen",
 )
+# RTSGeneric only exposes raw up/down/stop commands (no open/close)
+RTS_GENERIC = FixtureDevice(
+    "setup/cloud_somfy_connexoon_rts_asia.json",
+    "rts://1234-1234-6362/16718220",
+    "cover.palm_court_living_room_screen",
+)
 DISCRETE_GARAGE_DOOR = FixtureDevice(
     "setup/local_somfy_tahoma_v2_europe.json",
     "io://1234-5678-3293/12745774",
@@ -276,6 +282,7 @@ async def test_cover_entities_snapshot(
         ),
         (UP_DOWN_VENETIAN_BLIND, SERVICE_OPEN_COVER, "open", None, CoverState.OPENING),
         (UP_DOWN_SHEER_SCREEN, SERVICE_OPEN_COVER, "open", None, CoverState.OPENING),
+        (RTS_GENERIC, SERVICE_OPEN_COVER, "up", None, CoverState.OPENING),
         (
             DYNAMIC_VENETIAN_BLIND,
             SERVICE_OPEN_COVER,
@@ -334,6 +341,7 @@ async def test_cover_entities_snapshot(
             CoverState.CLOSING,
         ),
         (UP_DOWN_SHEER_SCREEN, SERVICE_CLOSE_COVER, "close", None, CoverState.CLOSING),
+        (RTS_GENERIC, SERVICE_CLOSE_COVER, "down", None, CoverState.CLOSING),
         (
             DYNAMIC_VENETIAN_BLIND,
             SERVICE_CLOSE_COVER,
@@ -396,6 +404,7 @@ async def test_cover_entities_snapshot(
         ),
         (UP_DOWN_VENETIAN_BLIND, SERVICE_STOP_COVER, "stop", None, STATE_UNKNOWN),
         (UP_DOWN_SHEER_SCREEN, SERVICE_STOP_COVER, "stop", None, STATE_UNKNOWN),
+        (RTS_GENERIC, SERVICE_STOP_COVER, "stop", None, STATE_UNKNOWN),
         (
             UP_DOWN_VENETIAN_BLIND,
             SERVICE_OPEN_COVER_TILT,
@@ -459,6 +468,7 @@ async def test_cover_entities_snapshot(
         "open-tilt-only-venetian-blind",
         "open-venetian-blind-rts",
         "open-sheer-screen-rts",
+        "open-rts-generic",
         "open-dynamic-venetian-blind",
         "close-roller-shutter",
         "close-awning",
@@ -479,6 +489,7 @@ async def test_cover_entities_snapshot(
         "close-tilt-only-venetian-blind",
         "close-venetian-blind-rts",
         "close-sheer-screen-rts",
+        "close-rts-generic",
         "close-dynamic-venetian-blind",
         "stop-roller-shutter",
         "stop-awning",
@@ -499,6 +510,7 @@ async def test_cover_entities_snapshot(
         "stop-tilt-tilt-only-venetian-blind",
         "stop-venetian-blind-rts",
         "stop-sheer-screen-rts",
+        "stop-rts-generic",
         "open-tilt-venetian-blind-rts",
         "close-tilt-venetian-blind-rts",
         "stop-tilt-venetian-blind-rts",


### PR DESCRIPTION
## Proposed change

`rts:GenericRTSComponent` only supports `up`/`down`/`stop`, so open/close never worked. Map open to `up` and close to `down`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #176608

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
