### PR TITLE
Add REST list endpoints for registries and usage prediction

### DIFF
--- a/homeassistant/components/config/area_registry.py
+++ b/homeassistant/components/config/area_registry.py
@@ -2,9 +2,11 @@
 
 from typing import Any
 
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import area_registry as ar
 
@@ -12,6 +14,7 @@ from homeassistant.helpers import area_registry as ar
 @callback
 def async_setup(hass: HomeAssistant) -> bool:
     """Enable the Area Registry views."""
+    hass.http.register_view(AreaRegistryListView)
     websocket_api.async_register_command(hass, websocket_list_areas)
     websocket_api.async_register_command(hass, websocket_create_area)
     websocket_api.async_register_command(hass, websocket_delete_area)
@@ -33,6 +36,19 @@ def websocket_list_areas(
         msg["id"],
         [entry.json_fragment for entry in registry.async_list_areas()],
     )
+
+
+class AreaRegistryListView(HomeAssistantView):
+    """View to list the area registry entries."""
+
+    url = "/api/config/area_registry/list"
+    name = "api:config:area_registry:list"
+
+    @callback
+    def get(self, request: web.Request) -> web.Response:
+        """Return the area registry entries."""
+        registry = ar.async_get(request.app[KEY_HASS])
+        return self.json([entry.json_fragment for entry in registry.async_list_areas()])
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -2,27 +2,61 @@
 
 from typing import Any, cast
 
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import loader
 from homeassistant.components import websocket_api
+from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.components.websocket_api import require_admin
+from homeassistant.const import CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryDisabler
+from homeassistant.helpers.http import MIN_COMPRESSED_RESPONSE_SIZE
 
 
 @callback
 def async_setup(hass: HomeAssistant) -> bool:
     """Enable the Device Registry views."""
 
+    hass.http.register_view(DeviceRegistryListView)
     websocket_api.async_register_command(hass, websocket_list_devices)
     websocket_api.async_register_command(hass, websocket_update_device)
     websocket_api.async_register_command(
         hass, websocket_remove_config_entry_from_device
     )
     return True
+
+
+class DeviceRegistryListView(HomeAssistantView):
+    """View to list the device registry entries."""
+
+    url = "/api/config/device_registry/list"
+    name = "api:config:device_registry:list"
+
+    @callback
+    def get(self, request: web.Request) -> web.Response:
+        """Return the device registry entries."""
+        registry = dr.async_get(request.app[KEY_HASS])
+        # Concatenate cached device registry item JSON serializations
+        inner = b",".join(
+            [
+                entry.json_repr
+                for entry in registry.devices.values()
+                if entry.json_repr is not None
+            ]
+        )
+        body = b"".join((b"[", inner, b"]"))
+        response = web.Response(
+            body=body,
+            content_type=CONTENT_TYPE_JSON,
+            zlib_executor_size=32768,
+        )
+        if len(body) > MIN_COMPRESSED_RESPONSE_SIZE:
+            response.enable_compression()
+        return response
 
 
 @callback

--- a/homeassistant/components/config/entity_registry.py
+++ b/homeassistant/components/config/entity_registry.py
@@ -3,17 +3,21 @@
 import logging
 from typing import Any
 
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.components import websocket_api
+from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.components.websocket_api import ERR_NOT_FOUND, require_admin
+from homeassistant.const import CONTENT_TYPE_JSON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
     config_validation as cv,
     device_registry as dr,
     entity_registry as er,
 )
+from homeassistant.helpers.http import MIN_COMPRESSED_RESPONSE_SIZE
 from homeassistant.helpers.json import json_dumps
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,6 +27,8 @@ _LOGGER = logging.getLogger(__name__)
 def async_setup(hass: HomeAssistant) -> bool:
     """Enable the Entity Registry views."""
 
+    hass.http.register_view(EntityRegistryListView)
+    hass.http.register_view(EntityRegistryListForDisplayView)
     websocket_api.async_register_command(hass, websocket_get_automatic_entity_ids)
     websocket_api.async_register_command(hass, websocket_get_entities)
     websocket_api.async_register_command(hass, websocket_get_entity)
@@ -60,6 +66,7 @@ def websocket_list_entities(
 
 
 _ENTITY_CATEGORIES_JSON = json_dumps(er.ENTITY_CATEGORY_INDEX_TO_VALUE)
+_ENTITY_CATEGORIES_JSON_BYTES = _ENTITY_CATEGORIES_JSON.encode()
 
 
 @websocket_api.websocket_command(
@@ -88,6 +95,70 @@ def websocket_list_entities_for_display(
     )
     msg_json = b"".join((msg_json_prefix, inner, b"]}}"))
     connection.send_message(msg_json)
+
+
+def _json_bytes_response(body: bytes) -> web.Response:
+    """Return a JSON response from raw bytes, compressing large bodies."""
+    response = web.Response(
+        body=body,
+        content_type=CONTENT_TYPE_JSON,
+        zlib_executor_size=32768,
+    )
+    if len(body) > MIN_COMPRESSED_RESPONSE_SIZE:
+        response.enable_compression()
+    return response
+
+
+class EntityRegistryListView(HomeAssistantView):
+    """View to list the entity registry entries."""
+
+    url = "/api/config/entity_registry/list"
+    name = "api:config:entity_registry:list"
+
+    @callback
+    def get(self, request: web.Request) -> web.Response:
+        """Return the entity registry entries."""
+        registry = er.async_get(request.app[KEY_HASS])
+        # Concatenate cached entity registry item JSON serializations
+        inner = b",".join(
+            [
+                entry.partial_json_repr
+                for entry in registry.entities.values()
+                if entry.partial_json_repr is not None
+            ]
+        )
+        return _json_bytes_response(b"".join((b"[", inner, b"]")))
+
+
+class EntityRegistryListForDisplayView(HomeAssistantView):
+    """View to list the entity registry entries limited to display data."""
+
+    url = "/api/config/entity_registry/list_for_display"
+    name = "api:config:entity_registry:list_for_display"
+
+    @callback
+    def get(self, request: web.Request) -> web.Response:
+        """Return the entity registry entries limited to display data."""
+        registry = er.async_get(request.app[KEY_HASS])
+        # Concatenate cached entity registry item JSON serializations
+        inner = b",".join(
+            [
+                entry.display_json_repr
+                for entry in registry.entities.values()
+                if entry.disabled_by is None and entry.display_json_repr is not None
+            ]
+        )
+        return _json_bytes_response(
+            b"".join(
+                (
+                    b'{"entity_categories":',
+                    _ENTITY_CATEGORIES_JSON_BYTES,
+                    b',"entities":[',
+                    inner,
+                    b"]}",
+                )
+            )
+        )
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/config/floor_registry.py
+++ b/homeassistant/components/config/floor_registry.py
@@ -1,10 +1,12 @@
-"""Websocket API to interact with the floor registry."""
+"""HTTP views and websocket API to interact with the floor registry."""
 
 from typing import Any
 
+from aiohttp import web
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
+from homeassistant.components.http import KEY_HASS, HomeAssistantView
 from homeassistant.components.websocket_api import ActiveConnection
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import floor_registry as fr
@@ -13,7 +15,8 @@ from homeassistant.helpers.floor_registry import FloorEntry
 
 @callback
 def async_setup(hass: HomeAssistant) -> bool:
-    """Register the floor registry WS commands."""
+    """Register the floor registry views and WS commands."""
+    hass.http.register_view(FloorRegistryListView)
     websocket_api.async_register_command(hass, websocket_list_floors)
     websocket_api.async_register_command(hass, websocket_create_floor)
     websocket_api.async_register_command(hass, websocket_delete_floor)
@@ -37,6 +40,19 @@ def websocket_list_floors(
         msg["id"],
         [_entry_dict(entry) for entry in registry.async_list_floors()],
     )
+
+
+class FloorRegistryListView(HomeAssistantView):
+    """View to list the floor registry entries."""
+
+    url = "/api/config/floor_registry/list"
+    name = "api:config:floor_registry:list"
+
+    @callback
+    def get(self, request: web.Request) -> web.Response:
+        """Return the floor registry entries."""
+        registry = fr.async_get(request.app[KEY_HASS])
+        return self.json([_entry_dict(entry) for entry in registry.async_list_floors()])
 
 
 @websocket_api.websocket_command(

--- a/homeassistant/components/usage_prediction/__init__.py
+++ b/homeassistant/components/usage_prediction/__init__.py
@@ -4,7 +4,10 @@ import asyncio
 from datetime import timedelta
 from typing import Any
 
+from aiohttp import web
+
 from homeassistant.components import websocket_api
+from homeassistant.components.http import KEY_HASS, KEY_HASS_USER, HomeAssistantView
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
@@ -21,6 +24,7 @@ CACHE_DURATION = timedelta(hours=24)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the usage prediction integration."""
+    hass.http.register_view(CommonControlView)
     websocket_api.async_register_command(hass, ws_common_control)
     hass.data[DATA_CACHE] = {}
     return True
@@ -42,6 +46,20 @@ async def ws_common_control(
             "entities": getattr(result, time_category),
         },
     )
+
+
+class CommonControlView(HomeAssistantView):
+    """View to get common control usage predictions for the current user."""
+
+    url = f"/api/{DOMAIN}/common_control"
+    name = f"api:{DOMAIN}:common_control"
+
+    async def get(self, request: web.Request) -> web.Response:
+        """Return common control usage predictions for the current user."""
+        hass = request.app[KEY_HASS]
+        result = await get_cached_common_control(hass, request[KEY_HASS_USER].id)
+        time_category = common_control.time_category(dt_util.now().hour)
+        return self.json({"entities": getattr(result, time_category)})
 
 
 async def get_cached_common_control(

--- a/tests/components/config/test_area_registry.py
+++ b/tests/components/config/test_area_registry.py
@@ -1,6 +1,7 @@
 """Test area_registry API."""
 
 from datetime import datetime
+from http import HTTPStatus
 from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
@@ -17,10 +18,15 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry as ar
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import ANY
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 
 @pytest.fixture(name="client")
@@ -28,6 +34,7 @@ async def client_fixture(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> MockHAClientWebSocket:
     """Fixture that can interact with the config manager API."""
+    assert await async_setup_component(hass, "http", {})
     area_registry.async_setup(hass)
     return await hass_ws_client(hass)
 
@@ -503,3 +510,41 @@ async def test_reorder_areas_persistence(
 
     area_ids = [area.id for area in area_registry.async_list_areas()]
     assert area_ids == [area2.id, area3.id, area1.id]
+
+
+async def test_rest_list_requires_auth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Test the REST list endpoint requires authentication."""
+    assert await async_setup_component(hass, "http", {})
+    area_registry.async_setup(hass)
+
+    client = await hass_client_no_auth()
+    resp = await client.get("/api/config/area_registry/list")
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+
+
+async def test_rest_list_areas_matches_websocket(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the REST list endpoint returns the same payload as the websocket command."""
+    assert await async_setup_component(hass, "http", {})
+    area_registry.async_setup(hass)
+    registry = ar.async_get(hass)
+    registry.async_create("mock 1")
+    registry.async_create("mock 2", aliases={"alias 1", "alias 2"})
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id({"type": "config/area_registry/list"})
+    ws_msg = await ws_client.receive_json()
+    assert ws_msg["success"]
+
+    client = await hass_client()
+    resp = await client.get("/api/config/area_registry/list")
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.json() == ws_msg["result"]

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -1,6 +1,7 @@
 """Test device_registry API."""
 
 from datetime import datetime
+from http import HTTPStatus
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -14,7 +15,11 @@ from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import MockConfigEntry, MockModule, mock_integration
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 
 @pytest.fixture(name="client")
@@ -22,6 +27,7 @@ async def client_fixture(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> MockHAClientWebSocket:
     """Fixture that can interact with the config manager API."""
+    assert await async_setup_component(hass, "http", {})
     device_registry.async_setup(hass)
     return await hass_ws_client(hass)
 
@@ -558,3 +564,56 @@ async def test_remove_config_entry_from_device_if_integration_remove(
     assert device_registry.async_get(device_entry_1.id).config_entries == {
         entry_1.entry_id
     }
+
+
+async def test_rest_list_requires_auth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Test the REST list endpoint requires authentication."""
+    assert await async_setup_component(hass, "http", {})
+    device_registry.async_setup(hass)
+
+    client = await hass_client_no_auth()
+    resp = await client.get("/api/config/device_registry/list")
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+
+
+async def test_rest_list_devices_matches_websocket(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the REST list endpoint returns the same payload as the websocket command."""
+    assert await async_setup_component(hass, "http", {})
+    device_registry.async_setup(hass)
+    registry = dr.async_get(hass)
+    entry = MockConfigEntry(title=None)
+    entry.add_to_hass(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        connections={("ethernet", "12:34:56:78:90:AB:CD:EF")},
+        identifiers={("bridgeid", "0123")},
+        manufacturer="manufacturer",
+        model="model",
+    )
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("bridgeid", "1234")},
+        manufacturer="manufacturer",
+        model="model",
+        via_device=("bridgeid", "0123"),
+        entry_type=dr.DeviceEntryType.SERVICE,
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id({"type": "config/device_registry/list"})
+    ws_msg = await ws_client.receive_json()
+    assert ws_msg["success"]
+
+    client = await hass_client()
+    resp = await client.get("/api/config/device_registry/list")
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.json() == ws_msg["result"]

--- a/tests/components/config/test_entity_registry.py
+++ b/tests/components/config/test_entity_registry.py
@@ -1,6 +1,7 @@
 """Test entity_registry API."""
 
 from datetime import datetime
+from http import HTTPStatus
 import logging
 
 from freezegun.api import FrozenDateTimeFactory
@@ -17,6 +18,7 @@ from homeassistant.helpers.entity_registry import (
     RegistryEntryDisabler,
     RegistryEntryHider,
 )
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
 from tests.common import (
@@ -27,7 +29,11 @@ from tests.common import (
     RegistryEntryWithDefaults,
     mock_registry,
 )
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 
 @pytest.fixture
@@ -35,6 +41,7 @@ async def client(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> MockHAClientWebSocket:
     """Fixture that can interact with the config manager API."""
+    assert await async_setup_component(hass, "http", {})
     entity_registry.async_setup(hass)
     return await hass_ws_client(hass)
 
@@ -1576,3 +1583,123 @@ async def test_get_automatic_entity_ids(
         # no test_domain.unknown in registry
         "test_domain.unknown": None,
     }
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "/api/config/entity_registry/list",
+        "/api/config/entity_registry/list_for_display",
+    ],
+)
+async def test_rest_list_requires_auth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    url: str,
+) -> None:
+    """Test the REST list endpoints require authentication."""
+    assert await async_setup_component(hass, "http", {})
+    entity_registry.async_setup(hass)
+
+    client = await hass_client_no_auth()
+    resp = await client.get(url)
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+
+
+@pytest.mark.parametrize(
+    ("ws_type", "url"),
+    [
+        (
+            "config/entity_registry/list",
+            "/api/config/entity_registry/list",
+        ),
+        (
+            "config/entity_registry/list_for_display",
+            "/api/config/entity_registry/list_for_display",
+        ),
+    ],
+)
+async def test_rest_list_matches_websocket(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+    ws_type: str,
+    url: str,
+) -> None:
+    """Test the REST list endpoints return the same payload as the websocket command."""
+    assert await async_setup_component(hass, "http", {})
+    entity_registry.async_setup(hass)
+    mock_registry(
+        hass,
+        {
+            "test_domain.name": RegistryEntryWithDefaults(
+                entity_id="test_domain.name",
+                unique_id="1234",
+                platform="test_platform",
+                name="Hello World",
+            ),
+            "sensor.precision": RegistryEntryWithDefaults(
+                entity_id="sensor.precision",
+                options={"sensor": {"suggested_display_precision": 0}},
+                platform="test_platform",
+                unique_id="5678",
+            ),
+            # Disabled entities are omitted from list_for_display but not from list
+            "test_domain.disabled": RegistryEntryWithDefaults(
+                disabled_by=RegistryEntryDisabler.USER,
+                entity_id="test_domain.disabled",
+                platform="test_platform",
+                unique_id="9ABC",
+            ),
+        },
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id({"type": ws_type})
+    ws_msg = await ws_client.receive_json()
+    assert ws_msg["success"]
+
+    client = await hass_client()
+    resp = await client.get(url)
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.json() == ws_msg["result"]
+
+
+@pytest.mark.parametrize(
+    ("entity_count", "expect_compression"),
+    [
+        pytest.param(1, False, id="small-body-not-compressed"),
+        pytest.param(50, True, id="large-body-compressed"),
+    ],
+)
+async def test_rest_list_compression_threshold(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    entity_count: int,
+    expect_compression: bool,
+) -> None:
+    """Test that only registry list responses above the size threshold are compressed."""
+    assert await async_setup_component(hass, "http", {})
+    entity_registry.async_setup(hass)
+    mock_registry(
+        hass,
+        {
+            f"test_domain.entity_{i}": RegistryEntryWithDefaults(
+                entity_id=f"test_domain.entity_{i}",
+                unique_id=str(i),
+                platform="test_platform",
+            )
+            for i in range(entity_count)
+        },
+    )
+
+    client = await hass_client()
+    resp = await client.get(
+        "/api/config/entity_registry/list",
+        headers={"Accept-Encoding": "gzip, deflate"},
+    )
+
+    assert resp.status == HTTPStatus.OK
+    assert ("Content-Encoding" in resp.headers) is expect_compression

--- a/tests/components/config/test_floor_registry.py
+++ b/tests/components/config/test_floor_registry.py
@@ -1,6 +1,7 @@
 """Test floor registry API."""
 
 from datetime import datetime
+from http import HTTPStatus
 from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
@@ -10,9 +11,14 @@ from pytest_unordered import unordered
 from homeassistant.components.config import floor_registry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import floor_registry as fr
+from homeassistant.setup import async_setup_component
 from homeassistant.util.dt import utcnow
 
-from tests.typing import MockHAClientWebSocket, WebSocketGenerator
+from tests.typing import (
+    ClientSessionGenerator,
+    MockHAClientWebSocket,
+    WebSocketGenerator,
+)
 
 
 @pytest.fixture(name="client")
@@ -20,6 +26,7 @@ async def client_fixture(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator
 ) -> MockHAClientWebSocket:
     """Fixture that can interact with the config manager API."""
+    assert await async_setup_component(hass, "http", {})
     floor_registry.async_setup(hass)
     return await hass_ws_client(hass)
 
@@ -451,3 +458,46 @@ async def test_reorder_floors_persistence(
 
     floor_ids = [floor.floor_id for floor in floor_registry.async_list_floors()]
     assert floor_ids == [floor2.floor_id, floor3.floor_id, floor1.floor_id]
+
+
+async def test_rest_list_requires_auth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Test the REST list endpoint requires authentication."""
+    assert await async_setup_component(hass, "http", {})
+    floor_registry.async_setup(hass)
+
+    client = await hass_client_no_auth()
+    resp = await client.get("/api/config/floor_registry/list")
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED
+
+
+async def test_rest_list_floors_matches_websocket(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the REST list endpoint returns the same payload as the websocket command."""
+    assert await async_setup_component(hass, "http", {})
+    floor_registry.async_setup(hass)
+    registry = fr.async_get(hass)
+    registry.async_create("First floor")
+    registry.async_create(
+        name="Second floor",
+        aliases={"top floor", "attic"},
+        icon="mdi:home-floor-2",
+        level=2,
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id({"type": "config/floor_registry/list"})
+    ws_msg = await ws_client.receive_json()
+    assert ws_msg["success"]
+
+    client = await hass_client()
+    resp = await client.get("/api/config/floor_registry/list")
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.json() == ws_msg["result"]

--- a/tests/components/usage_prediction/test_init.py
+++ b/tests/components/usage_prediction/test_init.py
@@ -1,6 +1,7 @@
 """Test usage_prediction integration."""
 
 import asyncio
+from http import HTTPStatus
 from unittest.mock import patch
 
 import pytest
@@ -9,6 +10,8 @@ from homeassistant.components.usage_prediction import DOMAIN, get_cached_common_
 from homeassistant.components.usage_prediction.models import EntityUsagePredictions
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
+
+from tests.typing import ClientSessionGenerator
 
 
 @pytest.mark.usefixtures("recorder_mock")
@@ -61,3 +64,51 @@ async def test_usage_prediction_caching(hass: HomeAssistant) -> None:
         finish_event.set()
         assert await task2 is results
         assert await task1 is results
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_rest_common_control(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test the REST common control endpoint returns predictions for the user."""
+    predictions = EntityUsagePredictions(
+        morning=["light.kitchen"],
+        afternoon=["climate.thermostat"],
+        evening=["light.bedroom"],
+        night=["lock.front_door"],
+    )
+
+    async def mock_predict(*args) -> EntityUsagePredictions:
+        return predictions
+
+    with (
+        patch(
+            "homeassistant.components.usage_prediction.common_control.async_predict_common_control",
+            mock_predict,
+        ),
+        patch(
+            "homeassistant.components.usage_prediction.common_control.time_category",
+            return_value="evening",
+        ),
+    ):
+        assert await async_setup_component(hass, DOMAIN, {})
+        client = await hass_client()
+        resp = await client.get("/api/usage_prediction/common_control")
+
+    assert resp.status == HTTPStatus.OK
+    assert await resp.json() == {"entities": ["light.bedroom"]}
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_rest_common_control_requires_auth(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+) -> None:
+    """Test the REST common control endpoint requires authentication."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    client = await hass_client_no_auth()
+    resp = await client.get("/api/usage_prediction/common_control")
+
+    assert resp.status == HTTPStatus.UNAUTHORIZED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add REST `GET` endpoints that mirror existing websocket list commands, so clients can fetch these lists over plain HTTP without opening a websocket connection:

- `GET /api/config/entity_registry/list`
- `GET /api/config/entity_registry/list_for_display`
- `GET /api/config/device_registry/list`
- `GET /api/config/area_registry/list`
- `GET /api/config/floor_registry/list`
- `GET /api/usage_prediction/common_control`

Each endpoint returns exactly the same payload as its websocket counterpart. The registry list views reuse the cached per-entry JSON serializations and enable compression for responses above the existing size threshold, the same way the websocket commands already do. The existing websocket commands are left unchanged.

**Motivation:** the companion app on Apple Watch restricts websocket usage to audio stream sessions, because of watchOS low-level networking limitations ([Apple TN3135: Low-level networking on watchOS](https://developer.apple.com/documentation/technotes/tn3135-low-level-networking-on-watchos)). It therefore cannot rely on the websocket API to fetch these registries, and needs a plain HTTP way to retrieve the same data.

This PR was AI assisted.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
