### PR TITLE
Rename async_remove_helper_config_entry_from_source_device

### DIFF
--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, config_entry.options[CONF_SOURCE]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/derivative/__init__.py
+++ b/homeassistant/components/derivative/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -71,7 +71,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, config_entry.options[CONF_SOURCE]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 from homeassistant.helpers.typing import ConfigType
 
@@ -154,7 +154,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_HUMIDIFIER]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/generic_hygrostat/__init__.py
+++ b/homeassistant/components/generic_hygrostat/__init__.py
@@ -17,7 +17,7 @@ from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 from homeassistant.helpers.typing import ConfigType
 
@@ -154,7 +154,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_HUMIDIFIER]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/generic_thermostat/__init__.py
+++ b/homeassistant/components/generic_thermostat/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 from .const import CONF_DUR_COOLDOWN, CONF_HEATER, CONF_MIN_DUR, CONF_SENSOR, PLATFORMS
@@ -82,7 +82,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_HEATER]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/generic_thermostat/__init__.py
+++ b/homeassistant/components/generic_thermostat/__init__.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 from .const import CONF_DUR_COOLDOWN, CONF_HEATER, CONF_MIN_DUR, CONF_SENSOR, PLATFORMS
@@ -82,7 +82,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_HEATER]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/history_stats/__init__.py
+++ b/homeassistant/components/history_stats/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 from homeassistant.helpers.template import Template
 
@@ -106,7 +106,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/history_stats/__init__.py
+++ b/homeassistant/components/history_stats/__init__.py
@@ -10,7 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 from homeassistant.helpers.template import Template
 
@@ -106,7 +106,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/integration/__init__.py
+++ b/homeassistant/components/integration/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 from .const import CONF_SOURCE_SENSOR
@@ -55,7 +55,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_SOURCE_SENSOR]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/integration/__init__.py
+++ b/homeassistant/components/integration/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 from .const import CONF_SOURCE_SENSOR
@@ -55,7 +55,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_SOURCE_SENSOR]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/mold_indicator/__init__.py
+++ b/homeassistant/components/mold_indicator/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 from .const import CONF_INDOOR_HUMIDITY, CONF_INDOOR_TEMP, CONF_OUTDOOR_TEMP
@@ -104,7 +104,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, config_entry.options[CONF_INDOOR_HUMIDITY]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/mold_indicator/__init__.py
+++ b/homeassistant/components/mold_indicator/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.event import async_track_entity_registry_updated_event
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 from .const import CONF_INDOOR_HUMIDITY, CONF_INDOOR_TEMP, CONF_OUTDOOR_TEMP
@@ -104,7 +104,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, config_entry.options[CONF_INDOOR_HUMIDITY]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/statistics/__init__.py
+++ b/homeassistant/components/statistics/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 DOMAIN = "statistics"
@@ -63,7 +63,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/statistics/__init__.py
+++ b/homeassistant/components/statistics/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 DOMAIN = "statistics"
@@ -63,7 +63,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 from .const import CONF_INVERT, CONF_TARGET_DOMAIN
@@ -89,7 +89,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_get_parent_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/switch_as_x/__init__.py
+++ b/homeassistant/components/switch_as_x/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 from .const import CONF_INVERT, CONF_TARGET_DOMAIN
@@ -89,7 +89,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_get_parent_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -20,9 +20,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.device import (
     async_remove_stale_devices_links_keep_current_device,
 )
-from homeassistant.helpers.helper_integration import (
-    async_remove_helper_config_entry_from_source_device,
-)
+from homeassistant.helpers.helper_integration import async_remove_helper_device
 from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
@@ -139,7 +137,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         if config_entry.minor_version < 2:
             # Remove the template config entry from the source device
             if source_device_id := config_entry.options.get(CONF_DEVICE_ID):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/template/__init__.py
+++ b/homeassistant/components/template/__init__.py
@@ -20,7 +20,7 @@ from homeassistant.helpers import discovery
 from homeassistant.helpers.device import (
     async_remove_stale_devices_links_keep_current_device,
 )
-from homeassistant.helpers.helper_integration import async_remove_helper_device
+from homeassistant.helpers.helper_integration import async_remove_helper_devices
 from homeassistant.helpers.reload import async_reload_integration_platforms
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.typing import ConfigType
@@ -137,7 +137,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
         if config_entry.minor_version < 2:
             # Remove the template config entry from the source device
             if source_device_id := config_entry.options.get(CONF_DEVICE_ID):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/threshold/__init__.py
+++ b/homeassistant/components/threshold/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/threshold/__init__.py
+++ b/homeassistant/components/threshold/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -56,7 +56,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/trend/__init__.py
+++ b/homeassistant/components/trend/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 PLATFORMS = [Platform.BINARY_SENSOR]
@@ -62,7 +62,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/trend/__init__.py
+++ b/homeassistant/components/trend/__init__.py
@@ -8,7 +8,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 PLATFORMS = [Platform.BINARY_SENSOR]
@@ -62,7 +62,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_ENTITY_ID]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 from homeassistant.helpers.typing import ConfigType
 
@@ -264,7 +264,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_SOURCE_SENSOR]
             ):
-                async_remove_helper_device(
+                async_remove_helper_devices(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/components/utility_meter/__init__.py
+++ b/homeassistant/components/utility_meter/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device import async_entity_id_to_device_id
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
-    async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 from homeassistant.helpers.typing import ConfigType
 
@@ -264,7 +264,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             if source_device_id := async_entity_id_to_device_id(
                 hass, options[CONF_SOURCE_SENSOR]
             ):
-                async_remove_helper_config_entry_from_source_device(
+                async_remove_helper_device(
                     hass,
                     helper_config_entry_id=config_entry.entry_id,
                     source_device_id=source_device_id,

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -1,11 +1,12 @@
 """Helpers for helper integrations."""
 
-from collections.abc import Callable, Coroutine
+from collections.abc import Callable, Collection, Coroutine
 from typing import Any
 
 from homeassistant.core import CALLBACK_TYPE, Event, HomeAssistant, valid_entity_id
 
 from . import device_registry as dr, entity_registry as er
+from .deprecation import deprecated_function
 from .event import async_track_entity_registry_updated_event
 from .frame import ReportBehavior, report_usage
 
@@ -130,6 +131,193 @@ def async_handle_source_entity_changes(
     )
 
 
+def async_remove_helper_device(
+    hass: HomeAssistant,
+    *,
+    helper_config_entry_id: str,
+    source_device_id: str,
+    sweep_helper_devices: bool = False,
+    keep_device_ids: Collection[str] = (),
+) -> None:
+    """Migrate a helper which has tried to own a device instead of just linking to it.
+
+    In the single-config-entry device model a helper can no longer co-own the source
+    device. A helper that co-owned it before the single-config-entry device was introduced
+    now owns a split of it (linked by the pre-migration composite_device_id); a helper that
+    declared the source device's identifiers or connections in its device_info afterwards
+    now owns a fork (a separate device that copied that identity). This removes the helper's
+    duplicate device(s) and relinks its entities to the source device.
+
+    :param helper_config_entry_id: The config entry id of the helper being migrated.
+    :param source_device_id: The device the helper should link to. May be the pre-migration
+        composite id (as a helper that stored the device id before it was split passes) or a
+        concrete source device.
+    :param sweep_helper_devices: By default only the helper's single duplicate of
+        source_device_id (a split or fork) is removed. When True, every device the
+        helper owns except source_device_id and keep_device_ids is removed instead -
+        even when source_device_id no longer exists, in which case the helper's
+        entities are left without a device. Use this to clean up devices the helper
+        created but never removed itself, such as a fork left behind for each
+        previously selected source device.
+    :param keep_device_ids: Devices the helper legitimately owns which must not be removed.
+        Only consulted when sweep_helper_devices is True.
+    """
+    device_registry = dr.async_get(hass)
+    entity_registry = er.async_get(hass)
+
+    source_device = device_registry.async_get(source_device_id)
+    if source_device is None:
+        # The source device is gone. In sweep mode the helper's devices are still removed,
+        # leaving its entities without a device; targeted mode has no duplicate to match.
+        if sweep_helper_devices:
+            _sweep_helper_devices(
+                device_registry,
+                entity_registry,
+                helper_config_entry_id,
+                None,
+                keep_device_ids,
+            )
+        return
+
+    # source_device_id is either the pre-migration composite id (source_device is then the
+    # synthesized composite) or a concrete device. Its splits, if any, share this id as
+    # their composite_device_id.
+    source_is_concrete = source_device_id in device_registry.devices
+    composite_device_id = (
+        source_device.composite_device_id if source_is_concrete else source_device_id
+    )
+    split_devices = (
+        device_registry.async_get_devices_for_composite_device_id(composite_device_id)
+        if composite_device_id is not None
+        else []
+    )
+
+    # The helper's entities are relinked to the source device: itself when concrete, else
+    # the composite's recorded primary owner's split.
+    target_device_id = (
+        source_device_id
+        if source_is_concrete
+        else _composite_source_split_id(split_devices, helper_config_entry_id)
+    )
+
+    if sweep_helper_devices:
+        _sweep_helper_devices(
+            device_registry,
+            entity_registry,
+            helper_config_entry_id,
+            target_device_id,
+            keep_device_ids,
+        )
+    else:
+        _remove_duplicate_helper_device(
+            device_registry,
+            entity_registry,
+            helper_config_entry_id,
+            source_device,
+            composite_device_id,
+            target_device_id,
+        )
+
+
+def _composite_source_split_id(
+    split_devices: list[dr.DeviceEntry], helper_config_entry_id: str
+) -> str | None:
+    """Return the source split of a composite device.
+
+    This is the split owned by the composite's recorded primary config entry - the rule
+    _restore_composite_device uses - rather than an arbitrary non-helper split. None when
+    source_device_id is not a composite id or no such split exists.
+    """
+    if not split_devices:
+        return None
+    primary_config_entry_id = split_devices[0].composite_primary_config_entry
+    return next(
+        (
+            device.id
+            for device in split_devices
+            if device.config_entry_id == primary_config_entry_id
+            and device.config_entry_id != helper_config_entry_id
+        ),
+        None,
+    )
+
+
+def _remove_duplicate_helper_device(
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    helper_config_entry_id: str,
+    source_device: dr.DeviceEntry,
+    composite_device_id: str | None,
+    target_device_id: str | None,
+) -> None:
+    """Remove the helper's single duplicate of the source device.
+
+    The duplicate is either a split of the same pre-migration composite (linked by
+    composite_device_id) or a fork that copied the source device's identifiers or
+    connections into its device_info. Match on both, and only among the helper's own
+    devices, so unrelated helper-owned devices are left untouched.
+    """
+    duplicate = next(
+        (
+            device
+            for device in dr.async_entries_for_config_entry(
+                device_registry, helper_config_entry_id
+            )
+            if (
+                composite_device_id is not None
+                and device.composite_device_id == composite_device_id
+            )
+            or device.identifiers & source_device.identifiers
+            or device.connections & source_device.connections
+        ),
+        None,
+    )
+    if duplicate is None:
+        return
+    for entity in er.async_entries_for_config_entry(
+        entity_registry, helper_config_entry_id
+    ):
+        if entity.device_id == duplicate.id:
+            entity_registry.async_update_entity(
+                entity.entity_id, device_id=target_device_id
+            )
+    device_registry.async_remove_device(duplicate.id)
+
+
+def _sweep_helper_devices(
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    helper_config_entry_id: str,
+    target_device_id: str | None,
+    keep_device_ids: Collection[str],
+) -> None:
+    """Remove every device the helper owns except the target and the allow-list.
+
+    Sweeps up devices left behind when the user repeatedly changed the source device: the
+    helper's entities are relinked to the target device (except those already on a kept
+    device) and the other helper-owned devices are removed.
+    """
+    kept_device_ids = {*keep_device_ids}
+    if target_device_id is not None:
+        kept_device_ids.add(target_device_id)
+    for entity in er.async_entries_for_config_entry(
+        entity_registry, helper_config_entry_id
+    ):
+        if entity.device_id not in kept_device_ids:
+            entity_registry.async_update_entity(
+                entity.entity_id, device_id=target_device_id
+            )
+    for device in dr.async_entries_for_config_entry(
+        device_registry, helper_config_entry_id
+    ):
+        if device.id not in kept_device_ids:
+            device_registry.async_remove_device(device.id)
+
+
+@deprecated_function(
+    "homeassistant.helpers.helper_integration.async_remove_helper_device",
+    breaks_in_ha_version="2027.8.0",
+)
 def async_remove_helper_config_entry_from_source_device(
     hass: HomeAssistant,
     *,
@@ -138,65 +326,10 @@ def async_remove_helper_config_entry_from_source_device(
 ) -> None:
     """Migrate a helper which has tried to add its config entry to the source device.
 
-    A device belongs to a single config entry, and has been split into multiple devices
-    if it was co-owned by multiple config entries. This function handles both ids a
-    helper may pass as source_device_id:
-    - a pre-migration composite id (the id of the device before it was split): its split
-      children are known, so the helper's entities are moved onto the source-owned split
-      and the helper-owned split is removed;
-    - a plain source device id, with the helper owning a separate device: the helper's
-      entities are moved onto the source device and the helper's device is removed.
+    Deprecated alias of async_remove_helper_device, kept for custom integrations.
     """
-    device_registry = dr.async_get(hass)
-    entity_registry = er.async_get(hass)
-
-    helper_entity_entries = er.async_entries_for_config_entry(
-        entity_registry, helper_config_entry_id
+    async_remove_helper_device(
+        hass,
+        helper_config_entry_id=helper_config_entry_id,
+        source_device_id=source_device_id,
     )
-
-    # A pre-migration composite id resolves to the split devices it was migrated into
-    # (empty for any other id). Act on those children directly instead of relying on the
-    # deprecated config_entries shim and remove_config_entry_id: move the helper's entities
-    # onto a source-owned split and remove the helper-owned split.
-    if split_devices := device_registry.async_get_devices_for_composite_device_id(
-        source_device_id
-    ):
-        helper_device = next(
-            (
-                device
-                for device in split_devices
-                if device.config_entry_id == helper_config_entry_id
-            ),
-            None,
-        )
-        if helper_device is None:
-            return
-        target_device_id = next(
-            (
-                device.id
-                for device in split_devices
-                if device.config_entry_id != helper_config_entry_id
-            ),
-            None,
-        )
-        for helper in helper_entity_entries:
-            if helper.device_id == helper_device.id:
-                entity_registry.async_update_entity(
-                    helper.entity_id, device_id=target_device_id
-                )
-        device_registry.async_remove_device(helper_device.id)
-        return
-
-    # The helper owns a separate device. Move the helper's entities onto the source device,
-    # then remove the helper's device.
-    if not device_registry.async_get(source_device_id):
-        return
-    for helper_device in dr.async_entries_for_config_entry(
-        device_registry, helper_config_entry_id
-    ):
-        for helper in helper_entity_entries:
-            if helper.device_id == helper_device.id:
-                entity_registry.async_update_entity(
-                    helper.entity_id, device_id=source_device_id
-                )
-        device_registry.async_remove_device(helper_device.id)

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -136,38 +136,67 @@ def async_remove_helper_config_entry_from_source_device(
     helper_config_entry_id: str,
     source_device_id: str,
 ) -> None:
-    """Remove helper config entry from source device.
+    """Migrate a helper which has tried to add its config entry to the source device.
 
-    This is a convenience function to migrate from helpers which added their config
-    entry to the source device.
+    A device belongs to a single config entry, and has been split into multiple devices
+    if it was co-owned by multiple config entries. This function handles both ids a
+    helper may pass as source_device_id:
+    - a pre-migration composite id (the id of the device before it was split): its split
+      children are known, so the helper's entities are moved onto the source-owned split
+      and the helper-owned split is removed;
+    - a plain source device id, with the helper owning a separate device: the helper's
+      entities are moved onto the source device and the helper's device is removed.
     """
     device_registry = dr.async_get(hass)
-
-    if (
-        not (source_device := device_registry.async_get(source_device_id))
-        or helper_config_entry_id not in source_device.config_entries
-    ):
-        return
-
     entity_registry = er.async_get(hass)
+
     helper_entity_entries = er.async_entries_for_config_entry(
         entity_registry, helper_config_entry_id
     )
 
-    # Disconnect helper entities from the device to prevent them from
-    # being removed when the config entry link to the device is removed.
-    modified_helpers: list[er.RegistryEntry] = []
-    for helper in helper_entity_entries:
-        if helper.device_id != source_device_id:
-            continue
-        modified_helpers.append(helper)
-        entity_registry.async_update_entity(helper.entity_id, device_id=None)
-    # Remove the helper config entry from the device
-    device_registry.async_update_device(
-        source_device_id, remove_config_entry_id=helper_config_entry_id
-    )
-    # Connect the helper entity to the device
-    for helper in modified_helpers:
-        entity_registry.async_update_entity(
-            helper.entity_id, device_id=source_device_id
+    # A pre-migration composite id resolves to the split devices it was migrated into
+    # (empty for any other id). Act on those children directly instead of relying on the
+    # deprecated config_entries shim and remove_config_entry_id: move the helper's entities
+    # onto a source-owned split and remove the helper-owned split.
+    if split_devices := device_registry.async_get_devices_for_composite_device_id(
+        source_device_id
+    ):
+        helper_device = next(
+            (
+                device
+                for device in split_devices
+                if device.config_entry_id == helper_config_entry_id
+            ),
+            None,
         )
+        if helper_device is None:
+            return
+        target_device_id = next(
+            (
+                device.id
+                for device in split_devices
+                if device.config_entry_id != helper_config_entry_id
+            ),
+            None,
+        )
+        for helper in helper_entity_entries:
+            if helper.device_id == helper_device.id:
+                entity_registry.async_update_entity(
+                    helper.entity_id, device_id=target_device_id
+                )
+        device_registry.async_remove_device(helper_device.id)
+        return
+
+    # The helper owns a separate device. Move the helper's entities onto the source device,
+    # then remove the helper's device.
+    if not device_registry.async_get(source_device_id):
+        return
+    for helper_device in dr.async_entries_for_config_entry(
+        device_registry, helper_config_entry_id
+    ):
+        for helper in helper_entity_entries:
+            if helper.device_id == helper_device.id:
+                entity_registry.async_update_entity(
+                    helper.entity_id, device_id=source_device_id
+                )
+        device_registry.async_remove_device(helper_device.id)

--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -131,7 +131,7 @@ def async_handle_source_entity_changes(
     )
 
 
-def async_remove_helper_device(
+def async_remove_helper_devices(
     hass: HomeAssistant,
     *,
     helper_config_entry_id: str,
@@ -315,7 +315,7 @@ def _sweep_helper_devices(
 
 
 @deprecated_function(
-    "homeassistant.helpers.helper_integration.async_remove_helper_device",
+    "homeassistant.helpers.helper_integration.async_remove_helper_devices",
     breaks_in_ha_version="2027.8.0",
 )
 def async_remove_helper_config_entry_from_source_device(
@@ -326,9 +326,9 @@ def async_remove_helper_config_entry_from_source_device(
 ) -> None:
     """Migrate a helper which has tried to add its config entry to the source device.
 
-    Deprecated alias of async_remove_helper_device, kept for custom integrations.
+    Deprecated alias of async_remove_helper_devices, kept for custom integrations.
     """
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry_id,
         source_device_id=source_device_id,

--- a/tests/helpers/test_helper_integration.py
+++ b/tests/helpers/test_helper_integration.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.event import async_track_entity_registry_updated_even
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
     async_remove_helper_config_entry_from_source_device,
+    async_remove_helper_device,
 )
 
 from tests.common import (
@@ -511,17 +512,36 @@ async def test_async_handle_source_entity_new_entity_id(
     assert events == []
 
 
-async def test_async_remove_helper_config_entry_from_pre_split_composite_device(
+@pytest.mark.parametrize(
+    ("helper_identifiers", "helper_has_composite_identifiers"),
+    [
+        # Freshly split: the helper's split still carries the identifiers copied from the
+        # co-owned device
+        pytest.param({(SOURCE_DOMAIN, "1")}, True, id="not_activated"),
+        # Activated: the helper re-registered its device, pruning it to its own identifiers
+        pytest.param({(HELPER_DOMAIN, "1")}, False, id="activated"),
+    ],
+)
+@pytest.mark.parametrize(
+    "source_via_composite_id",
+    [pytest.param(True, id="composite_id"), pytest.param(False, id="source_split")],
+)
+async def test_async_remove_helper_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
+    helper_identifiers: set[tuple[str, str]],
+    helper_has_composite_identifiers: bool,
+    source_via_composite_id: bool,
 ) -> None:
-    """Test migrating a helper off a pre-migration composite source device.
+    """Test migrating a helper off a device it co-owned before the migration split.
 
-    The single-config-entry migration split a device co-owned by the source and helper
-    config entries into one device per config entry, sharing the pre-migration id as their
-    composite id. A helper storing that pre-migration id as its source device is migrated
-    by moving its entities onto the source-owned split and removing the helper-owned split.
+    The migration split the co-owned device into a source split and a helper split sharing
+    the pre-migration id as their composite id. The helper's split is found via that id -
+    both while it still carries the identifiers copied at the split and once the helper has
+    re-registered and pruned them to its own - and whether the caller passes the composite
+    id or the concrete source split. Its entities move onto the source split; its split is
+    removed.
     """
     source_config_entry = MockConfigEntry(domain=SOURCE_DOMAIN)
     source_config_entry.add_to_hass(hass)
@@ -531,19 +551,23 @@ async def test_async_remove_helper_config_entry_from_pre_split_composite_device(
 
     source_split = device_registry.async_get_or_create(
         config_entry_id=source_config_entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
         identifiers={(SOURCE_DOMAIN, "1")},
     )
     helper_split = device_registry.async_get_or_create(
         config_entry_id=helper_config_entry.entry_id,
-        identifiers={(HELPER_DOMAIN, "1")},
+        identifiers=helper_identifiers,
     )
-    # Simulate the migration split: both devices share the pre-migration composite id
+    # Both are splits of the same pre-migration device, sharing its id and primary owner
     device_registry.devices[source_split.id] = attr.evolve(
-        source_split, composite_device_id=composite_id
+        source_split,
+        composite_device_id=composite_id,
+        composite_primary_config_entry=source_config_entry.entry_id,
     )
     device_registry.devices[helper_split.id] = attr.evolve(
-        helper_split, composite_device_id=composite_id
+        helper_split,
+        composite_device_id=composite_id,
+        composite_primary_config_entry=source_config_entry.entry_id,
+        has_composite_identifiers=helper_has_composite_identifiers,
     )
     # A helper entity on the helper's split, plus one not linked to any device
     helper_entity_entry = entity_registry.async_get_or_create(
@@ -556,16 +580,14 @@ async def test_async_remove_helper_config_entry_from_pre_split_composite_device(
     extra_helper_entity_entry = entity_registry.async_get_or_create(
         "sensor", HELPER_DOMAIN, "2", config_entry=helper_config_entry
     )
-    # The helper stores the pre-migration composite id as its source device
-    assert device_registry.async_get(composite_id) is not None
 
-    async_remove_helper_config_entry_from_source_device(
+    async_remove_helper_device(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
-        source_device_id=composite_id,
+        source_device_id=composite_id if source_via_composite_id else source_split.id,
     )
 
-    # The helper's entity moved onto the source-owned split; its own split was removed
+    # The helper's entity moved onto the source split; its own split was removed
     assert (
         entity_registry.async_get(helper_entity_entry.entity_id).device_id
         == source_split.id
@@ -577,9 +599,291 @@ async def test_async_remove_helper_config_entry_from_pre_split_composite_device(
     assert device_registry.async_get(source_split.id) is not None
 
 
+async def test_async_remove_helper_device_multiple_co_owners(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """With more than two co-owners, the helper's entities go to the primary's split.
+
+    A pre-migration device can be co-owned by more than two config entries. The source
+    split is identified by the composite's recorded primary owner, not by split order, so
+    the helper's entities are not relinked onto an unrelated integration's split.
+    """
+    source_config_entry = MockConfigEntry(domain=SOURCE_DOMAIN)
+    source_config_entry.add_to_hass(hass)
+    other_config_entry = MockConfigEntry(domain="other")
+    other_config_entry.add_to_hass(hass)
+    helper_config_entry = MockConfigEntry(domain=HELPER_DOMAIN)
+    helper_config_entry.add_to_hass(hass)
+    composite_id = "pre_split_composite_id"
+
+    # other_split is indexed before source_split, so a split-order heuristic would wrongly
+    # pick it as the source; the recorded primary (source) must win instead.
+    other_split = device_registry.async_get_or_create(
+        config_entry_id=other_config_entry.entry_id, identifiers={("other", "1")}
+    )
+    source_split = device_registry.async_get_or_create(
+        config_entry_id=source_config_entry.entry_id, identifiers={(SOURCE_DOMAIN, "1")}
+    )
+    helper_split = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id, identifiers={(HELPER_DOMAIN, "1")}
+    )
+    for split in (other_split, source_split, helper_split):
+        device_registry.devices[split.id] = attr.evolve(
+            split,
+            composite_device_id=composite_id,
+            composite_primary_config_entry=source_config_entry.entry_id,
+        )
+    helper_entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "1",
+        config_entry=helper_config_entry,
+        device_id=helper_split.id,
+    )
+
+    async_remove_helper_device(
+        hass,
+        helper_config_entry_id=helper_config_entry.entry_id,
+        source_device_id=composite_id,
+    )
+
+    # Relinked to the primary owner's (source) split, not the unrelated other split, which
+    # is left untouched
+    assert (
+        entity_registry.async_get(helper_entity_entry.entity_id).device_id
+        == source_split.id
+    )
+    assert device_registry.async_get(helper_split.id) is None
+    assert device_registry.async_get(other_split.id) is not None
+    assert device_registry.async_get(source_split.id) is not None
+
+
+async def test_async_remove_helper_device_fork(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """A helper that forked the source device via device_info is cleaned up.
+
+    Declaring a foreign device's identifiers/connections in device_info no longer co-owns
+    it; it forks a separate helper-owned device with no composite lineage. The fork is
+    removed and its entities relinked to the source device, while unrelated helper-owned
+    devices are left alone.
+    """
+    source_config_entry = MockConfigEntry(domain=SOURCE_DOMAIN)
+    source_config_entry.add_to_hass(hass)
+    helper_config_entry = MockConfigEntry(domain=HELPER_DOMAIN)
+    helper_config_entry.add_to_hass(hass)
+
+    source_device = device_registry.async_get_or_create(
+        config_entry_id=source_config_entry.entry_id,
+        identifiers={(SOURCE_DOMAIN, "1")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    # The helper forked the source device by copying its identity into device_info
+    fork = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(SOURCE_DOMAIN, "1")},
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+    assert fork.id != source_device.id
+    assert fork.composite_device_id is None
+    helper_entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "1",
+        config_entry=helper_config_entry,
+        device_id=fork.id,
+    )
+    # An unrelated device the helper owns, which must be left untouched
+    unrelated_device = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(HELPER_DOMAIN, "unrelated")},
+    )
+    unrelated_entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "2",
+        config_entry=helper_config_entry,
+        device_id=unrelated_device.id,
+    )
+
+    async_remove_helper_device(
+        hass,
+        helper_config_entry_id=helper_config_entry.entry_id,
+        source_device_id=source_device.id,
+    )
+
+    # The fork is removed and its entity relinked to the source device
+    assert (
+        entity_registry.async_get(helper_entity_entry.entity_id).device_id
+        == source_device.id
+    )
+    assert device_registry.async_get(fork.id) is None
+    assert device_registry.async_get(source_device.id) is not None
+    # The unrelated helper-owned device and its entity are untouched
+    assert device_registry.async_get(unrelated_device.id) is not None
+    assert (
+        entity_registry.async_get(unrelated_entity_entry.entity_id).device_id
+        == unrelated_device.id
+    )
+
+
+async def test_async_remove_helper_device_sweep(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Broad mode sweeps every helper device except the source and the allow-list.
+
+    A helper that forked a device for each source it linked to, without removing the
+    old forks, accumulates stale devices that don't match the current source (so the
+    targeted match never sees them). sweep_helper_devices removes them and relinks the
+    helper's entities - including a stranded, device-less one - to the source, while
+    keep_device_ids and the source device are preserved.
+    """
+    source_config_entry = MockConfigEntry(domain=SOURCE_DOMAIN)
+    source_config_entry.add_to_hass(hass)
+    helper_config_entry = MockConfigEntry(domain=HELPER_DOMAIN)
+    helper_config_entry.add_to_hass(hass)
+
+    source_device = device_registry.async_get_or_create(
+        config_entry_id=source_config_entry.entry_id,
+        identifiers={(SOURCE_DOMAIN, "current")},
+    )
+    # Two stale forks left behind from previously-selected source devices (their identity
+    # no longer matches the current source)
+    stale_fork_1 = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(HELPER_DOMAIN, "stale_1")},
+    )
+    stale_fork_2 = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(HELPER_DOMAIN, "stale_2")},
+    )
+    # A device the helper legitimately owns, kept via the allow-list
+    kept_device = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(HELPER_DOMAIN, "kept")},
+    )
+    entity_on_stale_1 = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "1",
+        config_entry=helper_config_entry,
+        device_id=stale_fork_1.id,
+    )
+    entity_on_stale_2 = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "2",
+        config_entry=helper_config_entry,
+        device_id=stale_fork_2.id,
+    )
+    # A stranded helper entity, not linked to any device
+    stranded_entity = entity_registry.async_get_or_create(
+        "sensor", HELPER_DOMAIN, "3", config_entry=helper_config_entry
+    )
+    entity_on_kept = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "4",
+        config_entry=helper_config_entry,
+        device_id=kept_device.id,
+    )
+
+    async_remove_helper_device(
+        hass,
+        helper_config_entry_id=helper_config_entry.entry_id,
+        source_device_id=source_device.id,
+        sweep_helper_devices=True,
+        keep_device_ids={kept_device.id},
+    )
+
+    # Both stale forks are removed; the kept device and the source device remain
+    assert device_registry.async_get(stale_fork_1.id) is None
+    assert device_registry.async_get(stale_fork_2.id) is None
+    assert device_registry.async_get(kept_device.id) is not None
+    assert device_registry.async_get(source_device.id) is not None
+    # Entities off the removed forks - and the stranded one - are relinked to the source
+    for entity_entry in (entity_on_stale_1, entity_on_stale_2, stranded_entity):
+        assert (
+            entity_registry.async_get(entity_entry.entity_id).device_id
+            == source_device.id
+        )
+    # The entity on the kept device is left alone
+    assert (
+        entity_registry.async_get(entity_on_kept.entity_id).device_id == kept_device.id
+    )
+
+
+async def test_async_remove_helper_device_sweep_source_device_gone(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Sweep mode removes the helper's devices even when the source device is gone.
+
+    With no source device to relink to, the helper's entities are left without a device and
+    its devices are still removed.
+    """
+    helper_config_entry = MockConfigEntry(domain=HELPER_DOMAIN)
+    helper_config_entry.add_to_hass(hass)
+
+    stale_fork = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(HELPER_DOMAIN, "stale")},
+    )
+    entity_on_fork = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        "1",
+        config_entry=helper_config_entry,
+        device_id=stale_fork.id,
+    )
+
+    async_remove_helper_device(
+        hass,
+        helper_config_entry_id=helper_config_entry.entry_id,
+        source_device_id="nonexistent_device_id",
+        sweep_helper_devices=True,
+    )
+
+    # The helper's device is removed and its entity left without a device
+    assert device_registry.async_get(stale_fork.id) is None
+    assert entity_registry.async_get(entity_on_fork.entity_id).device_id is None
+
+
+async def test_async_remove_helper_config_entry_from_source_device_deprecated(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The old name is a deprecated alias delegating to async_remove_helper_device."""
+    with patch(
+        "homeassistant.helpers.helper_integration.async_remove_helper_device"
+    ) as mock_remove_helper_device:
+        async_remove_helper_config_entry_from_source_device(
+            hass,
+            helper_config_entry_id="helper_config_entry_id",
+            source_device_id="source_device_id",
+        )
+
+    mock_remove_helper_device.assert_called_once_with(
+        hass,
+        helper_config_entry_id="helper_config_entry_id",
+        source_device_id="source_device_id",
+    )
+    assert (
+        "async_remove_helper_config_entry_from_source_device was called" in caplog.text
+    )
+    assert "async_remove_helper_device instead" in caplog.text
+
+
 @pytest.mark.parametrize("use_entity_registry_id", [True, False])
 @pytest.mark.usefixtures("source_entity_entry")
-async def test_async_remove_helper_config_entry_from_source_device_helper_not_in_device(
+async def test_async_remove_helper_device_helper_not_in_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -600,7 +904,7 @@ async def test_async_remove_helper_config_entry_from_source_device_helper_not_in
 
     events = listen_entity_registry_events(hass)
 
-    async_remove_helper_config_entry_from_source_device(
+    async_remove_helper_device(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id=source_device.id,
@@ -608,71 +912,3 @@ async def test_async_remove_helper_config_entry_from_source_device_helper_not_in
 
     # Check we got the expected events
     assert events == []
-
-
-@pytest.mark.parametrize("use_entity_registry_id", [True, False])
-@pytest.mark.usefixtures("source_entity_entry")
-async def test_async_remove_helper_config_entry_from_source_device_post_split(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    entity_registry: er.EntityRegistry,
-    helper_config_entry: MockConfigEntry,
-    source_config_entry: ConfigEntry,
-    source_device: dr.DeviceEntry,
-) -> None:
-    """Test cleaning up a helper-owned device split off from the source device.
-
-    In the single-config-entry model the migration splits a device co-owned by the source
-    and helper config entries into a source-owned device and a separate helper-owned
-    device. The helper's entities must be moved onto the source device and the helper's
-    device removed.
-    """
-    # The helper owns a separate device (the migration split it off from the source
-    # device), with a helper entity linked to it.
-    helper_device = device_registry.async_get_or_create(
-        config_entry_id=helper_config_entry.entry_id,
-        connections={(dr.CONNECTION_NETWORK_MAC, "AA:BB:CC:DD:EE:FF")},
-    )
-    helper_entity_entry = entity_registry.async_get_or_create(
-        "sensor",
-        HELPER_DOMAIN,
-        helper_config_entry.entry_id,
-        config_entry=helper_config_entry,
-        device_id=helper_device.id,
-        original_name="ABC",
-    )
-    # A second helper entity, not connected to any device
-    extra_helper_entity_entry = entity_registry.async_get_or_create(
-        "sensor",
-        HELPER_DOMAIN,
-        f"{helper_config_entry.entry_id}_2",
-        config_entry=helper_config_entry,
-        original_name="ABC",
-    )
-
-    events = listen_entity_registry_events(hass)
-
-    async_remove_helper_config_entry_from_source_device(
-        hass,
-        helper_config_entry_id=helper_config_entry.entry_id,
-        source_device_id=source_device.id,
-    )
-
-    # The helper entity was moved to the source device and the helper device removed
-    assert (
-        entity_registry.async_get(helper_entity_entry.entity_id).device_id
-        == source_device.id
-    )
-    assert (
-        entity_registry.async_get(extra_helper_entity_entry.entity_id).device_id is None
-    )
-    assert device_registry.async_get(helper_device.id) is None
-
-    # Check we got the expected events
-    assert events == [
-        {
-            "action": "update",
-            "changes": {"device_id": helper_device.id},
-            "entity_id": helper_entity_entry.entity_id,
-        },
-    ]

--- a/tests/helpers/test_helper_integration.py
+++ b/tests/helpers/test_helper_integration.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
+import attr
 import pytest
 
 from homeassistant.config_entries import ConfigEntry
@@ -510,65 +511,70 @@ async def test_async_handle_source_entity_new_entity_id(
     assert events == []
 
 
-@pytest.mark.parametrize("use_entity_registry_id", [True, False])
-@pytest.mark.usefixtures("source_entity_entry")
-async def test_async_remove_helper_config_entry_from_source_device(
+async def test_async_remove_helper_config_entry_from_pre_split_composite_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
-    helper_config_entry: MockConfigEntry,
-    helper_entity_entry: er.RegistryEntry,
-    source_config_entry: ConfigEntry,
-    source_device: dr.DeviceEntry,
 ) -> None:
-    """Test removing the helper config entry from the source device."""
-    # In the single-owner model the migration helper only acts when the helper config
-    # entry owns the source device. Move the source device to the helper config entry
-    # and record a pending move back to the source config entry, so removing the helper
-    # config entry hands the device back to the source config entry instead of deleting
-    # it.
-    device_registry.async_update_device(
-        source_device.id,
-        add_config_entry_id=helper_config_entry.entry_id,
-        remove_config_entry_id=source_config_entry.entry_id,
-    )
-    device_registry.async_update_device(
-        source_device.id, add_config_entry_id=source_config_entry.entry_id
-    )
-    source_device = device_registry.async_get(source_device.id)
-    assert source_device.config_entries == {helper_config_entry.entry_id}
+    """Test migrating a helper off a pre-migration composite source device.
 
-    # Create a helper entity entry, not connected to the source device
-    extra_helper_entity_entry = entity_registry.async_get_or_create(
+    The single-config-entry migration split a device co-owned by the source and helper
+    config entries into one device per config entry, sharing the pre-migration id as their
+    composite id. A helper storing that pre-migration id as its source device is migrated
+    by moving its entities onto the source-owned split and removing the helper-owned split.
+    """
+    source_config_entry = MockConfigEntry(domain=SOURCE_DOMAIN)
+    source_config_entry.add_to_hass(hass)
+    helper_config_entry = MockConfigEntry(domain=HELPER_DOMAIN)
+    helper_config_entry.add_to_hass(hass)
+    composite_id = "pre_split_composite_id"
+
+    source_split = device_registry.async_get_or_create(
+        config_entry_id=source_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+        identifiers={(SOURCE_DOMAIN, "1")},
+    )
+    helper_split = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        identifiers={(HELPER_DOMAIN, "1")},
+    )
+    # Simulate the migration split: both devices share the pre-migration composite id
+    device_registry.devices[source_split.id] = attr.evolve(
+        source_split, composite_device_id=composite_id
+    )
+    device_registry.devices[helper_split.id] = attr.evolve(
+        helper_split, composite_device_id=composite_id
+    )
+    # A helper entity on the helper's split, plus one not linked to any device
+    helper_entity_entry = entity_registry.async_get_or_create(
         "sensor",
         HELPER_DOMAIN,
-        f"{helper_config_entry.entry_id}_2",
+        "1",
         config_entry=helper_config_entry,
-        original_name="ABC",
+        device_id=helper_split.id,
     )
-    assert extra_helper_entity_entry.entity_id != helper_entity_entry.entity_id
-
-    events = listen_entity_registry_events(hass)
+    extra_helper_entity_entry = entity_registry.async_get_or_create(
+        "sensor", HELPER_DOMAIN, "2", config_entry=helper_config_entry
+    )
+    # The helper stores the pre-migration composite id as its source device
+    assert device_registry.async_get(composite_id) is not None
 
     async_remove_helper_config_entry_from_source_device(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
-        source_device_id=source_device.id,
+        source_device_id=composite_id,
     )
 
-    # Check we got the expected events
-    assert events == [
-        {
-            "action": "update",
-            "changes": {"device_id": source_device.id},
-            "entity_id": helper_entity_entry.entity_id,
-        },
-        {
-            "action": "update",
-            "changes": {"device_id": None},
-            "entity_id": helper_entity_entry.entity_id,
-        },
-    ]
+    # The helper's entity moved onto the source-owned split; its own split was removed
+    assert (
+        entity_registry.async_get(helper_entity_entry.entity_id).device_id
+        == source_split.id
+    )
+    assert (
+        entity_registry.async_get(extra_helper_entity_entry.entity_id).device_id is None
+    )
+    assert device_registry.async_get(helper_split.id) is None
+    assert device_registry.async_get(source_split.id) is not None
 
 
 @pytest.mark.parametrize("use_entity_registry_id", [True, False])
@@ -602,3 +608,71 @@ async def test_async_remove_helper_config_entry_from_source_device_helper_not_in
 
     # Check we got the expected events
     assert events == []
+
+
+@pytest.mark.parametrize("use_entity_registry_id", [True, False])
+@pytest.mark.usefixtures("source_entity_entry")
+async def test_async_remove_helper_config_entry_from_source_device_post_split(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    helper_config_entry: MockConfigEntry,
+    source_config_entry: ConfigEntry,
+    source_device: dr.DeviceEntry,
+) -> None:
+    """Test cleaning up a helper-owned device split off from the source device.
+
+    In the single-config-entry model the migration splits a device co-owned by the source
+    and helper config entries into a source-owned device and a separate helper-owned
+    device. The helper's entities must be moved onto the source device and the helper's
+    device removed.
+    """
+    # The helper owns a separate device (the migration split it off from the source
+    # device), with a helper entity linked to it.
+    helper_device = device_registry.async_get_or_create(
+        config_entry_id=helper_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "AA:BB:CC:DD:EE:FF")},
+    )
+    helper_entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        helper_config_entry.entry_id,
+        config_entry=helper_config_entry,
+        device_id=helper_device.id,
+        original_name="ABC",
+    )
+    # A second helper entity, not connected to any device
+    extra_helper_entity_entry = entity_registry.async_get_or_create(
+        "sensor",
+        HELPER_DOMAIN,
+        f"{helper_config_entry.entry_id}_2",
+        config_entry=helper_config_entry,
+        original_name="ABC",
+    )
+
+    events = listen_entity_registry_events(hass)
+
+    async_remove_helper_config_entry_from_source_device(
+        hass,
+        helper_config_entry_id=helper_config_entry.entry_id,
+        source_device_id=source_device.id,
+    )
+
+    # The helper entity was moved to the source device and the helper device removed
+    assert (
+        entity_registry.async_get(helper_entity_entry.entity_id).device_id
+        == source_device.id
+    )
+    assert (
+        entity_registry.async_get(extra_helper_entity_entry.entity_id).device_id is None
+    )
+    assert device_registry.async_get(helper_device.id) is None
+
+    # Check we got the expected events
+    assert events == [
+        {
+            "action": "update",
+            "changes": {"device_id": helper_device.id},
+            "entity_id": helper_entity_entry.entity_id,
+        },
+    ]

--- a/tests/helpers/test_helper_integration.py
+++ b/tests/helpers/test_helper_integration.py
@@ -13,7 +13,7 @@ from homeassistant.helpers.event import async_track_entity_registry_updated_even
 from homeassistant.helpers.helper_integration import (
     async_handle_source_entity_changes,
     async_remove_helper_config_entry_from_source_device,
-    async_remove_helper_device,
+    async_remove_helper_devices,
 )
 
 from tests.common import (
@@ -526,7 +526,7 @@ async def test_async_handle_source_entity_new_entity_id(
     "source_via_composite_id",
     [pytest.param(True, id="composite_id"), pytest.param(False, id="source_split")],
 )
-async def test_async_remove_helper_device(
+async def test_async_remove_helper_devices(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -581,7 +581,7 @@ async def test_async_remove_helper_device(
         "sensor", HELPER_DOMAIN, "2", config_entry=helper_config_entry
     )
 
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id=composite_id if source_via_composite_id else source_split.id,
@@ -599,7 +599,7 @@ async def test_async_remove_helper_device(
     assert device_registry.async_get(source_split.id) is not None
 
 
-async def test_async_remove_helper_device_multiple_co_owners(
+async def test_async_remove_helper_devices_multiple_co_owners(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -643,7 +643,7 @@ async def test_async_remove_helper_device_multiple_co_owners(
         device_id=helper_split.id,
     )
 
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id=composite_id,
@@ -660,7 +660,7 @@ async def test_async_remove_helper_device_multiple_co_owners(
     assert device_registry.async_get(source_split.id) is not None
 
 
-async def test_async_remove_helper_device_fork(
+async def test_async_remove_helper_devices_fork(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -710,7 +710,7 @@ async def test_async_remove_helper_device_fork(
         device_id=unrelated_device.id,
     )
 
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id=source_device.id,
@@ -731,7 +731,7 @@ async def test_async_remove_helper_device_fork(
     )
 
 
-async def test_async_remove_helper_device_sweep(
+async def test_async_remove_helper_devices_sweep(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -794,7 +794,7 @@ async def test_async_remove_helper_device_sweep(
         device_id=kept_device.id,
     )
 
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id=source_device.id,
@@ -819,7 +819,7 @@ async def test_async_remove_helper_device_sweep(
     )
 
 
-async def test_async_remove_helper_device_sweep_source_device_gone(
+async def test_async_remove_helper_devices_sweep_source_device_gone(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -844,7 +844,7 @@ async def test_async_remove_helper_device_sweep_source_device_gone(
         device_id=stale_fork.id,
     )
 
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id="nonexistent_device_id",
@@ -860,9 +860,9 @@ async def test_async_remove_helper_config_entry_from_source_device_deprecated(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """The old name is a deprecated alias delegating to async_remove_helper_device."""
+    """The old name is a deprecated alias delegating to async_remove_helper_devices."""
     with patch(
-        "homeassistant.helpers.helper_integration.async_remove_helper_device"
+        "homeassistant.helpers.helper_integration.async_remove_helper_devices"
     ) as mock_remove_helper_device:
         async_remove_helper_config_entry_from_source_device(
             hass,
@@ -878,12 +878,12 @@ async def test_async_remove_helper_config_entry_from_source_device_deprecated(
     assert (
         "async_remove_helper_config_entry_from_source_device was called" in caplog.text
     )
-    assert "async_remove_helper_device instead" in caplog.text
+    assert "async_remove_helper_devices instead" in caplog.text
 
 
 @pytest.mark.parametrize("use_entity_registry_id", [True, False])
 @pytest.mark.usefixtures("source_entity_entry")
-async def test_async_remove_helper_device_helper_not_in_device(
+async def test_async_remove_helper_devices_helper_not_in_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
@@ -904,7 +904,7 @@ async def test_async_remove_helper_device_helper_not_in_device(
 
     events = listen_entity_registry_events(hass)
 
-    async_remove_helper_device(
+    async_remove_helper_devices(
         hass,
         helper_config_entry_id=helper_config_entry.entry_id,
         source_device_id=source_device.id,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename `async_remove_helper_config_entry_from_source_device` to `async_remove_helper_devices` and adapt it to new device model

The helper is now the only function to call to clean up devices incorrectly created by a helper, and replaces `async_remove_stale_devices_links_keep_entity_device` and `async_remove_stale_devices_links_keep_current_device` which are no longer valid with the new device registry model.

`async_remove_stale_devices_links_keep_entity_device` and `async_remove_stale_devices_links_keep_current_device` will be modified to do nothing except log a deprecation warning in a follow-up PR.

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
