### PR TITLE
Add ScorpionTrack vehicle sensors and adaptive polling

### DIFF
--- a/homeassistant/components/scorpiontrack/binary_sensor.py
+++ b/homeassistant/components/scorpiontrack/binary_sensor.py
@@ -1,0 +1,64 @@
+"""Binary sensor platform for ScorpionTrack."""
+
+from typing import override
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
+from .entity import ScorpionTrackEntity
+
+PARALLEL_UPDATES = 0
+
+IGNITION_DESCRIPTION = BinarySensorEntityDescription(
+    key="ignition",
+    translation_key="ignition",
+    device_class=BinarySensorDeviceClass.RUNNING,
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ScorpionTrackConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up ScorpionTrack ignition entities."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        ScorpionTrackIgnitionEntity(coordinator, vehicle.id)
+        for vehicle in coordinator.data.vehicles
+    )
+
+
+class ScorpionTrackIgnitionEntity(ScorpionTrackEntity, BinarySensorEntity):
+    """Represent a ScorpionTrack vehicle ignition state."""
+
+    entity_description = IGNITION_DESCRIPTION
+
+    def __init__(self, coordinator: ScorpionTrackCoordinator, vehicle_id: int) -> None:
+        """Initialize the ignition entity."""
+        super().__init__(coordinator, vehicle_id)
+        self._attr_unique_id = f"{coordinator.data.id}_{vehicle_id}_ignition"
+
+    def _available_ignition(self) -> bool | None:
+        """Return ignition when its vehicle is available."""
+        if not super().available:
+            return None
+        return self.get_vehicle().position.ignition
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if the ignition value is available."""
+        return self._available_ignition() is not None
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return ignition from the coordinator snapshot."""
+        return self._available_ignition()

--- a/homeassistant/components/scorpiontrack/const.py
+++ b/homeassistant/components/scorpiontrack/const.py
@@ -10,7 +10,8 @@ MANUFACTURER = "ScorpionTrack"
 
 CONF_SHARE_TOKEN = "share_token"
 
-DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
+ACTIVE_SCAN_INTERVAL = timedelta(seconds=15)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 
 PLATFORMS: tuple[Platform, ...] = (
     Platform.BINARY_SENSOR,

--- a/homeassistant/components/scorpiontrack/const.py
+++ b/homeassistant/components/scorpiontrack/const.py
@@ -12,4 +12,8 @@ CONF_SHARE_TOKEN = "share_token"
 
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
 
-PLATFORMS: tuple[Platform, ...] = (Platform.DEVICE_TRACKER,)
+PLATFORMS: tuple[Platform, ...] = (
+    Platform.BINARY_SENSOR,
+    Platform.DEVICE_TRACKER,
+    Platform.SENSOR,
+)

--- a/homeassistant/components/scorpiontrack/coordinator.py
+++ b/homeassistant/components/scorpiontrack/coordinator.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+from .const import ACTIVE_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +36,7 @@ class ScorpionTrackCoordinator(DataUpdateCoordinator[ScorpionTrackShare]):
     ) -> None:
         """Initialize the coordinator."""
         self.client = client
+        self._previous_share_had_active_vehicle = False
         self.vehicles_by_id: dict[int, ScorpionTrackVehicle] = {}
         super().__init__(
             hass,
@@ -55,6 +56,7 @@ class ScorpionTrackCoordinator(DataUpdateCoordinator[ScorpionTrackShare]):
             raise UpdateFailed(
                 translation_domain=DOMAIN,
                 translation_key="cannot_connect",
+                retry_after=DEFAULT_SCAN_INTERVAL.total_seconds(),
             ) from err
         except ScorpionTrackInvalidTokenError as err:
             raise ConfigEntryError(
@@ -68,4 +70,13 @@ class ScorpionTrackCoordinator(DataUpdateCoordinator[ScorpionTrackShare]):
             ) from err
         else:
             self.vehicles_by_id = {vehicle.id: vehicle for vehicle in share.vehicles}
+            share_has_active_vehicle = any(
+                vehicle.position.ignition is True for vehicle in share.vehicles
+            )
+            self.update_interval = (
+                ACTIVE_SCAN_INTERVAL
+                if share_has_active_vehicle or self._previous_share_had_active_vehicle
+                else DEFAULT_SCAN_INTERVAL
+            )
+            self._previous_share_had_active_vehicle = share_has_active_vehicle
             return share

--- a/homeassistant/components/scorpiontrack/icons.json
+++ b/homeassistant/components/scorpiontrack/icons.json
@@ -4,6 +4,11 @@
       "vehicle_location": {
         "default": "mdi:car"
       }
+    },
+    "sensor": {
+      "heading": {
+        "default": "mdi:compass"
+      }
     }
   }
 }

--- a/homeassistant/components/scorpiontrack/quality_scale.yaml
+++ b/homeassistant/components/scorpiontrack/quality_scale.yaml
@@ -77,9 +77,7 @@ rules:
   dynamic-devices: todo
   entity-category: done
   entity-device-class: done
-  entity-disabled-by-default:
-    status: exempt
-    comment: The created entities are useful for shared vehicle tracking and should be enabled by default.
+  entity-disabled-by-default: done
   entity-translations: done
   exception-translations: done
   icon-translations: done

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -1,0 +1,117 @@
+"""Sensor platform for ScorpionTrack."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime
+from typing import override
+
+from pyscorpiontrack import ScorpionTrackVehicle
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
+from homeassistant.const import DEGREE, EntityCategory, UnitOfSpeed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.typing import StateType
+
+from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
+from .entity import ScorpionTrackEntity
+
+PARALLEL_UPDATES = 0
+
+type ScorpionTrackSensorValue = StateType | datetime
+
+
+@dataclass(frozen=True, kw_only=True)
+class ScorpionTrackSensorEntityDescription(SensorEntityDescription):
+    """Describe a ScorpionTrack sensor entity."""
+
+    value_fn: Callable[[ScorpionTrackVehicle], ScorpionTrackSensorValue]
+
+
+SENSOR_DESCRIPTIONS: tuple[ScorpionTrackSensorEntityDescription, ...] = (
+    ScorpionTrackSensorEntityDescription(
+        key="speed",
+        translation_key="speed",
+        device_class=SensorDeviceClass.SPEED,
+        native_unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=1,
+        value_fn=lambda vehicle: vehicle.position.speed_kmh,
+    ),
+    ScorpionTrackSensorEntityDescription(
+        key="last_reported",
+        translation_key="last_reported",
+        device_class=SensorDeviceClass.TIMESTAMP,
+        entity_category=EntityCategory.DIAGNOSTIC,
+        value_fn=lambda vehicle: vehicle.position.timestamp,
+    ),
+    ScorpionTrackSensorEntityDescription(
+        key="heading",
+        translation_key="heading",
+        native_unit_of_measurement=DEGREE,
+        state_class=SensorStateClass.MEASUREMENT_ANGLE,
+        suggested_display_precision=0,
+        entity_registry_enabled_default=False,
+        value_fn=lambda vehicle: vehicle.position.bearing,
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ScorpionTrackConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up ScorpionTrack sensor entities."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        ScorpionTrackSensorEntity(coordinator, vehicle.id, description)
+        for vehicle in coordinator.data.vehicles
+        for description in SENSOR_DESCRIPTIONS
+    )
+
+
+class ScorpionTrackSensorEntity(ScorpionTrackEntity, SensorEntity):
+    """Represent a ScorpionTrack vehicle sensor."""
+
+    entity_description: ScorpionTrackSensorEntityDescription
+
+    def __init__(
+        self,
+        coordinator: ScorpionTrackCoordinator,
+        vehicle_id: int,
+        description: ScorpionTrackSensorEntityDescription,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(coordinator, vehicle_id)
+        self.entity_description = description
+        self._attr_unique_id = f"{coordinator.data.id}_{vehicle_id}_{description.key}"
+        if description.key == "speed":
+            self._attr_suggested_unit_of_measurement = (
+                UnitOfSpeed.MILES_PER_HOUR
+                if coordinator.data.uses_miles
+                else UnitOfSpeed.KILOMETERS_PER_HOUR
+            )
+
+    def _available_value(self) -> ScorpionTrackSensorValue:
+        """Return the current value when its vehicle is available."""
+        if not super().available:
+            return None
+        return self.entity_description.value_fn(self.get_vehicle())
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if the sensor value is available."""
+        return self._available_value() is not None
+
+    @property
+    @override
+    def native_value(self) -> ScorpionTrackSensorValue:
+        """Return the sensor value from the coordinator snapshot."""
+        return self._available_value()

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -112,6 +112,6 @@ class ScorpionTrackSensorEntity(ScorpionTrackEntity, SensorEntity):
 
     @property
     @override
-    def native_value(self) -> ScorpionTrackSensorValue:
+    def native_value(self) -> StateType | datetime:
         """Return the sensor value from the coordinator snapshot."""
         return self._available_value()

--- a/homeassistant/components/scorpiontrack/strings.json
+++ b/homeassistant/components/scorpiontrack/strings.json
@@ -32,5 +32,23 @@
     "share_unavailable": {
       "message": "The shared location is unavailable."
     }
+  },
+  "entity": {
+    "binary_sensor": {
+      "ignition": {
+        "name": "Ignition"
+      }
+    },
+    "sensor": {
+      "heading": {
+        "name": "Heading"
+      },
+      "last_reported": {
+        "name": "Last reported"
+      },
+      "speed": {
+        "name": "Speed"
+      }
+    }
   }
 }

--- a/homeassistant/components/scorpiontrack/strings.json
+++ b/homeassistant/components/scorpiontrack/strings.json
@@ -22,17 +22,6 @@
       }
     }
   },
-  "exceptions": {
-    "cannot_connect": {
-      "message": "The ScorpionTrack share could not be reached right now."
-    },
-    "invalid_token": {
-      "message": "ScorpionTrack rejected the configured share token."
-    },
-    "share_unavailable": {
-      "message": "The shared location is unavailable."
-    }
-  },
   "entity": {
     "binary_sensor": {
       "ignition": {
@@ -49,6 +38,17 @@
       "speed": {
         "name": "Speed"
       }
+    }
+  },
+  "exceptions": {
+    "cannot_connect": {
+      "message": "The ScorpionTrack share could not be reached right now."
+    },
+    "invalid_token": {
+      "message": "ScorpionTrack rejected the configured share token."
+    },
+    "share_unavailable": {
+      "message": "The shared location is unavailable."
     }
   }
 }

--- a/tests/components/scorpiontrack/snapshots/test_binary_sensor.ambr
+++ b/tests/components/scorpiontrack/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,52 @@
+# serializer version: 1
+# name: test_binary_sensor_state[binary_sensor.ab12_cde_ignition-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.ab12_cde_ignition',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Ignition',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.RUNNING: 'running'>,
+    'original_icon': None,
+    'original_name': 'Ignition',
+    'platform': 'scorpiontrack',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ignition',
+    'unique_id': '101_1_ignition',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_binary_sensor_state[binary_sensor.ab12_cde_ignition-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'running',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'AB12 CDE Ignition',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.ab12_cde_ignition',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---

--- a/tests/components/scorpiontrack/snapshots/test_sensor.ambr
+++ b/tests/components/scorpiontrack/snapshots/test_sensor.ambr
@@ -1,0 +1,170 @@
+# serializer version: 1
+# name: test_sensor_state[sensor.ab12_cde_heading-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT_ANGLE: 'measurement_angle'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ab12_cde_heading',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Heading',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 0,
+      }),
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Heading',
+    'platform': 'scorpiontrack',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'heading',
+    'unique_id': '101_1_heading',
+    'unit_of_measurement': '°',
+  })
+# ---
+# name: test_sensor_state[sensor.ab12_cde_heading-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'AB12 CDE Heading',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT_ANGLE: 'measurement_angle'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '°',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ab12_cde_heading',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '182.0',
+  })
+# ---
+# name: test_sensor_state[sensor.ab12_cde_last_reported-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.ab12_cde_last_reported',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Last reported',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Last reported',
+    'platform': 'scorpiontrack',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'last_reported',
+    'unique_id': '101_1_last_reported',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_state[sensor.ab12_cde_last_reported-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'timestamp',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'AB12 CDE Last reported',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ab12_cde_last_reported',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2026-07-16T12:00:00+00:00',
+  })
+# ---
+# name: test_sensor_state[sensor.ab12_cde_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ab12_cde_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Speed',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.SPEED: 'speed'>,
+    'original_icon': None,
+    'original_name': 'Speed',
+    'platform': 'scorpiontrack',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'speed',
+    'unique_id': '101_1_speed',
+    'unit_of_measurement': <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
+  })
+# ---
+# name: test_sensor_state[sensor.ab12_cde_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'speed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'AB12 CDE Speed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ab12_cde_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30.0122285850632',
+  })
+# ---

--- a/tests/components/scorpiontrack/test_binary_sensor.py
+++ b/tests/components/scorpiontrack/test_binary_sensor.py
@@ -1,0 +1,182 @@
+"""Test the ScorpionTrack binary sensor platform."""
+
+from collections.abc import Iterator
+from dataclasses import replace
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyscorpiontrack import ScorpionTrackShare
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.scorpiontrack.const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    PLATFORMS,
+)
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    Platform,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+IGNITION_ENTITY_ID = "binary_sensor.ab12_cde_ignition"
+
+
+def test_binary_sensor_platform_is_forwarded() -> None:
+    """Test the config entry forwards the binary sensor platform."""
+    assert Platform.BINARY_SENSOR in PLATFORMS
+
+
+def _get_state(hass: HomeAssistant) -> State:
+    """Return the ignition state that must exist."""
+    state = hass.states.get(IGNITION_ENTITY_ID)
+    assert state is not None
+    return state
+
+
+@pytest.fixture(autouse=True)
+def binary_sensor_platform_only() -> Iterator[None]:
+    """Set up only the binary sensor platform."""
+    with patch(
+        "homeassistant.components.scorpiontrack.PLATFORMS", (Platform.BINARY_SENSOR,)
+    ):
+        yield
+
+
+async def _async_refresh(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_scorpiontrack_client: AsyncMock,
+    share: ScorpionTrackShare,
+) -> None:
+    """Refresh the coordinator with the supplied share."""
+    mock_scorpiontrack_client.async_get_share.return_value = share
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def test_binary_sensor_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test binary sensor state, metadata, identifiers, and device assignment."""
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("ignition", "expected_state"),
+    [
+        pytest.param(True, STATE_ON, id="on"),
+        pytest.param(False, STATE_OFF, id="off"),
+        pytest.param(None, STATE_UNAVAILABLE, id="unavailable"),
+    ],
+)
+async def test_ignition_values(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    ignition: bool | None,
+    expected_state: str,
+) -> None:
+    """Test true, false, and absent ignition values."""
+    position = replace(mock_share.vehicles[0].position, ignition=ignition)
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=(replace(mock_share.vehicles[0], position=position),)
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert _get_state(hass).state == expected_state
+
+
+async def test_removed_vehicle_makes_ignition_unavailable(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test ignition becomes unavailable when its vehicle disappears."""
+    await setup_integration(hass, mock_config_entry)
+
+    await _async_refresh(
+        hass,
+        freezer,
+        mock_scorpiontrack_client,
+        replace(mock_share, vehicles=()),
+    )
+
+    assert _get_state(hass).state == STATE_UNAVAILABLE
+
+
+async def test_new_vehicles_after_setup_do_not_add_ignition_entities(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test vehicles added after setup do not add ignition entities."""
+    await setup_integration(hass, mock_config_entry)
+
+    new_vehicle = replace(
+        mock_share.vehicles[0],
+        id=2,
+        name="Tiguan",
+        registration="EF34 ABC",
+        model="Tiguan",
+    )
+    await _async_refresh(
+        hass,
+        freezer,
+        mock_scorpiontrack_client,
+        replace(mock_share, vehicles=(*mock_share.vehicles, new_vehicle)),
+    )
+
+    assert hass.states.get("binary_sensor.ef34_abc_ignition") is None
+
+
+async def test_ignition_properties_use_coordinator_snapshot_without_coordinates(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test ignition properties perform no I/O and expose no coordinates."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = _get_state(hass)
+    assert ATTR_LATITUDE not in state.attributes
+    assert ATTR_LONGITUDE not in state.attributes
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+
+
+async def test_ignition_reuses_vehicle_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test ignition uses the existing vehicle device identity."""
+    await setup_integration(hass, mock_config_entry)
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "101_1")})
+    assert device is not None
+    entry = entity_registry.async_get(IGNITION_ENTITY_ID)
+    assert entry is not None
+    assert entry.device_id == device.id

--- a/tests/components/scorpiontrack/test_coordinator.py
+++ b/tests/components/scorpiontrack/test_coordinator.py
@@ -1,0 +1,273 @@
+"""Test the ScorpionTrack coordinator."""
+
+from dataclasses import replace
+from datetime import timedelta
+from typing import cast
+from unittest.mock import AsyncMock
+
+from freezegun.api import FrozenDateTimeFactory
+from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
+import pytest
+
+from homeassistant.components.scorpiontrack.const import (
+    ACTIVE_SCAN_INTERVAL,
+    DEFAULT_SCAN_INTERVAL,
+)
+from homeassistant.components.scorpiontrack.coordinator import ScorpionTrackCoordinator
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_OFF,
+    UnitOfSpeed,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+
+
+def _get_state(hass: HomeAssistant, entity_id: str) -> State:
+    """Return an entity state that must exist."""
+    state = hass.states.get(entity_id)
+    assert state is not None
+    return state
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_active_refresh_updates_all_vehicle_entities(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test one active refresh updates tracker and telemetry entities."""
+    await setup_integration(hass, mock_config_entry)
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+
+    initial_timestamp = mock_share.vehicles[0].position.timestamp
+    assert initial_timestamp is not None
+    updated_timestamp = (initial_timestamp + ACTIVE_SCAN_INTERVAL).replace(
+        microsecond=0
+    )
+    updated_position = replace(
+        mock_share.vehicles[0].position,
+        latitude=52.52,
+        longitude=13.405,
+        timestamp=updated_timestamp,
+        speed_kmh=80.0,
+        ignition=False,
+        bearing=270.0,
+    )
+    updated_share = replace(
+        mock_share,
+        vehicles=(replace(mock_share.vehicles[0], position=updated_position),),
+    )
+    mock_scorpiontrack_client.async_get_share.return_value = updated_share
+
+    freezer.tick(ACTIVE_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
+    tracker = _get_state(hass, "device_tracker.ab12_cde")
+    assert tracker.attributes[ATTR_LATITUDE] == 52.52
+    assert tracker.attributes[ATTR_LONGITUDE] == 13.405
+    speed = _get_state(hass, "sensor.ab12_cde_speed")
+    assert float(speed.state) == pytest.approx(49.7, abs=0.05)
+    assert speed.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfSpeed.MILES_PER_HOUR
+    assert float(_get_state(hass, "sensor.ab12_cde_heading").state) == 270.0
+    assert (
+        _get_state(hass, "sensor.ab12_cde_last_reported").state
+        == updated_timestamp.isoformat()
+    )
+    assert _get_state(hass, "binary_sensor.ab12_cde_ignition").state == STATE_OFF
+
+
+@pytest.mark.parametrize(
+    ("ignition_states", "expected_interval"),
+    [
+        pytest.param((False,), DEFAULT_SCAN_INTERVAL, id="parked"),
+        pytest.param((None,), DEFAULT_SCAN_INTERVAL, id="unknown"),
+        pytest.param((False, True), ACTIVE_SCAN_INTERVAL, id="any-active"),
+    ],
+)
+async def test_initial_interval_follows_any_vehicle_ignition(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    ignition_states: tuple[bool | None, ...],
+    expected_interval: timedelta,
+) -> None:
+    """Test the initial interval follows explicit ignition state."""
+    vehicles = tuple(
+        replace(
+            mock_share.vehicles[0],
+            id=vehicle_id,
+            registration=f"TEST {vehicle_id}",
+            position=replace(
+                mock_share.vehicles[0].position,
+                ignition=ignition,
+            ),
+        )
+        for vehicle_id, ignition in enumerate(ignition_states, start=1)
+    )
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=vehicles
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    coordinator: ScorpionTrackCoordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == expected_interval
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+
+
+async def test_activity_requires_explicit_true_ignition(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test speed, status, and a truthy string do not imply activity."""
+    position = replace(
+        mock_share.vehicles[0].position,
+        speed_kmh=80.0,
+        ignition=cast(bool | None, "true"),
+    )
+    vehicle = replace(mock_share.vehicles[0], position=position, status="Moving")
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=(vehicle,)
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    coordinator: ScorpionTrackCoordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DEFAULT_SCAN_INTERVAL
+
+
+async def test_active_share_refreshes_after_fifteen_seconds(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test an active share is scheduled at the active cadence."""
+    await setup_integration(hass, mock_config_entry)
+
+    freezer.tick(ACTIVE_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
+
+
+async def test_active_share_gets_one_trailing_fast_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test activity provides one final fast refresh after ignition stops."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator: ScorpionTrackCoordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+    inactive_vehicle = replace(
+        mock_share.vehicles[0],
+        position=replace(mock_share.vehicles[0].position, ignition=False),
+    )
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=(inactive_vehicle,)
+    )
+
+    await coordinator.async_refresh()
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+    await coordinator.async_refresh()
+    assert coordinator.update_interval == DEFAULT_SCAN_INTERVAL
+    assert mock_scorpiontrack_client.async_get_share.await_count == 3
+
+
+async def test_inactive_share_remains_on_parked_interval(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test a sustained inactive share remains at the parked cadence."""
+    inactive_vehicle = replace(
+        mock_share.vehicles[0],
+        position=replace(mock_share.vehicles[0].position, ignition=False),
+    )
+    inactive_share = replace(mock_share, vehicles=(inactive_vehicle,))
+    mock_scorpiontrack_client.async_get_share.return_value = inactive_share
+
+    await setup_integration(hass, mock_config_entry)
+    coordinator: ScorpionTrackCoordinator = mock_config_entry.runtime_data
+    assert coordinator.update_interval == DEFAULT_SCAN_INTERVAL
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
+    assert coordinator.update_interval == DEFAULT_SCAN_INTERVAL
+
+
+async def test_connection_error_retries_after_parked_interval(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test a failed active refresh retries after sixty seconds."""
+    await setup_integration(hass, mock_config_entry)
+    coordinator: ScorpionTrackCoordinator = mock_config_entry.runtime_data
+    previous_data = coordinator.data
+
+    inactive_vehicle = replace(
+        mock_share.vehicles[0],
+        position=replace(mock_share.vehicles[0].position, ignition=False),
+    )
+    inactive_share = replace(mock_share, vehicles=(inactive_vehicle,))
+    mock_scorpiontrack_client.async_get_share.side_effect = (
+        ScorpionTrackConnectionError("Connection failed"),
+        inactive_share,
+        inactive_share,
+    )
+
+    freezer.tick(ACTIVE_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
+    assert not coordinator.last_update_success
+    assert coordinator.data is previous_data
+    assert coordinator.vehicles_by_id[1].position.ignition is True
+    assert isinstance(coordinator.last_exception, UpdateFailed)
+    assert (
+        coordinator.last_exception.retry_after == DEFAULT_SCAN_INTERVAL.total_seconds()
+    )
+
+    freezer.tick(ACTIVE_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_scorpiontrack_client.async_get_share.await_count == 2
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL - ACTIVE_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_scorpiontrack_client.async_get_share.await_count == 3
+    assert coordinator.last_update_success
+    assert coordinator.update_interval == ACTIVE_SCAN_INTERVAL
+
+    freezer.tick(ACTIVE_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert mock_scorpiontrack_client.async_get_share.await_count == 4
+    assert coordinator.update_interval == DEFAULT_SCAN_INTERVAL

--- a/tests/components/scorpiontrack/test_device_tracker.py
+++ b/tests/components/scorpiontrack/test_device_tracker.py
@@ -1,14 +1,14 @@
 """Test the ScorpionTrack device tracker platform."""
 
 from dataclasses import replace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -24,7 +24,11 @@ async def test_device_tracker_state(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the ScorpionTrack device tracker state and attributes."""
-    await setup_integration(hass, mock_config_entry)
+    with patch(
+        "homeassistant.components.scorpiontrack.PLATFORMS",
+        (Platform.DEVICE_TRACKER,),
+    ):
+        await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/scorpiontrack/test_sensor.py
+++ b/tests/components/scorpiontrack/test_sensor.py
@@ -1,0 +1,320 @@
+"""Test the ScorpionTrack sensor platform."""
+
+from collections.abc import Iterator
+from dataclasses import replace
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyscorpiontrack import ScorpionTrackShare
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.scorpiontrack.const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    PLATFORMS,
+)
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    Platform,
+    UnitOfSpeed,
+)
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+SPEED_ENTITY_ID = "sensor.ab12_cde_speed"
+LAST_REPORTED_ENTITY_ID = "sensor.ab12_cde_last_reported"
+HEADING_ENTITY_ID = "sensor.ab12_cde_heading"
+SENSOR_ENTITY_IDS = (
+    SPEED_ENTITY_ID,
+    LAST_REPORTED_ENTITY_ID,
+    HEADING_ENTITY_ID,
+)
+
+
+def test_sensor_platform_is_forwarded() -> None:
+    """Test the config entry forwards the sensor platform."""
+    assert Platform.SENSOR in PLATFORMS
+
+
+def _get_state(hass: HomeAssistant, entity_id: str) -> State:
+    """Return an entity state that must exist."""
+    state = hass.states.get(entity_id)
+    assert state is not None
+    return state
+
+
+@pytest.fixture(autouse=True)
+def sensor_platform_only() -> Iterator[None]:
+    """Set up only the sensor platform."""
+    with patch("homeassistant.components.scorpiontrack.PLATFORMS", (Platform.SENSOR,)):
+        yield
+
+
+async def _async_refresh(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_scorpiontrack_client: AsyncMock,
+    share: ScorpionTrackShare,
+) -> None:
+    """Refresh the coordinator with the supplied share."""
+    mock_scorpiontrack_client.async_get_share.return_value = share
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test sensor state, metadata, identifiers, and device assignment."""
+    position = replace(
+        mock_share.vehicles[0].position,
+        timestamp=datetime(2026, 7, 16, 12, tzinfo=UTC),
+    )
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=(replace(mock_share.vehicles[0], position=position),)
+    )
+    await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_heading_is_disabled_by_default(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test heading is disabled by the integration by default."""
+    await setup_integration(hass, mock_config_entry)
+
+    entry = entity_registry.async_get(HEADING_ENTITY_ID)
+    assert entry is not None
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.parametrize(
+    ("distance_units", "expected_state", "expected_unit"),
+    [
+        pytest.param(
+            "miles",
+            "30.0122285850632",
+            UnitOfSpeed.MILES_PER_HOUR,
+            id="miles-display",
+        ),
+        pytest.param(
+            "kilometers",
+            "48.3",
+            UnitOfSpeed.KILOMETERS_PER_HOUR,
+            id="metric-display",
+        ),
+    ],
+)
+async def test_speed_display_unit_uses_share_preference_with_kmh_native_value(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    distance_units: str,
+    expected_state: str,
+    expected_unit: UnitOfSpeed,
+) -> None:
+    """Test speed display units while API values remain native km/h."""
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, distance_units=distance_units
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = _get_state(hass, SPEED_ENTITY_ID)
+    assert state.state == expected_state
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == expected_unit
+    assert mock_share.vehicles[0].position.speed_kmh == 48.3
+
+
+async def test_speed_user_unit_override_survives_refresh_and_reload(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a user speed-unit override remains owned by Home Assistant."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_registry.async_update_entity_options(
+        SPEED_ENTITY_ID,
+        Platform.SENSOR,
+        {"unit_of_measurement": UnitOfSpeed.KILOMETERS_PER_HOUR},
+    )
+    await hass.async_block_till_done()
+
+    updated_position = replace(mock_share.vehicles[0].position, speed_kmh=64.4)
+    metric_share = replace(
+        mock_share,
+        distance_units="kilometers",
+        vehicles=(replace(mock_share.vehicles[0], position=updated_position),),
+    )
+    await _async_refresh(hass, freezer, mock_scorpiontrack_client, metric_share)
+
+    state = _get_state(hass, SPEED_ENTITY_ID)
+    assert state.state == "64.4"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfSpeed.KILOMETERS_PER_HOUR
+
+    reloaded_position = replace(updated_position, speed_kmh=80.5)
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share,
+        distance_units="miles",
+        vehicles=(replace(mock_share.vehicles[0], position=reloaded_position),),
+    )
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = _get_state(hass, SPEED_ENTITY_ID)
+    assert state.state == "80.5"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfSpeed.KILOMETERS_PER_HOUR
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_zero_sensor_values_are_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test zero speed and heading values remain available."""
+    position = replace(mock_share.vehicles[0].position, speed_kmh=0, bearing=0)
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=(replace(mock_share.vehicles[0], position=position),)
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert _get_state(hass, SPEED_ENTITY_ID).state == "0.0"
+    assert _get_state(hass, HEADING_ENTITY_ID).state == "0"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_none_sensor_values_are_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test absent sensor values are unavailable."""
+    position = replace(
+        mock_share.vehicles[0].position,
+        speed_kmh=None,
+        timestamp=None,
+        bearing=None,
+    )
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=(replace(mock_share.vehicles[0], position=position),)
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    assert {_get_state(hass, entity_id).state for entity_id in SENSOR_ENTITY_IDS} == {
+        STATE_UNAVAILABLE
+    }
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_removed_vehicle_makes_sensors_unavailable(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test existing sensors become unavailable when their vehicle disappears."""
+    await setup_integration(hass, mock_config_entry)
+
+    await _async_refresh(
+        hass,
+        freezer,
+        mock_scorpiontrack_client,
+        replace(mock_share, vehicles=()),
+    )
+
+    assert {_get_state(hass, entity_id).state for entity_id in SENSOR_ENTITY_IDS} == {
+        STATE_UNAVAILABLE
+    }
+
+
+async def test_new_vehicles_after_setup_do_not_add_sensor_entities(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test vehicles added after setup do not add sensor entities."""
+    await setup_integration(hass, mock_config_entry)
+
+    new_vehicle = replace(
+        mock_share.vehicles[0],
+        id=2,
+        name="Tiguan",
+        registration="EF34 ABC",
+        model="Tiguan",
+    )
+    await _async_refresh(
+        hass,
+        freezer,
+        mock_scorpiontrack_client,
+        replace(mock_share, vehicles=(*mock_share.vehicles, new_vehicle)),
+    )
+
+    assert hass.states.get("sensor.ef34_abc_speed") is None
+    assert hass.states.get("sensor.ef34_abc_last_reported") is None
+    assert hass.states.get("sensor.ef34_abc_heading") is None
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_sensor_properties_use_coordinator_snapshot_without_coordinates(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test sensor properties perform no I/O and expose no coordinates."""
+    await setup_integration(hass, mock_config_entry)
+
+    for entity_id in SENSOR_ENTITY_IDS:
+        state = _get_state(hass, entity_id)
+        assert ATTR_LATITUDE not in state.attributes
+        assert ATTR_LONGITUDE not in state.attributes
+
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+
+
+async def test_sensor_entities_reuse_vehicle_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test sensors use the existing vehicle device identity."""
+    await setup_integration(hass, mock_config_entry)
+
+    device = device_registry.async_get_device(identifiers={(DOMAIN, "101_1")})
+    assert device is not None
+    for entity_id in (SPEED_ENTITY_ID, LAST_REPORTED_ENTITY_ID):
+        entry = entity_registry.async_get(entity_id)
+        assert entry is not None
+        assert entry.device_id == device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

I built a broader HACS version of this integration some time ago. For my first Core submission, I deliberately kept the scope small so the shared link setup, vehicle identity, device tracker, and map behavior could be reviewed on their own. My intention was to establish that small foundation first, then add the other useful fields in focused follow ups once the basic integration had been accepted.

This is the first of those additions. It exposes speed, last reported time, and heading as sensors, together with an ignition binary sensor. These fields are already returned by the same shared feed, so the new entities do not make their own requests. Heading is disabled by default because I expect it to be less useful for most people.

The shared feed can use miles or kilometers. `pyscorpiontrack` normalizes the API value to km/h before Core receives it, so the speed sensor uses km/h as its native unit. The share preference is used only as Home Assistant's suggested display unit. Home Assistant then handles the display conversion and keeps the usual unit setting on the entity.

The existing coordinator remains the only owner of network requests. It polls every 15 seconds while any vehicle explicitly reports that its ignition is running. When an update first reports no running ignitions after an active period, it performs one more update after 15 seconds, then returns to updates every 60 seconds. A scheduled update that fails because of a connection problem is retried after 60 seconds. The existing device tracker and its map coordinates are unchanged, and the new entities do not create additional map markers.

Although there are no requests for individual entities, this does increase the frequency of the single share request. A continuously loaded entry can make about 1,440 requests per day when no ignition reports that it is running, compared with 720 before this change. It can make up to about 5,760 requests per day while continuously active. I wanted to call that out clearly rather than imply that the overall request volume is unchanged.

I installed the exact candidate on a separate Home Assistant OS VM and checked the entity states, shared device, map ownership, unit override, restart behavior, and the inactive request cadence of 60 seconds. The component tests cover the active, trailing, inactive, and connection failure timing paths, as well as the shared entity updates. I also ran Ruff and hassfest because this change adds platforms and coordinator behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue:
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46915
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

This PR does not change the integration dependency or requirements files.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr