### PR TITLE
Fix for ProxmoxVE compoenent failing authentication with realms containg upper case letters.

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -69,9 +69,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) ->
             if "@" in data.get(CONF_USERNAME, ""):
                 username, realm = data[CONF_USERNAME].split("@", 1)
                 data[CONF_USERNAME] = username
-                data[CONF_REALM] = realm.lower()
+                data[CONF_REALM] = realm
 
-        realm = data[CONF_REALM].lower()
+        realm = data[CONF_REALM]
 
         # If the realm is one of the base providers,
         # set the provider to match the realm.

--- a/homeassistant/components/proxmoxve/common.py
+++ b/homeassistant/components/proxmoxve/common.py
@@ -16,7 +16,7 @@ def sanitize_config_entry(input_data: Mapping[str, Any]) -> dict[str, Any]:
 
     realm = provider.lower()
     if provider == AUTH_OTHER:
-        realm = data[CONF_REALM].lower()
+        realm = data[CONF_REALM]
 
     data[CONF_REALM] = realm
     data[CONF_USERNAME] = f"{username}@{realm}"

--- a/tests/components/proxmoxve/conftest.py
+++ b/tests/components/proxmoxve/conftest.py
@@ -65,8 +65,8 @@ MOCK_TEST_TOKEN_CONFIG = {
 MOCK_TEST_OTHER_CONFIG = {
     **MOCK_TEST_CONFIG,
     CONF_AUTH_METHOD: "other",
-    CONF_REALM: "test_realm",
-    CONF_USERNAME: "test_user@test_realm",
+    CONF_REALM: "Test_Realm",
+    CONF_USERNAME: "test_user@Test_Realm",
 }
 
 MOCK_TEST_TOKEN_OTHER_CONFIG = {
@@ -75,8 +75,8 @@ MOCK_TEST_TOKEN_OTHER_CONFIG = {
     CONF_TOKEN_ID: "test_token_id",
     CONF_TOKEN_SECRET: "test_token_secret",
     CONF_AUTH_METHOD: "other",
-    CONF_REALM: "test_realm",
-    CONF_USERNAME: "test_user@test_realm",
+    CONF_REALM: "Test_Realm",
+    CONF_USERNAME: "test_user@Test_Realm",
 }
 
 

--- a/tests/components/proxmoxve/test_config_flow.py
+++ b/tests/components/proxmoxve/test_config_flow.py
@@ -76,7 +76,7 @@ MOCK_USER_STEP_OTHER = {
 
 MOCK_USER_AUTH_STEP_OTHER = {
     **MOCK_USER_AUTH_STEP_PASSWORD,
-    CONF_REALM: "test_realm",
+    CONF_REALM: "Test_Realm",
 }
 
 # Other authentication method with realm and token
@@ -87,7 +87,7 @@ MOCK_USER_STEP_OTHER_TOKEN = {
 
 MOCK_USER_AUTH_STEP_OTHER_TOKEN = {
     **MOCK_USER_AUTH_STEP_TOKEN,
-    CONF_REALM: "test_realm",
+    CONF_REALM: "Test_Realm",
 }
 
 MOCK_USER_SETUP = {CONF_NODES: ["pve1"]}
@@ -649,7 +649,7 @@ async def test_full_flow_reauth_token_other(
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
         user_input={
-            CONF_REALM: "test_realm",
+            CONF_REALM: "Test_Realm",
             CONF_TOKEN_ID: "test_token_id",
             CONF_TOKEN_SECRET: "new_token_secret",
         },

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -9,6 +9,7 @@ import requests
 from requests.exceptions import ConnectTimeout, SSLError
 
 from homeassistant.components.proxmoxve.const import (
+    AUTH_OTHER,
     AUTH_PAM,
     CONF_AUTH_METHOD,
     CONF_REALM,
@@ -121,25 +122,56 @@ async def test_setup_exceptions(
     assert mock_config_entry.state is expected_state
 
 
+@pytest.mark.parametrize(
+    ("mock_config_entry", "expected_auth_method", "expected_realm"),
+    [
+        (
+            MockConfigEntry(
+                domain=DOMAIN,
+                version=1,
+                unique_id="1",
+                data={
+                    CONF_HOST: "http://test_host",
+                    CONF_PORT: 8006,
+                    CONF_REALM: "pam",
+                    CONF_USERNAME: "test_user@pam",
+                    CONF_PASSWORD: "test_password",
+                    CONF_VERIFY_SSL: True,
+                },
+            ),
+            AUTH_PAM,
+            "pam",
+        ),
+        (
+            MockConfigEntry(
+                domain=DOMAIN,
+                version=1,
+                unique_id="1",
+                data={
+                    CONF_HOST: "http://test_host",
+                    CONF_PORT: 8006,
+                    CONF_REALM: "Test_Realm",
+                    CONF_USERNAME: "test_user@Test_Realm",
+                    CONF_PASSWORD: "test_password",
+                    CONF_VERIFY_SSL: True,
+                },
+            ),
+            AUTH_OTHER,
+            "Test_Realm",
+        ),
+    ],
+)
 async def test_migration_v1_to_v3(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    expected_auth_method: str,
+    expected_realm: str,
 ) -> None:
-    """Test migration from version 1."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=1,
-        unique_id="1",
-        data={
-            CONF_HOST: "http://test_host",
-            CONF_PORT: 8006,
-            CONF_REALM: "pam",
-            CONF_USERNAME: "test_user@pam",
-            CONF_PASSWORD: "test_password",
-            CONF_VERIFY_SSL: True,
-        },
-    )
+    """Test migration from version 1 to 3."""
+    entry = mock_config_entry
+
     entry.add_to_hass(hass)
     assert entry.version == 1
 
@@ -183,12 +215,105 @@ async def test_migration_v1_to_v3(
     await hass.async_block_till_done()
 
     assert entry.version == 3
+    assert entry.data[CONF_AUTH_METHOD] == expected_auth_method
+    assert entry.data[CONF_REALM] == expected_realm
 
     vm_entity_after = entity_registry.async_get(vm_entity.entity_id)
     container_entity_after = entity_registry.async_get(container_entity.entity_id)
 
     assert vm_entity_after.unique_id == f"{entry.entry_id}_100_status"
     assert container_entity_after.unique_id == f"{entry.entry_id}_200_status"
+
+
+@pytest.mark.parametrize(
+    ("mock_config_entry", "expected_auth_method", "expected_realm"),
+    [
+        (
+            MockConfigEntry(
+                domain=DOMAIN,
+                version=2,
+                unique_id="1",
+                data={
+                    CONF_HOST: "http://test_host",
+                    CONF_PORT: 8006,
+                    CONF_REALM: "pam",
+                    CONF_USERNAME: "test_user@pam",
+                    CONF_PASSWORD: "test_password",
+                    CONF_VERIFY_SSL: True,
+                },
+            ),
+            AUTH_PAM,
+            "pam",
+        ),
+        (
+            MockConfigEntry(
+                domain=DOMAIN,
+                version=2,
+                unique_id="1",
+                data={
+                    CONF_HOST: "http://test_host",
+                    CONF_PORT: 8006,
+                    CONF_REALM: "Test_Realm",
+                    CONF_USERNAME: "test_user@Test_Realm",
+                    CONF_PASSWORD: "test_password",
+                    CONF_VERIFY_SSL: True,
+                },
+            ),
+            AUTH_OTHER,
+            "Test_Realm",
+        ),
+        (
+            MockConfigEntry(
+                domain=DOMAIN,
+                version=2,
+                unique_id="1",
+                data={
+                    CONF_HOST: "http://test_host",
+                    CONF_PORT: 8006,
+                    CONF_USERNAME: "test_user@pam",
+                    CONF_PASSWORD: "test_password",
+                    CONF_VERIFY_SSL: True,
+                },
+            ),
+            AUTH_PAM,
+            "pam",
+        ),
+        (
+            MockConfigEntry(
+                domain=DOMAIN,
+                version=2,
+                unique_id="1",
+                data={
+                    CONF_HOST: "http://test_host",
+                    CONF_PORT: 8006,
+                    CONF_USERNAME: "test_user@Test_Realm",
+                    CONF_PASSWORD: "test_password",
+                    CONF_VERIFY_SSL: True,
+                },
+            ),
+            AUTH_OTHER,
+            "Test_Realm",
+        ),
+    ],
+)
+async def test_migration_v2_to_v3(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    expected_auth_method: str,
+    expected_realm: str,
+) -> None:
+    """Test migration from version 2 to 3."""
+    entry = mock_config_entry
+
+    entry.add_to_hass(hass)
+    assert entry.version == 2
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.version == 3
+    assert entry.data[CONF_AUTH_METHOD] == expected_auth_method
+    assert entry.data[CONF_REALM] == expected_realm
 
 
 async def test_offline_node(
@@ -207,61 +332,6 @@ async def test_offline_node(
 
     state = hass.states.get("binary_sensor.pve3_status")
     assert state.state == STATE_OFF
-
-
-async def test_migration_v2_to_v3(
-    hass: HomeAssistant,
-) -> None:
-    """Test migration from version 2 to 3."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=2,
-        unique_id="1",
-        data={
-            CONF_HOST: "http://test_host",
-            CONF_PORT: 8006,
-            CONF_REALM: "pam",
-            CONF_USERNAME: "test_user@pam",
-            CONF_PASSWORD: "test_password",
-            CONF_VERIFY_SSL: True,
-        },
-    )
-    entry.add_to_hass(hass)
-    assert entry.version == 2
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entry.version == 3
-    assert entry.data[CONF_AUTH_METHOD] == AUTH_PAM
-    assert entry.data[CONF_REALM] == AUTH_PAM
-
-
-async def test_migration_v2_to_v3_without_realm(
-    hass: HomeAssistant,
-) -> None:
-    """Test migration from version 2 to 3."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        version=2,
-        unique_id="1",
-        data={
-            CONF_HOST: "http://test_host",
-            CONF_PORT: 8006,
-            CONF_USERNAME: "test_user@pam",
-            CONF_PASSWORD: "test_password",
-            CONF_VERIFY_SSL: True,
-        },
-    )
-    entry.add_to_hass(hass)
-    assert entry.version == 2
-
-    await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entry.version == 3
-    assert entry.data[CONF_AUTH_METHOD] == AUTH_PAM
-    assert entry.data[CONF_REALM] == AUTH_PAM
 
 
 async def test_new_vm_creates_entity(


### PR DESCRIPTION
Fix for ProxmoxVE authentication. Realm is case sensitive, remove calling lower() on the realm value as doing so cause authentication to fail for any realm with upper case letters.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Removes lower() calls on realm values to preserve case of user input and config since realm is case sensitive.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176739
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
