### PR TITLE
Persist iZone controller host on config entries

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -4,7 +4,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_EXCLUDE, Platform
+from homeassistant.const import CONF_EXCLUDE, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
@@ -108,6 +108,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry,
             unique_id=controller.device_uid,
             title=new_title,
+            data={CONF_HOST: controller.device_ip},
         )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -242,8 +242,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(uid)
         self._abort_if_unique_id_configured()
-        # Discovery host is for confirm-step context only; runtime discovery owns
-        # current device IP state and keeps it up to date independently of entry data.
+        # Persist through confirm into entry data as CONF_HOST.
         self._discovered_controller_ip = host
         return await self.async_step_confirm()
 
@@ -357,7 +356,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         self._abort_if_unique_id_configured()
         return self.async_create_entry(
             title=self._entry_title(controller.device_uid),
-            data={},
+            data={CONF_HOST: controller.device_ip},
         )
 
     @callback

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -61,7 +61,7 @@ async def test_user_discovery_success(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000001"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.55"}
     assert result["result"].unique_id == "000000001"
 
 
@@ -82,7 +82,7 @@ async def test_user_discovery_default_selects_first_and_queues_other(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000001"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.1"}
     assert result["result"].unique_id == "000000001"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -120,7 +120,7 @@ async def test_broadcast_skips_already_configured_controller(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000002"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.2"}
     assert result["result"].unique_id == "000000002"
 
 
@@ -143,7 +143,7 @@ async def test_user_discovery_skips_yaml_excluded_controllers(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000002"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.2"}
     assert result["result"].unique_id == "000000002"
 
 
@@ -172,7 +172,7 @@ async def test_broadcast_multiple_unconfigured_shows_choice(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000001"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.2"}
     assert result["result"].unique_id == "000000001"
 
     entries = hass.config_entries.async_entries(DOMAIN)
@@ -251,6 +251,7 @@ async def test_select_controller_creates_selected_uid_and_queues_others(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000002"
+    assert result["data"] == {CONF_HOST: "192.0.2.1"}
     assert result["result"].unique_id == "000000002"
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
 
@@ -331,7 +332,7 @@ async def test_reuses_existing_discovery_service(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000002"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.2"}
     assert result["result"].unique_id == "000000002"
     mock_pizone_discovery.assert_not_called()
 
@@ -427,7 +428,7 @@ async def test_homekit_confirm_uses_discovered_host(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000001"
-    assert result["data"] == {}
+    assert result["data"] == {CONF_HOST: "192.0.2.3"}
     assert result["result"].unique_id == "000000001"
 
 
@@ -882,6 +883,7 @@ async def test_integration_discovery_confirm_creates_entry(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "iZone 000000002"
+    assert result["data"] == {CONF_HOST: "192.0.2.2"}
     assert result["result"].unique_id == "000000002"
 
 
@@ -1230,12 +1232,12 @@ def test_async_fan_out_skips_uids_already_in_progress() -> None:
 async def test_async_migrate_entry_clears_legacy_data(
     hass: HomeAssistant,
 ) -> None:
-    """v1→v2 migration clears legacy entry data; UID and title binding is deferred.
+    """v1→v2 migration clears legacy entry data; UID/host binding is deferred to setup.
 
     ConfigEntryNotReady retry semantics only work inside async_setup_entry — raising
     from async_migrate_entry permanently lands the entry in MIGRATION_ERROR with no
     retry path.  All network-dependent work is therefore intentionally deferred to
-    async_setup_entry.
+    async_setup_entry, which also persists CONF_HOST when the UID is resolved.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -1258,7 +1260,7 @@ async def test_async_migrate_entry_clears_legacy_data(
         await hass.async_block_till_done()
 
     assert entry.version == 2
-    assert entry.data == {}
+    assert entry.data == {CONF_HOST: "192.0.2.1"}
     assert entry.unique_id == "000000001"
     assert entry.title == "iZone 000000001"
 
@@ -1377,6 +1379,7 @@ async def test_setup_entry_resolves_legacy_uid_and_updates_title(
 
     assert entry.unique_id == "000000001"
     assert entry.title == expected_title
+    assert entry.data == {CONF_HOST: "192.0.2.2"}
 
 
 @pytest.mark.parametrize(
@@ -1502,7 +1505,7 @@ async def test_setup_entry_picks_eligible_controller_after_filtering_for_legacy_
         await hass.async_block_till_done()
 
     assert entry.unique_id == "000000002"
-    assert entry.data == {}
+    assert entry.data == {CONF_HOST: "192.0.2.2"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Please try to merge this before the 2026.8 cut.** New and re-bound entries will then store `CONF_HOST` in that release. If this lands later, far more installs will still have hostless `data={}` entries when coordinator-based setup needs a stored host, and the practical workaround for those is remove-and-re-add or more in-code work around pathways.

Persist the discovered controller IP as `CONF_HOST` on iZone config entries.

Until now, create paths discarded the known host and stored `data={}`. Discovery already had the IP for the confirm UI; this PR writes it into entry data on create, and also when a legacy `unique_id == "izone"` entry is bound to a real controller UID at setup time.

Runtime behaviour is unchanged (still uses discovery / `fetch_controller`). This prepares entries for a later coordinator-based setup that will use the stored host. Existing entries that already have `data={}` are left as-is; those can be removed and re-added if a future change requires `CONF_HOST`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] I have followed the [perfect PR recommendations](https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/) has all fields filled out correctly. Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`. Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests](https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure) in this repository.