### PR TITLE
Fix AttributeError in websocket_api target lookups for scalar target.entity shapes

### DIFF
--- a/homeassistant/components/websocket_api/automation.py
+++ b/homeassistant/components/websocket_api/automation.py
@@ -117,7 +117,9 @@ class _AutomationComponentLookupData:
                 # it rather than crash on the unhashable list.
                 supported_features={
                     feature
-                    for feature in entity_filter_config.get("supported_features", [])
+                    for feature in cv.ensure_list(
+                        entity_filter_config.get("supported_features", [])
+                    )
                     if not isinstance(feature, list)
                 },
             )

--- a/homeassistant/components/websocket_api/automation.py
+++ b/homeassistant/components/websocket_api/automation.py
@@ -8,7 +8,11 @@ from typing import Any, Self
 
 from homeassistant.const import CONF_TARGET
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er, target as target_helpers
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_registry as er,
+    target as target_helpers,
+)
 from homeassistant.helpers.condition import (
     async_get_all_descriptions as async_get_all_condition_descriptions,
 )
@@ -98,15 +102,24 @@ class _AutomationComponentLookupData:
         filters: list[_EntityFilter] = []
 
         primary_entities_only = target_description.get("primary_entities_only", True)
-        entity_filters_config = target_description.get("entity", [])
+        # TargetSelectorConfig.entity accepts a single filter dict or a list of
+        # them; normalize so both shapes can be iterated below.
+        entity_filters_config = cv.ensure_list(target_description.get("entity", []))
         for entity_filter_config in entity_filters_config:
             entity_filter = _EntityFilter(
                 integration=entity_filter_config.get("integration"),
-                domains=set(entity_filter_config.get("domain", [])),
-                device_classes=set(entity_filter_config.get("device_class", [])),
-                supported_features=set(
-                    entity_filter_config.get("supported_features", [])
+                domains=set(cv.ensure_list(entity_filter_config.get("domain", []))),
+                device_classes=set(
+                    cv.ensure_list(entity_filter_config.get("device_class", []))
                 ),
+                # A group can itself be a list of feature names requiring all of
+                # them together; that combination isn't resolved here, so drop
+                # it rather than crash on the unhashable list.
+                supported_features={
+                    feature
+                    for feature in entity_filter_config.get("supported_features", [])
+                    if not isinstance(feature, list)
+                },
             )
             filters.append(entity_filter)
 
@@ -155,14 +168,14 @@ def _get_automation_component_domains(
     If a filter is missing both domain and integration keys, None is added to the
     returned set.
     """
-    entity_filters_config = target_description.get("entity", [])
+    entity_filters_config = cv.ensure_list(target_description.get("entity", []))
     if not entity_filters_config:
         return {None}
 
     domains: set[str | None] = set()
     for entity_filter_config in entity_filters_config:
         filter_integration = entity_filter_config.get("integration")
-        filter_domains = entity_filter_config.get("domain", [])
+        filter_domains = cv.ensure_list(entity_filter_config.get("domain", []))
 
         if not filter_domains and not filter_integration:
             domains.add(None)

--- a/homeassistant/components/websocket_api/automation.py
+++ b/homeassistant/components/websocket_api/automation.py
@@ -102,8 +102,6 @@ class _AutomationComponentLookupData:
         filters: list[_EntityFilter] = []
 
         primary_entities_only = target_description.get("primary_entities_only", True)
-        # TargetSelectorConfig.entity accepts a single filter dict or a list of
-        # them; normalize so both shapes can be iterated below.
         entity_filters_config = cv.ensure_list(target_description.get("entity", []))
         for entity_filter_config in entity_filters_config:
             entity_filter = _EntityFilter(
@@ -112,15 +110,16 @@ class _AutomationComponentLookupData:
                 device_classes=set(
                     cv.ensure_list(entity_filter_config.get("device_class", []))
                 ),
-                # A group can itself be a list of feature names requiring all of
-                # them together; that combination isn't resolved here, so drop
-                # it rather than crash on the unhashable list.
+                # Only keep already-resolved integer masks: a group can itself be
+                # an unhashable list of feature names, and directly registered
+                # schemas (async_set_service_schema) may leave dotted feature
+                # strings unresolved; both would crash matches()'s `feature & ...`.
                 supported_features={
                     feature
                     for feature in cv.ensure_list(
                         entity_filter_config.get("supported_features", [])
                     )
-                    if not isinstance(feature, list)
+                    if isinstance(feature, int)
                 },
             )
             filters.append(entity_filter)

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -5055,6 +5055,37 @@ async def test_get_automation_component_lookup_table_cache(
     )
 
 
+async def test_get_automation_component_lookup_table_scalar_target_shapes(
+    hass: HomeAssistant,
+) -> None:
+    """Test target.entity given as a bare mapping instead of a list.
+
+    Real services.yaml files commonly declare `target: entity: {domain: ...}`
+    as a single mapping rather than a list (e.g. siren, blink), and
+    `domain`/`device_class` as a bare string rather than a list of one.
+    """
+    services: dict[str, dict[str, Any] | None] = {
+        "siren.turn_on": {
+            "target": {"entity": {"domain": "siren", "device_class": "siren"}}
+        },
+        "blink.trigger_camera": {
+            "target": {"entity": {"integration": "blink", "domain": "camera"}}
+        },
+    }
+
+    lookup_table = _get_automation_component_lookup_table(hass, "services", services)
+
+    assert set(lookup_table.domain_components) == {"siren", "blink", "camera"}
+
+    siren_filter = lookup_table.domain_components["siren"][0].filters[0]
+    assert siren_filter.domains == {"siren"}
+    assert siren_filter.device_classes == {"siren"}
+
+    blink_filter = lookup_table.domain_components["camera"][0].filters[0]
+    assert blink_filter.integration == "blink"
+    assert blink_filter.domains == {"camera"}
+
+
 @pytest.mark.parametrize(
     ("side_effect", "expect_success"),
     [(Exception("error"), False), (None, True)],

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -5081,6 +5081,44 @@ async def test_get_automation_component_lookup_table_scalar_target_shapes(
     assert blink_filter.domains == {"camera"}
 
 
+async def test_get_automation_component_lookup_table_unresolved_supported_features(
+    hass: HomeAssistant,
+) -> None:
+    """Test unresolved/nested supported_features are dropped, not just lists.
+
+    Descriptions registered directly via async_set_service_schema bypass
+    TargetSelector.CONFIG_SCHEMA, so supported_features can still contain
+    unresolved dotted feature-name strings (not just nested-list groups).
+    Keeping anything other than an already-resolved int would let a stray
+    string reach _EntityFilter.matches()'s `feature & entity_supported_features`
+    and raise TypeError.
+    """
+    services: dict[str, dict[str, Any] | None] = {
+        "siren.toggle": {
+            "target": {
+                "entity": {
+                    "domain": "siren",
+                    "supported_features": [
+                        8,
+                        "siren.SirenEntityFeature.TURN_ON",
+                        ["siren.SirenEntityFeature.TURN_OFF"],
+                    ],
+                }
+            }
+        },
+    }
+
+    lookup_table = _get_automation_component_lookup_table(hass, "services", services)
+
+    siren_filter = lookup_table.domain_components["siren"][0].filters[0]
+    assert siren_filter.supported_features == {8}
+
+    # Must not raise even though the source data had unresolved entries, and
+    # must match on the resolved mask alone.
+    hass.states.async_set("siren.test", "off", {"supported_features": 8})
+    assert siren_filter.matches(hass, "siren.test", "siren", "test") is True
+
+
 @pytest.mark.parametrize(
     ("side_effect", "expect_success"),
     [(Exception("error"), False), (None, True)],

--- a/tests/components/websocket_api/test_commands.py
+++ b/tests/components/websocket_api/test_commands.py
@@ -5058,12 +5058,7 @@ async def test_get_automation_component_lookup_table_cache(
 async def test_get_automation_component_lookup_table_scalar_target_shapes(
     hass: HomeAssistant,
 ) -> None:
-    """Test target.entity given as a bare mapping instead of a list.
-
-    Real services.yaml files commonly declare `target: entity: {domain: ...}`
-    as a single mapping rather than a list (e.g. siren, blink), and
-    `domain`/`device_class` as a bare string rather than a list of one.
-    """
+    """Test target.entity given as a bare mapping instead of a list."""
     services: dict[str, dict[str, Any] | None] = {
         "siren.turn_on": {
             "target": {"entity": {"domain": "siren", "device_class": "siren"}}


### PR DESCRIPTION
## Breaking change


## Proposed change

`target.entity` (and each filter's `domain`/`device_class`) may legitimately be
a single mapping/string rather than a list — this is the documented type in
`helpers/selector.py`'s `TargetSelectorConfig`/`EntityFilterSelectorConfig`
(`entity: EntityFilterSelectorConfig | list[EntityFilterSelectorConfig]`,
`domain: str | list[str]`).

`_get_automation_component_domains` and `_AutomationComponentLookupData.create`
in `homeassistant/components/websocket_api/automation.py` assumed the list
form only, so any service/trigger/condition description using the scalar form
crashed the "By target" action-picker in the automation editor with
`AttributeError: 'str' object has no attribute 'get'`.

A scan of every `services.yaml` / `triggers.yaml` / `conditions.yaml` in this
repo found **679** uses of the scalar form (e.g. `siren`, `blink`,
`hydrawise`, `watts`), so this wasn't an edge case — it broke "By target" for
most real installs.

This PR:
- Normalizes `target.entity` and each filter's `domain`/`device_class` with
  `cv.ensure_list` so both shapes are handled.
- Also guards `supported_features` against nested-list groups (e.g. `siren`'s
  `toggle` action declares an OR-of-feature-groups shape), which raised a
  separate, pre-existing `TypeError: unhashable type: 'list'` in the same
  lookup path. The nested-group combination itself isn't resolved here (would
  require resolving dotted enum-path strings to integer bitmasks); this PR
  only prevents the crash by dropping unresolvable groups.

Verified by reproducing the original `AttributeError`, then running the fixed
code against every real `target:` block found in the repo (0 crashes), and
confirming existing tests still pass with no regressions.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #176543
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
