### PR TITLE
Add sleep coordinator and sensors to Google Health

### DIFF
--- a/homeassistant/components/google_health/__init__.py
+++ b/homeassistant/components/google_health/__init__.py
@@ -1,5 +1,6 @@
 """The Google Health integration."""
 
+import asyncio
 from dataclasses import dataclass
 
 from google_health_api import GoogleHealthApi
@@ -18,7 +19,11 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 
 from . import api
 from .const import DOMAIN
-from .coordinator import GoogleHealthActivityCoordinator, GoogleHealthBodyCoordinator
+from .coordinator import (
+    GoogleHealthActivityCoordinator,
+    GoogleHealthBodyCoordinator,
+    GoogleHealthSleepCoordinator,
+)
 
 _PLATFORMS: list[Platform] = [Platform.SENSOR]
 
@@ -29,6 +34,7 @@ class GoogleHealthData:
 
     activity_coordinator: GoogleHealthActivityCoordinator | None = None
     body_coordinator: GoogleHealthBodyCoordinator | None = None
+    sleep_coordinator: GoogleHealthSleepCoordinator | None = None
 
 
 type GoogleHealthConfigEntry = ConfigEntry[GoogleHealthData]
@@ -64,16 +70,36 @@ async def async_setup_entry(
     activity_coordinator = None
     if all(scope in scopes for scope in api_client.steps.required_read_scopes):
         activity_coordinator = GoogleHealthActivityCoordinator(hass, entry, api_client)
-        await activity_coordinator.async_config_entry_first_refresh()
 
     body_coordinator = None
     if all(scope in scopes for scope in api_client.weight.required_read_scopes):
         body_coordinator = GoogleHealthBodyCoordinator(hass, entry, api_client)
-        await body_coordinator.async_config_entry_first_refresh()
+
+    sleep_coordinator = None
+    if all(scope in scopes for scope in api_client.sleep.required_read_scopes):
+        sleep_coordinator = GoogleHealthSleepCoordinator(hass, entry, api_client)
+
+    coordinators: list[
+        GoogleHealthActivityCoordinator
+        | GoogleHealthBodyCoordinator
+        | GoogleHealthSleepCoordinator
+    ] = []
+    if activity_coordinator:
+        coordinators.append(activity_coordinator)
+    if body_coordinator:
+        coordinators.append(body_coordinator)
+    if sleep_coordinator:
+        coordinators.append(sleep_coordinator)
+
+    if coordinators:
+        await asyncio.gather(
+            *(coord.async_config_entry_first_refresh() for coord in coordinators)
+        )
 
     entry.runtime_data = GoogleHealthData(
         activity_coordinator=activity_coordinator,
         body_coordinator=body_coordinator,
+        sleep_coordinator=sleep_coordinator,
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)

--- a/homeassistant/components/google_health/__init__.py
+++ b/homeassistant/components/google_health/__init__.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from dataclasses import dataclass
+from typing import Any
 
 from google_health_api import GoogleHealthApi
 from google_health_api.const import HealthApiScope
@@ -22,6 +23,7 @@ from .const import DOMAIN
 from .coordinator import (
     GoogleHealthActivityCoordinator,
     GoogleHealthBodyCoordinator,
+    GoogleHealthDataUpdateCoordinator,
     GoogleHealthSleepCoordinator,
 )
 
@@ -67,28 +69,21 @@ async def async_setup_entry(
 
     api_client = GoogleHealthApi(auth)
 
+    coordinators: list[GoogleHealthDataUpdateCoordinator[Any]] = []
+
     activity_coordinator = None
     if all(scope in scopes for scope in api_client.steps.required_read_scopes):
         activity_coordinator = GoogleHealthActivityCoordinator(hass, entry, api_client)
+        coordinators.append(activity_coordinator)
 
     body_coordinator = None
     if all(scope in scopes for scope in api_client.weight.required_read_scopes):
         body_coordinator = GoogleHealthBodyCoordinator(hass, entry, api_client)
+        coordinators.append(body_coordinator)
 
     sleep_coordinator = None
     if all(scope in scopes for scope in api_client.sleep.required_read_scopes):
         sleep_coordinator = GoogleHealthSleepCoordinator(hass, entry, api_client)
-
-    coordinators: list[
-        GoogleHealthActivityCoordinator
-        | GoogleHealthBodyCoordinator
-        | GoogleHealthSleepCoordinator
-    ] = []
-    if activity_coordinator:
-        coordinators.append(activity_coordinator)
-    if body_coordinator:
-        coordinators.append(body_coordinator)
-    if sleep_coordinator:
         coordinators.append(sleep_coordinator)
 
     if coordinators:

--- a/homeassistant/components/google_health/const.py
+++ b/homeassistant/components/google_health/const.py
@@ -17,5 +17,6 @@ OAUTH_SCOPES = [
     HealthApiScope.ACTIVITY_READ,
     HealthApiScope.PROFILE_READ,
     HealthApiScope.MEASUREMENTS_READ,
+    HealthApiScope.SLEEP_READ,
     HealthApiScope.USERINFO_PROFILE,
 ]

--- a/homeassistant/components/google_health/coordinator.py
+++ b/homeassistant/components/google_health/coordinator.py
@@ -18,6 +18,7 @@ from google_health_api.model import (
     DailyRestingHeartRate,
     DistanceRollupValue,
     FloorsRollupValue,
+    Sleep,
     StepsRollupValue,
     TotalCaloriesRollupValue,
     Weight,
@@ -211,3 +212,39 @@ class GoogleHealthBodyCoordinator(
             resting_heart_rate=resting_heart_rate,
             body_fat=body_fat,
         )
+
+
+@dataclass
+class GoogleHealthSleepData:
+    """Class to hold sleep data."""
+
+    sleep: Sleep | None = None
+
+
+class GoogleHealthSleepCoordinator(
+    GoogleHealthDataUpdateCoordinator[GoogleHealthSleepData]
+):
+    """Coordinator to fetch sleep data from Google Health API."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: GoogleHealthConfigEntry,
+        api_client: GoogleHealthApi,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=f"{DOMAIN}_sleep",
+            update_interval=BODY_POLLING_INTERVAL,
+            entry=entry,
+            api_client=api_client,
+        )
+
+    @override
+    async def _async_fetch_data(self) -> GoogleHealthSleepData:
+        """Fetch latest sleep session."""
+        sleep_result = await self.api.sleep.list(page_size=DEFAULT_PAGE_SIZE)
+        sleep = sleep_result.data_points[0].data if sleep_result.data_points else None
+        return GoogleHealthSleepData(sleep=sleep)

--- a/homeassistant/components/google_health/sensor.py
+++ b/homeassistant/components/google_health/sensor.py
@@ -10,7 +10,13 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfEnergy, UnitOfLength, UnitOfMass
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfLength,
+    UnitOfMass,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -23,6 +29,7 @@ from .coordinator import (
     GoogleHealthActivityCoordinator,
     GoogleHealthBodyCoordinator,
     GoogleHealthDataUpdateCoordinator,
+    GoogleHealthSleepCoordinator,
 )
 
 PARALLEL_UPDATES = 0
@@ -118,6 +125,71 @@ BODY_SENSORS: list[
     ),
 ]
 
+SLEEP_SENSORS: list[
+    GoogleHealthSensorEntityDescription[GoogleHealthSleepCoordinator, Any]
+] = [
+    GoogleHealthSensorEntityDescription[GoogleHealthSleepCoordinator, int | None](
+        key="sleep_asleep",
+        translation_key="sleep_asleep",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.sleep.summary.minutes_asleep
+            if data and data.sleep and data.sleep.summary
+            else None
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthSleepCoordinator, int | None](
+        key="sleep_awake",
+        translation_key="sleep_awake",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.sleep.summary.minutes_awake
+            if data and data.sleep and data.sleep.summary
+            else None
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthSleepCoordinator, int | None](
+        key="sleep_in_bed",
+        translation_key="sleep_in_bed",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.sleep.summary.minutes_in_sleep_period
+            if data and data.sleep and data.sleep.summary
+            else None
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthSleepCoordinator, int | None](
+        key="sleep_to_fall_asleep",
+        translation_key="sleep_to_fall_asleep",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.sleep.summary.minutes_to_fall_asleep
+            if data and data.sleep and data.sleep.summary
+            else None
+        ),
+    ),
+    GoogleHealthSensorEntityDescription[GoogleHealthSleepCoordinator, int | None](
+        key="sleep_after_wakeup",
+        translation_key="sleep_after_wakeup",
+        native_unit_of_measurement=UnitOfTime.MINUTES,
+        device_class=SensorDeviceClass.DURATION,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda data: (
+            data.sleep.summary.minutes_after_wake_up
+            if data and data.sleep and data.sleep.summary
+            else None
+        ),
+    ),
+]
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -137,6 +209,11 @@ async def async_setup_entry(
         entities.extend(
             GoogleHealthSensor(body_coordinator, entry.entry_id, description)
             for description in BODY_SENSORS
+        )
+    if (sleep_coordinator := data.sleep_coordinator) is not None:
+        entities.extend(
+            GoogleHealthSensor(sleep_coordinator, entry.entry_id, description)
+            for description in SLEEP_SENSORS
         )
 
     if entities:

--- a/homeassistant/components/google_health/strings.json
+++ b/homeassistant/components/google_health/strings.json
@@ -47,6 +47,21 @@
       "resting_heart_rate": {
         "name": "Resting heart rate"
       },
+      "sleep_after_wakeup": {
+        "name": "Time after waking up"
+      },
+      "sleep_asleep": {
+        "name": "Time asleep"
+      },
+      "sleep_awake": {
+        "name": "Time awake"
+      },
+      "sleep_in_bed": {
+        "name": "Time in bed"
+      },
+      "sleep_to_fall_asleep": {
+        "name": "Time to fall asleep"
+      },
       "steps": {
         "name": "Steps",
         "unit_of_measurement": "steps"

--- a/tests/components/google_health/conftest.py
+++ b/tests/components/google_health/conftest.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, patch
 from google_health_api.model import (
     BODY_FAT,
     DAILY_RESTING_HEART_RATE,
+    SLEEP,
     WEIGHT,
     ActiveEnergyBurnedRollupValue,
     DailyRollupDataPoint,
@@ -158,6 +159,11 @@ def mock_google_health_client() -> Generator[AsyncMock]:
         )
         client.body_fat = AsyncMock()
         client.body_fat.list.return_value = _list_fixture("body_fat.json", BODY_FAT)
+        client.sleep = AsyncMock()
+        client.sleep.list.return_value = _list_fixture("sleep.json", SLEEP)
+        client.sleep.required_read_scopes = [
+            "https://www.googleapis.com/auth/googlehealth.sleep.readonly"
+        ]
         client.get_identity.return_value = Identity.from_dict(
             load_json_object_fixture("identity.json", DOMAIN)
         )

--- a/tests/components/google_health/fixtures/sleep.json
+++ b/tests/components/google_health/fixtures/sleep.json
@@ -1,0 +1,22 @@
+{
+  "dataPoints": [
+    {
+      "name": "users/me/dataTypes/sleep/dataPoints/session-12345",
+      "sleep": {
+        "interval": {
+          "startTime": "2026-06-29T22:00:00Z",
+          "endTime": "2026-06-30T06:00:00Z",
+          "startUtcOffset": "-07:00",
+          "endUtcOffset": "-07:00"
+        },
+        "summary": {
+          "minutesToFallAsleep": 15,
+          "minutesAfterWakeUp": 10,
+          "minutesAsleep": 420,
+          "minutesInSleepPeriod": 480,
+          "minutesAwake": 60
+        }
+      }
+    }
+  ]
+}

--- a/tests/components/google_health/snapshots/test_sensor.ambr
+++ b/tests/components/google_health/snapshots/test_sensor.ambr
@@ -326,6 +326,296 @@
     'state': '10500',
   })
 # ---
+# name: test_all_entities[sensor.google_health_time_after_waking_up-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_time_after_waking_up',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time after waking up',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Time after waking up',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sleep_after_wakeup',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_sleep_after_wakeup',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_after_waking_up-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Time after waking up',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_time_after_waking_up',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '10',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_asleep-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_time_asleep',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time asleep',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Time asleep',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sleep_asleep',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_sleep_asleep',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_asleep-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Time asleep',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_time_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '420',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_awake-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_time_awake',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time awake',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Time awake',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sleep_awake',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_sleep_awake',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_awake-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Time awake',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_time_awake',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '60',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_in_bed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_time_in_bed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time in bed',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Time in bed',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sleep_in_bed',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_sleep_in_bed',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_in_bed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Time in bed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_time_in_bed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '480',
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_to_fall_asleep-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.google_health_time_to_fall_asleep',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Time to fall asleep',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 2,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.DURATION: 'duration'>,
+    'original_icon': None,
+    'original_name': 'Time to fall asleep',
+    'platform': 'google_health',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'sleep_to_fall_asleep',
+    'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_sleep_to_fall_asleep',
+    'unit_of_measurement': <UnitOfTime.MINUTES: 'min'>,
+  })
+# ---
+# name: test_all_entities[sensor.google_health_time_to_fall_asleep-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Time to fall asleep',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MINUTES: 'min'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.google_health_time_to_fall_asleep',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '15',
+  })
+# ---
 # name: test_all_entities[sensor.google_health_total_calories-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/google_health/test_config_flow.py
+++ b/tests/components/google_health/test_config_flow.py
@@ -63,6 +63,7 @@ async def test_full_flow(
         "&scope=https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly"
         "+https://www.googleapis.com/auth/googlehealth.profile.readonly"
         "+https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly"
+        "+https://www.googleapis.com/auth/googlehealth.sleep.readonly"
         "+https://www.googleapis.com/auth/userinfo.profile"
         "&access_type=offline"
         "&prompt=consent"

--- a/tests/components/google_health/test_init.py
+++ b/tests/components/google_health/test_init.py
@@ -37,6 +37,8 @@ async def test_setup_and_unload(
     assert hass.states.get("sensor.google_health_distance") is not None
     assert hass.states.get("sensor.google_health_weight") is not None
     assert hass.states.get("sensor.google_health_resting_heart_rate") is not None
+    assert hass.states.get("sensor.google_health_time_asleep") is not None
+    assert hass.states.get("sensor.google_health_time_awake") is not None
 
     assert await hass.config_entries.async_unload(config_entry.entry_id)
     await hass.async_block_till_done()
@@ -149,6 +151,30 @@ async def test_setup_missing_measurements_scope(
     assert hass.states.get("sensor.google_health_active_calories") is not None
     assert hass.states.get("sensor.google_health_total_calories") is not None
     assert hass.states.get("sensor.google_health_floors") is not None
+
+
+@pytest.mark.usefixtures("mock_google_health_client")
+@pytest.mark.parametrize(
+    "scopes",
+    [
+        [
+            "https://www.googleapis.com/auth/googlehealth.profile.readonly",
+            "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly",
+            "https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly",
+        ]
+    ],
+)
+async def test_setup_missing_sleep_scope(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test setup succeeds but sleep sensor is not added if sleep scope is missing."""
+    assert await integration_setup()
+    assert config_entry.state is config_entries.ConfigEntryState.LOADED
+
+    assert hass.states.get("sensor.google_health_time_asleep") is None
+    assert hass.states.get("sensor.google_health_time_awake") is None
 
 
 async def test_setup_oauth_implementation_unavailable(

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -3,6 +3,7 @@
 from collections.abc import Awaitable, Callable
 from unittest.mock import AsyncMock, patch
 
+from google_health_api.model import ListDataPointResult, _ListDataPointsModel
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -61,3 +62,20 @@ async def test_sensor_empty_rollup(
     floors_state = hass.states.get("sensor.google_health_floors")
     assert floors_state is not None
     assert floors_state.state == "0"
+
+
+async def test_sensor_empty_sleep(
+    hass: HomeAssistant,
+    mock_google_health_client: AsyncMock,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test sleep sensors when the sleep endpoint returns no data."""
+    mock_google_health_client.sleep.list.return_value = ListDataPointResult(
+        _ListDataPointsModel(data_points=[])
+    )
+
+    assert await integration_setup()
+
+    time_asleep_state = hass.states.get("sensor.google_health_time_asleep")
+    assert time_asleep_state is not None
+    assert time_asleep_state.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expand the Google Health integration by adding active calories, total calories, floors, body fat, and sleep sensors.

These have a separate OAuth scope and poll interval from some other signals so is a separate coordinator. (Not combined with body sensors to keep logic simpler for now)

Detailed changes.
- Adds `HealthApiScope.SLEEP_READ` scope to authorized OAuth scopes.
- Introduces parallel initial refreshes for all enabled coordinators during configuration entry setup to speed up integration startup.
- Implements `GoogleHealthSleepCoordinator` to fetch the latest sleep session and maps sleep summary values into sensors (time asleep, awake, in bed, to fall asleep, and after waking up).
- Dynamically sets up body and sleep sensors based on authorized OAuth scopes, preventing unauthorized API calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
