### PR TITLE
Deprecate passing add_helper_config_entry_to_device to async_handle_source_entity_changes

### DIFF
--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -27,7 +27,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -105,7 +105,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # humidifier's device.
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_humidifier_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/generic_thermostat/__init__.py
+++ b/homeassistant/components/generic_thermostat/__init__.py
@@ -33,7 +33,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # heater's device.
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_humidifier_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/history_stats/__init__.py
+++ b/homeassistant/components/history_stats/__init__.py
@@ -78,7 +78,6 @@ async def async_setup_entry(
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/integration/__init__.py
+++ b/homeassistant/components/integration/__init__.py
@@ -29,7 +29,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/mold_indicator/__init__.py
+++ b/homeassistant/components/mold_indicator/__init__.py
@@ -37,7 +37,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         # to the humidity sensor's device.
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/statistics/__init__.py
+++ b/homeassistant/components/statistics/__init__.py
@@ -35,7 +35,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -60,7 +60,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_get_parent_device_id(hass, entity_id),

--- a/homeassistant/components/threshold/__init__.py
+++ b/homeassistant/components/threshold/__init__.py
@@ -27,7 +27,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/trend/__init__.py
+++ b/homeassistant/components/trend/__init__.py
@@ -34,7 +34,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -205,7 +205,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(
         async_handle_source_entity_changes(
             hass,
-            add_helper_config_entry_to_device=False,
             helper_config_entry_id=entry.entry_id,
             set_source_entity_id_or_uuid=set_source_entity_id_or_uuid,
             source_device_id=async_entity_id_to_device_id(

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -43,6 +43,7 @@ def async_handle_source_entity_changes(
         entity or ask the user to select a new source entity.
     """
     if "add_helper_config_entry_to_device" in kwargs:
+        del kwargs["add_helper_config_entry_to_device"]
         # Adding the helper's config entry to the source device is no longer supported
         # now that a device belongs to a single config entry; the helper entities link to
         # the source device via their device_id instead.
@@ -51,6 +52,11 @@ def async_handle_source_entity_changes(
             "add_helper_config_entry_to_device, which no longer has any effect",
             core_behavior=ReportBehavior.LOG,
             breaks_in_ha_version="2027.8.0",
+        )
+    if kwargs:
+        raise TypeError(
+            "async_handle_source_entity_changes() got unexpected keyword arguments "
+            f"{', '.join(map(repr, kwargs))}"
         )
 
     async def async_registry_updated(

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -7,17 +7,18 @@ from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, valid_entity
 
 from . import device_registry as dr, entity_registry as er
 from .event import async_track_entity_registry_updated_event
+from .frame import ReportBehavior, report_usage
 
 
 def async_handle_source_entity_changes(
     hass: HomeAssistant,
     *,
-    add_helper_config_entry_to_device: bool = True,
     helper_config_entry_id: str,
     set_source_entity_id_or_uuid: Callable[[str], None],
     source_device_id: str | None,
     source_entity_id_or_uuid: str,
     source_entity_removed: Callable[[], Coroutine[Any, Any, None]] | None = None,
+    **kwargs: Any,
 ) -> CALLBACK_TYPE:
     """Handle changes to a helper entity's source entity.
 
@@ -31,11 +32,9 @@ def async_handle_source_entity_changes(
       called. If the source entity is identified by a UUID, the helper config entry
       is reloaded.
     - Source entity moved to another device: The helper entity is updated to link
-      to the new device, and the helper config entry removed from the old device
-      and added to the new device. Then the helper config entry is reloaded.
+      to the new device. Then the helper config entry is reloaded.
     - Source entity removed from the device: The helper entity is updated to link
-      to no device, and the helper config entry removed from the old device. Then
-      the helper config entry is reloaded.
+      to no device. Then the helper config entry is reloaded.
 
     :param set_source_entity_id_or_uuid: A function which updates the source entity
         ID or UUID, e.g., in the helper config entry options.
@@ -43,6 +42,16 @@ def async_handle_source_entity_changes(
         is removed. This can be used to clean up any resources related to the source
         entity or ask the user to select a new source entity.
     """
+    if "add_helper_config_entry_to_device" in kwargs:
+        # Adding the helper's config entry to the source device is no longer supported
+        # now that a device belongs to a single config entry; the helper entities link to
+        # the source device via their device_id instead.
+        report_usage(
+            "calls async_handle_source_entity_changes with "
+            "add_helper_config_entry_to_device, which no longer has any effect",
+            core_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2027.8.0",
+        )
 
     async def async_registry_updated(
         event: Event[er.EventEntityRegistryUpdatedData],
@@ -98,17 +107,6 @@ def async_handle_source_entity_changes(
             # Update the helper entity to link to the new device (or no device)
             entity_registry.async_update_entity(
                 helper_entity.entity_id, device_id=source_entity_entry.device_id
-            )
-
-        if add_helper_config_entry_to_device:
-            if source_entity_entry.device_id is not None:
-                device_registry.async_update_device(
-                    source_entity_entry.device_id,
-                    add_config_entry_id=helper_config_entry_id,
-                )
-
-            device_registry.async_update_device(
-                source_device_id, remove_config_entry_id=helper_config_entry_id
             )
 
         source_device_id = source_entity_entry.device_id

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -104,9 +104,8 @@ def async_handle_source_entity_changes(
             # No need to do any cleanup
             return
 
-        # The source entity has been moved to a different device, update the helper
-        # entities to link to the new device and the helper device to include the
-        # helper config entry
+        # The source entity has been moved to a different device; relink the helper
+        # entities to the new device.
         for helper_entity in entity_registry.entities.get_entries_for_config_entry_id(
             helper_config_entry_id
         ):

--- a/tests/helpers/test_helper_integration.py
+++ b/tests/helpers/test_helper_integration.py
@@ -238,6 +238,25 @@ async def test_async_handle_source_entity_changes_deprecated_kwarg(
     assert "add_helper_config_entry_to_device" in report_usage.call_args[0][0]
 
 
+async def test_async_handle_source_entity_changes_rejects_unknown_kwarg(
+    hass: HomeAssistant,
+) -> None:
+    """An unknown keyword argument still raises, as it did before **kwargs was added.
+
+    **kwargs only exists to swallow the deprecated add_helper_config_entry_to_device;
+    anything else (e.g. a misspelling) must not be silently accepted.
+    """
+    with pytest.raises(TypeError, match="unexpected keyword arguments 'unknown_kwarg'"):
+        async_handle_source_entity_changes(
+            hass,
+            helper_config_entry_id="helper_config_entry_id",
+            set_source_entity_id_or_uuid=Mock(),
+            source_device_id=None,
+            source_entity_id_or_uuid="sensor.test",
+            unknown_kwarg=True,
+        )
+
+
 async def test_async_handle_source_entity_changes_without_deprecated_kwarg(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/helpers/test_helper_integration.py
+++ b/tests/helpers/test_helper_integration.py
@@ -1,7 +1,7 @@
 """Tests for the helper entity helpers."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -211,6 +211,48 @@ def listen_entity_registry_events(
     hass.bus.async_listen(er.EVENT_ENTITY_REGISTRY_UPDATED, add_event)
 
     return events
+
+
+@pytest.mark.parametrize("add_helper_config_entry_to_device", [True, False])
+async def test_async_handle_source_entity_changes_deprecated_kwarg(
+    hass: HomeAssistant,
+    add_helper_config_entry_to_device: bool,
+) -> None:
+    """The removed add_helper_config_entry_to_device kwarg is accepted but reported.
+
+    It is swallowed by **kwargs so callers still passing it don't raise, and reported on
+    its presence rather than its value, since it no longer has any effect either way.
+    """
+    with patch("homeassistant.helpers.helper_integration.report_usage") as report_usage:
+        unsub = async_handle_source_entity_changes(
+            hass,
+            helper_config_entry_id="helper_config_entry_id",
+            set_source_entity_id_or_uuid=Mock(),
+            source_device_id=None,
+            source_entity_id_or_uuid="sensor.test",
+            add_helper_config_entry_to_device=add_helper_config_entry_to_device,
+        )
+    unsub()
+
+    report_usage.assert_called_once()
+    assert "add_helper_config_entry_to_device" in report_usage.call_args[0][0]
+
+
+async def test_async_handle_source_entity_changes_without_deprecated_kwarg(
+    hass: HomeAssistant,
+) -> None:
+    """Not passing the removed add_helper_config_entry_to_device kwarg is not reported."""
+    with patch("homeassistant.helpers.helper_integration.report_usage") as report_usage:
+        unsub = async_handle_source_entity_changes(
+            hass,
+            helper_config_entry_id="helper_config_entry_id",
+            set_source_entity_id_or_uuid=Mock(),
+            source_device_id=None,
+            source_entity_id_or_uuid="sensor.test",
+        )
+    unsub()
+
+    report_usage.assert_not_called()
 
 
 @pytest.mark.parametrize("source_entity_removed", [None])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate passing add_helper_config_entry_to_device to async_handle_source_entity_changes

As announced in https://developers.home-assistant.io/blog/2025/07/18/updated-pattern-for-helpers-linking-to-devices/, adding a helper's config entry to a foreign device is no longer a supported pattern and will stop working in HA Core 2026.8

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
