### PR TITLE
Use modern device registry API to remove devices (part 4)

### DIFF
--- a/homeassistant/components/tankerkoenig/coordinator.py
+++ b/homeassistant/components/tankerkoenig/coordinator.py
@@ -108,9 +108,7 @@ class TankerkoenigDataUpdateCoordinator(DataUpdateCoordinator[dict[str, PriceInf
                 for station_id in self._selected_stations
             ):
                 _LOGGER.debug("Removing obsolete device entry %s", device.name)
-                device_reg.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                device_reg.async_remove_device(device.id)
 
         if len(self.stations) > 10:
             _LOGGER.warning(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -508,10 +508,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             identifier in current_devices for identifier in device_entry.identifiers
         ):
             LOGGER.debug("Removing stale device %s", device_entry.id)
-            device_registry.async_update_device(
-                device_id=device_entry.id,
-                remove_config_entry_id=entry.entry_id,
-            )
+            device_registry.async_remove_device(device_entry.id)
 
     entry.runtime_data = TeslemetryData(
         vehicles=vehicles,

--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -98,9 +98,7 @@ def _remove_old_devices(
             (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
         )
         if mac and mac not in omada_devices:
-            device_registry.async_update_device(
-                registered_device.id, remove_config_entry_id=entry.entry_id
-            )
+            device_registry.async_remove_device(registered_device.id)
 
 
 async def async_migrate_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> bool:

--- a/homeassistant/components/tuya/__init__.py
+++ b/homeassistant/components/tuya/__init__.py
@@ -78,9 +78,7 @@ async def cleanup_device_registry(
     ):
         for item in device_entry.identifiers:
             if item[0] == DOMAIN and item[1] not in device_manager.device_map:
-                device_registry.async_update_device(
-                    device_entry.id, remove_config_entry_id=entry.entry_id
-                )
+                device_registry.async_remove_device(device_entry.id)
                 break
 
 

--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -297,10 +297,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
                 for identifier in device.identifiers
             ):
                 continue
-            device_registry.async_update_device(
-                device_id=device.id,
-                remove_config_entry_id=self.config_entry.entry_id,
-            )
+            device_registry.async_remove_device(device.id)
 
     def _on_ws_connect(self) -> None:
         """Handle WebSocket connection established."""

--- a/homeassistant/components/unifiprotect/migrate.py
+++ b/homeassistant/components/unifiprotect/migrate.py
@@ -148,11 +148,7 @@ def async_remove_aiport_devices(hass: HomeAssistant, entry: UFPConfigEntry) -> N
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
         if device.model_id != _AIPORT_DEVICE_TYPE:
             continue
-        # Detaching the config entry removes the device (it has no other entry)
-        # and its entities along with it.
-        device_registry.async_update_device(
-            device.id, remove_config_entry_id=entry.entry_id
-        )
+        device_registry.async_remove_device(device.id)
 
 
 @callback

--- a/homeassistant/components/velbus/__init__.py
+++ b/homeassistant/components/velbus/__init__.py
@@ -138,22 +138,18 @@ async def async_remove_config_entry_device(
     config_entry: VelbusConfigEntry,
     device_entry: dr.DeviceEntry,
 ) -> bool:
-    """Allow removing a Velbus device and detach its sub-devices.
+    """Allow removing a Velbus device and its sub-devices.
 
-    Sub-devices are detached from this config entry when their parent is
-    removed. If the device is still on the bus, it may be recreated when
-    the integration is reloaded or started again.
+    Sub-devices are removed along with their parent. If the device is still
+    on the bus, it may be recreated when the integration is reloaded or
+    started again.
     """
     if config_entry.entry_id not in device_entry.config_entries:
         return False
     dev_reg = dr.async_get(hass)
     for sub_device in dr.async_entries_for_config_entry(dev_reg, config_entry.entry_id):
         if sub_device.via_device_id == device_entry.id:
-            dev_reg.async_update_device(
-                sub_device.id,
-                remove_config_entry_id=config_entry.entry_id,
-                via_device_id=None,
-            )
+            dev_reg.async_remove_device(sub_device.id)
     return True
 
 

--- a/homeassistant/components/vistapool/__init__.py
+++ b/homeassistant/components/vistapool/__init__.py
@@ -150,9 +150,7 @@ def _async_remove_stale_devices(
     for device in dr.async_entries_for_config_entry(device_registry, entry.entry_id):
         pool_id = next((i[1] for i in device.identifiers if i[0] == DOMAIN), None)
         if pool_id is not None and pool_id not in valid_pool_ids:
-            device_registry.async_update_device(
-                device.id, remove_config_entry_id=entry.entry_id
-            )
+            device_registry.async_remove_device(device.id)
 
 
 async def _async_initial_refresh(

--- a/homeassistant/components/xbox/coordinator.py
+++ b/homeassistant/components/xbox/coordinator.py
@@ -127,9 +127,7 @@ class XboxConsolesCoordinator(XboxBaseCoordinator[dict[str, SmartglassConsole]])
                 and not set(device.identifiers) & identifiers
             ):
                 _LOGGER.debug("Removing stale device %s", device.name)
-                device_reg.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                device_reg.async_remove_device(device.id)
 
         return {console.id: console for console in consoles.result}
 

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -169,9 +169,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: YoLinkConfigEntry) -> bo
                 identifier[0] == DOMAIN
                 and device_coordinators.get(identifier[1]) is None
             ):
-                device_registry.async_update_device(
-                    device_entry.id, remove_config_entry_id=entry.entry_id
-                )
+                device_registry.async_remove_device(device_entry.id)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/yoto/coordinator.py
+++ b/homeassistant/components/yoto/coordinator.py
@@ -161,9 +161,7 @@ class YotoDataUpdateCoordinator(DataUpdateCoordinator[dict[str, YotoPlayer]]):
                 (ident[1] for ident in device.identifiers if ident[0] == DOMAIN), None
             )
             if player_id is not None and player_id not in self.client.players:
-                device_registry.async_update_device(
-                    device.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                device_registry.async_remove_device(device.id)
 
     async def _async_load_library(self) -> None:
         """Load the card library and groups; failures only affect browsing."""

--- a/homeassistant/components/youtube/__init__.py
+++ b/homeassistant/components/youtube/__init__.py
@@ -71,6 +71,4 @@ async def delete_devices(
     dev_entries = dr.async_entries_for_config_entry(device_registry, entry.entry_id)
     for dev_entry in dev_entries:
         if any(identifier[1] in channel_ids for identifier in dev_entry.identifiers):
-            device_registry.async_update_device(
-                dev_entry.id, remove_config_entry_id=entry.entry_id
-            )
+            device_registry.async_remove_device(dev_entry.id)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use modern device registry API to remove devices (part 4)

This PR updates only non-ambiguous cases where integrations loop over devices returned by `async_entries_for_config_entry`

This is a follow-up to PR https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
