### PR TITLE
Remove inert radius option from AirNow

### DIFF
--- a/homeassistant/components/airnow/__init__.py
+++ b/homeassistant/components/airnow/__init__.py
@@ -65,21 +65,16 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate old entry."""
     _LOGGER.debug("Migrating from version %s", entry.version)
 
-    if entry.version == 1:
-        # Version 1 stored the radius in data; version 2 moved it to options.
-        new_options = {CONF_RADIUS: entry.data[CONF_RADIUS]}
-        new_data = {k: v for k, v in entry.data.items() if k != CONF_RADIUS}
-
-        hass.config_entries.async_update_entry(
-            entry, data=new_data, options=new_options, version=2
-        )
-
-    if entry.version == 2:
+    if entry.version < 3:
         # The 2026 AirNow API dropped the distance parameter, so the radius
-        # option no longer affects lookups. Remove it.
+        # option no longer affects lookups. Strip it from both older layouts:
+        # version 1 kept it in data, version 2 in options.
+        new_data = {k: v for k, v in entry.data.items() if k != CONF_RADIUS}
         new_options = {k: v for k, v in entry.options.items() if k != CONF_RADIUS}
 
-        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
+        hass.config_entries.async_update_entry(
+            entry, data=new_data, options=new_options, version=3
+        )
 
     _LOGGER.info("Migration to version %s successful", entry.version)
 

--- a/homeassistant/components/airnow/__init__.py
+++ b/homeassistant/components/airnow/__init__.py
@@ -27,16 +27,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirNowConfigEntry) -> bo
     latitude = entry.data[CONF_LATITUDE]
     longitude = entry.data[CONF_LONGITUDE]
 
-    # Station Radius is a user-configurable option
-    distance = entry.options[CONF_RADIUS]
-
     # Reports are published hourly but update twice per hour
     update_interval = datetime.timedelta(minutes=30)
 
     # Setup the Coordinator
     session = async_get_clientsession(hass)
     coordinator = AirNowDataUpdateCoordinator(
-        hass, entry, session, api_key, latitude, longitude, distance, update_interval
+        hass, entry, session, api_key, latitude, longitude, update_interval
     )
 
     # Sync with Coordinator
@@ -69,13 +66,20 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     _LOGGER.debug("Migrating from version %s", entry.version)
 
     if entry.version == 1:
+        # Version 1 stored the radius in data; version 2 moved it to options.
         new_options = {CONF_RADIUS: entry.data[CONF_RADIUS]}
-        new_data = entry.data.copy()
-        del new_data[CONF_RADIUS]
+        new_data = {k: v for k, v in entry.data.items() if k != CONF_RADIUS}
 
         hass.config_entries.async_update_entry(
             entry, data=new_data, options=new_options, version=2
         )
+
+    if entry.version == 2:
+        # The 2026 AirNow API dropped the distance parameter, so the radius
+        # option no longer affects lookups. Remove it.
+        new_options = {k: v for k, v in entry.options.items() if k != CONF_RADIUS}
+
+        hass.config_entries.async_update_entry(entry, options=new_options, version=3)
 
     _LOGGER.info("Migration to version %s successful", entry.version)
 

--- a/homeassistant/components/airnow/config_flow.py
+++ b/homeassistant/components/airnow/config_flow.py
@@ -7,14 +7,9 @@ from pyairnow import WebServiceAPI
 from pyairnow.errors import AirNowError, EmptyResponseError, InvalidKeyError
 import voluptuous as vol
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigFlow,
-    ConfigFlowResult,
-    OptionsFlowWithReload,
-)
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -60,7 +55,7 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> bool:
 class AirNowConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for AirNow."""
 
-    VERSION = 2
+    VERSION = 3
 
     @override
     async def async_step_user(
@@ -90,14 +85,12 @@ class AirNowConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors["base"] = "unknown"
             else:
                 # Create Entry
-                radius = user_input.pop(CONF_RADIUS)
                 return self.async_create_entry(
                     title=(
                         f"AirNow Sensor at {user_input[CONF_LATITUDE]},"
                         f" {user_input[CONF_LONGITUDE]}"
                     ),
                     data=user_input,
-                    options={CONF_RADIUS: radius},
                 )
 
         return self.async_show_form(
@@ -111,44 +104,10 @@ class AirNowConfigFlow(ConfigFlow, domain=DOMAIN):
                     vol.Optional(
                         CONF_LONGITUDE, default=self.hass.config.longitude
                     ): cv.longitude,
-                    vol.Optional(CONF_RADIUS, default=150): vol.All(
-                        int, vol.Range(min=5)
-                    ),
                 }
             ),
             description_placeholders={"api_key_url": _API_KEY_URL},
             errors=errors,
-        )
-
-    @staticmethod
-    @callback
-    @override
-    def async_get_options_flow(
-        config_entry: ConfigEntry,
-    ) -> AirNowOptionsFlowHandler:
-        """Return the options flow."""
-        return AirNowOptionsFlowHandler()
-
-
-class AirNowOptionsFlowHandler(OptionsFlowWithReload):
-    """Handle an options flow for AirNow."""
-
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
-        """Manage the options."""
-        if user_input is not None:
-            return self.async_create_entry(data=user_input)
-
-        options_schema = vol.Schema(
-            {vol.Optional(CONF_RADIUS): vol.All(int, vol.Range(min=5))}
-        )
-
-        return self.async_show_form(
-            step_id="init",
-            data_schema=self.add_suggested_values_to_schema(
-                options_schema, self.config_entry.options
-            ),
         )
 
 

--- a/homeassistant/components/airnow/coordinator.py
+++ b/homeassistant/components/airnow/coordinator.py
@@ -51,13 +51,11 @@ class AirNowDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         api_key: str,
         latitude: float,
         longitude: float,
-        distance: int,
         update_interval: timedelta,
     ) -> None:
         """Initialize."""
         self.latitude = latitude
         self.longitude = longitude
-        self.distance = distance
 
         self.airnow = WebServiceAPI(api_key, session=session)
 

--- a/homeassistant/components/airnow/strings.json
+++ b/homeassistant/components/airnow/strings.json
@@ -6,7 +6,7 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_location": "No results found for that location, try changing the location or station radius.",
+      "invalid_location": "No results found for that location, try changing the location.",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
@@ -14,14 +14,12 @@
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
           "latitude": "[%key:common::config_flow::data::latitude%]",
-          "longitude": "[%key:common::config_flow::data::longitude%]",
-          "radius": "Station radius (miles; optional)"
+          "longitude": "[%key:common::config_flow::data::longitude%]"
         },
         "data_description": {
           "api_key": "To generate an API key, go to {api_key_url}.",
           "latitude": "The latitude of your location.",
-          "longitude": "The longitude of your location.",
-          "radius": "The radius in miles around your location to search for reporting stations."
+          "longitude": "The longitude of your location."
         },
         "description": "To generate an API key, go to {api_key_url}."
       }
@@ -37,18 +35,6 @@
         "state_attributes": {
           "lat": { "name": "[%key:common::config_flow::data::latitude%]" },
           "long": { "name": "[%key:common::config_flow::data::longitude%]" }
-        }
-      }
-    }
-  },
-  "options": {
-    "step": {
-      "init": {
-        "data": {
-          "radius": "Station radius (miles)"
-        },
-        "data_description": {
-          "radius": "The radius in miles around your location to search for reporting stations."
         }
       }
     }

--- a/tests/components/airnow/conftest.py
+++ b/tests/components/airnow/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.airnow.const import DOMAIN
-from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import HomeAssistant
 from homeassistant.util.json import JsonArrayType
 
@@ -21,7 +21,7 @@ def config_entry_fixture(
     """Define a config entry fixture."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        version=2,
+        version=3,
         entry_id="3bd2acb0e4f0476d40865546d0d91921",
         unique_id=f"{config[CONF_LATITUDE]}-{config[CONF_LONGITUDE]}",
         data=config,
@@ -44,9 +44,7 @@ def config_fixture() -> dict[str, Any]:
 @pytest.fixture(name="options")
 def options_fixture() -> dict[str, Any]:
     """Define a config options data fixture."""
-    return {
-        CONF_RADIUS: 150,
-    }
+    return {}
 
 
 @pytest.fixture(name="data", scope="package")

--- a/tests/components/airnow/snapshots/test_diagnostics.ambr
+++ b/tests/components/airnow/snapshots/test_diagnostics.ambr
@@ -30,7 +30,6 @@
       'entry_id': '3bd2acb0e4f0476d40865546d0d91921',
       'minor_version': 1,
       'options': dict({
-        'radius': 150,
       }),
       'pref_disable_new_entities': False,
       'pref_disable_polling': False,
@@ -39,7 +38,7 @@
       ]),
       'title': '**REDACTED**',
       'unique_id': '**REDACTED**',
-      'version': 2,
+      'version': 3,
     }),
   })
 # ---

--- a/tests/components/airnow/test_config_flow.py
+++ b/tests/components/airnow/test_config_flow.py
@@ -1,7 +1,7 @@
 """Test the AirNow config flow."""
 
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from pyairnow.errors import AirNowError, EmptyResponseError, InvalidKeyError
 import pytest
@@ -111,20 +111,46 @@ async def test_entry_already_exists(
 
 
 @pytest.mark.usefixtures("setup_airnow")
-async def test_config_migration_v2(hass: HomeAssistant) -> None:
-    """Test that the config migration from Version 1 to Version 2 works."""
+@pytest.mark.parametrize(
+    ("version", "entry_data", "entry_options"),
+    [
+        pytest.param(
+            1,
+            {
+                CONF_API_KEY: "1234",
+                CONF_LATITUDE: 33.6,
+                CONF_LONGITUDE: -118.1,
+                CONF_RADIUS: 25,
+            },
+            {},
+            id="v1_radius_in_data",
+        ),
+        pytest.param(
+            2,
+            {
+                CONF_API_KEY: "1234",
+                CONF_LATITUDE: 33.6,
+                CONF_LONGITUDE: -118.1,
+            },
+            {CONF_RADIUS: 10},
+            id="v2_radius_in_options",
+        ),
+    ],
+)
+async def test_config_migration(
+    hass: HomeAssistant,
+    version: int,
+    entry_data: dict[str, Any],
+    entry_options: dict[str, Any],
+) -> None:
+    """Test that migration to Version 3 removes the radius option."""
     config_entry = MockConfigEntry(
-        version=1,
+        version=version,
         domain=DOMAIN,
         title="AirNow",
-        data={
-            CONF_API_KEY: "1234",
-            CONF_LATITUDE: 33.6,
-            CONF_LONGITUDE: -118.1,
-            CONF_RADIUS: 25,
-        },
+        data=entry_data,
         source=config_entries.SOURCE_USER,
-        options={CONF_RADIUS: 10},
+        options=entry_options,
         unique_id="1234",
     )
     config_entry.add_to_hass(hass)
@@ -132,49 +158,6 @@ async def test_config_migration_v2(hass: HomeAssistant) -> None:
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert config_entry.version == 2
-    assert not config_entry.data.get(CONF_RADIUS)
-    assert config_entry.options.get(CONF_RADIUS) == 25
-
-
-@pytest.mark.usefixtures("setup_airnow")
-async def test_options_flow(hass: HomeAssistant) -> None:
-    """Test that the options flow works."""
-    config_entry = MockConfigEntry(
-        version=2,
-        domain=DOMAIN,
-        title="AirNow",
-        data={
-            CONF_API_KEY: "1234",
-            CONF_LATITUDE: 33.6,
-            CONF_LONGITUDE: -118.1,
-        },
-        source=config_entries.SOURCE_USER,
-        options={CONF_RADIUS: 10},
-        unique_id="1234",
-    )
-    config_entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    result = await hass.config_entries.options.async_init(config_entry.entry_id)
-
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "init"
-
-    with patch(
-        "homeassistant.components.airnow.async_setup_entry",
-        return_value=True,
-    ) as mock_setup_entry:
-        result = await hass.config_entries.options.async_configure(
-            result["flow_id"],
-            user_input={CONF_RADIUS: 25},
-        )
-        await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert config_entry.options == {
-        CONF_RADIUS: 25,
-    }
-    assert len(mock_setup_entry.mock_calls) == 1
+    assert config_entry.version == 3
+    assert CONF_RADIUS not in config_entry.data
+    assert CONF_RADIUS not in config_entry.options


### PR DESCRIPTION
## Breaking change

The station radius option is removed from the AirNow integration. The 2026 AirNow API dropped the distance parameter, so the radius no longer affects which reporting station is used. Existing entries are migrated automatically and no action is needed. Any previously configured radius value is discarded.

## Proposed change

Follow-up to #176622 (the pyairnow 1.4.0 bump), as discussed with @zweckj on that PR.

The 2026 AirNow endpoint has no distance parameter. pyairnow 1.4.0 emits a `DeprecationWarning` and ignores the value, and checked against the live API a radius of 5 and a radius of 150 return identical results with the lookup boundary fixed at 50 miles. The option was inert either way, but it was still shown in the config and options flows, and the `invalid_location` error told users to change the station radius, which does nothing.

This removes it:

- Drop `CONF_RADIUS` from the config flow schema.
- Remove the options flow, which only managed the radius.
- Migrate config entries to version 3, stripping the radius from data and options. The migration chains from version 1 (radius in data) and version 2 (radius in options).
- Reword the `invalid_location` error so it no longer recommends changing the radius.
- Drop the now-unused distance argument from the coordinator.

The migration is covered by a parametrized test for both the version 1 and version 2 starting points.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: related to #176622
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46909
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

