### PR TITLE
Add restore to number template entities

### DIFF
--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -11,7 +11,8 @@ from homeassistant.components.number import (
     DEVICE_CLASSES_SCHEMA,
     DOMAIN as NUMBER_DOMAIN,
     ENTITY_ID_FORMAT,
-    NumberEntity,
+    NumberExtraStoredData,
+    RestoreNumber,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -117,12 +118,14 @@ def async_create_preview_number(
     )
 
 
-class AbstractTemplateNumber(AbstractTemplateEntity, NumberEntity):
+class AbstractTemplateNumber(AbstractTemplateEntity, RestoreNumber):
     """Representation of a template number features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
     _state_option = CONF_STATE
+    _restore_state_extra_data = NumberExtraStoredData
+    _restore_state_properties = ("_attr_native_value",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -164,6 +167,16 @@ class AbstractTemplateNumber(AbstractTemplateEntity, NumberEntity):
                 run_variables={"value": value},
                 context=self._context,
             )
+
+    @override
+    def restore_extra_data(self, extra_data: NumberExtraStoredData) -> None:
+        """Restore the extra data."""
+        # Do not restore native_unit_of_measurement, this is always pulled from the
+        # number configuration.
+        self._attr_native_max_value = extra_data.native_max_value or DEFAULT_MAX_VALUE
+        self._attr_native_min_value = extra_data.native_min_value or DEFAULT_MIN_VALUE
+        self._attr_native_step = extra_data.native_step or DEFAULT_STEP
+        self._attr_native_value = extra_data.native_value
 
 
 class StateNumberEntity(TemplateEntity, AbstractTemplateNumber):

--- a/homeassistant/components/template/number.py
+++ b/homeassistant/components/template/number.py
@@ -173,9 +173,19 @@ class AbstractTemplateNumber(AbstractTemplateEntity, RestoreNumber):
         """Restore the extra data."""
         # Do not restore native_unit_of_measurement, this is always pulled from the
         # number configuration.
-        self._attr_native_max_value = extra_data.native_max_value or DEFAULT_MAX_VALUE
-        self._attr_native_min_value = extra_data.native_min_value or DEFAULT_MIN_VALUE
-        self._attr_native_step = extra_data.native_step or DEFAULT_STEP
+        self._attr_native_max_value = (
+            DEFAULT_MAX_VALUE
+            if extra_data.native_max_value is None
+            else extra_data.native_max_value
+        )
+        self._attr_native_min_value = (
+            DEFAULT_MIN_VALUE
+            if extra_data.native_min_value is None
+            else extra_data.native_min_value
+        )
+        self._attr_native_step = (
+            DEFAULT_STEP if extra_data.native_step is None else extra_data.native_step
+        )
         self._attr_native_value = extra_data.native_value
 
 

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -28,11 +28,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.typing import ConfigType
 
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_action,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -40,6 +42,8 @@ from .conftest import (
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
 from tests.common import MockConfigEntry
@@ -601,4 +605,134 @@ async def test_setup_valid_device_class(
     assert (
         hass.states.get(TEST_NUMBER.entity_id).attributes.get("device_class")
         == expected_device_class
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+    ),
+    [
+        (
+            "some_value",
+            {
+                "native_max_value": 80,
+                "native_min_value": 2,
+                "native_step": 2,
+                "native_unit_of_measurement": "°F",
+                "native_value": 10,
+            },
+            "10",
+            {
+                "step": 2,
+                "min": 2,
+                "max": 80,
+                "unit_of_measurement": "°C",
+            },
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "native_max_value": 80,
+                "native_min_value": 2,
+                "native_step": 2,
+                "native_unit_of_measurement": "°F",
+                "native_value": 10,
+            },
+            STATE_UNKNOWN,
+            {
+                "step": 1,
+                "min": 0,
+                "max": 100,
+                "unit_of_measurement": "°C",
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "native_max_value": 80,
+                "native_min_value": 2,
+                "native_step": 2,
+                "native_unit_of_measurement": "°F",
+                "native_value": 10,
+            },
+            STATE_UNKNOWN,
+            {
+                "step": 1,
+                "min": 0,
+                "max": 100,
+                "unit_of_measurement": "°C",
+            },
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    saved_state: str,
+    saved_extra_data: dict | None,
+    initial_state: str,
+    initial_attributes: ConfigType,
+) -> None:
+    """Test restoring trigger template weather."""
+
+    restored_attributes = {  # These should be ignored
+        "current_position": 5,
+        "current_tilt_position": 5,
+    }
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_NUMBER,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+        saved_attributes=restored_attributes,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_NUMBER,
+        style,
+        {
+            "max": "{{ state_attr('number.test_state', 'max') or 100 }}",
+            "min": "{{ state_attr('number.test_state', 'min') or 0 }}",
+            "state": "{{ state_attr('number.test_state', 'native_value') }}",
+            "step": "{{ state_attr('number.test_state', 'step') or 1 }}",
+            "set_value": [],
+            "device_class": "temperature",
+            "unit_of_measurement": "°C",
+        },
+        "state_attr('number.test_state', 'native_value') | float(0) > 6",
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_NUMBER,
+        initial_state,
+        initial_attributes,
+    )
+
+    await async_trigger(
+        hass,
+        "number.test_state",
+        "anything",
+        {
+            "native_value": 30,
+            "step": 3,
+            "min": 3,
+            "max": 60,
+        },
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_NUMBER,
+        "30.0",
+        {"step": 3, "min": 3, "max": 60},
     )

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -637,6 +637,23 @@ async def test_setup_valid_device_class(
             },
         ),
         (
+            "some_value",
+            {
+                "native_max_value": None,
+                "native_min_value": None,
+                "native_step": None,
+                "native_unit_of_measurement": "°F",
+                "native_value": 10,
+            },
+            "10",
+            {
+                "step": 1,
+                "min": 0,
+                "max": 100,
+                "unit_of_measurement": "°C",
+            },
+        ),
+        (
             STATE_UNAVAILABLE,
             {
                 "native_max_value": 80,
@@ -680,19 +697,13 @@ async def test_restore_state(
     initial_state: str,
     initial_attributes: ConfigType,
 ) -> None:
-    """Test restoring trigger template weather."""
-
-    restored_attributes = {  # These should be ignored
-        "current_position": 5,
-        "current_tilt_position": 5,
-    }
+    """Test restoring state."""
 
     setup_mock_template_entity_restore_state(
         hass,
         TEST_NUMBER,
         saved_state,
         saved_extra_data=saved_extra_data,
-        saved_attributes=restored_attributes,
     )
 
     await setup_restore_template_entity(

--- a/tests/components/template/test_number.py
+++ b/tests/components/template/test_number.py
@@ -734,7 +734,7 @@ async def test_restore_state(
         "number.test_state",
         "anything",
         {
-            "native_value": 30,
+            "native_value": 30.0,
             "step": 3,
             "min": 3,
             "max": 60,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to number template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
