### PR TITLE
Add PrusaLink filament metadata sensors

### DIFF
--- a/homeassistant/components/prusalink/__init__.py
+++ b/homeassistant/components/prusalink/__init__.py
@@ -19,6 +19,7 @@ from homeassistant.helpers.httpx_client import get_async_client
 from .config_flow import PrusaLinkConfigFlow
 from .const import DOMAIN
 from .coordinator import (
+    FileMetadataUpdateCoordinator,
     InfoUpdateCoordinator,
     JobUpdateCoordinator,
     LegacyStatusCoordinator,
@@ -48,14 +49,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: PrusaLinkConfigEntry) ->
         entry.data[CONF_PASSWORD],
     )
 
+    job_coordinator = JobUpdateCoordinator(hass, entry, api)
     coordinators: dict[str, PrusaLinkUpdateCoordinator] = {
         "legacy_status": LegacyStatusCoordinator(hass, entry, api),
         "status": StatusCoordinator(hass, entry, api),
-        "job": JobUpdateCoordinator(hass, entry, api),
+        "job": job_coordinator,
+        "file_metadata": FileMetadataUpdateCoordinator(
+            hass, entry, api, job_coordinator
+        ),
         "info": InfoUpdateCoordinator(hass, entry, api),
         "version": VersionUpdateCoordinator(hass, entry, api),
     }
-    for coordinator in coordinators.values():
+    for coordinator_type, coordinator in coordinators.items():
+        if coordinator_type == "file_metadata":
+            continue
         await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinators

--- a/homeassistant/components/prusalink/binary_sensor.py
+++ b/homeassistant/components/prusalink/binary_sensor.py
@@ -35,6 +35,7 @@ BINARY_SENSORS: dict[str, tuple[PrusaLinkBinarySensorEntityDescription, ...]] = 
     "status": (
         PrusaLinkBinarySensorEntityDescription[PrinterStatus](
             key="printer.status_connect",
+            translation_key="connectivity",
             device_class=BinarySensorDeviceClass.CONNECTIVITY,
             value_fn=lambda data: cast(
                 bool, cast(StatusInfo, data["printer"]["status_connect"])["ok"]

--- a/homeassistant/components/prusalink/coordinator.py
+++ b/homeassistant/components/prusalink/coordinator.py
@@ -5,7 +5,7 @@ import asyncio
 from datetime import timedelta
 import logging
 from time import monotonic
-from typing import TypeVar, override
+from typing import Any, TypeVar, override
 
 from httpx import ConnectError
 from pyprusalink import (
@@ -13,13 +13,21 @@ from pyprusalink import (
     LegacyPrinterStatus,
     PrinterInfo,
     PrinterStatus,
+    PrintFileMetadata,
     PrusaLink,
     VersionInfo,
 )
-from pyprusalink.types import InvalidAuth, PrusaLinkError
+from pyprusalink.file_metadata import parse_metadata_mapping
+from pyprusalink.types import (
+    FileTooLarge,
+    InvalidAuth,
+    JobFilePrint,
+    PrinterState,
+    PrusaLinkError,
+)
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -41,6 +49,7 @@ T = TypeVar(
     bound=PrinterStatus
     | LegacyPrinterStatus
     | JobInfo
+    | PrintFileMetadata
     | PrinterInfo
     | VersionInfo
     | None,
@@ -144,6 +153,116 @@ class JobUpdateCoordinator(PrusaLinkUpdateCoordinator[JobInfo | None]):
     async def _fetch_data(self) -> JobInfo | None:
         """Fetch the printer data."""
         return await self.api.get_job()
+
+
+class FileMetadataUpdateCoordinator(
+    PrusaLinkUpdateCoordinator[PrintFileMetadata | None]
+):
+    """Print file metadata update coordinator."""
+
+    _cache_key: tuple[str, int | None, int | None] | None = None
+    _cache_data: PrintFileMetadata | None = None
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: PrusaLinkConfigEntry,
+        api: PrusaLink,
+        job_coordinator: JobUpdateCoordinator,
+    ) -> None:
+        """Initialize the file metadata update coordinator."""
+        self.job_coordinator = job_coordinator
+        super().__init__(hass, config_entry, api)
+
+    @callback
+    @override
+    def async_add_listener(
+        self, update_callback: CALLBACK_TYPE, context: Any = None
+    ) -> CALLBACK_TYPE:
+        """Listen for data updates and fetch metadata when first needed."""
+        had_listeners = bool(self._listeners)
+        remove_listener = super().async_add_listener(update_callback, context)
+
+        if not had_listeners:
+            self.config_entry.async_create_background_task(
+                self.hass,
+                self.async_request_refresh(),
+                "prusalink fetch file metadata",
+            )
+
+        return remove_listener
+
+    @callback
+    def has_listeners(self) -> bool:
+        """Return if any enabled entity is listening for metadata updates."""
+        return bool(self._listeners)
+
+    @override
+    async def _async_update_data(self) -> PrintFileMetadata | None:
+        """Update the file metadata without blocking integration setup."""
+        try:
+            async with asyncio.timeout(30):
+                data = await self._fetch_data()
+        except (PrusaLinkError, TimeoutError, ConnectError) as err:
+            _LOGGER.debug("Could not fetch PrusaLink file metadata: %s", err)
+            data = None
+
+        self.update_interval = self._get_update_interval(data)
+        return data
+
+    @override
+    async def _fetch_data(self) -> PrintFileMetadata | None:
+        """Fetch metadata for the current print file."""
+        job = self.job_coordinator.data
+
+        if (
+            job is None
+            or job.get("state") == PrinterState.IDLE.value
+            or (job_file := job.get("file")) is None
+        ):
+            self._cache_key = None
+            self._cache_data = None
+            return None
+
+        if (metadata := job_file.get("meta")) is not None:
+            return parse_metadata_mapping(metadata)
+
+        download_path = _download_path(job_file)
+        cache_key = (download_path, job_file.get("size"), job_file.get("m_timestamp"))
+        if cache_key == self._cache_key:
+            return self._cache_data
+
+        try:
+            data = await self.api.get_file_metadata(download_path)
+        except FileTooLarge as err:
+            # Permanent for this exact file — retrying won't help, so cache
+            # the miss to avoid re-downloading it every poll.
+            _LOGGER.debug("PrusaLink file metadata unavailable: %s", err)
+            self._cache_key = cache_key
+            self._cache_data = None
+            return None
+        except PrusaLinkError as err:
+            # Transient (timeout, disconnect, etc): leave the cache key
+            # unchanged so the next poll retries this file instead of
+            # permanently returning None for it.
+            _LOGGER.debug("Could not fetch PrusaLink file metadata: %s", err)
+            return None
+
+        self._cache_key = cache_key
+        self._cache_data = data
+        return data
+
+
+def _download_path(job_file: JobFilePrint) -> str:
+    """Get the path that can be used to download a print file."""
+    if (refs := job_file.get("refs")) is not None and (
+        download_path := refs.get("download")
+    ) is not None:
+        return download_path
+
+    path = job_file["path"]
+    name = job_file["name"]
+    return f"{path.rstrip('/')}/{name}"
 
 
 class InfoUpdateCoordinator(PrusaLinkUpdateCoordinator[PrinterInfo]):

--- a/homeassistant/components/prusalink/manifest.json
+++ b/homeassistant/components/prusalink/manifest.json
@@ -11,5 +11,5 @@
   "documentation": "https://www.home-assistant.io/integrations/prusalink",
   "integration_type": "device",
   "iot_class": "local_polling",
-  "requirements": ["pyprusalink==3.0.0"]
+  "requirements": ["pyprusalink==3.1.0"]
 }

--- a/homeassistant/components/prusalink/sensor.py
+++ b/homeassistant/components/prusalink/sensor.py
@@ -11,6 +11,7 @@ from pyprusalink.types import (
     PrinterInfo,
     PrinterState,
     PrinterStatus,
+    PrintFileMetadata,
 )
 from pyprusalink.types_legacy import LegacyPrinterStatus, LegacyPrinterTelemetry
 
@@ -24,7 +25,10 @@ from homeassistant.const import (
     PERCENTAGE,
     REVOLUTIONS_PER_MINUTE,
     UnitOfLength,
+    UnitOfMass,
     UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -38,7 +42,7 @@ from .entity import PrusaLinkEntity, PrusaLinkEntityDescription
 
 @dataclass(frozen=True, kw_only=True)
 class PrusaLinkSensorEntityDescription[
-    T: (PrinterStatus, LegacyPrinterStatus, JobInfo, PrinterInfo)
+    T: (PrinterStatus, LegacyPrinterStatus, JobInfo, PrintFileMetadata, PrinterInfo)
 ](
     SensorEntityDescription,
     PrusaLinkEntityDescription,
@@ -46,6 +50,12 @@ class PrusaLinkSensorEntityDescription[
     """Describes PrusaLink sensor entity."""
 
     value_fn: Callable[[T], datetime | StateType]
+
+
+def _job_file_display_name(data: JobInfo) -> str:
+    """Return the display name for the active job file."""
+    job_file = cast(JobFilePrint, data["file"])
+    return job_file.get("display_name", job_file["name"])
 
 
 SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
@@ -175,11 +185,7 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
         PrusaLinkSensorEntityDescription[JobInfo](
             key="job.filename",
             translation_key="filename",
-            # `available_fn` guarantees `file` is not None at this point;
-            # the inner cast narrows the Optional for the index.
-            value_fn=lambda data: cast(
-                str, cast(JobFilePrint, data["file"])["display_name"]
-            ),
+            value_fn=_job_file_display_name,
             available_fn=lambda data: (
                 data.get("file") is not None
                 and data.get("state") != PrinterState.IDLE.value
@@ -214,6 +220,76 @@ SENSORS: dict[str, tuple[PrusaLinkSensorEntityDescription, ...]] = {
                 data.get("time_remaining") is not None
                 and data.get("state") != PrinterState.IDLE.value
             ),
+        ),
+    ),
+    "file_metadata": (
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.filament_used_g",
+            translation_key="filament_used_weight",
+            native_unit_of_measurement=UnitOfMass.GRAMS,
+            device_class=SensorDeviceClass.WEIGHT,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data: data["filament_used_g"],
+            available_fn=lambda data: data.get("filament_used_g") is not None,
+            entity_registry_enabled_default=False,
+        ),
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.filament_used_mm",
+            translation_key="filament_used_length",
+            native_unit_of_measurement=UnitOfLength.METERS,
+            device_class=SensorDeviceClass.DISTANCE,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data: data["filament_used_mm"] / 1000,
+            available_fn=lambda data: data.get("filament_used_mm") is not None,
+            entity_registry_enabled_default=False,
+        ),
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.filament_used_cm3",
+            translation_key="filament_used_volume",
+            native_unit_of_measurement=UnitOfVolume.MILLILITERS,
+            device_class=SensorDeviceClass.VOLUME,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data: data["filament_used_cm3"],
+            available_fn=lambda data: data.get("filament_used_cm3") is not None,
+            entity_registry_enabled_default=False,
+        ),
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.filament_cost",
+            translation_key="filament_cost",
+            value_fn=lambda data: data["filament_cost"],
+            available_fn=lambda data: data.get("filament_cost") is not None,
+            entity_registry_enabled_default=False,
+        ),
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.filament_type",
+            translation_key="file_filament_type",
+            value_fn=lambda data: data["filament_type"],
+            available_fn=lambda data: data.get("filament_type") is not None,
+            entity_registry_enabled_default=False,
+        ),
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.estimated_printing_time_normal",
+            translation_key="estimated_printing_time_normal",
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data: data["estimated_printing_time_normal"],
+            available_fn=lambda data: (
+                data.get("estimated_printing_time_normal") is not None
+            ),
+            entity_registry_enabled_default=False,
+        ),
+        PrusaLinkSensorEntityDescription[PrintFileMetadata](
+            key="file.metadata.estimated_printing_time_silent",
+            translation_key="estimated_printing_time_silent",
+            native_unit_of_measurement=UnitOfTime.SECONDS,
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+            value_fn=lambda data: data["estimated_printing_time_silent"],
+            available_fn=lambda data: (
+                data.get("estimated_printing_time_silent") is not None
+            ),
+            entity_registry_enabled_default=False,
         ),
     ),
     "info": (

--- a/homeassistant/components/prusalink/strings.json
+++ b/homeassistant/components/prusalink/strings.json
@@ -18,6 +18,9 @@
   },
   "entity": {
     "binary_sensor": {
+      "connectivity": {
+        "name": "Connectivity"
+      },
       "farm_mode": {
         "name": "Farm mode"
       },
@@ -48,11 +51,32 @@
       }
     },
     "sensor": {
+      "estimated_printing_time_normal": {
+        "name": "Estimated printing time"
+      },
+      "estimated_printing_time_silent": {
+        "name": "Estimated silent printing time"
+      },
       "fan_hotend": {
         "name": "Hotend fan"
       },
       "fan_print": {
         "name": "Print fan"
+      },
+      "filament_cost": {
+        "name": "Filament cost"
+      },
+      "filament_used_length": {
+        "name": "Filament used length"
+      },
+      "filament_used_volume": {
+        "name": "Filament used volume"
+      },
+      "filament_used_weight": {
+        "name": "Filament used weight"
+      },
+      "file_filament_type": {
+        "name": "File filament type"
       },
       "filename": {
         "name": "Filename"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2500,7 +2500,7 @@ pyprof2calltree==1.4.5
 pyprosegur==0.0.14
 
 # homeassistant.components.prusalink
-pyprusalink==3.0.0
+pyprusalink==3.1.0
 
 # homeassistant.components.ps4
 pyps4-2ndscreen==1.3.1

--- a/tests/components/prusalink/conftest.py
+++ b/tests/components/prusalink/conftest.py
@@ -204,11 +204,20 @@ def mock_job_api_attention(
 
 
 @pytest.fixture
+def mock_file_metadata_api() -> Generator[dict[str, Any]]:
+    """Mock PrusaLink print file metadata."""
+    resp: dict[str, Any] = {}
+    with patch("pyprusalink.PrusaLink.get_file_metadata", return_value=resp):
+        yield resp
+
+
+@pytest.fixture
 def mock_api(
     mock_version_api: dict[str, str],
     mock_info_api: dict[str, Any],
     mock_get_legacy_printer: dict[str, Any],
     mock_get_status_idle: dict[str, Any],
     mock_job_api_idle: None,
+    mock_file_metadata_api: dict[str, Any],
 ) -> None:
     """Mock PrusaLink API."""

--- a/tests/components/prusalink/test_sensor.py
+++ b/tests/components/prusalink/test_sensor.py
@@ -20,7 +20,10 @@ from homeassistant.const import (
     REVOLUTIONS_PER_MINUTE,
     Platform,
     UnitOfLength,
+    UnitOfMass,
     UnitOfTemperature,
+    UnitOfTime,
+    UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
@@ -36,7 +39,9 @@ def setup_sensor_platform_only():
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
-async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) -> None:
+async def test_sensors_no_job(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry, mock_api: None
+) -> None:
     """Test sensors while no job active."""
     assert await async_setup_component(hass, DOMAIN, {})
 
@@ -142,9 +147,9 @@ async def test_sensors_no_job(hass: HomeAssistant, mock_config_entry, mock_api) 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors_idle_job_mk3(
     hass: HomeAssistant,
-    mock_config_entry,
-    mock_api,
-    mock_job_api_idle_mk3,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_job_api_idle_mk3: dict[str, Any],
 ) -> None:
     """Test sensors while job state is idle (MK3)."""
     assert await async_setup_component(hass, DOMAIN, {})
@@ -251,10 +256,10 @@ async def test_sensors_idle_job_mk3(
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_sensors_active_job(
     hass: HomeAssistant,
-    mock_config_entry,
-    mock_api,
-    mock_get_status_printing,
-    mock_job_api_printing,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_get_status_printing: dict[str, Any],
+    mock_job_api_printing: dict[str, Any],
 ) -> None:
     """Test sensors while active job."""
     with patch(
@@ -295,6 +300,170 @@ async def test_sensors_active_job(
     assert state is not None
     assert state.state == "2500"
     assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == REVOLUTIONS_PER_MINUTE
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_filename_sensor_falls_back_to_name(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_get_status_printing: dict[str, Any],
+    mock_job_api_printing: dict[str, Any],
+) -> None:
+    """Test the filename sensor uses `name` when `display_name` is absent."""
+    del mock_job_api_printing["file"]["display_name"]
+
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    state = hass.states.get("sensor.workshop_mock_title_filename")
+    assert state is not None
+    assert state.state == "TabletStand3~4.BGC"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_file_metadata_sensors(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_get_status_printing: dict[str, Any],
+    mock_job_api_printing: dict[str, Any],
+    mock_file_metadata_api: dict[str, Any],
+) -> None:
+    """Test print file metadata sensors."""
+    mock_file_metadata_api.update(
+        {
+            "filament_used_g": 24.41,
+            "filament_used_mm": 8184.17,
+            "filament_used_cm3": 19.69,
+            "filament_cost": 0.68,
+            "filament_type": "PLA",
+            "estimated_printing_time_normal": 3811,
+            "estimated_printing_time_silent": 4256,
+        }
+    )
+
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_used_weight")
+    assert state is not None
+    assert state.state == "24.41"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfMass.GRAMS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.WEIGHT
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_used_length")
+    assert state is not None
+    assert state.state == "8.18417"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfLength.METERS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DISTANCE
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_used_volume")
+    assert state is not None
+    assert state.state == "19.69"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfVolume.MILLILITERS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.VOLUME
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_cost")
+    assert state is not None
+    assert state.state == "0.68"
+
+    state = hass.states.get("sensor.workshop_mock_title_file_filament_type")
+    assert state is not None
+    assert state.state == "PLA"
+
+    state = hass.states.get("sensor.workshop_mock_title_estimated_printing_time")
+    assert state is not None
+    assert state.state == "3811"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTime.SECONDS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DURATION
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+    state = hass.states.get("sensor.workshop_mock_title_estimated_silent_printing_time")
+    assert state is not None
+    assert state.state == "4256"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTime.SECONDS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.DURATION
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+
+async def test_file_metadata_not_fetched_when_sensors_disabled(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_get_status_printing: dict[str, Any],
+    mock_job_api_printing: dict[str, Any],
+) -> None:
+    """Test disabled-by-default metadata sensors do not download the print file."""
+    with patch("pyprusalink.PrusaLink.get_file_metadata") as get_file_metadata:
+        assert await async_setup_component(hass, DOMAIN, {})
+
+    assert hass.states.get("sensor.workshop_mock_title_filament_used_weight") is None
+    get_file_metadata.assert_not_called()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_file_metadata_sensors_from_job_meta(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_get_status_printing: dict[str, Any],
+    mock_job_api_printing: dict[str, Any],
+) -> None:
+    """Test print file metadata sensors from job metadata."""
+    mock_job_api_printing["file"]["meta"] = {
+        "filament used [g]": "24.41",
+        "filament_type": "PETG",
+        "estimated printing time (normal mode)": "1h 3m 31s",
+    }
+
+    with patch("pyprusalink.PrusaLink.get_file_metadata") as get_file_metadata:
+        assert await async_setup_component(hass, DOMAIN, {})
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_used_weight")
+    assert state is not None
+    assert state.state == "24.41"
+
+    state = hass.states.get("sensor.workshop_mock_title_file_filament_type")
+    assert state is not None
+    assert state.state == "PETG"
+
+    state = hass.states.get("sensor.workshop_mock_title_estimated_printing_time")
+    assert state is not None
+    assert state.state == "3811"
+
+    get_file_metadata.assert_not_called()
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_file_metadata_sensors_unavailable_when_download_times_out(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_api: None,
+    mock_get_status_printing: dict[str, Any],
+    mock_job_api_printing: dict[str, Any],
+    mock_file_metadata_api: dict[str, Any],
+) -> None:
+    """Test a download timeout doesn't block setup, and a later refresh retries."""
+    with patch(
+        "pyprusalink.PrusaLink.get_file_metadata", side_effect=TimeoutError
+    ) as get_file_metadata:
+        assert await async_setup_component(hass, DOMAIN, {})
+        get_file_metadata.assert_called_once()
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_used_weight")
+    assert state is not None
+    assert state.state == "unavailable"
+
+    mock_file_metadata_api["filament_used_g"] = 24.41
+    coordinator = mock_config_entry.runtime_data["file_metadata"]
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get("sensor.workshop_mock_title_filament_used_weight")
+    assert state is not None
+    assert state.state == "24.41"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")


### PR DESCRIPTION
## Proposed change

Adds disabled-by-default PrusaLink sensors for print file metadata: filament used (weight/length/volume), filament type, filament cost, and estimated printing time (normal/silent). This is planned/sliced metadata from the print file, not live measured consumption.

PrusaLink's `/api/v1/job` can include `file.meta` directly, and the integration prefers that when present. Current Buddy firmware (checked against v6.5.3) does not populate `file.meta` for `.bgcode` jobs — see [prusa3d/Prusa-Link-Web#527](https://github.com/prusa3d/Prusa-Link-Web/issues/527). When metadata sensors are enabled and `file.meta` is missing, the integration falls back to `pyprusalink.get_file_metadata()`, which streams the referenced print file (capped, in memory) and parses known PrusaSlicer G-code/BG-code metadata comments.

To keep this fallback cheap:
- The metadata coordinator only starts fetching once an entity actually listens to it — so with sensors left disabled (the default), no file is ever downloaded.
- Results are cached by `(download_path, size, m_timestamp)`, so at most one download happens per active print file while Home Assistant is running.
- The download is capped at 16 MiB and enforced both via `Content-Length` and while streaming, raising `FileTooLarge` if exceeded.

Also includes a small, unrelated test-driven fix: added `translation_key="connectivity"` to the connectivity binary sensor, required for entity ID/translation tests to pass after regenerating translations.

### Dependency

Bumps `pyprusalink` 3.0.0 → 3.1.0:
- Adds `PrusaLink.get_file_metadata()` and the metadata parser.
- Changelog / release notes: https://github.com/home-assistant-libs/pyprusalink/releases/tag/3.1.0
- Diff: https://github.com/home-assistant-libs/pyprusalink/compare/3.0.0...3.1.0

Note: 3.1.0 also made `display_name` optional on `JobFilePrint` (`NotRequired`), so the existing filename sensor now falls back to `name` when `display_name` is absent.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/prusa3d/Prusa-Link-Web/issues/527 (upstream firmware gap this fallback works around)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Smoke-tested against a real Prusa Core One on firmware `6.5.3+12780` / PrusaLink server `2.1.2`. `/api/v1/job` did not include `file.meta`, but the active `.bgcode` file's metadata was successfully downloaded and parsed via the fallback path.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
