### PR TITLE
Validate disabled_by flag in async_update_device

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1955,13 +1955,15 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         if pending_move is not UNDEFINED and pending_move != old._pending_move:  # noqa: SLF001
             new_values["pending_move"] = pending_move
 
-        # Identifiers and connections are unique per config entry, so when the device is
-        # moved to another config entry they are validated against the new one
+        # The config entry owning the device after the update. Identifiers and
+        # connections are unique per config entry, so they are validated against the
+        # owning entry, as is the disabled state.
         effective_config_entry_id = (
             target_config_entry_id
             if target_config_entry_id is not UNDEFINED
             else old.config_entry_id
         )
+        is_move = effective_config_entry_id != old.config_entry_id
 
         added_connections: set[tuple[str, str]] | None = None
         added_identifiers: set[tuple[str, str]] | None = None
@@ -2009,7 +2011,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # overwrite the index slot of a device that already has the same identity there.
         # A full new_identifiers / new_connections replacement is validated above;
         # merge_* only adds, so the retained old values still need checking here.
-        if effective_config_entry_id != old.config_entry_id:
+        if is_move:
             if new_identifiers is UNDEFINED:
                 self._validate_identifiers(
                     device_id, effective_config_entry_id, old.identifiers, False
@@ -2025,28 +2027,27 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # CONFIG_ENTRY when the owning config entry is enabled. An inconsistent
         # disabled_by is ignored; this will raise in HA Core 2027.8.
         # On a move, reflect the new owning config entry's disabled state (as restoring
-        # a deleted device does) unless disabled_by was passed explicitly: disable an
-        # enabled device moved onto a disabled entry, and clear a CONFIG_ENTRY disable
-        # when moved onto an enabled entry. A USER disable is preserved.
-        if (
-            target_config_entry_id is not UNDEFINED
-            and target_config_entry_id != old.config_entry_id
-        ):
-            is_move = True
-            owning_entry_id = target_config_entry_id
-        else:
-            is_move = False
-            owning_entry_id = old.config_entry_id
+        # a deleted device does) unless a consistent disabled_by was passed explicitly:
+        # disable an enabled device moved onto a disabled entry, and clear a
+        # CONFIG_ENTRY disable when moved onto an enabled entry. A USER disable is
+        # preserved. A new device is reconciled the same way after an inconsistent
+        # disabled_by was discarded, so a create can't leave the device's disabled
+        # state contradicting the owning entry's.
         if (disabled_by is not UNDEFINED or is_move) and (
-            owning_entry := self.hass.config_entries.async_get_entry(owning_entry_id)
-        ) is not None:
-            context = (
-                "when moving a device to" if is_move else "on a device belonging to"
+            owning_entry := self.hass.config_entries.async_get_entry(
+                effective_config_entry_id
             )
+        ) is not None:
+            if is_move:
+                context = "when moving a device to"
+            elif is_new:
+                context = "when creating a device attached to"
+            else:
+                context = "on a device belonging to"
             if disabled_by is None and owning_entry.disabled_by:
                 report_usage(
                     f"sets disabled_by to None {context} the disabled "
-                    f"config entry {owning_entry_id}",
+                    f"config entry {effective_config_entry_id}",
                     core_behavior=ReportBehavior.LOG,
                     breaks_in_ha_version="2027.8",
                 )
@@ -2057,12 +2058,12 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             ):
                 report_usage(
                     f"sets disabled_by to DeviceEntryDisabler.CONFIG_ENTRY {context} "
-                    f"the enabled config entry {owning_entry_id}",
+                    f"the enabled config entry {effective_config_entry_id}",
                     core_behavior=ReportBehavior.LOG,
                     breaks_in_ha_version="2027.8",
                 )
                 disabled_by = UNDEFINED
-            if is_move and disabled_by is UNDEFINED:
+            if (is_move or is_new) and disabled_by is UNDEFINED:
                 if owning_entry.disabled_by:
                     if old.disabled_by is None:
                         disabled_by = DeviceEntryDisabler.CONFIG_ENTRY
@@ -2112,7 +2113,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # identity move, so match the target entry's deleted device by the full identity.
         match_identifiers: set[tuple[str, str]] | None
         match_connections: set[tuple[str, str]] | None
-        if effective_config_entry_id != old.config_entry_id:
+        if is_move:
             match_identifiers = new.identifiers
             match_connections = new.connections
         else:
@@ -2200,9 +2201,10 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             can't be disabled by CONFIG_ENTRY when the owning config entry is enabled.
             An inconsistent disabled_by is deprecated and ignored; this will raise in
             HA Core 2027.8.
-        :param new_config_entry_id: Move the device to this config entry. Unless
-            disabled_by is passed explicitly, the device's disabled state is updated
-            to reflect the new config entry's disabled state.
+        :param new_config_entry_id: Move the device to this config entry. Unless a
+            disabled_by consistent with the new config entry's disabled state is
+            passed explicitly, the device's disabled state is updated to reflect the
+            new config entry's disabled state.
         :param new_config_subentry_id: Move the device to this subentry.
         :param remove_config_entry_id: Remove the device if it is the device's config
             entry, unless combined with add_config_entry_id to move the device.

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2030,10 +2030,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         # a deleted device does) unless a consistent disabled_by was passed explicitly:
         # disable an enabled device moved onto a disabled entry, and clear a
         # CONFIG_ENTRY disable when moved onto an enabled entry. A USER disable is
-        # preserved. A new device is reconciled the same way after an inconsistent
-        # disabled_by was discarded, so a create can't leave the device's disabled
-        # state contradicting the owning entry's.
-        if (disabled_by is not UNDEFINED or is_move) and (
+        # preserved. A new device is reconciled the same way, so a create can't
+        # leave the device's disabled state contradicting the owning entry's.
+        if (disabled_by is not UNDEFINED or is_move or is_new) and (
             owning_entry := self.hass.config_entries.async_get_entry(
                 effective_config_entry_id
             )

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -2019,26 +2019,55 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                     device_id, effective_config_entry_id, old.connections, False
                 )
 
-        # On a move, reflect the new owning config entry's disabled state (as restoring a
-        # deleted device does) unless disabled_by was passed explicitly: disable an
+        # An explicit disabled_by must be consistent with the disabled state of the
+        # config entry owning the device after the update: a device can't be enabled
+        # when the owning config entry is disabled, and can't be disabled by
+        # CONFIG_ENTRY when the owning config entry is enabled. An inconsistent
+        # disabled_by is ignored; this will raise in HA Core 2027.8.
+        # On a move, reflect the new owning config entry's disabled state (as restoring
+        # a deleted device does) unless disabled_by was passed explicitly: disable an
         # enabled device moved onto a disabled entry, and clear a CONFIG_ENTRY disable
         # when moved onto an enabled entry. A USER disable is preserved.
         if (
-            disabled_by is UNDEFINED
-            and target_config_entry_id is not UNDEFINED
+            target_config_entry_id is not UNDEFINED
             and target_config_entry_id != old.config_entry_id
-            and (
-                target_entry := self.hass.config_entries.async_get_entry(
-                    target_config_entry_id
-                )
-            )
-            is not None
         ):
-            if target_entry.disabled_by:
-                if old.disabled_by is None:
-                    disabled_by = DeviceEntryDisabler.CONFIG_ENTRY
-            elif old.disabled_by is DeviceEntryDisabler.CONFIG_ENTRY:
-                disabled_by = None
+            is_move = True
+            owning_entry_id = target_config_entry_id
+        else:
+            is_move = False
+            owning_entry_id = old.config_entry_id
+        if (disabled_by is not UNDEFINED or is_move) and (
+            owning_entry := self.hass.config_entries.async_get_entry(owning_entry_id)
+        ) is not None:
+            context = (
+                "when moving a device to" if is_move else "on a device belonging to"
+            )
+            if disabled_by is None and owning_entry.disabled_by:
+                report_usage(
+                    f"sets disabled_by to None {context} the disabled "
+                    f"config entry {owning_entry_id}",
+                    core_behavior=ReportBehavior.LOG,
+                    breaks_in_ha_version="2027.8",
+                )
+                disabled_by = UNDEFINED
+            elif (
+                disabled_by is DeviceEntryDisabler.CONFIG_ENTRY
+                and not owning_entry.disabled_by
+            ):
+                report_usage(
+                    f"sets disabled_by to DeviceEntryDisabler.CONFIG_ENTRY {context} "
+                    f"the enabled config entry {owning_entry_id}",
+                    core_behavior=ReportBehavior.LOG,
+                    breaks_in_ha_version="2027.8",
+                )
+                disabled_by = UNDEFINED
+            if is_move and disabled_by is UNDEFINED:
+                if owning_entry.disabled_by:
+                    if old.disabled_by is None:
+                        disabled_by = DeviceEntryDisabler.CONFIG_ENTRY
+                elif old.disabled_by is DeviceEntryDisabler.CONFIG_ENTRY:
+                    disabled_by = None
 
         for attr_name, value in (
             ("area_id", area_id),
@@ -2165,7 +2194,15 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             moves the device; on its own it does nothing.
         :param add_config_subentry_id: Deprecated. Combined with remove_config_subentry_id
             it moves the device to another subentry; on its own it does nothing.
-        :param new_config_entry_id: Move the device to this config entry.
+        :param disabled_by: Disable or enable the device. Must be consistent with the
+            disabled state of the config entry owning the device after the update:
+            a device can't be enabled when the owning config entry is disabled, and
+            can't be disabled by CONFIG_ENTRY when the owning config entry is enabled.
+            An inconsistent disabled_by is deprecated and ignored; this will raise in
+            HA Core 2027.8.
+        :param new_config_entry_id: Move the device to this config entry. Unless
+            disabled_by is passed explicitly, the device's disabled state is updated
+            to reflect the new config entry's disabled state.
         :param new_config_subentry_id: Move the device to this subentry.
         :param remove_config_entry_id: Remove the device if it is the device's config
             entry, unless combined with add_config_entry_id to move the device.

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -9,6 +9,7 @@ from anthropic import (
     AuthenticationError,
     BadRequestError,
 )
+import attr
 import httpx
 from httpx import URL, Request, Response
 import pytest
@@ -952,13 +953,19 @@ async def test_migrate_entry_to_v2_3(
     conversation_device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         config_subentry_id=conversation_subentry_id,
-        disabled_by=device_disabled_by,
         identifiers={(DOMAIN, mock_config_entry.entry_id)},
         name=mock_config_entry.title,
         manufacturer="Anthropic",
         model="Claude",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
+    # A stale disabled_by flag can't be set through the registry API, which
+    # validates it against the config entry's disabled state; write it
+    # directly to simulate existing storage.
+    conversation_device = attr.evolve(
+        conversation_device, disabled_by=device_disabled_by
+    )
+    device_registry.devices[conversation_device.id] = conversation_device
     conversation_entity = entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import attr
 import pytest
 from requests.exceptions import Timeout
 from syrupy.assertion import SnapshotAssertion
@@ -1214,13 +1215,19 @@ async def test_migrate_entry_from_v2_3(
     conversation_device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         config_subentry_id=conversation_subentry_id,
-        disabled_by=device_disabled_by,
         identifiers={(DOMAIN, mock_config_entry.entry_id)},
         name=mock_config_entry.title,
         manufacturer="Google",
         model="Generative AI",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
+    # A stale disabled_by flag can't be set through the registry API, which
+    # validates it against the config entry's disabled state; write it
+    # directly to simulate existing storage.
+    conversation_device = attr.evolve(
+        conversation_device, disabled_by=device_disabled_by
+    )
+    device_registry.devices[conversation_device.id] = conversation_device
     conversation_entity = entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,

--- a/tests/components/ollama/test_init.py
+++ b/tests/components/ollama/test_init.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
+import attr
 from httpx import ConnectError
 from ollama import ResponseError
 import pytest
@@ -1046,13 +1047,19 @@ async def test_migrate_entry_from_v3_2(
     conversation_device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         config_subentry_id=conversation_subentry_id,
-        disabled_by=device_disabled_by,
         identifiers={(DOMAIN, mock_config_entry.entry_id)},
         name=mock_config_entry.title,
         manufacturer="Ollama",
         model="Ollama",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
+    # A stale disabled_by flag can't be set through the registry API, which
+    # validates it against the config entry's disabled state; write it
+    # directly to simulate existing storage.
+    conversation_device = attr.evolve(
+        conversation_device, disabled_by=device_disabled_by
+    )
+    device_registry.devices[conversation_device.id] = conversation_device
     conversation_entity = entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,

--- a/tests/components/openai_conversation/test_init.py
+++ b/tests/components/openai_conversation/test_init.py
@@ -3,6 +3,7 @@
 from typing import Any
 from unittest.mock import AsyncMock, Mock, mock_open, patch
 
+import attr
 import httpx
 from openai import (
     APIConnectionError,
@@ -1631,13 +1632,19 @@ async def test_migrate_entry_from_v2_3(
     conversation_device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         config_subentry_id=conversation_subentry_id,
-        disabled_by=device_disabled_by,
         identifiers={(DOMAIN, mock_config_entry.entry_id)},
         name=mock_config_entry.title,
         manufacturer="OpenAI",
         model="ChatGPT",
         entry_type=dr.DeviceEntryType.SERVICE,
     )
+    # A stale disabled_by flag can't be set through the registry API, which
+    # validates it against the config entry's disabled state; write it
+    # directly to simulate existing storage.
+    conversation_device = attr.evolve(
+        conversation_device, disabled_by=device_disabled_by
+    )
+    device_registry.devices[conversation_device.id] = conversation_device
     conversation_entity = entity_registry.async_get_or_create(
         "conversation",
         DOMAIN,

--- a/tests/components/waqi/test_init.py
+++ b/tests/components/waqi/test_init.py
@@ -4,6 +4,7 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 
 from aiowaqi import WAQIError
+import attr
 import pytest
 
 from homeassistant.components.waqi import DOMAIN
@@ -249,8 +250,12 @@ async def test_migration_from_v1_disabled(
         identifiers={(DOMAIN, mock_config_entry.unique_id)},
         name=mock_config_entry.title,
         entry_type=dr.DeviceEntryType.SERVICE,
-        disabled_by=DeviceEntryDisabler.CONFIG_ENTRY,
     )
+    # A stale disabled_by flag can't be set through the registry API, which
+    # validates it against the config entry's disabled state; write it
+    # directly to simulate existing storage.
+    device_1 = attr.evolve(device_1, disabled_by=DeviceEntryDisabler.CONFIG_ENTRY)
+    device_registry.devices[device_1.id] = device_1
     entity_registry.async_get_or_create(
         "sensor",
         DOMAIN,

--- a/tests/components/waqi/test_init.py
+++ b/tests/components/waqi/test_init.py
@@ -272,6 +272,11 @@ async def test_migration_from_v1_disabled(
         name=mock_config_entry_2.title,
         entry_type=dr.DeviceEntryType.SERVICE,
     )
+    # A device created on a disabled config entry is disabled by the registry
+    # API; clear the flag directly to simulate existing storage with a stale
+    # enabled device.
+    device_2 = attr.evolve(device_2, disabled_by=None)
+    device_registry.devices[device_2.id] = device_2
     entity_registry.async_get_or_create(
         "sensor",
         DOMAIN,

--- a/tests/components/wolflink/test_init.py
+++ b/tests/components/wolflink/test_init.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+import attr
 from freezegun.api import FrozenDateTimeFactory
 from httpx import RequestError
 import pytest
@@ -76,9 +77,11 @@ async def test_migration_v1_to_v2(
         manufacturer=MANUFACTURER,
         name="test-device",
     )
-    device_registry.async_update_device(
-        device.id, disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY
-    )
+    # A stale disabled_by flag can't be set through the registry API, which
+    # validates it against the config entry's disabled state; write it
+    # directly to simulate existing storage.
+    device = attr.evolve(device, disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY)
+    device_registry.devices[device.id] = device
     entity = entity_registry.async_get_or_create(
         domain="sensor",
         platform=DOMAIN,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4667,6 +4667,45 @@ async def test_create_with_conflicting_disabled_by_ignored(
     ) in caplog.text
 
 
+async def test_create_reflects_config_entry_disabled_state(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A new device without an explicit disabled_by reflects the owning entry's state."""
+    disabled_entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    enabled_entry = MockConfigEntry()
+    enabled_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id, identifiers={("test", "1")}
+    )
+    assert device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+
+    enabled_device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id, identifiers={("test", "2")}
+    )
+    assert enabled_device.disabled_by is None
+
+    # Restoring a deleted device from a legacy store without a recorded
+    # disabled_by is reconciled the same way
+    device_registry.async_remove_device(device.id)
+    deleted_entry = device_registry.deleted_devices[device.id]
+    device_registry.deleted_devices[device.id] = attr.evolve(
+        deleted_entry, disabled_by=UNDEFINED
+    )
+    restored = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id, identifiers={("test", "1")}
+    )
+    assert restored.id == device.id
+    assert restored.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+
+    assert "Detected code that" not in caplog.text
+
+
 async def test_update_explicit_disabled_by(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -5521,7 +5560,9 @@ async def test_restore_device(
     ("device_disabled_by", "expected_disabled_by"),
     [
         (None, None),
-        (dr.DeviceEntryDisabler.CONFIG_ENTRY, dr.DeviceEntryDisabler.CONFIG_ENTRY),
+        # A CONFIG_ENTRY disable contradicts the enabled config entry and is
+        # cleared when the device is restored
+        (dr.DeviceEntryDisabler.CONFIG_ENTRY, None),
         (dr.DeviceEntryDisabler.INTEGRATION, dr.DeviceEntryDisabler.INTEGRATION),
         (dr.DeviceEntryDisabler.USER, dr.DeviceEntryDisabler.USER),
         (UNDEFINED, None),

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4623,6 +4623,50 @@ async def test_update_conflicting_disabled_by_ignored(
     ) in caplog.text
 
 
+async def test_create_with_conflicting_disabled_by_ignored(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit disabled_by contradicting the owning entry's disabled state.
+
+    When creating a device, the conflicting disabled_by is ignored, the disabled
+    state is updated to reflect the owning config entry's disabled state, and a
+    deprecation warning is logged. This will raise in HA Core 2027.8.
+    """
+    disabled_entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    enabled_entry = MockConfigEntry()
+    enabled_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id,
+        identifiers={("test", "1")},
+        disabled_by=None,
+    )
+    assert device.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+    assert (
+        "Detected code that sets disabled_by to None when creating a device "
+        f"attached to the disabled config entry {disabled_entry.entry_id}. This "
+        "will stop working in Home Assistant 2027.8, please report this issue"
+    ) in caplog.text
+
+    enabled_device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id,
+        identifiers={("test", "2")},
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    assert enabled_device.disabled_by is None
+    assert (
+        "Detected code that sets disabled_by to DeviceEntryDisabler.CONFIG_ENTRY "
+        "when creating a device attached to the enabled config entry "
+        f"{enabled_entry.entry_id}. This will stop working in Home Assistant "
+        "2027.8, please report this issue"
+    ) in caplog.text
+
+
 async def test_update_explicit_disabled_by(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -4324,18 +4324,22 @@ async def test_update_suggested_area(
 
 
 @pytest.mark.parametrize(
-    "device_disabled_by",
+    ("config_entry_disabled_by", "device_disabled_by"),
     [
-        None,
-        dr.DeviceEntryDisabler.CONFIG_ENTRY,
-        dr.DeviceEntryDisabler.INTEGRATION,
-        dr.DeviceEntryDisabler.USER,
+        (None, None),
+        (
+            config_entries.ConfigEntryDisabler.USER,
+            dr.DeviceEntryDisabler.CONFIG_ENTRY,
+        ),
+        (None, dr.DeviceEntryDisabler.INTEGRATION),
+        (None, dr.DeviceEntryDisabler.USER),
     ],
 )
 @pytest.mark.usefixtures("freezer")
 async def test_update_add_config_entry_disabled_by(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    config_entry_disabled_by: config_entries.ConfigEntryDisabler | None,
     device_disabled_by: dr.DeviceEntryDisabler | None,
 ) -> None:
     """Check how the disabled_by flag is treated when adding a config entry.
@@ -4344,7 +4348,7 @@ async def test_update_add_config_entry_disabled_by(
     transient pending move (completed by a subsequent remove of the current owner), so on
     its own it leaves the device - including its disabled_by flag - unchanged.
     """
-    config_entry_1 = MockConfigEntry(title=None)
+    config_entry_1 = MockConfigEntry(title=None, disabled_by=config_entry_disabled_by)
     config_entry_1.add_to_hass(hass)
     config_entry_2 = MockConfigEntry(title=None)
     config_entry_2.add_to_hass(hass)
@@ -4377,20 +4381,25 @@ async def test_update_add_config_entry_disabled_by(
 
 
 @pytest.mark.parametrize(
-    ("device_disabled_by", "expected_disabled_by"),
+    ("config_entry_disabled_by", "device_disabled_by", "expected_disabled_by"),
     [
         # An enabled device moved onto a disabled entry is disabled by CONFIG_ENTRY
-        (None, dr.DeviceEntryDisabler.CONFIG_ENTRY),
+        (None, None, dr.DeviceEntryDisabler.CONFIG_ENTRY),
         # An existing CONFIG_ENTRY / INTEGRATION / USER disable is preserved
-        (dr.DeviceEntryDisabler.CONFIG_ENTRY, dr.DeviceEntryDisabler.CONFIG_ENTRY),
-        (dr.DeviceEntryDisabler.INTEGRATION, dr.DeviceEntryDisabler.INTEGRATION),
-        (dr.DeviceEntryDisabler.USER, dr.DeviceEntryDisabler.USER),
+        (
+            config_entries.ConfigEntryDisabler.USER,
+            dr.DeviceEntryDisabler.CONFIG_ENTRY,
+            dr.DeviceEntryDisabler.CONFIG_ENTRY,
+        ),
+        (None, dr.DeviceEntryDisabler.INTEGRATION, dr.DeviceEntryDisabler.INTEGRATION),
+        (None, dr.DeviceEntryDisabler.USER, dr.DeviceEntryDisabler.USER),
     ],
 )
 @pytest.mark.usefixtures("freezer")
 async def test_update_remove_config_entry_disabled_by(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    config_entry_disabled_by: config_entries.ConfigEntryDisabler | None,
     device_disabled_by: dr.DeviceEntryDisabler | None,
     expected_disabled_by: dr.DeviceEntryDisabler | None,
 ) -> None:
@@ -4402,7 +4411,7 @@ async def test_update_remove_config_entry_disabled_by(
     disabled entry becomes CONFIG_ENTRY-disabled, while a USER/INTEGRATION disable - or an
     existing CONFIG_ENTRY disable - is kept.
     """
-    config_entry_1 = MockConfigEntry(title=None)
+    config_entry_1 = MockConfigEntry(title=None, disabled_by=config_entry_disabled_by)
     config_entry_1.add_to_hass(hass)
     config_entry_2 = MockConfigEntry(
         title=None, disabled_by=config_entries.ConfigEntryDisabler.USER
@@ -4491,6 +4500,243 @@ async def test_move_to_enabled_config_entry_clears_config_entry_disable(
     )
     assert moved_user is not None
     assert moved_user.disabled_by is dr.DeviceEntryDisabler.USER
+
+
+async def test_move_with_conflicting_disabled_by_ignored(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit disabled_by contradicting the target entry's disabled state.
+
+    The conflicting disabled_by is ignored, the disabled state is updated to
+    reflect the new config entry's disabled state, and a deprecation warning is
+    logged. This will raise in HA Core 2027.8.
+    """
+    disabled_entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    enabled_entry = MockConfigEntry()
+    enabled_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id, identifiers={("test", "1")}
+    )
+    moved = device_registry.async_update_device(
+        device.id,
+        disabled_by=None,
+        new_config_entry_id=disabled_entry.entry_id,
+    )
+    assert moved is not None
+    assert moved.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+    assert (
+        "Detected code that sets disabled_by to None when moving a device to the "
+        f"disabled config entry {disabled_entry.entry_id}. This will stop working "
+        "in Home Assistant 2027.8, please report this issue"
+    ) in caplog.text
+
+    disabled_device = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id,
+        identifiers={("test", "2")},
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    moved_disabled = device_registry.async_update_device(
+        disabled_device.id,
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+        new_config_entry_id=enabled_entry.entry_id,
+    )
+    assert moved_disabled is not None
+    assert moved_disabled.disabled_by is None
+    assert (
+        "Detected code that sets disabled_by to DeviceEntryDisabler.CONFIG_ENTRY "
+        f"when moving a device to the enabled config entry {enabled_entry.entry_id}. "
+        "This will stop working in Home Assistant 2027.8, please report this issue"
+    ) in caplog.text
+
+    # The same validation applies when the move is performed by removing the
+    # owning config entry after a pending move was recorded.
+    pending_device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id, identifiers={("test", "3")}
+    )
+    device_registry.async_update_device(
+        pending_device.id, add_config_entry_id=disabled_entry.entry_id
+    )
+    caplog.clear()
+    moved_pending = device_registry.async_update_device(
+        pending_device.id,
+        disabled_by=None,
+        remove_config_entry_id=enabled_entry.entry_id,
+    )
+    assert moved_pending is not None
+    assert moved_pending.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+    assert (
+        "Detected code that sets disabled_by to None when moving a device to the "
+        f"disabled config entry {disabled_entry.entry_id}. This will stop working "
+        "in Home Assistant 2027.8, please report this issue"
+    ) in caplog.text
+
+
+async def test_update_conflicting_disabled_by_ignored(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit disabled_by contradicting the owning entry's disabled state.
+
+    Without a move, the conflicting disabled_by is ignored and a deprecation
+    warning is logged. This will raise in HA Core 2027.8.
+    """
+    disabled_entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    enabled_entry = MockConfigEntry()
+    enabled_entry.add_to_hass(hass)
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id,
+        identifiers={("test", "1")},
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    updated = device_registry.async_update_device(device.id, disabled_by=None)
+    assert updated is not None
+    assert updated.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+    assert (
+        "Detected code that sets disabled_by to None on a device belonging to the "
+        f"disabled config entry {disabled_entry.entry_id}. This will stop working "
+        "in Home Assistant 2027.8, please report this issue"
+    ) in caplog.text
+
+    enabled_device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id, identifiers={("test", "2")}
+    )
+    updated_enabled = device_registry.async_update_device(
+        enabled_device.id, disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY
+    )
+    assert updated_enabled is not None
+    assert updated_enabled.disabled_by is None
+    assert (
+        "Detected code that sets disabled_by to DeviceEntryDisabler.CONFIG_ENTRY on "
+        f"a device belonging to the enabled config entry {enabled_entry.entry_id}. "
+        "This will stop working in Home Assistant 2027.8, please report this issue"
+    ) in caplog.text
+
+
+async def test_update_explicit_disabled_by(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """An explicit disabled_by consistent with the owning entry's state is applied."""
+    disabled_entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    enabled_entry = MockConfigEntry()
+    enabled_entry.add_to_hass(hass)
+
+    # A USER disable is accepted on a device of a disabled entry, and the device
+    # can be flagged CONFIG_ENTRY again
+    device = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id,
+        identifiers={("test", "1")},
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    updated = device_registry.async_update_device(
+        device.id, disabled_by=dr.DeviceEntryDisabler.USER
+    )
+    assert updated is not None
+    assert updated.disabled_by is dr.DeviceEntryDisabler.USER
+    updated = device_registry.async_update_device(
+        device.id, disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY
+    )
+    assert updated is not None
+    assert updated.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+
+    # A USER disable and enabling are accepted on a device of an enabled entry
+    enabled_device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id, identifiers={("test", "2")}
+    )
+    updated_enabled = device_registry.async_update_device(
+        enabled_device.id, disabled_by=dr.DeviceEntryDisabler.USER
+    )
+    assert updated_enabled is not None
+    assert updated_enabled.disabled_by is dr.DeviceEntryDisabler.USER
+    updated_enabled = device_registry.async_update_device(
+        enabled_device.id, disabled_by=None
+    )
+    assert updated_enabled is not None
+    assert updated_enabled.disabled_by is None
+
+    assert "Detected code that" not in caplog.text
+
+
+async def test_move_with_explicit_disabled_by(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """An explicit disabled_by consistent with the target entry's state is applied."""
+    disabled_entry = MockConfigEntry(
+        disabled_by=config_entries.ConfigEntryDisabler.USER
+    )
+    disabled_entry.add_to_hass(hass)
+    enabled_entry = MockConfigEntry()
+    enabled_entry.add_to_hass(hass)
+
+    # A USER disable is accepted on a move to a disabled entry
+    device = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id, identifiers={("test", "1")}
+    )
+    moved = device_registry.async_update_device(
+        device.id,
+        disabled_by=dr.DeviceEntryDisabler.USER,
+        new_config_entry_id=disabled_entry.entry_id,
+    )
+    assert moved is not None
+    assert moved.disabled_by is dr.DeviceEntryDisabler.USER
+
+    # A USER disable is accepted on a move to an enabled entry (the
+    # CONFIG_ENTRY to USER rewrite used by migrations)
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id,
+        identifiers={("test", "2")},
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+    )
+    moved_2 = device_registry.async_update_device(
+        device_2.id,
+        disabled_by=dr.DeviceEntryDisabler.USER,
+        new_config_entry_id=enabled_entry.entry_id,
+    )
+    assert moved_2 is not None
+    assert moved_2.disabled_by is dr.DeviceEntryDisabler.USER
+
+    # A CONFIG_ENTRY disable is accepted on a move to a disabled entry
+    device_3 = device_registry.async_get_or_create(
+        config_entry_id=enabled_entry.entry_id,
+        identifiers={("test", "3")},
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+    moved_3 = device_registry.async_update_device(
+        device_3.id,
+        disabled_by=dr.DeviceEntryDisabler.CONFIG_ENTRY,
+        new_config_entry_id=disabled_entry.entry_id,
+    )
+    assert moved_3 is not None
+    assert moved_3.disabled_by is dr.DeviceEntryDisabler.CONFIG_ENTRY
+
+    # No disable is accepted on a move to an enabled entry
+    device_4 = device_registry.async_get_or_create(
+        config_entry_id=disabled_entry.entry_id,
+        identifiers={("test", "4")},
+        disabled_by=dr.DeviceEntryDisabler.USER,
+    )
+    moved_4 = device_registry.async_update_device(
+        device_4.id,
+        disabled_by=None,
+        new_config_entry_id=enabled_entry.entry_id,
+    )
+    assert moved_4 is not None
+    assert moved_4.disabled_by is None
 
 
 async def test_move_to_config_entry_with_colliding_identity_raises(
@@ -5353,7 +5599,7 @@ async def test_restore_migrated_device_disabled_by(
 @pytest.mark.parametrize(
     (
         "config_entry_disabled_by",
-        "device_disabled_by_initial",
+        "device_disabled_by_deleted",
         "device_disabled_by_restored",
     ),
     [
@@ -5409,7 +5655,7 @@ async def test_restore_disabled_by(
     device_registry: dr.DeviceRegistry,
     mock_config_entry: MockConfigEntry,
     config_entry_disabled_by: config_entries.ConfigEntryDisabler | None,
-    device_disabled_by_initial: dr.DeviceEntryDisabler | None,
+    device_disabled_by_deleted: dr.DeviceEntryDisabler | None,
     device_disabled_by_restored: dr.DeviceEntryDisabler | None,
 ) -> None:
     """Check how the disabled_by flag is treated when restoring a device."""
@@ -5423,7 +5669,6 @@ async def test_restore_disabled_by(
         config_subentry_id=None,
         configuration_url="http://config_url_orig.bla",
         connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
-        disabled_by=device_disabled_by_initial,
         entry_type=dr.DeviceEntryType.SERVICE,
         hw_version="hw_version_orig",
         identifiers={("bridgeid", "0123")},
@@ -5437,8 +5682,6 @@ async def test_restore_disabled_by(
         via_device="via_device_id_orig",
     )
 
-    assert entry.disabled_by == device_disabled_by_initial
-
     assert len(device_registry.devices) == 1
     assert len(device_registry.deleted_devices) == 0
 
@@ -5446,6 +5689,16 @@ async def test_restore_disabled_by(
 
     assert len(device_registry.devices) == 0
     assert len(device_registry.deleted_devices) == 1
+
+    # Simulate the disabled_by flag the device had when it was deleted. The
+    # device may have been deleted before the config entry's disabled state
+    # last changed - deleted devices are not updated when a config entry is
+    # enabled or disabled, so the stored flag can contradict the entry's
+    # current disabled state.
+    deleted_entry = device_registry.deleted_devices[entry.id]
+    device_registry.deleted_devices[entry.id] = attr.evolve(
+        deleted_entry, disabled_by=device_disabled_by_deleted
+    )
 
     # This will restore the original device, user customizations of
     # area_id, disabled_by, labels and name_by_user will be restored


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate disabled_by flag in `async_update_device`: It should not be possible to enable a device attached to a disabled config entry or to set disabled_by to CONFIG_ENTRY for a device attached to an enabled config entry

This PR deprecates + logs warning, in release HA Core 2027.8 we will instead raise.

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
