### PR TITLE
Mitigate crash in ScannerEntity related to device registry changes

### DIFF
--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -707,15 +707,37 @@ class ScannerEntity(
             await super().async_internal_added_to_hass()
             return
 
+        dev_reg = dr.async_get(self.hass)
+        # find_device_entry may return a synthesized pre-migration composite whose id is
+        # not a real device and can't be assigned to an entity; resolve it to the split
+        # owned by this config entry so we attach to (and register on) a concrete device.
+        if device_entry.id not in dev_reg.devices:
+            device_entry = next(
+                (
+                    split
+                    for split in dev_reg.async_get_devices_for_composite_device_id(
+                        device_entry.id
+                    )
+                    if split.config_entry_id == self.platform.config_entry.entry_id
+                ),
+                None,
+            )
+
         # Attach entry to device
-        if self.registry_entry.device_id != device_entry.id:
+        if (
+            device_entry is not None
+            and self.registry_entry.device_id != device_entry.id
+        ):
             self.registry_entry = er.async_get(self.hass).async_update_entity(
                 self.entity_id, device_id=device_entry.id
             )
 
         # Attach device to config entry
-        if self.platform.config_entry.entry_id not in device_entry.config_entries:
-            dr.async_get(self.hass).async_update_device(
+        if (
+            device_entry is not None
+            and self.platform.config_entry.entry_id not in device_entry.config_entries
+        ):
+            dev_reg.async_update_device(
                 device_entry.id,
                 add_config_entry_id=self.platform.config_entry.entry_id,
             )

--- a/homeassistant/components/device_tracker/entity.py
+++ b/homeassistant/components/device_tracker/entity.py
@@ -710,7 +710,7 @@ class ScannerEntity(
         dev_reg = dr.async_get(self.hass)
         # find_device_entry may return a synthesized pre-migration composite whose id is
         # not a real device and can't be assigned to an entity; resolve it to the split
-        # owned by this config entry so we attach to (and register on) a concrete device.
+        # owned by this config entry so we attach to a concrete device.
         if device_entry.id not in dev_reg.devices:
             device_entry = next(
                 (
@@ -730,16 +730,6 @@ class ScannerEntity(
         ):
             self.registry_entry = er.async_get(self.hass).async_update_entity(
                 self.entity_id, device_id=device_entry.id
-            )
-
-        # Attach device to config entry
-        if (
-            device_entry is not None
-            and self.platform.config_entry.entry_id not in device_entry.config_entries
-        ):
-            dev_reg.async_update_device(
-                device_entry.id,
-                add_config_entry_id=self.platform.config_entry.entry_id,
             )
 
         # Do this last or else the entity registry update listener has been installed

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1658,6 +1658,50 @@ async def test_scanner_entity_attaches_to_split_of_composite_device(
     assert entity_entry.device_id == own_split.id
 
 
+async def test_scanner_entity_composite_device_without_own_split(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """A composite with no split owned by the scanner's config entry attaches nothing.
+
+    The composite id is not a real device and can't be assigned to an entity, so with no
+    split to resolve to the entity is added without a device instead of raising.
+    """
+    mac = TEST_MAC_ADDRESS
+    other_entry_1 = MockConfigEntry(domain="other_1")
+    other_entry_1.add_to_hass(hass)
+    other_entry_2 = MockConfigEntry(domain="other_2")
+    other_entry_2.add_to_hass(hass)
+    old_id = "composite00000000000000000000000"
+    # Both splits belong to other config entries, none to the scanner's
+    for entry, identifier in ((other_entry_1, "one"), (other_entry_2, "two")):
+        split = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+            identifiers={("other", identifier)},
+        )
+        device_registry.devices[split.id] = attr.evolve(
+            split, composite_device_id=old_id
+        )
+    composite = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+    )
+    assert composite is not None
+    assert composite.id == old_id
+    assert old_id not in device_registry.devices
+
+    scanner_entity = MockScannerEntity(mac_address=mac, unique_id=f"{mac}_scanner")
+    scanner_entity.entity_id = "device_tracker.composite_scanner"
+    await create_mock_platform(hass, config_entry, [scanner_entity])
+
+    # Added without a device rather than raising on the un-assignable composite id
+    entity_entry = entity_registry.async_get("device_tracker.composite_scanner")
+    assert entity_entry is not None
+    assert entity_entry.device_id is None
+
+
 async def test_connected_device_registered(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from typing import Any
 
+import attr
 import pytest
 
 from homeassistant.components.device_tracker import (
@@ -1609,6 +1610,57 @@ async def test_register_mac_ignored(
     entity_entry = entity_registry.async_get(entity_id)
     assert entity_entry is not None
     assert entity_entry.disabled_by == er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_scanner_entity_attaches_to_split_of_composite_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """A mac-based scanner entity attaches to its config entry's split, not the composite.
+
+    async_get_device resolves a shared MAC to a synthesized pre-migration composite whose
+    id is not a real device; the entity must attach to the split owned by its own config
+    entry instead of crashing while trying to assign the composite id.
+    """
+    mac = TEST_MAC_ADDRESS
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    old_id = "composite00000000000000000000000"
+    own_split = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+        identifiers={(TEST_DOMAIN, "own")},
+    )
+    other_split = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+        identifiers={("other", "x")},
+    )
+    # Simulate a migration split: both devices share the pre-migration composite id
+    device_registry.devices[own_split.id] = attr.evolve(
+        own_split, composite_device_id=old_id
+    )
+    device_registry.devices[other_split.id] = attr.evolve(
+        other_split, composite_device_id=old_id
+    )
+    # async_get_device now resolves the shared MAC to the synthesized composite
+    composite = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)}
+    )
+    assert composite is not None
+    assert composite.id == old_id
+    assert old_id not in device_registry.devices
+
+    scanner_entity = MockScannerEntity(mac_address=mac, unique_id=f"{mac}_scanner")
+    scanner_entity.entity_id = "device_tracker.composite_scanner"
+    await create_mock_platform(hass, config_entry, [scanner_entity])
+
+    # Attached to its own split, not the un-assignable composite id
+    entity_entry = entity_registry.async_get("device_tracker.composite_scanner")
+    assert entity_entry is not None
+    assert entity_entry.device_id == own_split.id
 
 
 async def test_connected_device_registered(

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1619,7 +1619,6 @@ async def test_scanner_entity_attaches_to_split_of_composite_device(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that a scanner entity attaches to its config entry's split device."""
-    """
     mac = TEST_MAC_ADDRESS
     other_entry = MockConfigEntry(domain="other")
     other_entry.add_to_hass(hass)

--- a/tests/components/device_tracker/test_entity.py
+++ b/tests/components/device_tracker/test_entity.py
@@ -1618,11 +1618,7 @@ async def test_scanner_entity_attaches_to_split_of_composite_device(
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """A mac-based scanner entity attaches to its config entry's split, not the composite.
-
-    async_get_device resolves a shared MAC to a synthesized pre-migration composite whose
-    id is not a real device; the entity must attach to the split owned by its own config
-    entry instead of crashing while trying to assign the composite id.
+    """Test that a scanner entity attaches to its config entry's split device."""
     """
     mac = TEST_MAC_ADDRESS
     other_entry = MockConfigEntry(domain="other")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Mitigate crash in `ScannerEntity` related to device registry changes

Note: This does not implement `ScannerEntity` architecture changes aligning with the device registry changes, it just prevents scanners trying to connect themselves to a removed composite device id

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
