### PR TITLE
Add TextSelector in config flow SMA

### DIFF
--- a/homeassistant/components/sma/config_flow.py
+++ b/homeassistant/components/sma/config_flow.py
@@ -209,8 +209,7 @@ class SmaConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
                 data_schema=STEP_USER_DATA_SCHEMA,
-                suggested_values=user_input
-                or {k: v for k, v in reconf_entry.data.items() if k != CONF_PASSWORD},
+                suggested_values=user_input or dict(reconf_entry.data),
             ),
             errors=errors,
         )

--- a/homeassistant/components/sma/config_flow.py
+++ b/homeassistant/components/sma/config_flow.py
@@ -27,11 +27,49 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import format_mac
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 from homeassistant.helpers.service_info.dhcp import DhcpServiceInfo
 
 from .const import CONF_GROUP, DOMAIN, GROUPS
 
 _LOGGER = logging.getLogger(__name__)
+
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.URL)
+        ),
+        vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+        vol.Optional(CONF_GROUP, default=GROUPS[0]): vol.In(GROUPS),
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        ),
+    }
+)
+
+
+STEP_DISCOVERY_CONFIRM_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_SSL, default=False): cv.boolean,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+        vol.Optional(CONF_GROUP, default=GROUPS[0]): vol.In(GROUPS),
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(
+                type=TextSelectorType.PASSWORD,
+                autocomplete="current-password",
+            )
+        ),
+    }
+)
 
 
 async def validate_input(
@@ -130,18 +168,9 @@ class SmaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_HOST, default=self._data[CONF_HOST]): cv.string,
-                    vol.Optional(CONF_SSL, default=self._data[CONF_SSL]): cv.boolean,
-                    vol.Optional(
-                        CONF_VERIFY_SSL, default=self._data[CONF_VERIFY_SSL]
-                    ): cv.boolean,
-                    vol.Optional(CONF_GROUP, default=self._data[CONF_GROUP]): vol.In(
-                        GROUPS
-                    ),
-                    vol.Required(CONF_PASSWORD): cv.string,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_USER_DATA_SCHEMA,
+                suggested_values=user_input,
             ),
             errors=errors,
         )
@@ -172,21 +201,16 @@ class SmaConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_SSL: user_input[CONF_SSL],
                         CONF_VERIFY_SSL: user_input[CONF_VERIFY_SSL],
                         CONF_GROUP: user_input[CONF_GROUP],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
                     },
                 )
 
         return self.async_show_form(
             step_id="reconfigure",
             data_schema=self.add_suggested_values_to_schema(
-                data_schema=vol.Schema(
-                    {
-                        vol.Required(CONF_HOST): cv.string,
-                        vol.Optional(CONF_SSL): cv.boolean,
-                        vol.Optional(CONF_VERIFY_SSL): cv.boolean,
-                        vol.Optional(CONF_GROUP): vol.In(GROUPS),
-                    }
-                ),
-                suggested_values=user_input or dict(reconf_entry.data),
+                data_schema=STEP_USER_DATA_SCHEMA,
+                suggested_values=user_input
+                or {k: v for k, v in reconf_entry.data.items() if k != CONF_PASSWORD},
             ),
             errors=errors,
         )
@@ -221,7 +245,12 @@ class SmaConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reauth_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_PASSWORD): cv.string,
+                    vol.Required(CONF_PASSWORD): TextSelector(
+                        TextSelectorConfig(
+                            type=TextSelectorType.PASSWORD,
+                            autocomplete="current-password",
+                        )
+                    ),
                 }
             ),
             errors=errors,
@@ -290,17 +319,9 @@ class SmaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="discovery_confirm",
-            data_schema=vol.Schema(
-                {
-                    vol.Optional(CONF_SSL, default=self._data[CONF_SSL]): cv.boolean,
-                    vol.Optional(
-                        CONF_VERIFY_SSL, default=self._data[CONF_VERIFY_SSL]
-                    ): cv.boolean,
-                    vol.Optional(CONF_GROUP, default=self._data[CONF_GROUP]): vol.In(
-                        GROUPS
-                    ),
-                    vol.Required(CONF_PASSWORD): cv.string,
-                }
+            data_schema=self.add_suggested_values_to_schema(
+                data_schema=STEP_DISCOVERY_CONFIRM_DATA_SCHEMA,
+                suggested_values=user_input,
             ),
             description_placeholders={CONF_HOST: self._data[CONF_HOST]},
             errors=errors,

--- a/tests/components/sma/__init__.py
+++ b/tests/components/sma/__init__.py
@@ -40,6 +40,7 @@ MOCK_USER_RECONFIGURE = {
     CONF_SSL: True,
     CONF_VERIFY_SSL: False,
     CONF_GROUP: "user",
+    CONF_PASSWORD: "new_password",
 }
 
 

--- a/tests/components/sma/test_config_flow.py
+++ b/tests/components/sma/test_config_flow.py
@@ -8,7 +8,13 @@ import pytest
 
 from homeassistant.components.sma.const import CONF_GROUP, DOMAIN
 from homeassistant.config_entries import SOURCE_DHCP, SOURCE_USER
-from homeassistant.const import CONF_HOST, CONF_MAC, CONF_SSL, CONF_VERIFY_SSL
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_MAC,
+    CONF_PASSWORD,
+    CONF_SSL,
+    CONF_VERIFY_SSL,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers.device_registry import format_mac
@@ -338,6 +344,7 @@ async def test_full_flow_reconfigure(
     assert entry.data[CONF_SSL] is True
     assert entry.data[CONF_VERIFY_SSL] is False
     assert entry.data[CONF_GROUP] == "user"
+    assert entry.data[CONF_PASSWORD] == "new_password"
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -385,6 +392,7 @@ async def test_full_flow_reconfigure_exceptions(
     assert entry.data[CONF_SSL] is True
     assert entry.data[CONF_VERIFY_SSL] is False
     assert entry.data[CONF_GROUP] == "user"
+    assert entry.data[CONF_PASSWORD] == "new_password"
     assert len(mock_setup_entry.mock_calls) == 1
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add TextSelectors in SMA's config flow and added the password in the reconfigure flow. In my perspective this was a missing feature for a reconfigure to give full control to the user.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
