### PR TITLE
Catch missing restore keys for template cover, device_tracker, and fan

### DIFF
--- a/homeassistant/components/template/cover.py
+++ b/homeassistant/components/template/cover.py
@@ -175,14 +175,17 @@ class CoverExtraStoredData(ExtraStoredData):
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self:
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         """Initialize a stored cover state from a dict."""
-        return cls(
-            current_cover_position=restored["current_cover_position"],
-            current_cover_tilt_position=restored["current_cover_tilt_position"],
-            is_opening=restored["is_opening"],
-            is_closing=restored["is_closing"],
-        )
+        try:
+            return cls(
+                current_cover_position=restored["current_cover_position"],
+                current_cover_tilt_position=restored["current_cover_tilt_position"],
+                is_opening=restored["is_opening"],
+                is_closing=restored["is_closing"],
+            )
+        except KeyError:
+            return None
 
 
 class AbstractTemplateCover(AbstractTemplateEntity, CoverEntity, RestoreEntity):

--- a/homeassistant/components/template/device_tracker.py
+++ b/homeassistant/components/template/device_tracker.py
@@ -191,14 +191,17 @@ class TrackerExtraStoredData(ExtraStoredData):
         return asdict(self)
 
     @classmethod
-    def from_dict(cls, restored: dict[str, Any]) -> Self:
+    def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         """Initialize a stored tracker state from a dict."""
-        return cls(
-            in_zones=restored["in_zones"],
-            latitude=restored["latitude"],
-            longitude=restored["longitude"],
-            location_accuracy=restored["location_accuracy"],
-        )
+        try:
+            return cls(
+                in_zones=restored["in_zones"],
+                latitude=restored["latitude"],
+                longitude=restored["longitude"],
+                location_accuracy=restored["location_accuracy"],
+            )
+        except KeyError:
+            return None
 
 
 class AbstractTemplateTracker(AbstractTemplateEntity, TrackerEntity, RestoreEntity):

--- a/homeassistant/components/template/fan.py
+++ b/homeassistant/components/template/fan.py
@@ -175,28 +175,16 @@ class FanExtraStoredData(ExtraStoredData):
     @classmethod
     def from_dict(cls, restored: dict[str, Any]) -> Self | None:
         """Initialize a stored fan data from a dict."""
-        is_on = restored.get("is_on")
-        percentage = restored.get("percentage")
-        preset_mode = restored.get("preset_mode")
-        oscillating = restored.get("oscillating")
-        direction = restored.get("direction")
-        if is_on is not None and not isinstance(is_on, bool):
+        try:
+            return cls(
+                is_on=restored["is_on"],
+                percentage=restored["percentage"],
+                preset_mode=restored["preset_mode"],
+                oscillating=restored["oscillating"],
+                direction=restored["direction"],
+            )
+        except KeyError:
             return None
-        if percentage is not None and not isinstance(percentage, int):
-            return None
-        if preset_mode is not None and not isinstance(preset_mode, str):
-            return None
-        if oscillating is not None and not isinstance(oscillating, bool):
-            return None
-        if direction is not None and not isinstance(direction, str):
-            return None
-        return cls(
-            is_on=is_on,
-            percentage=percentage,
-            preset_mode=preset_mode,
-            oscillating=oscillating,
-            direction=direction,
-        )
 
 
 class AbstractTemplateFan(AbstractTemplateEntity, FanEntity, RestoreEntity):

--- a/tests/components/template/test_cover.py
+++ b/tests/components/template/test_cover.py
@@ -1193,6 +1193,21 @@ async def test_flow_preview(
             CoverState.OPEN,
         ),
         (
+            # Missing Key
+            CoverState.OPEN,
+            {
+                "current_cover_position": 0,
+                "current_cover_tilt_position": 10,
+                "is_closing": False,
+            },
+            STATE_UNKNOWN,
+            {
+                "current_position": None,
+                "current_tilt_position": None,
+            },
+            CoverState.OPEN,
+        ),
+        (
             STATE_UNAVAILABLE,
             {
                 "current_cover_position": 0,

--- a/tests/components/template/test_device_tracker.py
+++ b/tests/components/template/test_device_tracker.py
@@ -685,6 +685,21 @@ async def test_flow_preview(
             },
         ),
         (
+            # Missing Key
+            STATE_HOME,
+            {
+                "in_zones": [],
+                "location_accuracy": 10.0,
+            },
+            STATE_UNKNOWN,
+            {
+                "in_zones": [],
+                "latitude": None,
+                "longitude": None,
+                "gps_accuracy": None,
+            },
+        ),
+        (
             STATE_UNAVAILABLE,
             {
                 "in_zones": [],

--- a/tests/components/template/test_fan.py
+++ b/tests/components/template/test_fan.py
@@ -1436,6 +1436,21 @@ async def test_flow_preview(
             },
         ),
         (
+            # Missing Key
+            STATE_ON,
+            {
+                "is_on": True,
+                "percentage": 0,
+            },
+            STATE_UNKNOWN,
+            {
+                "percentage": None,
+                "preset_mode": None,
+                "oscillating": None,
+                "direction": None,
+            },
+        ),
+        (
             STATE_UNAVAILABLE,
             {
                 "is_on": True,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Template cover, device_tracker, and fan did not catch missing keys in restore data.  This PR adds the ability to catch missing keys.

The PR also removes unnecessary type checking for template fan.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
