### PR TITLE
Fix SMTP attaching valid images as files when content sniffing fails

### DIFF
--- a/homeassistant/components/smtp/helpers.py
+++ b/homeassistant/components/smtp/helpers.py
@@ -142,9 +142,10 @@ def _attach_file(
         # Not all valid images are recognized from their content, e.g. JPEGs
         # written by ffmpeg for camera.snapshot start with a comment marker
         # instead of JFIF/Exif, so fall back to guessing from the filename.
-        mime_type, _ = mimetypes.guess_type(atch_name)
+        # Compressed files (e.g. .svgz) must not be labeled as plain images.
+        mime_type, encoding = mimetypes.guess_type(atch_name)
         maintype, _, subtype = (mime_type or "").partition("/")
-        if maintype == "image":
+        if encoding is None and maintype == "image":
             attachment = MIMEImage(file_bytes, _subtype=subtype)
 
     if attachment is None:

--- a/homeassistant/components/smtp/helpers.py
+++ b/homeassistant/components/smtp/helpers.py
@@ -5,6 +5,7 @@ from email.mime.image import MIMEImage
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 import logging
+import mimetypes
 import os
 from pathlib import Path
 import smtplib
@@ -134,26 +135,35 @@ def _attach_file(
         _LOGGER.warning("Attachment %s not found. Skipping", atch_name)
         return None
 
-    attachment: MIMEImage | MIMEApplication
+    attachment: MIMEImage | MIMEApplication | None = None
     try:
         attachment = MIMEImage(file_bytes)
     except TypeError:
+        # Not all valid images are recognized from their content, e.g. JPEGs
+        # written by ffmpeg for camera.snapshot start with a comment marker
+        # instead of JFIF/Exif, so fall back to guessing from the filename.
+        mime_type, _ = mimetypes.guess_type(atch_name)
+        maintype, _, subtype = (mime_type or "").partition("/")
+        if maintype == "image":
+            attachment = MIMEImage(file_bytes, _subtype=subtype)
+
+    if attachment is None:
         _LOGGER.warning(
-            "Attachment %s has an unknown MIME type. Falling back to file",
+            "Could not determine an image type for attachment %s from its"
+            " content or filename. Falling back to file",
             atch_name,
         )
         attachment = MIMEApplication(file_bytes, Name=os.path.basename(atch_name))
         attachment["Content-Disposition"] = (
             f'attachment; filename="{os.path.basename(atch_name)}"'
         )
+    elif content_id:
+        attachment.add_header("Content-ID", f"<{content_id}>")
     else:
-        if content_id:
-            attachment.add_header("Content-ID", f"<{content_id}>")
-        else:
-            attachment.add_header(
-                "Content-Disposition",
-                f"attachment; filename={os.path.basename(atch_name)}",
-            )
+        attachment.add_header(
+            "Content-Disposition",
+            f"attachment; filename={os.path.basename(atch_name)}",
+        )
 
     return attachment
 

--- a/homeassistant/components/smtp/helpers.py
+++ b/homeassistant/components/smtp/helpers.py
@@ -144,9 +144,10 @@ def _attach_file(
         # Not all valid images are recognized from their content, e.g. JPEGs
         # written by ffmpeg for camera.snapshot start with a comment marker
         # instead of JFIF/Exif, so fall back to guessing from the filename.
-        mime_type, _ = mimetypes.guess_type(atch_name)
+        # Compressed files (e.g. .svgz) must not be labeled as plain images.
+        mime_type, encoding = mimetypes.guess_type(atch_name)
         maintype, _, subtype = (mime_type or "").partition("/")
-        if maintype == "image":
+        if encoding is None and maintype == "image":
             attachment = MIMEImage(file_bytes, _subtype=subtype)
 
     if attachment is None:

--- a/homeassistant/components/smtp/helpers.py
+++ b/homeassistant/components/smtp/helpers.py
@@ -137,26 +137,35 @@ def _attach_file(
         _LOGGER.warning("Attachment %s not found. Skipping", atch_name)
         return None
 
-    attachment: MIMEImage | MIMEApplication
+    attachment: MIMEImage | MIMEApplication | None = None
     try:
         attachment = MIMEImage(file_bytes)
     except TypeError:
+        # Not all valid images are recognized from their content, e.g. JPEGs
+        # written by ffmpeg for camera.snapshot start with a comment marker
+        # instead of JFIF/Exif, so fall back to guessing from the filename.
+        mime_type, _ = mimetypes.guess_type(atch_name)
+        maintype, _, subtype = (mime_type or "").partition("/")
+        if maintype == "image":
+            attachment = MIMEImage(file_bytes, _subtype=subtype)
+
+    if attachment is None:
         _LOGGER.warning(
-            "Attachment %s has an unknown MIME type. Falling back to file",
+            "Could not determine an image type for attachment %s from its"
+            " content or filename. Falling back to file",
             atch_name,
         )
         attachment = MIMEApplication(file_bytes, Name=os.path.basename(atch_name))
         attachment["Content-Disposition"] = (
             f'attachment; filename="{os.path.basename(atch_name)}"'
         )
+    elif content_id:
+        attachment.add_header("Content-ID", f"<{content_id}>")
     else:
-        if content_id:
-            attachment.add_header("Content-ID", f"<{content_id}>")
-        else:
-            attachment.add_header(
-                "Content-Disposition",
-                f"attachment; filename={os.path.basename(atch_name)}",
-            )
+        attachment.add_header(
+            "Content-Disposition",
+            f"attachment; filename={os.path.basename(atch_name)}",
+        )
 
     return attachment
 

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -139,7 +139,7 @@ def test_send_message(
 
 
 def test_send_message_with_unsniffable_jpeg(
-    hass: HomeAssistant, message, tmp_path: Path
+    hass: HomeAssistant, message: MockSMTP, tmp_path: Path
 ) -> None:
     """Verify a JPEG the stdlib cannot sniff is still attached as an image.
 

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -1,5 +1,6 @@
 """The tests for the notify smtp platform."""
 
+import gzip
 from pathlib import Path
 import re
 from smtplib import (
@@ -156,6 +157,20 @@ def test_send_message_with_unsniffable_jpeg(
         result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
     assert "Content-Type: image/jpeg" in result
     assert "application/octet-stream" not in result
+
+
+def test_send_message_with_compressed_image(
+    hass: HomeAssistant, message: MockSMTP, tmp_path: Path
+) -> None:
+    """Verify a compressed image is attached as a file, not a plain image."""
+    image_file = tmp_path / "diagram.svgz"
+    image_file.write_bytes(gzip.compress(b"<svg xmlns='http://www.w3.org/2000/svg'/>"))
+    message.hass = hass
+    hass.config.allowlist_external_dirs.add(tmp_path)
+    with patch("email.utils.make_msgid", return_value="<mock@mock>"):
+        result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
+    assert "application/octet-stream" in result
+    assert "Content-Type: image/" not in result
 
 
 @pytest.mark.parametrize(

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -138,6 +138,26 @@ def test_send_message(
         assert content_type in result
 
 
+def test_send_message_with_unsniffable_jpeg(
+    hass: HomeAssistant, message, tmp_path: Path
+) -> None:
+    """Verify a JPEG the stdlib cannot sniff is still attached as an image.
+
+    JPEGs written by ffmpeg for camera.snapshot start with an SOI + COM
+    marker instead of JFIF/Exif, which MIMEImage does not recognize.
+    """
+    image_file = tmp_path / "doorphone.jpg"
+    image_file.write_bytes(
+        bytes.fromhex("ffd8fffe0010") + b"Lavc62.28.102\x00" + bytes.fromhex("ffdb")
+    )
+    message.hass = hass
+    hass.config.allowlist_external_dirs.add(tmp_path)
+    with patch("email.utils.make_msgid", return_value="<mock@mock>"):
+        result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
+    assert "Content-Type: image/jpeg" in result
+    assert "application/octet-stream" not in result
+
+
 @pytest.mark.parametrize(
     ("message_data", "data", "content_type"),
     [

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -12,6 +12,7 @@ from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components import camera, image, media_source
 from homeassistant.components.notify import (
+    ATTR_DATA,
     ATTR_MESSAGE,
     ATTR_TARGET,
     DOMAIN as NOTIFY_DOMAIN,
@@ -122,40 +123,6 @@ def test_send_message(
     with patch("email.utils.make_msgid", return_value=sample_email):
         result, _ = message.send_message(message_data, data=data)
         assert content_type in result
-
-
-def test_send_message_with_unsniffable_jpeg(
-    hass: HomeAssistant, message: MockSMTP, tmp_path: Path
-) -> None:
-    """Verify a JPEG the stdlib cannot sniff is still attached as an image.
-
-    JPEGs written by ffmpeg for camera.snapshot start with an SOI + COM
-    marker instead of JFIF/Exif, which MIMEImage does not recognize.
-    """
-    image_file = tmp_path / "doorphone.jpg"
-    image_file.write_bytes(
-        bytes.fromhex("ffd8fffe0010") + b"Lavc62.28.102\x00" + bytes.fromhex("ffdb")
-    )
-    message.hass = hass
-    hass.config.allowlist_external_dirs.add(tmp_path)
-    with patch("email.utils.make_msgid", return_value="<mock@mock>"):
-        result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
-    assert "Content-Type: image/jpeg" in result
-    assert "application/octet-stream" not in result
-
-
-def test_send_message_with_compressed_image(
-    hass: HomeAssistant, message: MockSMTP, tmp_path: Path
-) -> None:
-    """Verify a compressed image is attached as a file, not a plain image."""
-    image_file = tmp_path / "diagram.svgz"
-    image_file.write_bytes(gzip.compress(b"<svg xmlns='http://www.w3.org/2000/svg'/>"))
-    message.hass = hass
-    hass.config.allowlist_external_dirs.add(tmp_path)
-    with patch("email.utils.make_msgid", return_value="<mock@mock>"):
-        result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
-    assert "application/octet-stream" in result
-    assert "Content-Type: image/" not in result
 
 
 @pytest.mark.parametrize(
@@ -717,3 +684,69 @@ async def test_deprecated_legacy_notify_action(
     assert issue_registry.async_get_issue(
         domain=DOMAIN, issue_id="deprecated_notify_action_home_assistant"
     )
+
+
+@pytest.mark.parametrize(
+    ("file_name", "file_bytes", "expected", "not_expected"),
+    [
+        (
+            "doorphone.jpg",
+            bytes.fromhex("ffd8fffe0010")
+            + b"Lavc62.28.102\x00"
+            + bytes.fromhex("ffdb"),
+            "Content-Type: image/jpeg",
+            "application/octet-stream",
+        ),
+        (
+            "diagram.svgz",
+            gzip.compress(b"<svg xmlns='http://www.w3.org/2000/svg'/>"),
+            "application/octet-stream",
+            "Content-Type: image/",
+        ),
+    ],
+    ids=[
+        "Verify a JPEG the stdlib cannot sniff is attached as an image.",
+        "Verify a compressed image is attached as a file.",
+    ],
+)
+@pytest.mark.usefixtures("aiosmtplib")
+async def test_legacy_notify_image_attachment(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    smtp: MagicMock,
+    tmp_path: Path,
+    file_name: str,
+    file_bytes: bytes,
+    expected: str,
+    not_expected: str,
+) -> None:
+    """Test the MIME type images are attached with.
+
+    JPEGs written by ffmpeg for camera.snapshot start with an SOI + COM marker
+    instead of JFIF/Exif, which MIMEImage does not recognize, so the file name
+    decides the type. Compressed images stay on the file attachment path.
+    """
+
+    image_file = tmp_path / file_name
+    image_file.write_bytes(file_bytes)
+    hass.config.allowlist_external_dirs.add(tmp_path)
+
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        "home_assistant",
+        {
+            ATTR_MESSAGE: "Test msg",
+            ATTR_DATA: {"images": [str(image_file)]},
+        },
+        blocking=True,
+    )
+
+    sent_message = smtp.sendmail.call_args[0][2]
+    assert expected in sent_message
+    assert not_expected not in sent_message

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -123,6 +123,26 @@ def test_send_message(
         assert content_type in result
 
 
+def test_send_message_with_unsniffable_jpeg(
+    hass: HomeAssistant, message, tmp_path: Path
+) -> None:
+    """Verify a JPEG the stdlib cannot sniff is still attached as an image.
+
+    JPEGs written by ffmpeg for camera.snapshot start with an SOI + COM
+    marker instead of JFIF/Exif, which MIMEImage does not recognize.
+    """
+    image_file = tmp_path / "doorphone.jpg"
+    image_file.write_bytes(
+        bytes.fromhex("ffd8fffe0010") + b"Lavc62.28.102\x00" + bytes.fromhex("ffdb")
+    )
+    message.hass = hass
+    hass.config.allowlist_external_dirs.add(tmp_path)
+    with patch("email.utils.make_msgid", return_value="<mock@mock>"):
+        result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
+    assert "Content-Type: image/jpeg" in result
+    assert "application/octet-stream" not in result
+
+
 @pytest.mark.parametrize(
     ("message_data", "data", "content_type"),
     [

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -1,5 +1,6 @@
 """The tests for the notify smtp platform."""
 
+import gzip
 from pathlib import Path
 import re
 from smtplib import SMTPException, SMTPServerDisconnected
@@ -141,6 +142,20 @@ def test_send_message_with_unsniffable_jpeg(
         result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
     assert "Content-Type: image/jpeg" in result
     assert "application/octet-stream" not in result
+
+
+def test_send_message_with_compressed_image(
+    hass: HomeAssistant, message: MockSMTP, tmp_path: Path
+) -> None:
+    """Verify a compressed image is attached as a file, not a plain image."""
+    image_file = tmp_path / "diagram.svgz"
+    image_file.write_bytes(gzip.compress(b"<svg xmlns='http://www.w3.org/2000/svg'/>"))
+    message.hass = hass
+    hass.config.allowlist_external_dirs.add(tmp_path)
+    with patch("email.utils.make_msgid", return_value="<mock@mock>"):
+        result, _ = message.send_message("Test msg", data={"images": [str(image_file)]})
+    assert "application/octet-stream" in result
+    assert "Content-Type: image/" not in result
 
 
 @pytest.mark.parametrize(

--- a/tests/components/smtp/test_notify.py
+++ b/tests/components/smtp/test_notify.py
@@ -124,7 +124,7 @@ def test_send_message(
 
 
 def test_send_message_with_unsniffable_jpeg(
-    hass: HomeAssistant, message, tmp_path: Path
+    hass: HomeAssistant, message: MockSMTP, tmp_path: Path
 ) -> None:
     """Verify a JPEG the stdlib cannot sniff is still attached as an image.
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Images generated by `camera.snapshot` (written by ffmpeg) were attached to SMTP notifications as `application/octet-stream` instead of `image/jpeg`.

Root cause: these JPEGs start with an SOI + COM comment marker (`FFD8FFFE`, e.g. containing `Lavc62.28.102`) instead of JFIF/Exif markers, and the stdlib content sniffing used by `MIMEImage` (the `imghdr` successor) only recognizes JPEGs with `JFIF`/`Exif` at offset 6 or a `FFD8FFDB` (SOI + DQT) prefix. The resulting `TypeError` sent the attachment down the generic-file fallback path in `_attach_file()`.

This change falls back to `mimetypes.guess_type()` on the attachment filename when content sniffing fails, and only attaches as a generic file when the filename doesn't indicate an image either. The fallback warning text is also reworded, since the previous "has an unknown MIME type" was misleading — the type is known from the filename; it's the content sniffing that fails.

A test covering an ffmpeg-style SOI+COM JPEG is included (fails with `application/octet-stream` before the fix, passes with `image/jpeg` after).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176760
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

