### PR TITLE
fix: unhandled exception crashing MCP streamable endpoint requests (#176734)

### DIFF
--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -35,7 +35,12 @@ from http import HTTPStatus
 import logging
 
 from aiohttp import web
-from aiohttp.web_exceptions import HTTPBadRequest, HTTPNotFound
+from aiohttp.web_exceptions import (
+    HTTPBadRequest,
+    HTTPGatewayTimeout,
+    HTTPInternalServerError,
+    HTTPNotFound,
+)
 from aiohttp_sse import sse_response
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
@@ -288,9 +293,25 @@ async def _async_handle_streamable_message(
                 await streams.read_stream_writer.send(SessionMessage(message))
                 session_message = await anext(streams.write_stream_reader)
                 tg.cancel_scope.cancel()
+        except* TimeoutError as eg:
+            # The MCP server never produced a response within TIMEOUT, e.g. an
+            # out-of-sequence or malformed probe that the session can't turn
+            # into a reply. This is a request-caused failure, not a server bug.
+            _LOGGER.debug(
+                "Timed out waiting for MCP server response: %s", eg.exceptions
+            )
+            raise HTTPGatewayTimeout(text="Timed out waiting for a response") from eg
         except* Exception as eg:
-            _LOGGER.debug("Error processing streamable MCP request: %s", eg.exceptions)
-            raise HTTPBadRequest(text="Could not process request") from eg
+            # Anything else is unexpected (a defect in our code or the MCP
+            # SDK), so surface it as a server error and log it loudly instead
+            # of hiding it behind a client-error status at debug level.
+            _LOGGER.exception(
+                "Unexpected error processing streamable MCP request",
+                exc_info=eg,
+            )
+            raise HTTPInternalServerError(
+                text="Internal error processing request"
+            ) from eg
 
         _LOGGER.debug("Sending response: %s", session_message)
         return web.json_response(

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -281,12 +281,16 @@ async def _async_handle_streamable_message(
                 streams.read_stream, streams.write_stream, options, stateless=True
             )
 
-        async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
-            tg.start_soon(run_server)
+        try:
+            async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
+                tg.start_soon(run_server)
 
-            await streams.read_stream_writer.send(SessionMessage(message))
-            session_message = await anext(streams.write_stream_reader)
-            tg.cancel_scope.cancel()
+                await streams.read_stream_writer.send(SessionMessage(message))
+                session_message = await anext(streams.write_stream_reader)
+                tg.cancel_scope.cancel()
+        except* Exception as eg:
+            _LOGGER.debug("Error processing streamable MCP request: %s", eg.exceptions)
+            raise HTTPBadRequest(text="Could not process request") from eg
 
         _LOGGER.debug("Sending response: %s", session_message)
         return web.json_response(

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -294,17 +294,11 @@ async def _async_handle_streamable_message(
                 session_message = await anext(streams.write_stream_reader)
                 tg.cancel_scope.cancel()
         except* TimeoutError as eg:
-            # The MCP server never produced a response within TIMEOUT, e.g. an
-            # out-of-sequence or malformed probe that the session can't turn
-            # into a reply. This is a request-caused failure, not a server bug.
             _LOGGER.debug(
                 "Timed out waiting for MCP server response: %s", eg.exceptions
             )
             raise HTTPGatewayTimeout(text="Timed out waiting for a response") from eg
         except* Exception as eg:
-            # Anything else is unexpected (a defect in our code or the MCP
-            # SDK), so surface it as a server error and log it loudly instead
-            # of hiding it behind a client-error status at debug level.
             _LOGGER.exception(
                 "Unexpected error processing streamable MCP request",
                 exc_info=eg,

--- a/homeassistant/components/mcp_server/http.py
+++ b/homeassistant/components/mcp_server/http.py
@@ -286,6 +286,7 @@ async def _async_handle_streamable_message(
                 streams.read_stream, streams.write_stream, options, stateless=True
             )
 
+        session_message: SessionMessage | None = None
         try:
             async with asyncio.timeout(TIMEOUT), anyio.create_task_group() as tg:
                 tg.start_soon(run_server)
@@ -307,6 +308,7 @@ async def _async_handle_streamable_message(
                 text="Internal error processing request"
             ) from eg
 
+        assert session_message is not None
         _LOGGER.debug("Sending response: %s", session_message)
         return web.json_response(
             data=session_message.message.model_dump(by_alias=True, exclude_none=True),

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -1,5 +1,6 @@
 """Test the Model Context Protocol Server init module."""
 
+import asyncio
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from http import HTTPStatus
@@ -217,12 +218,11 @@ async def test_streamable_error_processing_request(
     setup_integration: None,
     hass_client: ClientSessionGenerator,
 ) -> None:
-    """Test a failure while processing a streamable request returns a structured 400.
+    """Test an unexpected failure while processing a streamable request returns a structured 500.
 
-    This simulates a client probing the endpoint (e.g. a schema/initialize
-    probe) in a way that causes the underlying MCP server run to fail. The
-    endpoint should respond with a structured client error instead of an
-    unhandled exception.
+    This simulates a defect in the underlying MCP server run (not a
+    request-caused failure). The endpoint should respond with a structured
+    server error instead of an unhandled exception or a misleading 400.
     """
     client = await hass_client()
 
@@ -236,9 +236,45 @@ async def test_streamable_error_processing_request(
             headers={"accept": CONTENT_TYPE_JSON},
         )
 
-    assert response.status == HTTPStatus.BAD_REQUEST
+    assert response.status == HTTPStatus.INTERNAL_SERVER_ERROR
     response_data = await response.text()
-    assert response_data == "Could not process request"
+    assert response_data == "Internal error processing request"
+
+
+async def test_streamable_timeout_processing_request(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a request the MCP server never responds to returns a structured 504.
+
+    This simulates the originally reported crash: an out-of-sequence or
+    malformed probe that the session can't turn into a reply, so the
+    request-handling task group never receives a response before the
+    timeout. The endpoint should respond with a structured timeout error
+    instead of hanging or crashing.
+    """
+    client = await hass_client()
+
+    async def hang_forever(*args: Any, **kwargs: Any) -> None:
+        await asyncio.sleep(3600)
+
+    with (
+        patch("homeassistant.components.mcp_server.http.TIMEOUT", 0.05),
+        patch(
+            "homeassistant.components.mcp_server.http.Server.run",
+            side_effect=hang_forever,
+        ),
+    ):
+        response = await client.post(
+            STREAMABLE_API,
+            json=INITIALIZE_MESSAGE,
+            headers={"accept": CONTENT_TYPE_JSON},
+        )
+
+    assert response.status == HTTPStatus.GATEWAY_TIMEOUT
+    response_data = await response.text()
+    assert response_data == "Timed out waiting for a response"
 
 
 async def test_http_sse_multiple_config_entries(

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -212,6 +212,35 @@ async def test_http_messages_invalid_message_format(
     assert response_data == "Could not parse message"
 
 
+async def test_streamable_error_processing_request(
+    hass: HomeAssistant,
+    setup_integration: None,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test a failure while processing a streamable request returns a structured 400.
+
+    This simulates a client probing the endpoint (e.g. a schema/initialize
+    probe) in a way that causes the underlying MCP server run to fail. The
+    endpoint should respond with a structured client error instead of an
+    unhandled exception.
+    """
+    client = await hass_client()
+
+    with patch(
+        "homeassistant.components.mcp_server.http.Server.run",
+        side_effect=RuntimeError("boom"),
+    ):
+        response = await client.post(
+            STREAMABLE_API,
+            json=INITIALIZE_MESSAGE,
+            headers={"accept": CONTENT_TYPE_JSON},
+        )
+
+    assert response.status == HTTPStatus.BAD_REQUEST
+    response_data = await response.text()
+    assert response_data == "Could not process request"
+
+
 async def test_http_sse_multiple_config_entries(
     hass: HomeAssistant,
     setup_integration: None,

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -218,12 +218,7 @@ async def test_streamable_error_processing_request(
     setup_integration: None,
     hass_client: ClientSessionGenerator,
 ) -> None:
-    """Test an unexpected failure while processing a streamable request returns a structured 500.
-
-    This simulates a defect in the underlying MCP server run (not a
-    request-caused failure). The endpoint should respond with a structured
-    server error instead of an unhandled exception or a misleading 400.
-    """
+    """Test unexpected server failure returns 500, not an unhandled exception."""
     client = await hass_client()
 
     with patch(
@@ -246,14 +241,7 @@ async def test_streamable_timeout_processing_request(
     setup_integration: None,
     hass_client: ClientSessionGenerator,
 ) -> None:
-    """Test a request the MCP server never responds to returns a structured 504.
-
-    This simulates the originally reported crash: an out-of-sequence or
-    malformed probe that the session can't turn into a reply, so the
-    request-handling task group never receives a response before the
-    timeout. The endpoint should respond with a structured timeout error
-    instead of hanging or crashing.
-    """
+    """Test a request that times out returns 504 instead of hanging or crashing."""
     client = await hass_client()
 
     async def hang_forever(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

None.

## Proposed change

Fixes #176734

**Root cause:** The `/api/mcp` Streamable HTTP endpoint (`ModelContextProtocolStreamableView`) spawns a background `anyio` task that runs the MCP SDK's `Server.run()` for the lifetime of a single request, inside an `asyncio.timeout()` + `anyio.create_task_group()` block. If that per-request task fails for any reason (a malformed/incomplete probe the MCP SDK cannot service, or the 60s timeout expiring), the failure surfaces as a raw `ExceptionGroup`/`TimeoutError` that was not caught in `_async_handle_streamable_message`. This propagated past the view handler as an unstructured traceback dump.

**Fix:** Wrap the task group in a `try/except*` block:
- `except* TimeoutError` → HTTP 504 Gateway Timeout (request-caused: the server never produced a reply in time)
- `except* Exception` → HTTP 500 Internal Server Error (unexpected defect logged at ERROR level, not hidden at DEBUG)

**Tests added:**
- `test_streamable_error_processing_request` — unexpected `RuntimeError` from `Server.run` → 500
- `test_streamable_timeout_processing_request` — `Server.run` hangs past TIMEOUT → 504

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Additional information

- This PR fixes the regression where bare MCP probes (e.g. from clients checking endpoint availability) caused the HA server process to restart.
- Tested against HA test suite for the `mcp_server` component.