### PR TITLE
Use modern device registry API for device move in wolflink

### DIFF
--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -175,18 +175,11 @@ def _reattach_device_to_hub(
     if device_disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY:
         device_disabled_by = dr.DeviceEntryDisabler.USER
 
-    if source_entry.entry_id != hub_entry.entry_id:
-        device_registry.async_update_device(
-            device.id,
-            disabled_by=device_disabled_by,
-            add_config_entry_id=hub_entry.entry_id,
-            remove_config_entry_id=source_entry.entry_id,
-        )
-    else:
-        device_registry.async_update_device(
-            device.id,
-            disabled_by=device_disabled_by,
-        )
+    device_registry.async_update_device(
+        device.id,
+        disabled_by=device_disabled_by,
+        new_config_entry_id=hub_entry.entry_id,
+    )
 
     for entity_entry in er.async_entries_for_device(
         entity_registry, device.id, include_disabled_entities=True

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.httpx_client import create_async_httpx_client
+from homeassistant.helpers.typing import UNDEFINED, UndefinedType
 
 from .const import DOMAIN, MANUFACTURER
 from .coordinator import WolflinkConfigEntry, WolfLinkCoordinator
@@ -171,8 +172,14 @@ def _reattach_device_to_hub(
     if device is None:
         return
 
-    device_disabled_by = device.disabled_by
-    if device_disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY:
+    # The device registry will set the disabled_by flag to None when moving a
+    # device disabled by CONFIG_ENTRY to an enabled config entry, but we want
+    # to set it to USER instead.
+    device_disabled_by: dr.DeviceEntryDisabler | UndefinedType = UNDEFINED
+    if (
+        device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+        and hub_entry.disabled_by is None
+    ):
         device_disabled_by = dr.DeviceEntryDisabler.USER
 
     device_registry.async_update_device(

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -11,7 +11,7 @@ from wolf_comm.token_auth import InvalidAuth
 from wolf_comm.wolf_client import FetchFailed, ParameterReadError
 
 from homeassistant.components.wolflink.const import DOMAIN, MANUFACTURER
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryDisabler, ConfigEntryState
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -250,6 +250,58 @@ async def test_migration_merges_duplicate_v1_entries(
     device = device_registry.async_get(device_5678.id)
     assert device is not None
     assert device.config_entries == {surviving.entry_id}
+
+
+async def test_migration_merge_into_disabled_hub(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test an enabled device merged onto a disabled hub entry gets disabled."""
+    hub_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="test-username",
+        data={CONF_USERNAME: "test-username", CONF_PASSWORD: "test-password"},
+        version=2,
+        minor_version=2,
+        disabled_by=ConfigEntryDisabler.USER,
+    )
+    hub_entry.add_to_hass(hass)
+    legacy_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="5678",
+        data={**LEGACY_CONFIG, "device_id": 5678},
+        version=1,
+        minor_version=2,
+    )
+    legacy_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=legacy_entry.entry_id,
+        identifiers={(DOMAIN, "5678")},
+        manufacturer=MANUFACTURER,
+        name="test-device",
+    )
+
+    with patch(
+        "homeassistant.components.wolflink.WolfClient",
+        autospec=True,
+    ) as wolf_mock:
+        wolf_mock.return_value.fetch_system_list.side_effect = RequestError(
+            "Unable to connect"
+        )
+        await hass.config_entries.async_setup(legacy_entry.entry_id)
+        await hass.async_block_till_done()
+
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].entry_id == hub_entry.entry_id
+
+    # The device was reattached to the disabled hub entry, and its disabled
+    # state now reflects the new owning entry's disabled state.
+    migrated_device = device_registry.async_get(device.id)
+    assert migrated_device is not None
+    assert migrated_device.config_entries == {hub_entry.entry_id}
+    assert migrated_device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
 
 
 async def test_migration_v1_list_device_id(hass: HomeAssistant) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use modern device registry API for device move in wolflink

This is a follow-up to PR https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
