### PR TITLE
Deprecate no longer working device helpers

### DIFF
--- a/homeassistant/helpers/device.py
+++ b/homeassistant/helpers/device.py
@@ -3,6 +3,7 @@
 from homeassistant.core import HomeAssistant, callback
 
 from . import device_registry as dr, entity_registry as er
+from .frame import ReportBehavior, report_usage
 
 
 @callback
@@ -41,13 +42,18 @@ def async_device_info_to_link_from_entity(
 ) -> dr.DeviceInfo | None:
     """DeviceInfo with information to link a device from an entity.
 
-    DeviceInfo will only return information to categorize as a link.
+    Deprecated, always returns None; set entity.device_entry instead.
     """
-
-    return async_device_info_to_link_from_device_id(
-        hass,
-        async_entity_id_to_device_id(hass, entity_id_or_uuid),
+    report_usage(
+        "calls async_device_info_to_link_from_entity, which is deprecated and always "
+        "returns None: a device_info carrying another device's identifiers implicitly "
+        "added the caller's config entry to that device, which a single-config-entry "
+        "device can't represent. Set entity.device_entry = "
+        "async_entity_id_to_device(hass, source_entity_id) instead",
+        core_behavior=ReportBehavior.LOG,
+        breaks_in_ha_version="2027.8.0",
     )
+    return None
 
 
 @callback
@@ -57,18 +63,17 @@ def async_device_info_to_link_from_device_id(
 ) -> dr.DeviceInfo | None:
     """DeviceInfo with information to link a device from a device id.
 
-    DeviceInfo will only return information to categorize as a link.
+    Deprecated, always returns None; set entity.device_entry instead.
     """
-
-    dev_reg = dr.async_get(hass)
-
-    if device_id is None or (device := dev_reg.async_get(device_id=device_id)) is None:
-        return None
-
-    return dr.DeviceInfo(
-        identifiers=device.identifiers,
-        connections=device.connections,
+    report_usage(
+        "calls async_device_info_to_link_from_device_id, which is deprecated and always "
+        "returns None: a device_info carrying another device's identifiers implicitly "
+        "added the caller's config entry to that device, which a single-config-entry "
+        "device can't represent. Set entity.device_entry to the target device instead",
+        core_behavior=ReportBehavior.LOG,
+        breaks_in_ha_version="2027.8.0",
     )
+    return None
 
 
 @callback

--- a/tests/helpers/test_device.py
+++ b/tests/helpers/test_device.py
@@ -1,5 +1,7 @@
 """Tests for the Device Utils."""
 
+from unittest.mock import patch
+
 import pytest
 import voluptuous as vol
 
@@ -103,7 +105,13 @@ async def test_device_info_to_link(
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test for returning device info with device link information."""
+    """The link helpers are deprecated and always return None.
+
+    A device_info carrying another device's identifiers implicitly added the caller's
+    config entry to that device, which a single-config-entry device can't represent - it
+    would silently fork a duplicate instead. Entities still attach to another config
+    entry's device by setting entity.device_entry.
+    """
     config_entry = MockConfigEntry(domain="my")
     config_entry.add_to_hass(hass)
 
@@ -112,7 +120,6 @@ async def test_device_info_to_link(
         connections={("mac", "30:31:32:33:34:00")},
         config_entry_id=config_entry.entry_id,
     )
-    assert device is not None
 
     # Source entity registry
     source_entity = entity_registry.async_get_or_create(
@@ -125,33 +132,30 @@ async def test_device_info_to_link(
     await hass.async_block_till_done()
     assert entity_registry.async_get("sensor.test_source") is not None
 
-    result = async_device_info_to_link_from_entity(
-        hass, entity_id_or_uuid=source_entity.entity_id
-    )
-    assert result == {
-        "identifiers": {("test", "my_device")},
-        "connections": {("mac", "30:31:32:33:34:00")},
-    }
-
-    result = async_device_info_to_link_from_device_id(hass, device_id=device.id)
-    assert result == {
-        "identifiers": {("test", "my_device")},
-        "connections": {("mac", "30:31:32:33:34:00")},
-    }
+    # No link device_info is returned, even for an existing entity and device
+    with patch("homeassistant.helpers.device.report_usage") as report_usage:
+        assert (
+            async_device_info_to_link_from_entity(
+                hass, entity_id_or_uuid=source_entity.entity_id
+            )
+            is None
+        )
+        assert (
+            async_device_info_to_link_from_device_id(hass, device_id=device.id) is None
+        )
+    assert report_usage.call_count == 2
 
     # With a non-existent entity id
-    result = async_device_info_to_link_from_entity(
-        hass, entity_id_or_uuid="sensor.invalid"
+    assert (
+        async_device_info_to_link_from_entity(hass, entity_id_or_uuid="sensor.invalid")
+        is None
     )
-    assert result is None
 
     # With a non-existent device id
-    result = async_device_info_to_link_from_device_id(hass, device_id="abcdefghi")
-    assert result is None
+    assert async_device_info_to_link_from_device_id(hass, device_id="abcdefghi") is None
 
     # With a None device id
-    result = async_device_info_to_link_from_device_id(hass, device_id=None)
-    assert result is None
+    assert async_device_info_to_link_from_device_id(hass, device_id=None) is None
 
 
 async def test_remove_stale_device_links_keep_entity_device(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate no longer working device helpers `helpers.device.async_device_info_to_link_from_entity` and `helpers.device.async_device_info_to_link_from_device_id`

As announced in https://developers.home-assistant.io/blog/2025/07/18/updated-pattern-for-helpers-linking-to-devices/, adding a helper's config entry to a foreign device is no longer a supported pattern and will stop working in HA Core 2026.8

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
