### PR TITLE
Update vizio config entry host on zeroconf rediscovery

### DIFF
--- a/homeassistant/components/vizio/config_flow.py
+++ b/homeassistant/components/vizio/config_flow.py
@@ -2,7 +2,6 @@
 
 import copy
 import logging
-import socket
 from typing import Any, override
 
 from pyvizio import VizioAsync, async_guess_device_type
@@ -29,7 +28,6 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
-from homeassistant.util.network import is_ip_address
 
 from . import DATA_APPS
 from .const import (
@@ -93,15 +91,6 @@ def _get_pairing_schema(input_dict: dict[str, Any] | None = None) -> vol.Schema:
     return vol.Schema(
         {vol.Required(CONF_PIN, default=input_dict.get(CONF_PIN, "")): str}
     )
-
-
-def _host_is_same(host1: str, host2: str) -> bool:
-    """Check if host1 and host2 are the same."""
-    host1 = host1.split(":", maxsplit=1)[0]
-    host1 = host1 if is_ip_address(host1) else socket.gethostbyname(host1)
-    host2 = host2.split(":", maxsplit=1)[0]
-    host2 = host2 if is_ip_address(host2) else socket.gethostbyname(host2)
-    return host1 == host2
 
 
 class VizioOptionsConfigFlow(OptionsFlow):
@@ -294,7 +283,7 @@ class VizioConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="cannot_connect")
 
         await self.async_set_unique_id(unique_id=unique_id, raise_on_progress=True)
-        self._abort_if_unique_id_configured()
+        self._abort_if_unique_id_configured(updates={CONF_HOST: host})
 
         # Form must be shown after discovery so user can confirm/update configuration
         # before ConfigEntry creation.

--- a/tests/components/vizio/conftest.py
+++ b/tests/components/vizio/conftest.py
@@ -26,7 +26,6 @@ from .const import (
     RESPONSE_TOKEN,
     UNIQUE_ID,
     VERSION,
-    ZEROCONF_HOST,
     MockCompletePairingResponse,
     MockStartPairingResponse,
 )
@@ -334,15 +333,5 @@ def vizio_update_with_apps_on_input_fixture(vizio_update: None) -> Generator[Non
             "homeassistant.components.vizio.VizioAsync.get_current_app_config",
             return_value=AppConfig("unknown", 1, "app"),
         ),
-    ):
-        yield
-
-
-@pytest.fixture(name="vizio_hostname_check")
-def vizio_hostname_check() -> Generator[None]:
-    """Mock vizio hostname resolution."""
-    with patch(
-        "homeassistant.components.vizio.config_flow.socket.gethostbyname",
-        return_value=ZEROCONF_HOST,
     ):
         yield

--- a/tests/components/vizio/test_config_flow.py
+++ b/tests/components/vizio/test_config_flow.py
@@ -445,6 +445,36 @@ async def test_zeroconf_flow_already_configured(hass: HomeAssistant) -> None:
     # Flow should abort because device is already setup
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == HOST
+
+
+@pytest.mark.usefixtures(
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
+)
+async def test_zeroconf_flow_already_configured_updates_host(
+    hass: HomeAssistant,
+) -> None:
+    """Test zeroconf discovery updates the stored host when the IP has changed."""
+    config = MOCK_SPEAKER_CONFIG.copy()
+    config[CONF_HOST] = HOST2
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data=config,
+        options={CONF_VOLUME_STEP: VOLUME_STEP},
+        unique_id=UNIQUE_ID,
+    )
+    entry.add_to_hass(hass)
+
+    # Rediscover the same device on a new IP address
+    discovery_info = dataclasses.replace(MOCK_ZEROCONF_SERVICE_INFO)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
+    )
+
+    # Flow should abort and the entry host should be updated to the new IP
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == HOST
 
 
 @pytest.mark.usefixtures(
@@ -555,10 +585,7 @@ async def test_zeroconf_abort_when_ignored(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures(
-    "vizio_connect",
-    "vizio_bypass_setup",
-    "vizio_hostname_check",
-    "vizio_guess_device_type",
+    "vizio_connect", "vizio_bypass_setup", "vizio_guess_device_type"
 )
 async def test_zeroconf_flow_already_configured_hostname(hass: HomeAssistant) -> None:
     """Test already configured during zeroconf when entry uses hostname."""
@@ -578,6 +605,8 @@ async def test_zeroconf_flow_already_configured_hostname(hass: HomeAssistant) ->
         DOMAIN, context={"source": SOURCE_ZEROCONF}, data=discovery_info
     )
 
-    # Flow should abort because device is already setup
+    # Flow should abort because device is already setup and the hostname should
+    # be replaced with the discovered IP
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+    assert entry.data[CONF_HOST] == HOST


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When a Vizio device is rediscovered via zeroconf and its serial number matches an existing config entry, the flow previously aborted with `already_configured` without updating anything. If the device had received a new IP address (DHCP lease change, or switching between ethernet and wifi as described in the linked issue), the config entry kept pointing at the old address and the device became unreachable until the user manually fixed it.

`async_step_zeroconf` now passes `updates={CONF_HOST: host}` to `_abort_if_unique_id_configured`, so the stored `ip:port` is updated to the newly discovered address and the entry is automatically reloaded. Note this also replaces a user-configured hostname with the discovered IP; that's intentional, since discovery will keep the IP current from then on.

The now-unused `_host_is_same` helper (dead code that performed blocking DNS resolution) and the `vizio_hostname_check` test fixture that existed to support it have been removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176369
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
