### PR TITLE
Add restore state to vacuum template entities

### DIFF
--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -243,7 +243,7 @@ class VacuumExtraStoredData(ExtraStoredData):
                 activity=activity,
                 fan_speed=restored["fan_speed"],
             )
-        except KeyError:
+        except KeyError, ValueError:
             return None
 
 

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -235,7 +235,7 @@ class VacuumExtraStoredData(ExtraStoredData):
     def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         """Initialize a stored vacuum state from a dict."""
         try:
-            activity: VacuumActivity | None
+            activity: VacuumActivity | None = None
             if _activity := restored["activity"]:
                 activity = VacuumActivity(_activity)
 
@@ -407,7 +407,7 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity, RestoreE
     @property
     @override
     def extra_restore_state_data(self) -> VacuumExtraStoredData:
-        """Return cover specific state data to be restored."""
+        """Return vacuum specific state data to be restored."""
         return VacuumExtraStoredData(
             activity=self._attr_activity,
             fan_speed=self._attr_fan_speed,

--- a/homeassistant/components/template/vacuum.py
+++ b/homeassistant/components/template/vacuum.py
@@ -1,8 +1,9 @@
 """Support for Template vacuums."""
 
 from collections.abc import Callable
+from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any, override
+from typing import TYPE_CHECKING, Any, Self, override
 
 import voluptuous as vol
 
@@ -28,6 +29,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
+from homeassistant.helpers.restore_state import ExtraStoredData, RestoreEntity
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import TriggerUpdateCoordinator, validators as template_validators
@@ -214,12 +216,45 @@ def validate_segments(
     return parse
 
 
-class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
+@dataclass(kw_only=True)
+class VacuumExtraStoredData(ExtraStoredData):
+    """Holds extra stored data for template vacuum entities."""
+
+    activity: VacuumActivity | None
+    fan_speed: str | None
+
+    @override
+    def as_dict(self) -> dict[str, Any]:
+        """Return a dict representation of the vacuum data."""
+        return {
+            "activity": self.activity.value if self.activity else None,
+            "fan_speed": self.fan_speed,
+        }
+
+    @classmethod
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
+        """Initialize a stored vacuum state from a dict."""
+        try:
+            activity: VacuumActivity | None
+            if _activity := restored["activity"]:
+                activity = VacuumActivity(_activity)
+
+            return cls(
+                activity=activity,
+                fan_speed=restored["fan_speed"],
+            )
+        except KeyError:
+            return None
+
+
+class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity, RestoreEntity):
     """Representation of a template vacuum features."""
 
     _entity_id_format = ENTITY_ID_FORMAT
     _optimistic_entity = True
     _state_option = CONF_STATE
+    _restore_state_extra_data = VacuumExtraStoredData
+    _restore_state_properties = ("_attr_activity",)
 
     # The super init is not called because TemplateEntity
     # and TriggerEntity will call
@@ -368,6 +403,21 @@ class AbstractTemplateVacuum(AbstractTemplateEntity, StateVacuumEntity):
             await self.async_run_script(
                 script, run_variables={"fan_speed": fan_speed}, context=self._context
             )
+
+    @property
+    @override
+    def extra_restore_state_data(self) -> VacuumExtraStoredData:
+        """Return cover specific state data to be restored."""
+        return VacuumExtraStoredData(
+            activity=self._attr_activity,
+            fan_speed=self._attr_fan_speed,
+        )
+
+    @override
+    def restore_extra_data(self, extra_data: VacuumExtraStoredData) -> None:
+        """Restore the extra data."""
+        self._attr_activity = extra_data.activity
+        self._attr_fan_speed = extra_data.fan_speed
 
 
 class TemplateStateVacuumEntity(TemplateEntity, AbstractTemplateVacuum):

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -1363,7 +1363,7 @@ async def test_restore_state(
     initial_state: str,
     initial_attributes: ConfigType,
 ) -> None:
-    """Test restoring trigger template weather."""
+    """Test restoring trigger template vacuum."""
 
     setup_mock_template_entity_restore_state(
         hass,

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -25,12 +25,14 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er, issue_registry as ir
 from homeassistant.helpers.entity_component import async_update_entity
+from homeassistant.helpers.restore_state import STORAGE_KEY as RESTORE_STATE_KEY
 from homeassistant.helpers.typing import ConfigType
 
 from .conftest import (
     ConfigurationStyle,
     TemplatePlatformSetup,
     assert_action,
+    assert_state_and_attributes,
     async_get_flow_preview_state,
     async_trigger,
     make_test_action,
@@ -38,9 +40,11 @@ from .conftest import (
     setup_and_test_nested_unique_id,
     setup_and_test_unique_id,
     setup_entity,
+    setup_mock_template_entity_restore_state,
+    setup_restore_template_entity,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_mock_restore_state_shutdown_restart
 from tests.components.vacuum import common
 from tests.typing import WebSocketGenerator
 
@@ -1283,3 +1287,177 @@ async def test_flow_preview(
     )
 
     assert state["state"] == VacuumActivity.CLEANING
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+@pytest.mark.parametrize(
+    (
+        "saved_state",
+        "saved_extra_data",
+        "initial_state",
+        "initial_attributes",
+    ),
+    [
+        (
+            "some_value",
+            {
+                "activity": VacuumActivity.DOCKED,
+                "fan_speed": "high",
+            },
+            VacuumActivity.DOCKED,
+            {
+                "fan_speed": "high",
+            },
+        ),
+        (
+            "some_value",
+            {
+                "activity": VacuumActivity.DOCKED,
+            },
+            STATE_UNKNOWN,
+            {
+                "fan_speed": None,
+            },
+        ),
+        (
+            "some_value",
+            {
+                "fan_speed": "high",
+            },
+            STATE_UNKNOWN,
+            {
+                "fan_speed": None,
+            },
+        ),
+        (
+            STATE_UNAVAILABLE,
+            {
+                "activity": VacuumActivity.DOCKED,
+                "fan_speed": "high",
+            },
+            STATE_UNKNOWN,
+            {
+                "fan_speed": None,
+            },
+        ),
+        (
+            STATE_UNKNOWN,
+            {
+                "activity": VacuumActivity.DOCKED,
+                "fan_speed": "high",
+            },
+            STATE_UNKNOWN,
+            {
+                "fan_speed": None,
+            },
+        ),
+    ],
+)
+async def test_restore_state(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    saved_state: str,
+    saved_extra_data: dict | None,
+    initial_state: str,
+    initial_attributes: ConfigType,
+) -> None:
+    """Test restoring trigger template weather."""
+
+    setup_mock_template_entity_restore_state(
+        hass,
+        TEST_VACUUM,
+        saved_state,
+        saved_extra_data=saved_extra_data,
+    )
+
+    await setup_restore_template_entity(
+        hass,
+        TEST_VACUUM,
+        style,
+        {
+            "state": "{{ state_attr('sensor.test_state', 'activity') }}",
+            "start": [],
+            "fan_speed": "{{ state_attr('sensor.test_state', 'fan_speed') }}",
+            "fan_speeds": ["low", "high"],
+            "set_fan_speed": [],
+        },
+        "state_attr('sensor.test_state', 'activity') == 'cleaning'",
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_VACUUM,
+        initial_state,
+        initial_attributes,
+    )
+
+    await async_trigger(
+        hass,
+        "sensor.test_state",
+        "anything",
+        {"activity": VacuumActivity.CLEANING, "fan_speed": "low"},
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_VACUUM,
+        VacuumActivity.CLEANING,
+        {
+            "fan_speed": "low",
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "style", [ConfigurationStyle.MODERN, ConfigurationStyle.TRIGGER]
+)
+async def test_saving_state(
+    hass: HomeAssistant,
+    style: ConfigurationStyle,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test restore saved state."""
+
+    await setup_entity(
+        hass,
+        TEST_VACUUM,
+        style,
+        1,
+        config={
+            "state": "{{ state_attr('sensor.test_state', 'activity') }}",
+            "start": [],
+            "fan_speed": "{{ state_attr('sensor.test_state', 'fan_speed') }}",
+            "fan_speeds": ["low", "high"],
+            "set_fan_speed": [],
+        },
+    )
+
+    await async_trigger(
+        hass,
+        TEST_STATE_ENTITY_ID,
+        "anything",
+        {"activity": VacuumActivity.DOCKED, "fan_speed": "high"},
+    )
+
+    assert_state_and_attributes(
+        hass,
+        TEST_VACUUM,
+        VacuumActivity.DOCKED,
+        {
+            "fan_speed": "high",
+        },
+    )
+
+    await async_mock_restore_state_shutdown_restart(hass)
+
+    assert len(hass_storage[RESTORE_STATE_KEY]["data"]) == 1
+    state = hass_storage[RESTORE_STATE_KEY]["data"][0]["state"]
+    assert state["entity_id"] == TEST_VACUUM.entity_id
+
+    extra_data = hass_storage[RESTORE_STATE_KEY]["data"][0]["extra_data"]
+    assert extra_data == {
+        "activity": "docked",
+        "fan_speed": "high",
+    }

--- a/tests/components/template/test_vacuum.py
+++ b/tests/components/template/test_vacuum.py
@@ -1314,6 +1314,16 @@ async def test_flow_preview(
         (
             "some_value",
             {
+                "activity": "do",
+            },
+            STATE_UNKNOWN,
+            {
+                "fan_speed": None,
+            },
+        ),
+        (
+            "some_value",
+            {
                 "activity": VacuumActivity.DOCKED,
             },
             STATE_UNKNOWN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add restore state to vacume template entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
