### PR TITLE
Add power control to Daikin zone climates

### DIFF
--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -540,6 +540,14 @@ class DaikinZoneClimate(DaikinEntity, ClimateEntity):
         await self.coordinator.async_refresh()
 
     @override
+    async def async_toggle(self) -> None:
+        """Toggle the zone."""
+        if self.device.zones[self._zone_id][1] == "1":
+            await self.async_turn_off()
+        else:
+            await self.async_turn_on()
+
+    @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Disallow changing HVAC mode via zone climate."""
         raise HomeAssistantError(

--- a/homeassistant/components/daikin/climate.py
+++ b/homeassistant/components/daikin/climate.py
@@ -392,7 +392,11 @@ class DaikinZoneClimate(DaikinEntity, ClimateEntity):
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_has_entity_name = True
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
     _attr_target_temperature_step = 1
 
     def __init__(self, coordinator: DaikinCoordinator, zone_id: int) -> None:
@@ -404,17 +408,25 @@ class DaikinZoneClimate(DaikinEntity, ClimateEntity):
         self._attr_name = f"{zone_name} temperature"
 
     @property
+    def _main_hvac_mode(self) -> HVACMode:
+        """Return the main unit HVAC mode."""
+        daikin_mode = self.device.represent(HA_ATTR_TO_DAIKIN[ATTR_HVAC_MODE])[1]
+        return DAIKIN_TO_HA_STATE.get(daikin_mode, HVACMode.HEAT_COOL)
+
+    @property
     @override
     def hvac_modes(self) -> list[HVACMode]:
         """Return the hvac modes (mirrors the main unit)."""
-        return [self.hvac_mode]
+        return [self._main_hvac_mode]
 
     @property
     @override
     def hvac_mode(self) -> HVACMode:
         """Return the current HVAC mode."""
-        daikin_mode = self.device.represent(HA_ATTR_TO_DAIKIN[ATTR_HVAC_MODE])[1]
-        return DAIKIN_TO_HA_STATE.get(daikin_mode, HVACMode.HEAT_COOL)
+        main_mode = self._main_hvac_mode
+        if main_mode == HVACMode.OFF or self.device.zones[self._zone_id][1] != "1":
+            return HVACMode.OFF
+        return main_mode
 
     @property
     @override
@@ -427,7 +439,7 @@ class DaikinZoneClimate(DaikinEntity, ClimateEntity):
     def target_temperature(self) -> float | None:
         """Return the zone target temperature for the active mode."""
         heating, cooling = _zone_temperature_lists(self.device)
-        mode = self.hvac_mode
+        mode = self._main_hvac_mode
         if mode == HVACMode.HEAT:
             return _zone_temperature_from_list(heating, self._zone_id)
         if mode == HVACMode.COOL:
@@ -499,7 +511,7 @@ class DaikinZoneClimate(DaikinEntity, ClimateEntity):
         if target is None:
             raise _zone_error("zone_parameters_unavailable")
 
-        mode = self.hvac_mode
+        mode = self._main_hvac_mode
         if mode == HVACMode.HEAT:
             zone_key = DAIKIN_ZONE_TEMP_HEAT
         elif mode == HVACMode.COOL:
@@ -514,6 +526,18 @@ class DaikinZoneClimate(DaikinEntity, ClimateEntity):
             raise _zone_error("zone_set_failed") from err
 
         await self.coordinator.async_request_refresh()
+
+    @override
+    async def async_turn_on(self) -> None:
+        """Turn the zone on."""
+        await self.device.set_zone(self._zone_id, "zone_onoff", "1")
+        await self.coordinator.async_refresh()
+
+    @override
+    async def async_turn_off(self) -> None:
+        """Turn the zone off."""
+        await self.device.set_zone(self._zone_id, "zone_onoff", "0")
+        await self.coordinator.async_refresh()
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:

--- a/tests/components/daikin/test_zone_climate.py
+++ b/tests/components/daikin/test_zone_climate.py
@@ -376,6 +376,7 @@ async def test_zone_climate_properties(
         "expected_zone_state",
         "expected_climate_state",
         "expected_switch_state",
+        "main_mode",
     ),
     [
         pytest.param(
@@ -384,6 +385,7 @@ async def test_zone_climate_properties(
             "1",
             HVACMode.COOL,
             STATE_ON,
+            "cool",
             id="climate-turn-on",
         ),
         pytest.param(
@@ -392,6 +394,7 @@ async def test_zone_climate_properties(
             "0",
             HVACMode.OFF,
             STATE_OFF,
+            "cool",
             id="climate-turn-off",
         ),
         pytest.param(
@@ -400,7 +403,17 @@ async def test_zone_climate_properties(
             "0",
             HVACMode.OFF,
             STATE_OFF,
+            "cool",
             id="climate-toggle-off",
+        ),
+        pytest.param(
+            SERVICE_TOGGLE,
+            "1",
+            "0",
+            HVACMode.OFF,
+            STATE_OFF,
+            "off",
+            id="climate-toggle-zone-on-main-off",
         ),
     ],
 )
@@ -413,12 +426,13 @@ async def test_zone_climate_power_controls(
     expected_zone_state: str,
     expected_climate_state: HVACMode,
     expected_switch_state: str,
+    main_mode: str,
 ) -> None:
     """Zone climate and switch power controls stay synchronized."""
     configure_zone_device(
         zone_device,
         zones=[["Living", initial_zone_state, 22]],
-        mode="cool",
+        mode=main_mode,
     )
 
     async def set_zone(zone_id: int, key: str, value: str) -> None:

--- a/tests/components/daikin/test_zone_climate.py
+++ b/tests/components/daikin/test_zone_climate.py
@@ -13,14 +13,22 @@ from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_HVAC_MODE,
     SERVICE_SET_TEMPERATURE,
+    ClimateEntityFeature,
     HVACAction,
     HVACMode,
 )
 from homeassistant.components.daikin.const import DOMAIN, KEY_MAC
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
     ATTR_TEMPERATURE,
     CONF_HOST,
+    SERVICE_TOGGLE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
@@ -60,6 +68,17 @@ def _zone_entity_id(
         CLIMATE_DOMAIN,
         DOMAIN,
         f"{zone_device.mac}-zone{zone_id}-temperature",
+    )
+
+
+def _zone_switch_entity_id(
+    entity_registry: er.EntityRegistry, zone_device: ZoneDevice, zone_id: int
+) -> str | None:
+    """Return the entity id for a zone switch unique id."""
+    return entity_registry.async_get_entity_id(
+        SWITCH_DOMAIN,
+        DOMAIN,
+        f"{zone_device.mac}-zone{zone_id}",
     )
 
 
@@ -145,12 +164,16 @@ async def test_zone_climate_sets_temperature_for_active_mode(
     """Setting temperature updates the active mode zone value."""
     configure_zone_device(
         zone_device,
-        zones=[["Living", "1", 22], ["Office", "1", 21]],
+        zones=[["Living", "0", 22], ["Office", "1", 21]],
         mode=mode,
     )
     await _async_setup_daikin(hass, zone_device)
     entity_id = _zone_entity_id(entity_registry, zone_device, 0)
     assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == HVACMode.OFF
+    assert state.attributes[ATTR_TEMPERATURE] == 22.0
 
     await _async_set_zone_temperature(hass, entity_id, 23)
 
@@ -302,15 +325,25 @@ async def test_zone_climate_set_temperature_requires_heat_or_cool(
     assert err.value.translation_key == "zone_hvac_mode_unsupported"
 
 
+@pytest.mark.parametrize(
+    ("zone_state", "expected_state", "expected_action"),
+    [
+        pytest.param("1", HVACMode.COOL, HVACAction.COOLING, id="zone-on"),
+        pytest.param("0", HVACMode.OFF, HVACAction.OFF, id="zone-off"),
+    ],
+)
 async def test_zone_climate_properties(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     zone_device: ZoneDevice,
+    zone_state: str,
+    expected_state: HVACMode,
+    expected_action: HVACAction,
 ) -> None:
     """Zone climate exposes expected state attributes."""
     configure_zone_device(
         zone_device,
-        zones=[["Living", "1", 22]],
+        zones=[["Living", zone_state, 22]],
         target_temperature=24,
         mode="cool",
         heating_values="20",
@@ -322,25 +355,159 @@ async def test_zone_climate_properties(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == HVACMode.COOL
-    assert state.attributes[ATTR_HVAC_ACTION] == HVACAction.COOLING
+    assert state.state == expected_state
+    assert state.attributes[ATTR_HVAC_ACTION] == expected_action
     assert state.attributes[ATTR_TEMPERATURE] == 18.0
     assert state.attributes[ATTR_MIN_TEMP] == 22.0
     assert state.attributes[ATTR_MAX_TEMP] == 26.0
     assert state.attributes[ATTR_HVAC_MODES] == [HVACMode.COOL]
+    assert state.attributes[ATTR_SUPPORTED_FEATURES] == (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
     assert state.attributes["zone_id"] == 0
 
 
+@pytest.mark.parametrize(
+    (
+        "service",
+        "initial_zone_state",
+        "expected_zone_state",
+        "expected_climate_state",
+        "expected_switch_state",
+    ),
+    [
+        pytest.param(
+            SERVICE_TURN_ON,
+            "0",
+            "1",
+            HVACMode.COOL,
+            STATE_ON,
+            id="climate-turn-on",
+        ),
+        pytest.param(
+            SERVICE_TURN_OFF,
+            "1",
+            "0",
+            HVACMode.OFF,
+            STATE_OFF,
+            id="climate-turn-off",
+        ),
+        pytest.param(
+            SERVICE_TOGGLE,
+            "1",
+            "0",
+            HVACMode.OFF,
+            STATE_OFF,
+            id="climate-toggle-off",
+        ),
+    ],
+)
+async def test_zone_climate_power_controls(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    zone_device: ZoneDevice,
+    service: str,
+    initial_zone_state: str,
+    expected_zone_state: str,
+    expected_climate_state: HVACMode,
+    expected_switch_state: str,
+) -> None:
+    """Zone climate and switch power controls stay synchronized."""
+    configure_zone_device(
+        zone_device,
+        zones=[["Living", initial_zone_state, 22]],
+        mode="cool",
+    )
+
+    async def set_zone(zone_id: int, key: str, value: str) -> None:
+        assert key == "zone_onoff"
+        zone_device.zones[zone_id][1] = value
+
+    zone_device.set_zone.side_effect = set_zone
+    await _async_setup_daikin(hass, zone_device)
+    climate_entity_id = _zone_entity_id(entity_registry, zone_device, 0)
+    switch_entity_id = _zone_switch_entity_id(entity_registry, zone_device, 0)
+    assert climate_entity_id is not None
+    assert switch_entity_id is not None
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: climate_entity_id},
+        blocking=True,
+    )
+
+    zone_device.set_zone.assert_awaited_once_with(0, "zone_onoff", expected_zone_state)
+    zone_device.set.assert_not_awaited()
+    climate_state = hass.states.get(climate_entity_id)
+    switch_state = hass.states.get(switch_entity_id)
+    assert climate_state is not None
+    assert switch_state is not None
+    assert climate_state.state == expected_climate_state
+    assert switch_state.state == expected_switch_state
+
+
+async def test_zone_switch_updates_zone_climate(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    zone_device: ZoneDevice,
+) -> None:
+    """The existing zone switch updates the zone climate state."""
+    configure_zone_device(
+        zone_device,
+        zones=[["Living", "1", 22]],
+        mode="cool",
+    )
+
+    async def set_zone(zone_id: int, key: str, value: str) -> None:
+        assert key == "zone_onoff"
+        zone_device.zones[zone_id][1] = value
+
+    zone_device.set_zone.side_effect = set_zone
+    await _async_setup_daikin(hass, zone_device)
+    climate_entity_id = _zone_entity_id(entity_registry, zone_device, 0)
+    switch_entity_id = _zone_switch_entity_id(entity_registry, zone_device, 0)
+    assert climate_entity_id is not None
+    assert switch_entity_id is not None
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: switch_entity_id},
+        blocking=True,
+    )
+
+    zone_device.set_zone.assert_awaited_once_with(0, "zone_onoff", "0")
+    zone_device.set.assert_not_awaited()
+    climate_state = hass.states.get(climate_entity_id)
+    switch_state = hass.states.get(switch_entity_id)
+    assert climate_state is not None
+    assert switch_state is not None
+    assert climate_state.state == HVACMode.OFF
+    assert switch_state.state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected_state"),
+    [
+        pytest.param("auto", HVACMode.HEAT_COOL, id="auto"),
+        pytest.param("off", HVACMode.OFF, id="off"),
+    ],
+)
 async def test_zone_climate_target_temperature_inactive_mode(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     zone_device: ZoneDevice,
+    mode: str,
+    expected_state: HVACMode,
 ) -> None:
     """In non-heating/cooling modes, zone target temperature is None."""
     configure_zone_device(
         zone_device,
         zones=[["Living", "1", 22]],
-        mode="auto",
+        mode=mode,
         heating_values="bad",
         cooling_values="19",
     )
@@ -350,7 +517,7 @@ async def test_zone_climate_target_temperature_inactive_mode(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.state == HVACMode.HEAT_COOL
+    assert state.state == expected_state
     assert state.attributes[ATTR_TEMPERATURE] is None
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Align Daikin zone climate power state with the corresponding zone switch. Zone climate entities now expose the standard climate turn-on and turn-off features, with `climate.turn_on`, `climate.turn_off`, and `climate.toggle` controlling only that zone.

The existing read-only, single-HVAC-mode design remains unchanged. A disabled zone reports `off` while retaining its main system mode in `hvac_modes`, and its heat or cool target remains visible and adjustable. Turning a zone on or off does not change the main Daikin unit.

This is one cohesive entity-behavior change building on #152642, #164170, and #164297. No dependency, manifest, translation, coordinator, switch, or entity identifier changes are included.

Local validation:

- `uv run pytest tests/components/daikin/test_zone_climate.py` (21 passed)
- `uv run pytest tests/components/daikin` (39 passed)
- `uv run pytest tests/components/daikin --cov=homeassistant.components.daikin --cov-report=term-missing` (39 passed, 89% integration coverage)
- `uv run prek run --all-files` (passed)

Compatible-hardware validation completed on an Airbase BRP15B61 running firmware 1.2.1. Verified `climate.turn_on`, `climate.turn_off`, and `climate.toggle`; climate/switch synchronisation in both directions; target adjustment while a zone is disabled; main-unit-off behaviour; and that zone power controls leave the main unit unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46913
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
