### PR TITLE
Add restore to select template entities

### DIFF
--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -184,7 +184,7 @@ class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity, RestoreEntity
         """Return select specific state data to be restored."""
         return SelectExtraStoredData(
             current_option=self._attr_current_option,
-            options=self._attr_options,
+            options=self._attr_options or [],
         )
 
     @override

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -1,7 +1,8 @@
 """Support for selects which integrates with other components."""
 
+from dataclasses import asdict, dataclass
 import logging
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, Self, override
 
 import voluptuous as vol
 
@@ -18,6 +19,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator, validators as template_validators
@@ -106,12 +108,38 @@ def async_create_preview_select(
     )
 
 
-class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity):
+@dataclass(kw_only=True)
+class SelectExtraStoredData(ExtraStoredData):
+    """Holds extra stored data for template select entities."""
+
+    current_option: str | None
+    options: list[str]
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the select data."""
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        """Initialize a stored select state from a dict."""
+        try:
+            return cls(
+                current_option=restored["current_option"],
+                options=restored["options"],
+            )
+        except KeyError:
+            return None
+
+
+class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity, RestoreEntity):
     """Representation of a template select features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
     _state_option = CONF_STATE
+    _restore_state_extra_data = SelectExtraStoredData
+    _restore_state_properties = ("_attr_current_option",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -124,7 +152,7 @@ class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity):
 
         self.setup_state_template(
             "_attr_current_option",
-            cv.string,
+            template_validators.string(self, CONF_STATE),
         )
         self.setup_template(
             CONF_OPTIONS,
@@ -149,6 +177,21 @@ class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity):
                 run_variables={"option": option},
                 context=self._context,
             )
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> SelectExtraStoredData:
+        """Return cover specific state data to be restored."""
+        return SelectExtraStoredData(
+            current_option=self._attr_current_option,
+            options=self._attr_options,
+        )
+
+    @override
+    def restore_extra_data(self, extra_data: SelectExtraStoredData) -> None:
+        """Restore the extra data."""
+        self._attr_current_option = extra_data.current_option
+        self._attr_options = extra_data.options
 
 
 class TemplateSelect(TemplateEntity, AbstractTemplateSelect):

--- a/homeassistant/components/template/select.py
+++ b/homeassistant/components/template/select.py
@@ -181,7 +181,7 @@ class AbstractTemplateSelect(AbstractTemplateEntity, SelectEntity, RestoreEntity
     @property
     @override
     def extra_restore_state_data(self) -> SelectExtraStoredData:
-        """Return cover specific state data to be restored."""
+        """Return select specific state data to be restored."""
         return SelectExtraStoredData(
             current_option=self._attr_current_option,
             options=self._attr_options,

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -26,11 +26,13 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.typing import ConfigType
 
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_action,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -38,6 +40,8 @@ from .conftest import (
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
 from tests.common import MockConfigEntry, assert_setup_component
@@ -212,6 +216,9 @@ async def test_template_select(hass: HomeAssistant, calls: list[ServiceCall]) ->
 
     await async_trigger(hass, TEST_STATE_ENTITY_ID, "c", attributes)
     _verify(hass, "c", ["a", "b", "c"])
+
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "none", attributes)
+    _verify(hass, STATE_UNKNOWN, ["a", "b", "c"])
 
 
 def _verify(
@@ -555,4 +562,132 @@ async def test_nested_unique_id(
         entity_registry,
         TEST_OPTIONS_WITHOUT_STATE,
         "{{ 'test' }}",
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+    ),
+    [
+        (
+            "something",
+            {
+                "current_option": "something",
+                "options": ["something", "anything"],
+            },
+            "something",
+            {
+                "options": ["something", "anything"],
+            },
+        ),
+        (
+            "something",
+            {
+                "current_option": "something",
+            },
+            STATE_UNKNOWN,
+            {
+                "options": [],
+            },
+        ),
+        (
+            "something",
+            {
+                "options": ["something", "anything"],
+            },
+            STATE_UNKNOWN,
+            {
+                "options": [],
+            },
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "current_option": "something",
+                "options": ["something", "anything"],
+            },
+            STATE_UNKNOWN,
+            {
+                "options": [],
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "current_option": "something",
+                "options": ["something", "anything"],
+            },
+            STATE_UNKNOWN,
+            {
+                "options": [],
+            },
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    saved_state: str,
+    saved_extra_data: dict | None,
+    initial_state: str,
+    initial_attributes: ConfigType,
+) -> None:
+    """Test restoring trigger template weather."""
+
+    restored_attributes = {  # These should be ignored
+        "current_position": 5,
+        "current_tilt_position": 5,
+    }
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_SELECT,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+        saved_attributes=restored_attributes,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_SELECT,
+        style,
+        {
+            "state": "{{ state_attr('sensor.test_state', 'option') }}",
+            "options": "{{ state_attr('sensor.test_state', 'options') or [] }}",
+            "select_option": [],
+        },
+        "is_state('sensor.test_state', 'something_new')",
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_SELECT,
+        initial_state,
+        initial_attributes,
+    )
+
+    await async_trigger(
+        hass,
+        "sensor.test_state",
+        "anything",
+        {
+            "options": ["something", "anything", "something_new"],
+            "option": "something_new",
+        },
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_SELECT,
+        "something_new",
+        {
+            "options": ["something", "anything", "something_new"],
+        },
     )

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -639,19 +639,13 @@ async def test_restore_state(
     initial_state: str,
     initial_attributes: ConfigType,
 ) -> None:
-    """Test restoring trigger template weather."""
-
-    restored_attributes = {  # These should be ignored
-        "current_position": 5,
-        "current_tilt_position": 5,
-    }
+    """Test restoring trigger template selects."""
 
     setup_mock_template_entity_restore_state(
         hass,
         TEST_SELECT,
         saved_state,
         saved_extra_data=saved_extra_data,
-        saved_attributes=restored_attributes,
     )
 
     await setup_restore_template_entity(

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -639,7 +639,7 @@ async def test_restore_state(
     initial_state: str,
     initial_attributes: ConfigType,
 ) -> None:
-    """Test restoring trigger template selects."""
+    """Test restoring state."""
 
     setup_mock_template_entity_restore_state(
         hass,

--- a/tests/components/template/test_select.py
+++ b/tests/components/template/test_select.py
@@ -217,7 +217,7 @@ async def test_template_select(hass: HomeAssistant, calls: list[ServiceCall]) ->
     await async_trigger(hass, TEST_STATE_ENTITY_ID, "c", attributes)
     _verify(hass, "c", ["a", "b", "c"])
 
-    await async_trigger(hass, TEST_STATE_ENTITY_ID, "none", attributes)
+    await async_trigger(hass, TEST_STATE_ENTITY_ID, "None", attributes)
     _verify(hass, STATE_UNKNOWN, ["a", "b", "c"])
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to select template entities.
Fix an issue where template select does not allow `none` to set `unknown` due to misconfigured config validation.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
