### PR TITLE
Use library-managed auto update frequency in victron_gx

### DIFF
--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from victron_mqtt import (
+    UPDATE_FREQUENCY_AUTO,
     AuthenticationError,
     CannotConnectError,
     Device as VictronVenusDevice,
@@ -33,8 +34,6 @@ from homeassistant.helpers.redact import async_redact_data
 from .const import CONF_INSTALLATION_ID, CONF_SERIAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
-
-UPDATE_INTERVAL_SECONDS = 30
 
 TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
 
@@ -76,7 +75,7 @@ class Hub:
             model_name=config.get(CONF_MODEL) or None,
             serial=config.get(CONF_SERIAL) or None,
             operation_mode=OperationMode.FULL,
-            update_frequency_seconds=UPDATE_INTERVAL_SECONDS,
+            update_frequency_seconds=UPDATE_FREQUENCY_AUTO,
         )
         self._hub.on_new_metric = self._on_new_metric
         self.new_metric_callbacks: dict[MetricKind, NewMetricCallback] = {}

--- a/tests/components/victron_gx/test_init.py
+++ b/tests/components/victron_gx/test_init.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from victron_mqtt import (
+    UPDATE_FREQUENCY_AUTO,
     AuthenticationError,
     CannotConnectError,
     Hub as VictronVenusHub,
@@ -51,6 +52,23 @@ async def test_load_unload_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_hub_created_with_auto_update_frequency(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_victron_hub_library: MagicMock,
+) -> None:
+    """Test the library hub is created with the auto update frequency profile."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        mock_victron_hub_library.call_args.kwargs["update_frequency_seconds"]
+        == UPDATE_FREQUENCY_AUTO
+    )
 
 
 @pytest.mark.usefixtures("mock_victron_hub_library")


### PR DESCRIPTION
## Proposed change

The `victron_gx` integration currently hardcodes `update_frequency_seconds=30` when creating the library `Hub`, so every metric — including grid/battery power, which can swing hundreds of watts within seconds — refreshes at most every 30 s.

`victron-mqtt` 2026.7.4 (bumped in #176614) added an `"auto"` update-frequency profile (tomer-w/victron_mqtt#114): each metric resolves its own interval from its metric type — 5 s for `POWER`, `APPARENT_POWER` and `CURRENT`, 30 s for everything else. As before, non-numeric values always propagate on change and the keepalive re-publish flushes skipped values.

This PR switches the integration to `UPDATE_FREQUENCY_AUTO` and drops the hardcoded constant. The interval choice now lives in the library, which owns the metric semantics, so power dashboards feel live while slow-moving metrics keep the conservative cadence. No user-facing configuration is added, in line with the [appropriate-polling](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/appropriate-polling/) quality-scale rule.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#46894
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Library change: tomer-w/victron_mqtt#114 (released in [v2026.7.4](https://github.com/tomer-w/victron_mqtt/releases/tag/v2026.7.4)). The throttling behavior itself is implemented and tested in the library; on the integration side, a test asserts the hub is constructed with the auto profile (the silent fallback if the kwarg were ever dropped would be `None`, i.e. unthrottled).

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
