### PR TITLE
Support all statistics as attrs in MinMaxSensor

### DIFF
--- a/homeassistant/components/min_max/config_flow.py
+++ b/homeassistant/components/min_max/config_flow.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
 )
 
-from .const import CONF_ENTITY_IDS, CONF_ROUND_DIGITS, DOMAIN
+from .const import CONF_ALL_STATISTICS, CONF_ENTITY_IDS, CONF_ROUND_DIGITS, DOMAIN
 
 _STATISTIC_MEASURES = [
     "min",
@@ -46,6 +46,7 @@ OPTIONS_SCHEMA = vol.Schema(
                 min=0, max=6, mode=selector.NumberSelectorMode.BOX
             ),
         ),
+        vol.Optional(CONF_ALL_STATISTICS, default=False): selector.BooleanSelector(),
     }
 )
 

--- a/homeassistant/components/min_max/const.py
+++ b/homeassistant/components/min_max/const.py
@@ -2,5 +2,7 @@
 
 DOMAIN = "min_max"
 
+CONF_ALL_STATISTICS = "all_statistics"
 CONF_ENTITY_IDS = "entity_ids"
 CONF_ROUND_DIGITS = "round_digits"
+DEFAULT_ALL_STATISTICS = False

--- a/homeassistant/components/min_max/sensor.py
+++ b/homeassistant/components/min_max/sensor.py
@@ -36,7 +36,13 @@ from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
 
 from . import PLATFORMS
-from .const import CONF_ENTITY_IDS, CONF_ROUND_DIGITS, DOMAIN
+from .const import (
+    CONF_ALL_STATISTICS,
+    CONF_ENTITY_IDS,
+    CONF_ROUND_DIGITS,
+    DEFAULT_ALL_STATISTICS,
+    DOMAIN,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,6 +78,7 @@ PLATFORM_SCHEMA = SENSOR_PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME): cv.string,
         vol.Required(CONF_ENTITY_IDS): cv.entity_ids,
         vol.Optional(CONF_ROUND_DIGITS, default=2): vol.Coerce(int),
+        vol.Optional(CONF_ALL_STATISTICS, default=False): cv.boolean,
         vol.Optional(CONF_UNIQUE_ID): cv.string,
     }
 )
@@ -89,6 +96,9 @@ async def async_setup_entry(
     )
     sensor_type = config_entry.options[CONF_TYPE]
     round_digits = int(config_entry.options[CONF_ROUND_DIGITS])
+    all_statistics = config_entry.options.get(
+        CONF_ALL_STATISTICS, DEFAULT_ALL_STATISTICS
+    )
 
     async_add_entities(
         [
@@ -97,6 +107,7 @@ async def async_setup_entry(
                 config_entry.title,
                 sensor_type,
                 round_digits,
+                all_statistics,
                 config_entry.entry_id,
             )
         ]
@@ -114,12 +125,17 @@ async def async_setup_platform(
     name: str | None = config.get(CONF_NAME)
     sensor_type: str = config[CONF_TYPE]
     round_digits: int = config[CONF_ROUND_DIGITS]
+    all_statistics: bool = config[CONF_ALL_STATISTICS]
     unique_id = config.get(CONF_UNIQUE_ID)
 
     await async_setup_reload_service(hass, DOMAIN, PLATFORMS)
 
     async_add_entities(
-        [MinMaxSensor(entity_ids, name, sensor_type, round_digits, unique_id)]
+        [
+            MinMaxSensor(
+                entity_ids, name, sensor_type, round_digits, all_statistics, unique_id
+            )
+        ]
     )
 
 
@@ -216,6 +232,7 @@ class MinMaxSensor(SensorEntity):
         name: str | None,
         sensor_type: str,
         round_digits: int,
+        all_statistics: bool,
         unique_id: str | None,
     ) -> None:
         """Initialize the min/max sensor."""
@@ -223,6 +240,7 @@ class MinMaxSensor(SensorEntity):
         self._entity_ids = entity_ids
         self._sensor_type = sensor_type
         self._round_digits = round_digits
+        self._all_statistics = all_statistics
 
         if name:
             self._attr_name = name
@@ -285,11 +303,19 @@ class MinMaxSensor(SensorEntity):
     @override
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes of the sensor."""
-        attributes: dict[str, list[str] | str | None] = {
-            ATTR_ENTITY_ID: self._entity_ids
-        }
-
-        if self._sensor_type == "min":
+        attributes: dict[str, Any] = {ATTR_ENTITY_ID: self._entity_ids}
+        if self._all_statistics:
+            attributes[ATTR_MIN_VALUE] = self.min_value
+            attributes[ATTR_MIN_ENTITY_ID] = self.min_entity_id
+            attributes[ATTR_MAX_VALUE] = self.max_value
+            attributes[ATTR_MAX_ENTITY_ID] = self.max_entity_id
+            attributes[ATTR_MEAN] = self.mean
+            attributes[ATTR_MEDIAN] = self.median
+            attributes[ATTR_LAST] = self.last
+            attributes[ATTR_LAST_ENTITY_ID] = self.last_entity_id
+            attributes[ATTR_RANGE] = self.range
+            attributes[ATTR_SUM] = self.sum
+        elif self._sensor_type == "min":
             attributes[ATTR_MIN_ENTITY_ID] = self.min_entity_id
         elif self._sensor_type == "max":
             attributes[ATTR_MAX_ENTITY_ID] = self.max_entity_id

--- a/homeassistant/components/min_max/strings.json
+++ b/homeassistant/components/min_max/strings.json
@@ -3,12 +3,14 @@
     "step": {
       "user": {
         "data": {
+          "all_statistics": "All statistics",
           "entity_ids": "Input entities",
           "name": "[%key:common::config_flow::data::name%]",
           "round_digits": "Precision",
           "type": "Statistic characteristic"
         },
         "data_description": {
+          "all_statistics": "Provide all statistics as attributes.",
           "round_digits": "Controls the number of decimal digits in the output when the statistics characteristic is mean, median or sum."
         },
         "description": "Create a sensor that calculates a min, max, mean, median or sum from a list of input sensors.",
@@ -20,6 +22,7 @@
     "step": {
       "init": {
         "data": {
+          "all_statistics": "[%key:component::min_max::config::step::user::data::all_statistics%]",
           "entity_ids": "[%key:component::min_max::config::step::user::data::entity_ids%]",
           "round_digits": "[%key:component::min_max::config::step::user::data::round_digits%]",
           "type": "[%key:component::min_max::config::step::user::data::type%]"

--- a/tests/components/min_max/test_config_flow.py
+++ b/tests/components/min_max/test_config_flow.py
@@ -41,6 +41,7 @@ async def test_config_flow(hass: HomeAssistant, platform: str) -> None:
         "name": "My min_max",
         "round_digits": 2.0,
         "type": "max",
+        "all_statistics": False,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -51,6 +52,7 @@ async def test_config_flow(hass: HomeAssistant, platform: str) -> None:
         "name": "My min_max",
         "round_digits": 2.0,
         "type": "max",
+        "all_statistics": False,
     }
     assert config_entry.title == "My min_max"
 
@@ -103,6 +105,7 @@ async def test_options(hass: HomeAssistant, platform: str) -> None:
         "name": "My min_max",
         "round_digits": 1,
         "type": "mean",
+        "all_statistics": False,
     }
     assert config_entry.data == {}
     assert config_entry.options == {
@@ -110,6 +113,7 @@ async def test_options(hass: HomeAssistant, platform: str) -> None:
         "name": "My min_max",
         "round_digits": 1,
         "type": "mean",
+        "all_statistics": False,
     }
     assert config_entry.title == "My min_max"
 

--- a/tests/components/min_max/test_sensor.py
+++ b/tests/components/min_max/test_sensor.py
@@ -101,6 +101,57 @@ async def test_min_sensor(
     assert entity.unique_id == "very_unique_id"
 
 
+async def test_min_sensor_all(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the min sensor."""
+    config = {
+        "sensor": {
+            "platform": "min_max",
+            "name": "test_min",
+            "type": "min",
+            "entity_ids": ["sensor.test_1", "sensor.test_2", "sensor.test_3"],
+            "all_statistics": True,
+            "unique_id": "very_unique_id",
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    entity_ids = config["sensor"]["entity_ids"]
+
+    for entity_id, value in dict(zip(entity_ids, VALUES, strict=False)).items():
+        hass.states.async_set(entity_id, value)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.test_min")
+
+    assert str(float(MIN_VALUE)) == state.state
+    assert entity_ids[2] == state.attributes.get("min_entity_id")
+    assert state.attributes.get(ATTR_STATE_CLASS) == SensorStateClass.MEASUREMENT
+
+    assert state.attributes.get("last") == VALUES[-1]
+    assert state.attributes.get("last_entity_id") == entity_ids[-1]
+
+    assert state.attributes.get("max_value") == MAX_VALUE
+    assert entity_ids[1] == state.attributes.get("max_entity_id")
+
+    assert state.attributes.get("mean") == MEAN
+
+    assert state.attributes.get("median") == MEDIAN
+
+    assert state.attributes.get("min_value") == MIN_VALUE
+    assert entity_ids[2] == state.attributes.get("min_entity_id")
+
+    assert state.attributes.get("range") == RANGE_4_DIGITS
+
+    assert state.attributes.get("sum") == SUM_VALUE
+
+    entity = entity_registry.async_get("sensor.test_min")
+    assert entity.unique_id == "very_unique_id"
+
+
 async def test_max_sensor(hass: HomeAssistant) -> None:
     """Test the max sensor."""
     config = {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add all_statistics as a configuration option.  Default false; when true this extends the set of attributes provided to include all values and associated entity ids for the statistics, including the one specified in sensor_type.

Feature request: https://github.com/orgs/home-assistant/discussions/4356

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/core/pull/176797
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
