### PR TITLE
Bump sharkiq to 1.5.1

### DIFF
--- a/homeassistant/components/sharkiq/manifest.json
+++ b/homeassistant/components/sharkiq/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["sharkiq"],
-  "requirements": ["sharkiq==1.5.0"]
+  "requirements": ["sharkiq==1.5.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3023,7 +3023,7 @@ serialx==1.8.2
 sfrbox-api==0.1.1
 
 # homeassistant.components.sharkiq
-sharkiq==1.5.0
+sharkiq==1.5.1
 
 # homeassistant.components.aquostv
 sharp_aquos_rc==0.3.2


### PR DESCRIPTION
## Proposed change

Bump `sharkiq` from `1.5.0` to `1.5.1`.

The upstream library release fixes the Auth0 login flow by using cross-origin authentication instead of the browser form POST flow:
https://github.com/sharkiqlibs/sharkiq/releases/tag/v1.5.1

## Type of change

- [x] Dependency upgrade

## Additional information

This addresses the authentication portion of recent SharkIQ setup failures. It does not attempt to solve the separate cloud API/device availability issue tracked in #151845.

## Checklist

- [x] The changed manifest JSON is valid.
- [x] The dependency exists on PyPI.
- [ ] Full Home Assistant test suite not run locally; CI should validate the dependency bump.