### PR TITLE
Use modern device registry API to remove devices (part 2)

### DIFF
--- a/homeassistant/components/honeywell/climate.py
+++ b/homeassistant/components/honeywell/climate.py
@@ -152,10 +152,8 @@ def remove_stale_devices(
             # If device_id is None an invalid device entry was
             # found for this config entry. If the device_id is not
             # in existing device ids it's a stale device entry.
-            # Remove config entry from this device entry in either case.
-            device_registry.async_update_device(
-                device_entry.id, remove_config_entry_id=config_entry.entry_id
-            )
+            # Remove the device entry in either case.
+            device_registry.async_remove_device(device_entry.id)
 
 
 class HoneywellUSThermostat(ClimateEntity):

--- a/homeassistant/components/hydrawise/coordinator.py
+++ b/homeassistant/components/hydrawise/coordinator.py
@@ -142,17 +142,13 @@ class HydrawiseMainDataUpdateCoordinator(HydrawiseDataUpdateCoordinator):
         if removed_zones := previous_zones - current_zones:
             LOGGER.debug("Removed zones: %s", ", ".join(removed_zones))
             for zone_id in removed_zones:
-                device_registry.async_update_device(
-                    device_id=previous_zones_by_id[zone_id].id,
-                    remove_config_entry_id=self.config_entry.entry_id,
-                )
+                device_registry.async_remove_device(previous_zones_by_id[zone_id].id)
 
         if removed_controllers := previous_controllers - current_controllers:
             LOGGER.debug("Removed controllers: %s", ", ".join(removed_controllers))
             for controller_id in removed_controllers:
-                device_registry.async_update_device(
-                    device_id=previous_controllers_by_id[controller_id].id,
-                    remove_config_entry_id=self.config_entry.entry_id,
+                device_registry.async_remove_device(
+                    previous_controllers_by_id[controller_id].id
                 )
 
         if new_controller_ids := current_controllers - previous_controllers:

--- a/homeassistant/components/ituran/coordinator.py
+++ b/homeassistant/components/ituran/coordinator.py
@@ -73,6 +73,4 @@ class IturanDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Vehicle]]):
         )
         for device in device_entries:
             if not device.identifiers.intersection(account_vehicles):
-                device_registry.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                device_registry.async_remove_device(device.id)

--- a/homeassistant/components/liebherr/__init__.py
+++ b/homeassistant/components/liebherr/__init__.py
@@ -106,10 +106,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: LiebherrConfigEntry) -> 
                 for device_id in device_ids:
                     if coordinator := data.coordinators.pop(device_id, None):
                         await coordinator.async_shutdown()
-                device_registry.async_update_device(
-                    device_id=device_entry.id,
-                    remove_config_entry_id=entry.entry_id,
-                )
+                device_registry.async_remove_device(device_entry.id)
 
         # Add new devices
         new_coordinators: list[LiebherrCoordinator] = []

--- a/homeassistant/components/matter/__init__.py
+++ b/homeassistant/components/matter/__init__.py
@@ -394,9 +394,7 @@ def _remove_via_devices(
     devices = dr.async_entries_for_config_entry(device_registry, config_entry.entry_id)
     for device in devices:
         if device.via_device_id == device_entry.id:
-            device_registry.async_update_device(
-                device.id, remove_config_entry_id=config_entry.entry_id
-            )
+            device_registry.async_remove_device(device.id)
 
 
 async def async_remove_config_entry_device(

--- a/homeassistant/components/melcloud_home/coordinator.py
+++ b/homeassistant/components/melcloud_home/coordinator.py
@@ -102,9 +102,7 @@ class MelCloudHomeCoordinator(DataUpdateCoordinator[UserContext]):
                 for identifier in device.identifiers
             ):
                 _LOGGER.debug("Removing stale device: %s", device.identifiers)
-                registry.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                registry.async_remove_device(device.id)
 
     @override
     async def _async_update_data(self) -> UserContext:

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -248,9 +248,7 @@ async def async_setup_entry(  # noqa: C901
     for device in dev_entries:
         for identifier in device.identifiers:
             if identifier[0] == DOMAIN and identifier[1] not in player_ids:
-                dev_reg.async_update_device(
-                    device.id, remove_config_entry_id=entry.entry_id
-                )
+                dev_reg.async_remove_device(device.id)
 
     return True
 

--- a/homeassistant/components/nest/__init__.py
+++ b/homeassistant/components/nest/__init__.py
@@ -236,10 +236,7 @@ class SignalUpdateCallback:
             if device_id in devices:
                 continue
             _LOGGER.info("Removing stale device entry '%s'", device_id)
-            device_registry.async_update_device(
-                device_id=device_entry.id,
-                remove_config_entry_id=self._config_entry.entry_id,
-            )
+            device_registry.async_remove_device(device_entry.id)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NestConfigEntry) -> bool:

--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -94,9 +94,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> 
             if device_entry.via_device_id is None:
                 router_id = device_entry.id
                 continue  # do not remove the router itself
-            device_registry.async_update_device(
-                device_entry.id, remove_config_entry_id=entry.entry_id
-            )
+            device_registry.async_remove_device(device_entry.id)
         # Remove entities that are no longer tracked
         entity_registry = er.async_get(hass)
         entries = er.async_entries_for_config_entry(entity_registry, entry.entry_id)

--- a/homeassistant/components/nobo_hub/__init__.py
+++ b/homeassistant/components/nobo_hub/__init__.py
@@ -137,9 +137,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: NoboHubConfigEntry) -> b
             device_registry, entry.entry_id
         ):
             if device.identifiers.isdisjoint(expected_identifiers):
-                device_registry.async_update_device(
-                    device.id, remove_config_entry_id=entry.entry_id
-                )
+                device_registry.async_remove_device(device.id)
 
     _cleanup_devices(hub)
     hub.register_callback(_cleanup_devices)

--- a/homeassistant/components/nordpool/__init__.py
+++ b/homeassistant/components/nordpool/__init__.py
@@ -66,6 +66,4 @@ async def cleanup_device(
                 continue
 
             LOGGER.debug("Removing device %s", entry.name)
-            device_reg.async_update_device(
-                entry.id, remove_config_entry_id=config_entry.entry_id
-            )
+            device_reg.async_remove_device(entry.id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use modern device registry API to remove devices (part 2)

This PR updates only non-ambiguous cases where integrations loop over devices returned by `async_entries_for_config_entry`

This is a follow-up to PR https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
