### PR TITLE
Add Tuya ktkzq category support (climate + switch)

### DIFF
--- a/homeassistant/components/tuya/climate.py
+++ b/homeassistant/components/tuya/climate.py
@@ -78,6 +78,10 @@ CLIMATE_DESCRIPTIONS: dict[DeviceCategory, TuyaClimateEntityDescription] = {
         key="",
         switch_only_hvac_mode=HVACMode.COOL,
     ),
+    DeviceCategory.KTKZQ: TuyaClimateEntityDescription(
+        key="",
+        switch_only_hvac_mode=HVACMode.COOL,
+    ),
     DeviceCategory.QN: TuyaClimateEntityDescription(
         key="",
         switch_only_hvac_mode=HVACMode.HEAT,

--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -487,6 +487,13 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
             entity_category=EntityCategory.CONFIG,
         ),
     ),
+    DeviceCategory.KTKZQ: (
+        SwitchEntityDescription(
+            key=DPCode.CHILD_LOCK,
+            translation_key="child_lock",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
     DeviceCategory.KS: (
         SwitchEntityDescription(
             key=DPCode.ANION,

--- a/tests/components/tuya/fixtures/ktkzq_urzivdhumrwfakie.json
+++ b/tests/components/tuya/fixtures/ktkzq_urzivdhumrwfakie.json
@@ -1,0 +1,74 @@
+{
+  "endpoint": "https://apigw.tuyaeu.com",
+  "mqtt_connected": true,
+  "disabled_by": null,
+  "disabled_polling": false,
+  "name": "VITAL+",
+  "category": "ktkzq",
+  "product_id": "urzivdhumrwfakie",
+  "product_name": "VITAL+",
+  "online": true,
+  "sub": false,
+  "time_zone": "+10:00",
+  "active_time": "2026-07-16T10:14:21+00:00",
+  "create_time": "2026-07-16T10:14:21+00:00",
+  "update_time": "2026-07-16T10:14:21+00:00",
+  "function": {
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103",
+        "min": 3,
+        "max": 45,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "power_switch": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status_range": {
+    "temp_set": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103",
+        "min": 3,
+        "max": 45,
+        "scale": 0,
+        "step": 1
+      }
+    },
+    "temp_current": {
+      "type": "Integer",
+      "value": {
+        "unit": "\u2103",
+        "min": -400,
+        "max": 1000,
+        "scale": 1,
+        "step": 1
+      }
+    },
+    "child_lock": {
+      "type": "Boolean",
+      "value": {}
+    },
+    "power_switch": {
+      "type": "Boolean",
+      "value": {}
+    }
+  },
+  "status": {
+    "temp_set": 13,
+    "temp_current": 48,
+    "child_lock": true,
+    "power_switch": true
+  },
+  "set_up": false,
+  "support_local": true
+}


### PR DESCRIPTION
## Proposed change

The  category (Air conditioner controller) is already defined as a  constant in  but has no entity descriptions in the climate or switch platforms. Tuya devices in this category (e.g. **Vital+ Ice Bath Pro** chiller, product_id: ) get no entities created in Home Assistant.

This PR adds  to:
-  in  with  (matching the existing  air conditioner pattern)
-  in  with  (matching the existing  entry pattern)

The  translation key already exists in  — no new translations needed.

## Device data points

| DP | Code | Type | Details |
|----|------|------|---------|
| 2 |  | Integer | 3-45°C, scale 0, step 1 |
| 3 |  | Integer | -40 to 100°C, scale 1 |
| 7 |  | Boolean | Child lock |
| 108 |  | Boolean | Chiller on/off |

## Note on  dpcode

The on/off datapoint for this device is named  (not ). The climate  in  currently only looks for , so the climate entity's on/off control requires a companion fix:
- https://github.com/home-assistant-libs/tuya-device-handlers/pull/413

That PR extends the lookup to accept  as a tuple, benefiting any device using the  dpcode.

## Related

- Companion PR: https://github.com/home-assistant-libs/tuya-device-handlers/pull/413
- Related issue: https://github.com/home-assistant-libs/tuya-device-handlers/issues/276
- Supersedes the quirk approach in https://github.com/home-assistant-libs/tuya-device-handlers/pull/405

## Checklist

- [x] The code change is tested and works locally (verified on actual hardware)
- [x] Local tests pass with the test fixture
- [ ] Snapshot files need regeneration — CI will show required  updates
- [x] The code follows the existing  category pattern exactly