### PR TITLE
Add stale device handlng to Gatus (2/4)

### DIFF
--- a/homeassistant/components/gatus/coordinator.py
+++ b/homeassistant/components/gatus/coordinator.py
@@ -8,6 +8,7 @@ from gatus_api import EndpointStatus, GatusClient, GatusClientError
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -25,6 +26,17 @@ class GatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, EndpointStatus]
         """Initialize the coordinator."""
         self.url = url.rstrip("/")
         self.client = GatusClient(url=self.url, session=async_get_clientsession(hass))
+        self._entry_id = entry.entry_id
+        device_registry = dr.async_get(hass)
+        self._known_endpoint_keys = {
+            identifier[1].removeprefix(f"{entry.entry_id}_")
+            for device in dr.async_entries_for_config_entry(
+                device_registry, entry.entry_id
+            )
+            for identifier in device.identifiers
+            if identifier[0] == DOMAIN
+            and identifier[1].startswith(f"{entry.entry_id}_")
+        }
 
         super().__init__(
             hass,
@@ -44,5 +56,20 @@ class GatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, EndpointStatus]
                 translation_domain=DOMAIN,
                 translation_key="update_failed",
             ) from err
+
+        current_keys = {ep.key for ep in raw_endpoints}
+        stale_keys = self._known_endpoint_keys - current_keys
+        if stale_keys:
+            device_registry = dr.async_get(self.hass)
+            for key in stale_keys:
+                device = device_registry.async_get_device(
+                    identifiers={(DOMAIN, f"{self._entry_id}_{key}")}
+                )
+                if device is not None:
+                    device_registry.async_update_device(
+                        device.id,
+                        remove_config_entry_id=self._entry_id,
+                    )
+        self._known_endpoint_keys = current_keys
 
         return {ep.key: ep for ep in raw_endpoints}

--- a/homeassistant/components/gatus/coordinator.py
+++ b/homeassistant/components/gatus/coordinator.py
@@ -61,11 +61,15 @@ class GatusDataUpdateCoordinator(DataUpdateCoordinator[dict[str, EndpointStatus]
         stale_keys = self._known_endpoint_keys - current_keys
         if stale_keys:
             device_registry = dr.async_get(self.hass)
-            for key in stale_keys:
-                device = device_registry.async_get_device(
-                    identifiers={(DOMAIN, f"{self._entry_id}_{key}")}
-                )
-                if device is not None:
+            for device in dr.async_entries_for_config_entry(
+                device_registry, self._entry_id
+            ):
+                if any(
+                    identifier[0] == DOMAIN
+                    and identifier[1].startswith(f"{self._entry_id}_")
+                    and identifier[1].removeprefix(f"{self._entry_id}_") in stale_keys
+                    for identifier in device.identifiers
+                ):
                     device_registry.async_update_device(
                         device.id,
                         remove_config_entry_id=self._entry_id,

--- a/homeassistant/components/gatus/quality_scale.yaml
+++ b/homeassistant/components/gatus/quality_scale.yaml
@@ -80,7 +80,7 @@ rules:
   repair-issues:
     status: exempt
     comment: Integration does not require user intervention repairs.
-  stale-devices: todo
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/tests/components/gatus/test_init.py
+++ b/tests/components/gatus/test_init.py
@@ -8,6 +8,7 @@ import pytest
 from homeassistant.components.gatus.coordinator import GatusDataUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
@@ -44,3 +45,55 @@ async def test_setup_failure_retry(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("mock_gatus_client")
+async def test_remove_stale_device_runtime(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_gatus_client: AsyncMock,
+) -> None:
+    """Test that a device is removed at runtime when it is no longer returned by the Gatus API."""
+    await setup_integration(hass, mock_config_entry)
+
+    device_registry = dr.async_get(hass)
+    device = device_registry.async_get_device(
+        identifiers={("gatus", f"{mock_config_entry.entry_id}_backend_service")}
+    )
+    assert device is not None
+
+    mock_gatus_client.get_endpoints_statuses.return_value = []
+
+    coordinator = mock_config_entry.runtime_data
+    await coordinator.async_refresh()
+
+    device = device_registry.async_get_device(
+        identifiers={("gatus", f"{mock_config_entry.entry_id}_backend_service")}
+    )
+    assert device is None
+
+
+@pytest.mark.usefixtures("mock_gatus_client")
+async def test_remove_stale_device_on_startup(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that stale devices in the registry are removed on startup."""
+    mock_config_entry.add_to_hass(hass)
+
+    device_registry = dr.async_get(hass)
+    stale_device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("gatus", f"{mock_config_entry.entry_id}_stale_service")},
+        name="Stale Service",
+    )
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(stale_device.id) is None
+
+    active_device = device_registry.async_get_device(
+        identifiers={("gatus", f"{mock_config_entry.entry_id}_backend_service")}
+    )
+    assert active_device is not None

--- a/tests/components/gatus/test_init.py
+++ b/tests/components/gatus/test_init.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from freezegun.api import FrozenDateTimeFactory
 from gatus_api import GatusClientError
 import pytest
 
@@ -12,7 +13,7 @@ from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.mark.usefixtures("mock_gatus_client")
@@ -52,6 +53,7 @@ async def test_remove_stale_device_runtime(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_gatus_client: AsyncMock,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that a device is removed at runtime when it is no longer returned by the Gatus API."""
     await setup_integration(hass, mock_config_entry)
@@ -72,8 +74,9 @@ async def test_remove_stale_device_runtime(
 
     mock_gatus_client.get_endpoints_statuses.return_value = []
 
-    coordinator = mock_config_entry.runtime_data
-    await coordinator.async_refresh()
+    freezer.tick(30)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     device = next(
         (

--- a/tests/components/gatus/test_init.py
+++ b/tests/components/gatus/test_init.py
@@ -57,8 +57,16 @@ async def test_remove_stale_device_runtime(
     await setup_integration(hass, mock_config_entry)
 
     device_registry = dr.async_get(hass)
-    device = device_registry.async_get_device(
-        identifiers={("gatus", f"{mock_config_entry.entry_id}_backend_service")}
+    device = next(
+        (
+            dev
+            for dev in dr.async_entries_for_config_entry(
+                device_registry, mock_config_entry.entry_id
+            )
+            if ("gatus", f"{mock_config_entry.entry_id}_backend_service")
+            in dev.identifiers
+        ),
+        None,
     )
     assert device is not None
 
@@ -67,8 +75,16 @@ async def test_remove_stale_device_runtime(
     coordinator = mock_config_entry.runtime_data
     await coordinator.async_refresh()
 
-    device = device_registry.async_get_device(
-        identifiers={("gatus", f"{mock_config_entry.entry_id}_backend_service")}
+    device = next(
+        (
+            dev
+            for dev in dr.async_entries_for_config_entry(
+                device_registry, mock_config_entry.entry_id
+            )
+            if ("gatus", f"{mock_config_entry.entry_id}_backend_service")
+            in dev.identifiers
+        ),
+        None,
     )
     assert device is None
 
@@ -93,7 +109,15 @@ async def test_remove_stale_device_on_startup(
 
     assert device_registry.async_get(stale_device.id) is None
 
-    active_device = device_registry.async_get_device(
-        identifiers={("gatus", f"{mock_config_entry.entry_id}_backend_service")}
+    active_device = next(
+        (
+            dev
+            for dev in dr.async_entries_for_config_entry(
+                device_registry, mock_config_entry.entry_id
+            )
+            if ("gatus", f"{mock_config_entry.entry_id}_backend_service")
+            in dev.identifiers
+        ),
+        None,
     )
     assert active_device is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implement automatic removal of stale endpoint devices when they are no longer returned by the Gatus API. This handles cleanup both dynamically at runtime and during integration startup, and updates the quality scale status of the integration.

Gatus always returns the full array in the endpoint we are hitting, thus if an endpoint was previously present and now removed it is safe to assume it has been removed explicitly by the user and as such, should be removed from HA.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46911
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
