### PR TITLE
Refresh add-on update entities after store reload through Supervisor API proxy

### DIFF
--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -1411,6 +1411,10 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
             log_failures, raise_on_auth_failed, scheduled, raise_on_entry_error
         )
 
+    async def async_refresh_after_store_reload(self) -> None:
+        """Refresh addon data when the store was already reloaded externally."""
+        await super()._async_refresh(log_failures=True)
+
     async def force_addon_info_data_refresh(self, addon_slug: str) -> None:
         """Force refresh of addon info data for a specific addon."""
         try:

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -1413,7 +1413,8 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
 
     async def async_refresh_after_store_reload(self) -> None:
         """Refresh addon data when the store was already reloaded externally."""
-        await super()._async_refresh(log_failures=True)
+        async with self._debounced_refresh.async_lock():
+            await super()._async_refresh(log_failures=True)
 
     async def force_addon_info_data_refresh(self, addon_slug: str) -> None:
         """Force refresh of addon info data for a specific addon."""

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -60,9 +60,9 @@ WS_NO_ADMIN_ENDPOINTS = re.compile(
     r")$"
 )
 
-# Endpoints that reload the add-on store. After one of these the add-on update
+# Endpoint that reloads the add-on store. Afterwards the add-on update
 # entities must be refreshed so they don't report stale update information.
-STORE_RELOAD_ENDPOINTS = {"/addons/reload", "/store/reload"}
+STORE_RELOAD_ENDPOINT = "/store/reload"
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -166,7 +166,7 @@ async def websocket_supervisor_api(
             data.pop("options", None)
         connection.send_result(msg[WS_ID], data)
 
-        if command in STORE_RELOAD_ENDPOINTS and (
+        if command == STORE_RELOAD_ENDPOINT and (
             coordinator := hass.data.get(ADDONS_COORDINATOR)
         ):
             hass.async_create_task(coordinator.async_refresh_after_store_reload())

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -166,8 +166,10 @@ async def websocket_supervisor_api(
             data.pop("options", None)
         # Await so the frontend only sees the reload finish once the add-on
         # update entities reflect the reloaded store.
-        if command == STORE_RELOAD_ENDPOINT and (
-            coordinator := hass.data.get(ADDONS_COORDINATOR)
+        if (
+            command == STORE_RELOAD_ENDPOINT
+            and msg[ATTR_METHOD] == "post"
+            and (coordinator := hass.data.get(ADDONS_COORDINATOR))
         ):
             await coordinator.async_refresh_after_store_reload()
 

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -164,12 +164,14 @@ async def websocket_supervisor_api(
         # sensitive information and the frontend does not require it for ingress.
         if not connection.user.is_admin and WS_ADDONS_INFO_ENDPOINT.match(command):
             data.pop("options", None)
-        connection.send_result(msg[WS_ID], data)
-
+        # Await so the frontend only sees the reload finish once the add-on
+        # update entities reflect the reloaded store.
         if command == STORE_RELOAD_ENDPOINT and (
             coordinator := hass.data.get(ADDONS_COORDINATOR)
         ):
-            hass.async_create_task(coordinator.async_refresh_after_store_reload())
+            await coordinator.async_refresh_after_store_reload()
+
+        connection.send_result(msg[WS_ID], data)
 
 
 @websocket_api.require_admin

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.dispatcher import (
 
 from .config import HassioUpdateParametersDict
 from .const import (
+    ADDONS_COORDINATOR,
     ATTR_DATA,
     ATTR_ENDPOINT,
     ATTR_METHOD,
@@ -58,6 +59,10 @@ WS_NO_ADMIN_ENDPOINTS = re.compile(
     f"|{RE_ADDONS_INFO_ENDPOINT}"
     r")$"
 )
+
+# Endpoints that reload the add-on store. After one of these the add-on update
+# entities must be refreshed so they don't report stale update information.
+STORE_RELOAD_ENDPOINTS = {"/addons/reload", "/store/reload"}
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -160,6 +165,11 @@ async def websocket_supervisor_api(
         if not connection.user.is_admin and WS_ADDONS_INFO_ENDPOINT.match(command):
             data.pop("options", None)
         connection.send_result(msg[WS_ID], data)
+
+        if command in STORE_RELOAD_ENDPOINTS and (
+            coordinator := hass.data.get(ADDONS_COORDINATOR)
+        ):
+            hass.async_create_task(coordinator.async_refresh_after_store_reload())
 
 
 @websocket_api.require_admin

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -407,14 +407,14 @@ async def test_websocket_store_reload_refreshes_update_entities(
         )
     ]
     aioclient_mock.post(
-        "http://127.0.0.1/addons/reload", json={"result": "ok", "data": {}}
+        "http://127.0.0.1/store/reload", json={"result": "ok", "data": {}}
     )
 
     websocket_client = await hass_ws_client(hass)
     await websocket_client.send_json_auto_id(
         {
             WS_TYPE: WS_TYPE_API,
-            ATTR_ENDPOINT: "/addons/reload",
+            ATTR_ENDPOINT: "/store/reload",
             ATTR_METHOD: "post",
         }
     )

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -375,6 +375,57 @@ async def test_websocket_non_admin_user(
     assert msg["error"]["message"] == "Unauthorized"
 
 
+async def test_websocket_store_reload_refreshes_update_entities(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    supervisor_client: AsyncMock,
+    addons_list: AsyncMock,
+) -> None:
+    """Test add-on update entities refresh after a store reload via the API proxy."""
+    addons_list.return_value = [
+        replace(
+            addons_list.return_value[0],
+            update_available=False,
+            version_latest="2.0.0",
+        )
+    ]
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(hass, DOMAIN, {"hassio": {}})
+    await hass.async_block_till_done()
+
+    assert hass.states.get("update.test_update").state == "off"
+
+    addons_list.return_value = [
+        replace(
+            addons_list.return_value[0],
+            update_available=True,
+            version_latest="2.0.1",
+        )
+    ]
+    aioclient_mock.post(
+        "http://127.0.0.1/addons/reload", json={"result": "ok", "data": {}}
+    )
+
+    websocket_client = await hass_ws_client(hass)
+    await websocket_client.send_json_auto_id(
+        {
+            WS_TYPE: WS_TYPE_API,
+            ATTR_ENDPOINT: "/addons/reload",
+            ATTR_METHOD: "post",
+        }
+    )
+    msg = await websocket_client.receive_json()
+    assert msg["success"]
+    await hass.async_block_till_done()
+
+    assert hass.states.get("update.test_update").state == "on"
+    supervisor_client.store.reload.assert_not_called()
+
+
 async def test_update_addon(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -420,7 +420,6 @@ async def test_websocket_store_reload_refreshes_update_entities(
     )
     msg = await websocket_client.receive_json()
     assert msg["success"]
-    await hass.async_block_till_done()
 
     assert hass.states.get("update.test_update").state == "on"
     supervisor_client.store.reload.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When the user clicks "Check for updates" on the apps dashboard, the frontend reloads the add-on store through the `supervisor/api` websocket proxy and refetches add-on data directly from Supervisor, so the apps UI shows a newly found update immediately. However, `HassioAddOnDataUpdateCoordinator` only polls Supervisor every 15 minutes and gets no signal that the store was just reloaded. The add-on `update` entity therefore stays stale, and the more info dialog opened from the app page's "Update" button disagrees with the dashboard: it reports the add-on as up to date and the update button is disabled.

This PR triggers a refresh of the add-on coordinator after a successful `/store/reload` call proxied through the `supervisor/api` websocket command, so the add-on update entities sync as soon as the frontend's refresh completes. The refresh uses a new `async_refresh_after_store_reload` method that serializes through the coordinator's debouncer lock but skips the coordinator's own `store.reload()` call, since the store was just reloaded by the proxied request and reloading it again would duplicate the expensive git pulls on the Supervisor side.

The frontend currently calls the legacy `/addons/reload` alias; the companion frontend PR switches it to the canonical `/store/reload` endpoint matched here. Version skew is harmless in both directions since the websocket proxy is a generic passthrough: an older frontend calling `/addons/reload` behaves exactly as today, and a newer frontend against an older core still reloads the store fine, just without the immediate entity refresh.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176584
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53162

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DCaDoYyqULQbZoc226wCp3