### PR TITLE
Bump pydrawise to 2026.7.0

### DIFF
--- a/homeassistant/components/hydrawise/manifest.json
+++ b/homeassistant/components/hydrawise/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["pydrawise"],
-  "requirements": ["pydrawise==2026.4.0"]
+  "requirements": ["pydrawise==2026.7.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2137,7 +2137,7 @@ pydiscovergy==3.0.2
 pydoods==1.0.2
 
 # homeassistant.components.hydrawise
-pydrawise==2026.4.0
+pydrawise==2026.7.0
 
 # homeassistant.components.android_ip_webcam
 pydroid-ipcam==3.0.0


### PR DESCRIPTION
## Proposed change

Bump `pydrawise` from `2026.4.0` to `2026.7.0` for the Hydrawise integration.

This release includes two fixes for the same underlying bug class: the "Automatic Watering" switch entity repeatedly toggling ON/OFF with no corresponding change in Hydrawise, caused by `pydrawise`'s REST fallback path (used when its GraphQL API is rate-limited) misreporting a zone's suspension state.

- dknowles2/pydrawise#506: a zone suspended via the GraphQL API with a specific end date is no longer incorrectly reported as unsuspended when a REST-fallback poll shows a normal upcoming next run (the REST API has no way to represent a dated suspension).
- dknowles2/pydrawise#517: a zone that's active is no longer falsely reported as suspended when a REST-fallback poll returns an ambiguous "not scheduled to run" signal that the REST API also sends when e.g. a physical rain sensor is holding the zone off (previously this signal was always treated as an authoritative suspension).

Release notes: https://github.com/dknowles2/pydrawise/releases/tag/2026.7.0

## Type of change

- [x] Dependency upgrade

## Additional information

- This PR fixes or closes issue: fixes #176404
- Link to changelog/release notes: https://github.com/dknowles2/pydrawise/releases/tag/2026.7.0
- Comparison diff: https://github.com/dknowles2/pydrawise/compare/2026.4.0...2026.7.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
