### PR TITLE
Fix unstable KNX YAML unique_id when changing group address style

### DIFF
--- a/homeassistant/components/knx/binary_sensor.py
+++ b/homeassistant/components/knx/binary_sensor.py
@@ -34,7 +34,12 @@ from .const import (
     DOMAIN,
     KNX_MODULE_KEY,
 )
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_SENSOR
 from .storage.util import ConfigExtractor
@@ -127,7 +132,9 @@ class KnxYamlBinarySensor(_KnxBinarySensor, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address_state),
+            unique_id=build_yaml_unique_id(
+                self._device.remote_value.group_address_state
+            ),
             entity_config=config,
         )
 

--- a/homeassistant/components/knx/button.py
+++ b/homeassistant/components/knx/button.py
@@ -15,7 +15,12 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_PAYLOAD_LENGTH, CONF_VALUE, DOMAIN, KNX_ADDRESS, KNX_MODULE_KEY
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_DATA, CONF_ENTITY, CONF_GA_SEND
 from .storage.util import ConfigExtractor
@@ -82,7 +87,9 @@ class KnxYamlButton(_KnxButton, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=f"{self._device.remote_value.group_address}_{self._payload}",
+            unique_id=build_yaml_unique_id(
+                self._device.remote_value.group_address, self._payload
+            ),
             entity_config=config,
         )
 

--- a/homeassistant/components/knx/climate.py
+++ b/homeassistant/components/knx/climate.py
@@ -46,6 +46,7 @@ from .entity import (
     KnxUiEntityPlatformController,
     KnxYamlEntity,
     _KnxEntityBase,
+    build_yaml_unique_id,
 )
 from .knx_module import KNXModule
 from .schema import ClimateSchema
@@ -665,11 +666,11 @@ class KnxYamlClimate(_KnxClimate, KnxYamlEntity):
         self._device = _create_climate_yaml(knx_module.xknx, config)
         super().__init__(
             knx_module=knx_module,
-            unique_id=(
-                f"{self._device.temperature.group_address_state}_"
-                f"{self._device.target_temperature.group_address_state}_"
-                f"{self._device.target_temperature.group_address}_"
-                f"{self._device._setpoint_shift.group_address}"  # noqa: SLF001
+            unique_id=build_yaml_unique_id(
+                self._device.temperature.group_address_state,
+                self._device.target_temperature.group_address_state,
+                self._device.target_temperature.group_address,
+                self._device._setpoint_shift.group_address,  # noqa: SLF001
             ),
             entity_config=config,
         )

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -31,7 +31,12 @@ from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_SYNC_STATE, DOMAIN, KNX_MODULE_KEY, CoverConf
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .schema import CoverSchema
 from .storage.const import (
@@ -259,9 +264,9 @@ class KnxYamlCover(_KnxCover, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=(
-                f"{self._device.updown.group_address}_"
-                f"{self._device.position_target.group_address}"
+            unique_id=build_yaml_unique_id(
+                self._device.updown.group_address,
+                self._device.position_target.group_address,
             ),
             entity_config=config,
         )

--- a/homeassistant/components/knx/date.py
+++ b/homeassistant/components/knx/date.py
@@ -25,7 +25,12 @@ from .const import (
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_DATE
 from .storage.util import ConfigExtractor
@@ -109,7 +114,7 @@ class KnxYamlDate(_KNXDate, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
             entity_config=config,
         )
 

--- a/homeassistant/components/knx/datetime.py
+++ b/homeassistant/components/knx/datetime.py
@@ -26,7 +26,12 @@ from .const import (
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_DATETIME
 from .storage.util import ConfigExtractor
@@ -114,7 +119,7 @@ class KnxYamlDateTime(_KNXDateTime, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
             entity_config=config,
         )
 

--- a/homeassistant/components/knx/entity.py
+++ b/homeassistant/components/knx/entity.py
@@ -4,11 +4,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, override
 
 from xknx.devices import Device as XknxDevice
+from xknx.telegram.address import DeviceGroupAddress, GroupAddress
 
 from homeassistant.const import CONF_ENTITY_CATEGORY, CONF_NAME, EntityCategory
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
-from homeassistant.helpers.entity_platform import EntityPlatform
+from homeassistant.helpers.entity_platform import (
+    EntityPlatform,
+    async_get_current_platform,
+)
 from homeassistant.helpers.entity_registry import RegistryEntry
 
 from .const import CONF_DEFAULT_ENTITY_ID, DOMAIN
@@ -17,6 +23,54 @@ from .storage.const import CONF_DEVICE_INFO
 
 if TYPE_CHECKING:
     from .knx_module import KNXModule
+
+
+def _stable_group_address_repr(part: DeviceGroupAddress | None | int | str) -> str:
+    """Render a unique_id part independent of `GroupAddress.address_format`."""
+    if isinstance(part, GroupAddress):
+        # Always LONG (main/middle/sub) derived from raw, so the representation
+        # does not change when the global address format changes (e.g. on ETS
+        # project import). This is bijective with raw, keeping ids unique.
+        return (
+            f"{(part.raw >> 11) & 0b11111}/{(part.raw >> 8) & 0b111}/{part.raw & 0xFF}"
+        )
+    # InternalGroupAddress is already format-independent; None renders as "None"
+    return str(part)
+
+
+def build_yaml_unique_id(
+    *parts: DeviceGroupAddress | None | int | str,
+) -> tuple[str, str]:
+    """Return `(new_stable_id, legacy_id)` for a YAML entity.
+
+    `new_stable_id` is independent of the global group address format. `legacy_id`
+    matches the id produced before this fix (using the current global format) and is
+    used to migrate registry entries of installations not using the 3-level style.
+    Pass the result as `unique_id` to `KnxYamlEntity`, which runs the migration.
+    """
+    new_id = "_".join(_stable_group_address_repr(part) for part in parts)
+    legacy_id = "_".join(str(part) for part in parts)
+    return new_id, legacy_id
+
+
+@callback
+def async_migrate_yaml_unique_id(
+    hass: HomeAssistant, platform: str, legacy_id: str, new_id: str
+) -> None:
+    """Migrate a YAML entity unique_id from the legacy format to the stable one."""
+    # migration from unstable group address string parts added in 2026.8
+    if legacy_id == new_id:
+        return
+    ent_reg = er.async_get(hass)
+    if (entity_id := ent_reg.async_get_entity_id(platform, DOMAIN, legacy_id)) is None:
+        return
+    try:
+        ent_reg.async_update_entity(entity_id, new_unique_id=new_id)
+    except ValueError:
+        # A stable-id entity already exists next to the legacy one - e.g. the
+        # original entity was orphaned under the stable id when the pre-fix bug
+        # registered the legacy entry. Keep the stable entry, drop the legacy one.
+        ent_reg.async_remove(entity_id)
 
 
 @dataclass(slots=True, frozen=True)
@@ -121,13 +175,24 @@ class KnxYamlEntity(_KnxEntityBase):
     def __init__(
         self,
         knx_module: KNXModule,
-        unique_id: str,
+        unique_id: tuple[str, str],  # new_stable_id, legacy_id for migration
         entity_config: dict[str, Any],
     ) -> None:
-        """Initialize the YAML entity."""
+        """Initialize the YAML entity.
+
+        `unique_id` is the `(new_stable_id, legacy_id)` tuple from
+        `build_yaml_unique_id`; the legacy id is migrated to the stable one.
+        """
+        new_unique_id, legacy_unique_id = unique_id
+        async_migrate_yaml_unique_id(
+            knx_module.hass,
+            async_get_current_platform().domain,
+            legacy_unique_id,
+            new_unique_id,
+        )
         self._knx_module = knx_module
         self._attr_name = entity_config[CONF_NAME] or None
-        self._attr_unique_id = unique_id
+        self._attr_unique_id = new_unique_id
         self._attr_entity_category = entity_config.get(CONF_ENTITY_CATEGORY)
 
         default_entity_id: str | None

--- a/homeassistant/components/knx/fan.py
+++ b/homeassistant/components/knx/fan.py
@@ -25,7 +25,12 @@ from homeassistant.util.percentage import (
 from homeassistant.util.scaling import int_states_in_range
 
 from .const import CONF_SYNC_STATE, DOMAIN, KNX_ADDRESS, KNX_MODULE_KEY, FanConf
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .schema import FanSchema
 from .storage.const import (
@@ -233,10 +238,8 @@ class KnxYamlFan(_KnxFan, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=(
-                str(self._device.speed.group_address)
-                if self._device.speed.group_address
-                else str(self._device.switch.group_address)
+            unique_id=build_yaml_unique_id(
+                self._device.speed.group_address or self._device.switch.group_address
             ),
             entity_config=config,
         )

--- a/homeassistant/components/knx/light.py
+++ b/homeassistant/components/knx/light.py
@@ -5,6 +5,7 @@ from typing import Any, cast, override
 from propcache.api import cached_property
 from xknx import XKNX
 from xknx.devices.light import ColorTemperatureType, Light as XknxLight, XYYColor
+from xknx.telegram.address import DeviceGroupAddress
 
 from homeassistant import config_entries
 from homeassistant.components.light import (
@@ -27,7 +28,12 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util import color as color_util
 
 from .const import CONF_SYNC_STATE, DOMAIN, KNX_ADDRESS, KNX_MODULE_KEY, ColorTempModes
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .schema import LightSchema
 from .storage.const import (
@@ -572,21 +578,21 @@ class KnxYamlLight(_KnxLight, KnxYamlEntity):
         self._device = _create_yaml_light(knx_module.xknx, config)
         super().__init__(
             knx_module=knx_module,
-            unique_id=self._device_unique_id(),
+            unique_id=build_yaml_unique_id(*self._unique_id_parts()),
             entity_config=config,
         )
         self._attr_color_mode = next(iter(self.supported_color_modes))
         self._attr_max_color_temp_kelvin: int = config[LightSchema.CONF_MAX_KELVIN]
         self._attr_min_color_temp_kelvin: int = config[LightSchema.CONF_MIN_KELVIN]
 
-    def _device_unique_id(self) -> str:
-        """Return unique id for this device."""
+    def _unique_id_parts(self) -> tuple[DeviceGroupAddress | None, ...]:
+        """Return the group addresses this device's unique id is built from."""
         if self._device.switch.group_address is not None:
-            return f"{self._device.switch.group_address}"
+            return (self._device.switch.group_address,)
         return (
-            f"{self._device.red.brightness.group_address}_"
-            f"{self._device.green.brightness.group_address}_"
-            f"{self._device.blue.brightness.group_address}"
+            self._device.red.brightness.group_address,
+            self._device.green.brightness.group_address,
+            self._device.blue.brightness.group_address,
         )
 
 

--- a/homeassistant/components/knx/notify.py
+++ b/homeassistant/components/knx/notify.py
@@ -15,7 +15,12 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, KNX_ADDRESS, KNX_MODULE_KEY
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_SEND
 from .storage.util import ConfigExtractor
@@ -79,7 +84,7 @@ class KnxYamlNotify(_KnxNotify, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
             entity_config=config,
         )
 

--- a/homeassistant/components/knx/number.py
+++ b/homeassistant/components/knx/number.py
@@ -34,7 +34,12 @@ from .const import (
     NumberConf,
 )
 from .dpt import get_supported_dpts
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_SENSOR
 from .storage.util import ConfigExtractor
@@ -117,7 +122,7 @@ class KnxYamlNumber(_KnxNumber, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.sensor_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.sensor_value.group_address),
             entity_config=config,
         )
         dpt_string = self._device.sensor_value.dpt_class.dpt_number_str()

--- a/homeassistant/components/knx/scene.py
+++ b/homeassistant/components/knx/scene.py
@@ -20,6 +20,7 @@ from .entity import (
     KnxUiEntityPlatformController,
     KnxYamlEntity,
     _KnxEntityBase,
+    build_yaml_unique_id,
 )
 from .knx_module import KNXModule
 from .schema import SceneSchema
@@ -91,8 +92,8 @@ class KnxYamlScene(_KnxScene, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=(
-                f"{self._device.scene_value.group_address}_{self._device.scene_number}"
+            unique_id=build_yaml_unique_id(
+                self._device.scene_value.group_address, self._device.scene_number
             ),
             entity_config=config,
         )

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -27,7 +27,7 @@ from .const import (
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxYamlEntity
+from .entity import KnxYamlEntity, build_yaml_unique_id
 from .knx_module import KNXModule
 from .schema import SelectSchema
 
@@ -67,7 +67,7 @@ class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
         self._device = _create_raw_value(knx_module.xknx, config)
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
             entity_config=config,
         )
         self._option_payloads: dict[str, int] = {

--- a/homeassistant/components/knx/sensor.py
+++ b/homeassistant/components/knx/sensor.py
@@ -43,6 +43,7 @@ from .entity import (
     KnxUiEntityPlatformController,
     KnxYamlEntity,
     _KnxEntityBase,
+    build_yaml_unique_id,
 )
 from .knx_module import KNXModule
 from .schema import SensorSchema
@@ -211,7 +212,9 @@ class KnxYamlSensor(_KnxSensor, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.sensor_value.group_address_state),
+            unique_id=build_yaml_unique_id(
+                self._device.sensor_value.group_address_state
+            ),
             entity_config=config,
         )
         dpt_string = self._device.sensor_value.dpt_class.dpt_number_str()

--- a/homeassistant/components/knx/switch.py
+++ b/homeassistant/components/knx/switch.py
@@ -30,7 +30,12 @@ from .const import (
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .schema import SwitchSchema
 from .storage.const import CONF_ENTITY, CONF_GA_SWITCH
@@ -116,7 +121,7 @@ class KnxYamlSwitch(_KnxSwitch, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.switch.group_address),
+            unique_id=build_yaml_unique_id(self._device.switch.group_address),
             entity_config=config,
         )
         self._attr_device_class = config.get(CONF_DEVICE_CLASS)

--- a/homeassistant/components/knx/text.py
+++ b/homeassistant/components/knx/text.py
@@ -32,7 +32,12 @@ from .const import (
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_TEXT
 from .storage.util import ConfigExtractor
@@ -122,7 +127,7 @@ class KnxYamlText(_KnxText, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
             entity_config=config,
         )
         self._attr_mode = config[CONF_MODE]

--- a/homeassistant/components/knx/time.py
+++ b/homeassistant/components/knx/time.py
@@ -25,7 +25,12 @@ from .const import (
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY, CONF_GA_TIME
 from .storage.util import ConfigExtractor
@@ -109,7 +114,7 @@ class KnxYamlTime(_KNXTime, KnxYamlEntity):
         )
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device.remote_value.group_address),
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
             entity_config=config,
         )
 

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import ConfigType
 
 from .const import KNX_MODULE_KEY
-from .entity import KnxYamlEntity
+from .entity import KnxYamlEntity, build_yaml_unique_id
 from .knx_module import KNXModule
 from .schema import WeatherSchema
 
@@ -87,7 +87,9 @@ class KNXWeather(KnxYamlEntity, WeatherEntity):
         self._device = _create_weather(knx_module.xknx, config)
         super().__init__(
             knx_module=knx_module,
-            unique_id=str(self._device._temperature.group_address_state),  # noqa: SLF001
+            unique_id=build_yaml_unique_id(
+                self._device._temperature.group_address_state  # noqa: SLF001
+            ),
             entity_config=config,
         )
 

--- a/tests/components/knx/test_unique_id.py
+++ b/tests/components/knx/test_unique_id.py
@@ -1,0 +1,119 @@
+"""Test KNX entity unique_id generation and migration."""
+
+from collections.abc import Generator
+from unittest.mock import patch
+
+import pytest
+from xknx.telegram.address import GroupAddress, GroupAddressType, InternalGroupAddress
+
+from homeassistant.components.knx.const import DOMAIN, KNX_ADDRESS
+from homeassistant.components.knx.entity import build_yaml_unique_id
+from homeassistant.components.knx.schema import SwitchSchema
+from homeassistant.const import CONF_NAME, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import KNXTestKit
+
+
+@pytest.fixture
+def two_level_address_format() -> Generator[None]:
+    """Force the global group address format to 2-level (SHORT)."""
+    with patch(
+        "homeassistant.components.knx.project.KNXProject.get_address_format",
+        return_value=GroupAddressType.SHORT,
+    ):
+        yield
+
+
+@pytest.mark.parametrize(
+    "address_format",
+    [GroupAddressType.LONG, GroupAddressType.SHORT, GroupAddressType.FREE],
+)
+def test_build_yaml_unique_id_is_format_independent(
+    monkeypatch: pytest.MonkeyPatch, address_format: GroupAddressType
+) -> None:
+    """The stable unique_id is always the LONG form regardless of global format."""
+    monkeypatch.setattr(GroupAddress, "address_format", address_format)
+    new_id, _legacy_id = build_yaml_unique_id(GroupAddress("1/2/3"))
+    assert new_id == "1/2/3"
+
+
+def test_build_yaml_unique_id_parts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Composite ids keep non-address parts and legacy ids follow the global format."""
+    monkeypatch.setattr(GroupAddress, "address_format", GroupAddressType.SHORT)
+    new_id, legacy_id = build_yaml_unique_id(
+        GroupAddress("1/2/3"), None, InternalGroupAddress("i-foo"), 24
+    )
+    assert new_id == "1/2/3_None_i-foo_24"
+    assert legacy_id == "1/515_None_i-foo_24"
+
+
+@pytest.mark.usefixtures("two_level_address_format")
+async def test_yaml_unique_id_stable_with_two_level_style(
+    hass: HomeAssistant, knx: KNXTestKit, entity_registry: er.EntityRegistry
+) -> None:
+    """A 2-level style install still gets the LONG unique_id, not the 2-level string."""
+    await knx.setup_integration(
+        {SwitchSchema.PLATFORM: {CONF_NAME: "test", KNX_ADDRESS: "1/2/3"}}
+    )
+    entry = entity_registry.async_get("switch.test")
+    assert entry
+    assert entry.unique_id == "1/2/3"
+
+
+@pytest.mark.usefixtures("two_level_address_format")
+async def test_yaml_unique_id_migration(
+    hass: HomeAssistant, knx: KNXTestKit, entity_registry: er.EntityRegistry
+) -> None:
+    """A legacy (2-level) unique_id is migrated to the stable LONG form."""
+    legacy_unique_id = "1/515"
+    knx.mock_config_entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        object_id_base="test",
+        domain=Platform.SWITCH,
+        platform=DOMAIN,
+        unique_id=legacy_unique_id,
+        config_entry=knx.mock_config_entry,
+    )
+    await knx.setup_integration(
+        {SwitchSchema.PLATFORM: {CONF_NAME: "test", KNX_ADDRESS: "1/2/3"}},
+        add_entry_to_hass=False,
+    )
+    entry = entity_registry.async_get("switch.test")
+    assert entry
+    assert entry.unique_id == "1/2/3"
+    assert not entity_registry.async_get_entity_id(
+        Platform.SWITCH, DOMAIN, legacy_unique_id
+    )
+
+
+@pytest.mark.usefixtures("two_level_address_format")
+async def test_yaml_unique_id_migration_collision(
+    hass: HomeAssistant, knx: KNXTestKit, entity_registry: er.EntityRegistry
+) -> None:
+    """A stale legacy entry is removed when the stable unique_id already exists."""
+    legacy_unique_id = "1/515"
+    new_unique_id = "1/2/3"
+    knx.mock_config_entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        domain=Platform.SWITCH,
+        platform=DOMAIN,
+        unique_id=new_unique_id,
+        config_entry=knx.mock_config_entry,
+    )
+    legacy_entry = entity_registry.async_get_or_create(
+        domain=Platform.SWITCH,
+        platform=DOMAIN,
+        unique_id=legacy_unique_id,
+        config_entry=knx.mock_config_entry,
+    )
+    await knx.setup_integration(
+        {SwitchSchema.PLATFORM: {CONF_NAME: "test", KNX_ADDRESS: "1/2/3"}},
+        add_entry_to_hass=False,
+    )
+    assert entity_registry.async_get_entity_id(Platform.SWITCH, DOMAIN, new_unique_id)
+    assert not entity_registry.async_get_entity_id(
+        Platform.SWITCH, DOMAIN, legacy_unique_id
+    )
+    assert entity_registry.async_get(legacy_entry.entity_id) is None


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

KNX YAML entity `unique_id`s are built from the string representation of xknx
group addresses (`str(GroupAddress)` / f-strings). That string depends on the
global `GroupAddress.address_format` class attribute, which xknx overwrites from
the imported ETS project's `group_address_style`.

As a result, importing an ETS project with a 2-level (or free) group address
style into a setup that previously ran with the default 3-level style makes the
same address (e.g. `1/2/3`) render differently (`1/515` / `2563`). On the next
reload every affected entity gets a **new** `unique_id`, orphaning the original
registry entries — history, area and customizations become stranded on disabled
"ghost" entities. The addresses themselves are unchanged; only their rendering
changed.

This PR derives the `unique_id` from a format-independent representation:
`GroupAddress.raw` is rendered always in the LONG `main/middle/sub` form (which
is bijective with `raw`, so uniqueness is preserved). `InternalGroupAddress` is
already format-independent, and `None`/literal parts (scene number, button
payload) render unchanged.

- New helpers `build_yaml_unique_id()` and `async_migrate_yaml_unique_id()` in
  `entity.py`; every YAML platform now builds its id through them.
- Because LONG is xknx's default, **3-level installations see no change** and the
  migration is a no-op for them.
- Installations that registered entities under a 2-level/free style get their
  YAML `unique_id`s migrated in the entity registry. On collision (the original
  stable-id entity still exists next to a legacy one — the exact situation left
  behind by the pre-fix bug) the stale legacy entry is dropped so the entity
  re-binds to the original.
- UI/config-store entities (`knx_es_<ulid>` ids) and the diagnostic sensors are
  unaffected.

The migration is annotated with the release it was added in (2026.8) so it can
be removed again once installations have had time to migrate.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176602
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
