### PR TITLE
Hide OpenAI advanced options behind the recommended toggle

### DIFF
--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -310,7 +310,6 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
             vol.Required(CONF_RECOMMENDED, default=options.get(CONF_RECOMMENDED, False))
         ] = bool
 
-        # Advanced options, shown (and applied) only while "recommended" is disabled.
         not_recommended: data_entry_flow.FieldCondition = {
             "field": CONF_RECOMMENDED,
             "value": False,

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -364,10 +364,10 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
             if user_input.get(CONF_CHAT_MODEL) in UNSUPPORTED_MODELS:
                 errors[CONF_CHAT_MODEL] = "model_not_supported"
 
+            options.update(user_input)
+            if CONF_LLM_HASS_API in options and CONF_LLM_HASS_API not in user_input:
+                options.pop(CONF_LLM_HASS_API)
             if not errors:
-                options.update(user_input)
-                if CONF_LLM_HASS_API in options and CONF_LLM_HASS_API not in user_input:
-                    options.pop(CONF_LLM_HASS_API)
                 return await self.async_step_model()
 
         return self.async_show_form(

--- a/homeassistant/components/openai_conversation/config_flow.py
+++ b/homeassistant/components/openai_conversation/config_flow.py
@@ -9,6 +9,7 @@ import openai
 import voluptuous as vol
 from voluptuous_openapi import convert
 
+from homeassistant import data_entry_flow
 from homeassistant.components.zone import ENTITY_ID_HOME
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
@@ -262,6 +263,7 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
             return self.async_abort(reason="entry_not_loaded")
 
         options = self.options
+        errors: dict[str, str] = {}
 
         hass_apis: list[SelectOptionDict] = [
             SelectOptionDict(
@@ -308,6 +310,41 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
             vol.Required(CONF_RECOMMENDED, default=options.get(CONF_RECOMMENDED, False))
         ] = bool
 
+        # Advanced options, shown (and applied) only while "recommended" is disabled.
+        not_recommended: data_entry_flow.FieldCondition = {
+            "field": CONF_RECOMMENDED,
+            "value": False,
+        }
+        step_schema.update(
+            {
+                data_entry_flow.Optional(
+                    CONF_CHAT_MODEL,
+                    default=RECOMMENDED_CHAT_MODEL,
+                    visible=not_recommended,
+                ): str,
+                data_entry_flow.Optional(
+                    CONF_MAX_TOKENS,
+                    default=RECOMMENDED_MAX_TOKENS,
+                    visible=not_recommended,
+                ): int,
+                data_entry_flow.Optional(
+                    CONF_TOP_P,
+                    default=RECOMMENDED_TOP_P,
+                    visible=not_recommended,
+                ): NumberSelector(NumberSelectorConfig(min=0, max=1, step=0.05)),
+                data_entry_flow.Optional(
+                    CONF_TEMPERATURE,
+                    default=RECOMMENDED_TEMPERATURE,
+                    visible=not_recommended,
+                ): NumberSelector(NumberSelectorConfig(min=0, max=2, step=0.05)),
+                data_entry_flow.Optional(
+                    CONF_STORE_RESPONSES,
+                    default=RECOMMENDED_STORE_RESPONSES,
+                    visible=not_recommended,
+                ): bool,
+            }
+        )
+
         if user_input is not None:
             if not user_input.get(CONF_LLM_HASS_API):
                 user_input.pop(CONF_LLM_HASS_API, None)
@@ -324,58 +361,17 @@ class OpenAISubentryFlowHandler(ConfigSubentryFlow):
                     data=user_input,
                 )
 
-            options.update(user_input)
-            if CONF_LLM_HASS_API in options and CONF_LLM_HASS_API not in user_input:
-                options.pop(CONF_LLM_HASS_API)
-            return await self.async_step_additional()
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=self.add_suggested_values_to_schema(
-                vol.Schema(step_schema), options
-            ),
-        )
-
-    async def async_step_additional(
-        self, user_input: dict[str, Any] | None = None
-    ) -> SubentryFlowResult:
-        """Manage additional options."""
-        options = self.options
-        errors: dict[str, str] = {}
-
-        step_schema: VolDictType = {
-            vol.Optional(
-                CONF_CHAT_MODEL,
-                default=RECOMMENDED_CHAT_MODEL,
-            ): str,
-            vol.Optional(
-                CONF_MAX_TOKENS,
-                default=RECOMMENDED_MAX_TOKENS,
-            ): int,
-            vol.Optional(
-                CONF_TOP_P,
-                default=RECOMMENDED_TOP_P,
-            ): NumberSelector(NumberSelectorConfig(min=0, max=1, step=0.05)),
-            vol.Optional(
-                CONF_TEMPERATURE,
-                default=RECOMMENDED_TEMPERATURE,
-            ): NumberSelector(NumberSelectorConfig(min=0, max=2, step=0.05)),
-            vol.Optional(
-                CONF_STORE_RESPONSES,
-                default=RECOMMENDED_STORE_RESPONSES,
-            ): bool,
-        }
-
-        if user_input is not None:
-            options.update(user_input)
             if user_input.get(CONF_CHAT_MODEL) in UNSUPPORTED_MODELS:
                 errors[CONF_CHAT_MODEL] = "model_not_supported"
 
             if not errors:
+                options.update(user_input)
+                if CONF_LLM_HASS_API in options and CONF_LLM_HASS_API not in user_input:
+                    options.pop(CONF_LLM_HASS_API)
                 return await self.async_step_model()
 
         return self.async_show_form(
-            step_id="additional",
+            step_id="init",
             data_schema=self.add_suggested_values_to_schema(
                 vol.Schema(step_schema), options
             ),

--- a/homeassistant/components/openai_conversation/strings.json
+++ b/homeassistant/components/openai_conversation/strings.json
@@ -47,23 +47,18 @@
         "user": "Add AI task"
       },
       "step": {
-        "additional": {
-          "data": {
-            "chat_model": "[%key:common::generic::model%]",
-            "max_tokens": "[%key:component::openai_conversation::config_subentries::conversation::step::additional::data::max_tokens%]",
-            "store_responses": "[%key:component::openai_conversation::config_subentries::conversation::step::additional::data::store_responses%]",
-            "temperature": "[%key:component::openai_conversation::config_subentries::conversation::step::additional::data::temperature%]",
-            "top_p": "[%key:component::openai_conversation::config_subentries::conversation::step::additional::data::top_p%]"
-          },
-          "data_description": {
-            "store_responses": "[%key:component::openai_conversation::config_subentries::conversation::step::additional::data_description::store_responses%]"
-          },
-          "title": "[%key:component::openai_conversation::config_subentries::conversation::step::additional::title%]"
-        },
         "init": {
           "data": {
+            "chat_model": "[%key:common::generic::model%]",
+            "max_tokens": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data::max_tokens%]",
             "name": "[%key:common::config_flow::data::name%]",
-            "recommended": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data::recommended%]"
+            "recommended": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data::recommended%]",
+            "store_responses": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data::store_responses%]",
+            "temperature": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data::temperature%]",
+            "top_p": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data::top_p%]"
+          },
+          "data_description": {
+            "store_responses": "[%key:component::openai_conversation::config_subentries::conversation::step::init::data_description::store_responses%]"
           }
         },
         "model": {
@@ -111,28 +106,21 @@
         "user": "Add conversation agent"
       },
       "step": {
-        "additional": {
+        "init": {
           "data": {
             "chat_model": "[%key:common::generic::model%]",
+            "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
             "max_tokens": "Maximum tokens to return in response",
+            "name": "[%key:common::config_flow::data::name%]",
+            "prompt": "[%key:common::config_flow::data::prompt%]",
+            "recommended": "Recommended model settings",
             "store_responses": "Store requests and responses in OpenAI",
             "temperature": "Temperature",
             "top_p": "Top P"
           },
           "data_description": {
+            "prompt": "Instruct how the LLM should respond. This can be a template.",
             "store_responses": "If enabled, requests and responses are stored by OpenAI and visible in your OpenAI dashboard logs"
-          },
-          "title": "Additional settings"
-        },
-        "init": {
-          "data": {
-            "llm_hass_api": "[%key:common::config_flow::data::llm_hass_api%]",
-            "name": "[%key:common::config_flow::data::name%]",
-            "prompt": "[%key:common::config_flow::data::prompt%]",
-            "recommended": "Recommended model settings"
-          },
-          "data_description": {
-            "prompt": "Instruct how the LLM should respond. This can be a template."
           }
         },
         "model": {

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -251,7 +251,6 @@ async def test_subentry_unsupported_model(
     assert subentry_flow["step_id"] == "init"
     assert subentry_flow["errors"] == {"chat_model": "model_not_supported"}
 
-    # Redisplay keeps the submitted values so the errored model field stays shown.
     suggested = {
         key.schema: key.description["suggested_value"]
         for key in subentry_flow["data_schema"].schema
@@ -285,7 +284,6 @@ async def test_subentry_advanced_options_visible_when_not_recommended(
         CONF_STORE_RESPONSES,
     ):
         assert visibility[field] == not_recommended
-    # the recommended toggle itself is always shown
     assert visibility[CONF_RECOMMENDED] is None
 
 

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -243,21 +243,12 @@ async def test_subentry_unsupported_model(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
-        },
-    )
-    await hass.async_block_till_done()
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    # Configure additional step
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_CHAT_MODEL: "o1-mini",
         },
     )
     await hass.async_block_till_done()
     assert subentry_flow["type"] is FlowResultType.FORM
+    assert subentry_flow["step_id"] == "init"
     assert subentry_flow["errors"] == {"chat_model": "model_not_supported"}
 
 
@@ -299,15 +290,6 @@ async def test_subentry_reasoning_effort_list(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
-        },
-    )
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    # Configure additional step
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_CHAT_MODEL: model,
         },
     )
@@ -353,15 +335,6 @@ async def test_subentry_reasoning_summary_visibility(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
-        },
-    )
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    # Configure additional step
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_CHAT_MODEL: model,
         },
     )
@@ -402,14 +375,6 @@ async def test_subentry_reasoning_summary_options(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
-        },
-    )
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_CHAT_MODEL: model,
         },
     )
@@ -450,13 +415,8 @@ async def test_subentry_reasoning_summary_default_sanitized_on_model_switch(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
+            CONF_CHAT_MODEL: "o3",
         },
-    )
-    assert subentry_flow["step_id"] == "additional"
-
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {CONF_CHAT_MODEL: "o3"},
     )
     assert subentry_flow["step_id"] == "model"
 
@@ -516,15 +476,6 @@ async def test_subentry_service_tier_list(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
-        },
-    )
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    # Configure additional step
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_CHAT_MODEL: model,
         },
     )
@@ -562,15 +513,6 @@ async def test_subentry_unsupported_reasoning_effort(
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
             CONF_LLM_HASS_API: ["assist"],
-        },
-    )
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    # Configure additional step
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_CHAT_MODEL: "gpt-5",
         },
     )
@@ -672,8 +614,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pro",
-                },
-                {
                     CONF_TEMPERATURE: 1.0,
                     CONF_CHAT_MODEL: "o1-pro",
                     CONF_TOP_P: RECOMMENDED_TOP_P,
@@ -706,8 +646,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pirate",
-                },
-                {
                     CONF_TEMPERATURE: 0.3,
                     CONF_CHAT_MODEL: RECOMMENDED_CHAT_MODEL,
                     CONF_TOP_P: RECOMMENDED_TOP_P,
@@ -763,8 +701,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like super Mario",
-                },
-                {
                     CONF_TEMPERATURE: 0.8,
                     CONF_CHAT_MODEL: "gpt-4o",
                     CONF_TOP_P: 0.9,
@@ -818,8 +754,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pirate",
-                },
-                {
                     CONF_TEMPERATURE: 0.8,
                     CONF_CHAT_MODEL: "gpt-5.6",
                     CONF_TOP_P: 0.9,
@@ -941,8 +875,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pirate",
-                },
-                {
                     CONF_TEMPERATURE: 0.8,
                     CONF_CHAT_MODEL: "o3-mini",
                     CONF_TOP_P: 0.9,
@@ -986,8 +918,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pirate",
-                },
-                {
                     CONF_TEMPERATURE: 0.8,
                     CONF_CHAT_MODEL: "gpt-4o",
                     CONF_TOP_P: 0.9,
@@ -1041,8 +971,6 @@ async def test_form_invalid_auth(hass: HomeAssistant, side_effect, error) -> Non
                 {
                     CONF_RECOMMENDED: False,
                     CONF_PROMPT: "Speak like a pirate",
-                },
-                {
                     CONF_TEMPERATURE: 0.8,
                     CONF_CHAT_MODEL: "gpt-5-pro",
                     CONF_TOP_P: 0.9,
@@ -1148,15 +1076,6 @@ async def test_subentry_web_search_user_location(
         {
             CONF_RECOMMENDED: False,
             CONF_PROMPT: "Speak like a pirate",
-        },
-    )
-    assert subentry_flow["type"] is FlowResultType.FORM
-    assert subentry_flow["step_id"] == "additional"
-
-    # Configure additional step
-    subentry_flow = await hass.config_entries.subentries.async_configure(
-        subentry_flow["flow_id"],
-        {
             CONF_TEMPERATURE: 1.0,
             CONF_CHAT_MODEL: RECOMMENDED_CHAT_MODEL,
             CONF_TOP_P: RECOMMENDED_TOP_P,
@@ -1313,22 +1232,11 @@ async def test_creating_ai_task_subentry_additional(
     assert result.get("type") is FlowResultType.FORM
     assert result.get("step_id") == "init"
 
-    # Go to additional settings
     result2 = await hass.config_entries.subentries.async_configure(
         result["flow_id"],
         {
             "name": "Advanced AI Task",
             CONF_RECOMMENDED: False,
-        },
-    )
-
-    assert result2.get("type") is FlowResultType.FORM
-    assert result2.get("step_id") == "additional"
-
-    # Configure additional settings
-    result3 = await hass.config_entries.subentries.async_configure(
-        result["flow_id"],
-        {
             CONF_CHAT_MODEL: "gpt-4o",
             CONF_MAX_TOKENS: 200,
             CONF_STORE_RESPONSES: True,
@@ -1337,8 +1245,8 @@ async def test_creating_ai_task_subentry_additional(
         },
     )
 
-    assert result3.get("type") is FlowResultType.FORM
-    assert result3.get("step_id") == "model"
+    assert result2.get("type") is FlowResultType.FORM
+    assert result2.get("step_id") == "model"
 
     # Configure model settings
     result4 = await hass.config_entries.subentries.async_configure(

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -251,6 +251,15 @@ async def test_subentry_unsupported_model(
     assert subentry_flow["step_id"] == "init"
     assert subentry_flow["errors"] == {"chat_model": "model_not_supported"}
 
+    # Redisplay keeps the submitted values so the errored model field stays shown.
+    suggested = {
+        key.schema: key.description["suggested_value"]
+        for key in subentry_flow["data_schema"].schema
+        if isinstance(key.description, dict) and "suggested_value" in key.description
+    }
+    assert suggested.get(CONF_RECOMMENDED) is False
+    assert suggested.get(CONF_CHAT_MODEL) == "o1-mini"
+
 
 @pytest.mark.parametrize(
     ("model", "reasoning_effort_options"),

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -261,6 +261,34 @@ async def test_subentry_unsupported_model(
     assert suggested.get(CONF_CHAT_MODEL) == "o1-mini"
 
 
+@pytest.mark.usefixtures("mock_init_component")
+async def test_subentry_advanced_options_visible_when_not_recommended(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Test advanced options carry the visibility condition hiding them when recommended."""
+    subentry = next(iter(mock_config_entry.subentries.values()))
+    subentry_flow = await mock_config_entry.start_subentry_reconfigure_flow(
+        hass, subentry.subentry_id
+    )
+    assert subentry_flow["step_id"] == "init"
+
+    visibility = {
+        key.schema: getattr(key, "visible", None)
+        for key in subentry_flow["data_schema"].schema
+    }
+    not_recommended = {"field": CONF_RECOMMENDED, "value": False}
+    for field in (
+        CONF_CHAT_MODEL,
+        CONF_MAX_TOKENS,
+        CONF_TOP_P,
+        CONF_TEMPERATURE,
+        CONF_STORE_RESPONSES,
+    ):
+        assert visibility[field] == not_recommended
+    # the recommended toggle itself is always shown
+    assert visibility[CONF_RECOMMENDED] is None
+
+
 @pytest.mark.parametrize(
     ("model", "reasoning_effort_options"),
     [

--- a/tests/components/openai_conversation/test_config_flow.py
+++ b/tests/components/openai_conversation/test_config_flow.py
@@ -222,7 +222,10 @@ async def test_subentry_recommended(
     await hass.async_block_till_done()
     assert options["type"] is FlowResultType.ABORT
     assert options["reason"] == "reconfigure_successful"
-    assert subentry.data["prompt"] == "Speak like a pirate"
+    assert subentry.data == {
+        CONF_PROMPT: "Speak like a pirate",
+        CONF_RECOMMENDED: True,
+    }
 
 
 async def test_subentry_unsupported_model(
@@ -258,33 +261,6 @@ async def test_subentry_unsupported_model(
     }
     assert suggested.get(CONF_RECOMMENDED) is False
     assert suggested.get(CONF_CHAT_MODEL) == "o1-mini"
-
-
-@pytest.mark.usefixtures("mock_init_component")
-async def test_subentry_advanced_options_visible_when_not_recommended(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
-    """Test advanced options carry the visibility condition hiding them when recommended."""
-    subentry = next(iter(mock_config_entry.subentries.values()))
-    subentry_flow = await mock_config_entry.start_subentry_reconfigure_flow(
-        hass, subentry.subentry_id
-    )
-    assert subentry_flow["step_id"] == "init"
-
-    visibility = {
-        key.schema: getattr(key, "visible", None)
-        for key in subentry_flow["data_schema"].schema
-    }
-    not_recommended = {"field": CONF_RECOMMENDED, "value": False}
-    for field in (
-        CONF_CHAT_MODEL,
-        CONF_MAX_TOKENS,
-        CONF_TOP_P,
-        CONF_TEMPERATURE,
-        CONF_STORE_RESPONSES,
-    ):
-        assert visibility[field] == not_recommended
-    assert visibility[CONF_RECOMMENDED] is None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change


## Proposed change

OpenAI Conversation's advanced options (chat model, max tokens, temperature, top P, store responses) are now shown in the same step as the "Recommended model settings" toggle and hidden while it is enabled, instead of a separate step. This uses the declarative conditional field visibility added in #176703.

Stacked on top of #176703 (base branch `condition_field_config_flow`); it depends on that PR and will be retargeted to `dev` once it merges.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

