### PR TITLE
Bump yalexs to 9.2.10

### DIFF
--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -30,5 +30,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==9.2.7", "yalexs-ble==3.3.1"]
+  "requirements": ["yalexs==9.2.10", "yalexs-ble==3.3.1"]
 }

--- a/homeassistant/components/yale/manifest.json
+++ b/homeassistant/components/yale/manifest.json
@@ -14,5 +14,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["socketio", "engineio", "yalexs"],
-  "requirements": ["yalexs==9.2.7", "yalexs-ble==3.3.1"]
+  "requirements": ["yalexs==9.2.10", "yalexs-ble==3.3.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3427,7 +3427,7 @@ yalexs-ble==3.3.1
 
 # homeassistant.components.august
 # homeassistant.components.yale
-yalexs==9.2.7
+yalexs==9.2.10
 
 # homeassistant.components.yeelight
 yeelight==0.7.16

--- a/tests/components/august/test_camera.py
+++ b/tests/components/august/test_camera.py
@@ -53,7 +53,7 @@ async def test_doorbell_refresh_content_token_recover(
         await _create_august_with_devices(
             hass,
             [doorbell_two],
-            brand=Brand.YALE_HOME,
+            brand=Brand.YALE_AUGUST,
         )
         url = hass.states.get(
             "camera.k98gidt45gul_name_k98gidt45gul_name_camera"
@@ -80,7 +80,7 @@ async def test_doorbell_refresh_content_token_fail(
         await _create_august_with_devices(
             hass,
             [doorbell_two],
-            brand=Brand.YALE_HOME,
+            brand=Brand.YALE_AUGUST,
         )
         url = hass.states.get(
             "camera.k98gidt45gul_name_k98gidt45gul_name_camera"

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -261,7 +261,7 @@ async def test_brand_migration_issue(hass: HomeAssistant) -> None:
     """Test removing the brand migration issue."""
     august_operative_lock = await _mock_operative_august_lock_detail(hass)
     config_entry, _ = await _create_august_with_devices(
-        hass, [august_operative_lock], brand=Brand.YALE_HOME
+        hass, [august_operative_lock], brand=Brand.YALE_AUGUST
     )
 
     assert config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
## Proposed change

Bumps yalexs from 9.2.7 to 9.2.10. Both the august and yale integrations depend on yalexs, so both manifests are bumped together (they share a single pinned version).

The reason for the bump is the activity handling fix in 9.2.10. Today the activity stream advances its per-device "latest activity" marker while it is still iterating a batch of activities. The activities API returns newest first, so when an older event arrives in the same batch as a newer one (which happens when an event is delayed), the older one is discarded as stale even though it was never processed. In practice lock/unlock events go missing in Home Assistant while they still appear in the August/Yale app, and the lock can sit on a stale state for a long time.

9.2.10 snapshots the marker before the poll, selects everything newer than it, and processes it in chronological order. It also isolates subscriber callback failures so one failing callback no longer drops the rest of a batch.

Upstream fixes included:
- Yale-Libs/yalexs#413 (process delayed activities chronologically)
- Yale-Libs/yalexs#416 (isolate subscriber callback failures)

One thing to flag: 9.2.8 removes the Brand.YALE_HOME enum member. No runtime code uses it (the august integration forces its own brand at setup and nothing branches on YALE_HOME), but a few August tests still referenced it, so this PR also updates those tests to Brand.YALE_AUGUST. The other in-between changes are type annotation corrections.

I have an August Wi-Fi lock on the august integration and hit exactly this. I have been running 9.2.10 on my own instance and lock/unlock events now come through and settle on the correct state instead of getting stuck. Should help with #174214 and #175779.

Release notes: https://github.com/Yale-Libs/yalexs/releases/tag/v9.2.10

## Type of change

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- Related issues: #174214, #175779

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
