### PR TITLE
Bump python-izone to 1.3.5

### DIFF
--- a/homeassistant/components/izone/manifest.json
+++ b/homeassistant/components/izone/manifest.json
@@ -10,5 +10,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "loggers": ["pizone"],
-  "requirements": ["python-izone==1.3.4"]
+  "requirements": ["python-izone==1.3.5"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2689,7 +2689,7 @@ python-homewizard-energy==10.1.0
 python-hpilo==4.4.3
 
 # homeassistant.components.izone
-python-izone==1.3.4
+python-izone==1.3.5
 
 # homeassistant.components.joaoapps_join
 python-join-api==0.1.1


### PR DESCRIPTION
## Proposed change

This bump is part of bringing the iZone library and Home Assistant integration onto and up the [integration quality scale](https://developers.home-assistant.io/docs/integration_quality_scale_index/) — updating the dependency pin is the first step; follow-up PRs will align the integration with the improved library API and broader quality-scale goals, as well as normalising the code towards a style more consistent with other integrations.

Bump the iZone integration dependency from `python-izone==1.3.4` to `python-izone==1.3.5`. This PR only changes the pin (`manifest.json` and `requirements_all.txt`). Home Assistant still calls the same legacy library API as with 1.3.4; integration code changes come in follow-up PRs.

1.3.5 is published on PyPI as a **pre-release** because it sits in an in-flight library/integration migration toward the quality scale: the new discovery and refresh API is present in the library, but Home Assistant still uses the legacy path until follow-up PRs land. The pin is safe for current integration behaviour.


### Library improvements in 1.3.5 (from user feedback)

These land via the dependency bump; no Home Assistant integration code is required for them:

- Sends `Connection: close` on HTTP GET requests, which greatly reduces how often some iZone bridges stop responding when connections are reused ([#176536](https://github.com/home-assistant/core/issues/176536))
- Unpaired bridge UID `000000000` is ignored during discovery instead of appearing as a broken controller
- iPower monitoring is off unless explicitly enabled in the library


**Library changelog (1.3.4 → 1.3.5):** [v1.3.4...v1.3.5](https://github.com/Swamp-Ig/pizone/compare/v1.3.4...v1.3.5)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #176536
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/) has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure) in this repository.
