### PR TITLE
Add screen power switch entity to LG webOS TV

### DIFF
--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -8,7 +8,7 @@ from aiowebostv import WebOsTvCommandError
 from homeassistant.const import Platform
 
 DOMAIN = "webostv"
-PLATFORMS = [Platform.MEDIA_PLAYER]
+PLATFORMS = [Platform.MEDIA_PLAYER, Platform.SWITCH]
 DEFAULT_NAME = "LG webOS TV"
 
 ATTR_PAYLOAD = "payload"

--- a/homeassistant/components/webostv/icons.json
+++ b/homeassistant/components/webostv/icons.json
@@ -1,4 +1,11 @@
 {
+  "entity": {
+    "switch": {
+      "screen": {
+        "default": "mdi:television"
+      }
+    }
+  },
   "services": {
     "button": {
       "service": "mdi:button-pointer"

--- a/homeassistant/components/webostv/quality_scale.yaml
+++ b/homeassistant/components/webostv/quality_scale.yaml
@@ -52,20 +52,12 @@ rules:
   dynamic-devices:
     status: exempt
     comment: The integration connects to a single device.
-  entity-category:
-    status: exempt
-    comment: The integration only registers one entity.
+  entity-category: done
   entity-device-class: done
-  entity-disabled-by-default:
-    status: exempt
-    comment: The integration only registers one entity.
-  entity-translations:
-    status: exempt
-    comment: There are no entities to translate.
+  entity-disabled-by-default: done
+  entity-translations: done
   exception-translations: done
-  icon-translations:
-    status: exempt
-    comment: The only entity can use the device class.
+  icon-translations: done
   reconfiguration-flow: done
   repair-issues:
     status: exempt

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -40,16 +40,16 @@
       }
     }
   },
+  "device_automation": {
+    "trigger_type": {
+      "webostv.turn_on": "Device is requested to turn on"
+    }
+  },
   "entity": {
     "switch": {
       "screen": {
         "name": "Screen"
       }
-    }
-  },
-  "device_automation": {
-    "trigger_type": {
-      "webostv.turn_on": "Device is requested to turn on"
     }
   },
   "exceptions": {

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -40,6 +40,13 @@
       }
     }
   },
+  "entity": {
+    "switch": {
+      "screen": {
+        "name": "Screen"
+      }
+    }
+  },
   "device_automation": {
     "trigger_type": {
       "webostv.turn_on": "Device is requested to turn on"

--- a/homeassistant/components/webostv/switch.py
+++ b/homeassistant/components/webostv/switch.py
@@ -74,10 +74,16 @@ class LgWebOSScreenSwitchEntity(SwitchEntity):
     @override
     async def async_added_to_hass(self) -> None:
         """Connect to client signals."""
+        await super().async_added_to_hass()
         await self._client.register_state_update_callback(
             self.async_handle_state_update
         )
         self._update_states()
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Unregister state update callback."""
+        self._client.unregister_state_update_callback(self.async_handle_state_update)
 
     async def async_handle_state_update(self, tv_state: WebOsTvState) -> None:
         """Update state from WebOsClient."""

--- a/homeassistant/components/webostv/switch.py
+++ b/homeassistant/components/webostv/switch.py
@@ -1,0 +1,106 @@
+"""Support for LG webOS TV switches."""
+
+from collections.abc import Callable, Coroutine
+from functools import wraps
+import logging
+from typing import Any, Concatenate, cast, override
+
+from aiowebostv import WebOsClient, WebOsTvState
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import DOMAIN, WEBOSTV_EXCEPTIONS
+from .helpers import WebOsTvConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: WebOsTvConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the LG webOS TV switches."""
+    async_add_entities([LgWebOSScreenSwitchEntity(entry)])
+
+
+def cmd[_R, **_P](
+    func: Callable[
+        Concatenate["LgWebOSScreenSwitchEntity", _P], Coroutine[Any, Any, _R]
+    ],
+) -> Callable[Concatenate["LgWebOSScreenSwitchEntity", _P], Coroutine[Any, Any, _R]]:
+    """Catch command exceptions."""
+
+    @wraps(func)
+    async def cmd_wrapper(
+        self: "LgWebOSScreenSwitchEntity", *args: _P.args, **kwargs: _P.kwargs
+    ) -> _R:
+        """Wrap all command methods."""
+        try:
+            return await func(self, *args, **kwargs)
+        except WEBOSTV_EXCEPTIONS as error:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="communication_error",
+                translation_placeholders={
+                    "name": str(self._entry.title),
+                    "func": func.__name__,
+                    "error": str(error),
+                },
+            ) from error
+
+    return cmd_wrapper
+
+
+class LgWebOSScreenSwitchEntity(SwitchEntity):
+    """Representation of an LG webOS TV screen switch."""
+
+    _attr_has_entity_name = True
+    _attr_translation_key = "screen"
+    _attr_name = "Screen"
+
+    def __init__(self, entry: WebOsTvConfigEntry) -> None:
+        """Initialize the screen switch entity."""
+        self._entry = entry
+        self._client: WebOsClient = entry.runtime_data
+        self._attr_unique_id = f"{entry.unique_id}_screen"
+        self._update_states()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Connect and subscribe to state updates."""
+        await super().async_added_to_hass()
+        await self._client.register_state_update_callback(
+            self.async_handle_state_update
+        )
+        self._update_states()
+
+    async def async_handle_state_update(self, tv_state: WebOsTvState) -> None:
+        """Update state from WebOsClient."""
+        self._update_states()
+        self.async_write_ha_state()
+
+    def _update_states(self) -> None:
+        """Update entity states."""
+        tv_state = self._client.tv_state
+        self._attr_is_on = tv_state.is_screen_on
+        self._attr_available = tv_state.is_on
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, cast(str, self._entry.unique_id))},
+            manufacturer="LG",
+            name=self._entry.title,
+        )
+
+    @cmd
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the screen on."""
+        await self._client.request("com.webos.service.tvpower/power/turnOnScreen")
+
+    @cmd
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the screen off."""
+        await self._client.request("com.webos.service.tvpower/power/turnOffScreen")

--- a/homeassistant/components/webostv/switch.py
+++ b/homeassistant/components/webostv/switch.py
@@ -1,11 +1,10 @@
-"""Support for LG webOS TV switches."""
+"""Support for LG webOS TV switch."""
 
 from collections.abc import Callable, Coroutine
 from functools import wraps
-import logging
-from typing import Any, Concatenate, cast, override
+from typing import Any, Concatenate, override
 
-from aiowebostv import WebOsClient, WebOsTvState
+from aiowebostv import WebOsClient, WebOsTvCommandError, WebOsTvState
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
@@ -13,10 +12,10 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN, WEBOSTV_EXCEPTIONS
-from .helpers import WebOsTvConfigEntry
+from . import WebOsTvConfigEntry
+from .const import DOMAIN
 
-_LOGGER = logging.getLogger(__name__)
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(
@@ -24,56 +23,57 @@ async def async_setup_entry(
     entry: WebOsTvConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up the LG webOS TV switches."""
-    async_add_entities([LgWebOSScreenSwitchEntity(entry)])
+    """Set up the LG webOS TV switch platform."""
+    client = entry.runtime_data
+
+    async_add_entities([LgWebOSScreenSwitchEntity(entry, client)])
 
 
 def cmd[_R, **_P](
-    func: Callable[
-        Concatenate["LgWebOSScreenSwitchEntity", _P], Coroutine[Any, Any, _R]
-    ],
-) -> Callable[Concatenate["LgWebOSScreenSwitchEntity", _P], Coroutine[Any, Any, _R]]:
+    func: Callable[Concatenate[LgWebOSScreenSwitchEntity, _P], Coroutine[Any, Any, _R]],
+) -> Callable[Concatenate[LgWebOSScreenSwitchEntity, _P], Coroutine[Any, Any, _R]]:
     """Catch command exceptions."""
 
     @wraps(func)
     async def cmd_wrapper(
-        self: "LgWebOSScreenSwitchEntity", *args: _P.args, **kwargs: _P.kwargs
+        self: LgWebOSScreenSwitchEntity, *args: _P.args, **kwargs: _P.kwargs
     ) -> _R:
         """Wrap all command methods."""
         try:
             return await func(self, *args, **kwargs)
-        except WEBOSTV_EXCEPTIONS as error:
+        except WebOsTvCommandError as exc:
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="communication_error",
                 translation_placeholders={
-                    "name": str(self._entry.title),
                     "func": func.__name__,
-                    "error": str(error),
+                    "name": self._entry.title,
+                    "error": str(exc),
                 },
-            ) from error
+            ) from exc
 
     return cmd_wrapper
 
 
 class LgWebOSScreenSwitchEntity(SwitchEntity):
-    """Representation of an LG webOS TV screen switch."""
+    """Representation of a LG webOS TV Screen Switch."""
 
     _attr_has_entity_name = True
     _attr_translation_key = "screen"
-    _attr_name = "Screen"
 
-    def __init__(self, entry: WebOsTvConfigEntry) -> None:
+    def __init__(self, entry: WebOsTvConfigEntry, client: WebOsClient) -> None:
         """Initialize the screen switch entity."""
         self._entry = entry
-        self._client: WebOsClient = entry.runtime_data
+        self._client = client
         self._attr_unique_id = f"{entry.unique_id}_screen"
-        self._update_states()
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, entry.unique_id)},
+            name=entry.title,
+        )
 
     @override
     async def async_added_to_hass(self) -> None:
-        """Connect and subscribe to state updates."""
-        await super().async_added_to_hass()
+        """Connect to client signals."""
         await self._client.register_state_update_callback(
             self.async_handle_state_update
         )
@@ -85,22 +85,18 @@ class LgWebOSScreenSwitchEntity(SwitchEntity):
         self.async_write_ha_state()
 
     def _update_states(self) -> None:
-        """Update entity states."""
-        tv_state = self._client.tv_state
-        self._attr_is_on = tv_state.is_screen_on
-        self._attr_available = tv_state.is_on
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, cast(str, self._entry.unique_id))},
-            manufacturer="LG",
-            name=self._entry.title,
-        )
+        """Update entity attributes."""
+        self._attr_available = self._client.tv_state.is_on
+        self._attr_is_on = self._client.tv_state.is_screen_on
 
     @cmd
+    @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the screen on."""
         await self._client.request("com.webos.service.tvpower/power/turnOnScreen")
 
     @cmd
+    @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the screen off."""
         await self._client.request("com.webos.service.tvpower/power/turnOffScreen")

--- a/tests/components/webostv/conftest.py
+++ b/tests/components/webostv/conftest.py
@@ -1,6 +1,7 @@
 """Common fixtures and objects for the LG webOS TV integration tests."""
 
 from collections.abc import Generator
+import inspect
 from unittest.mock import AsyncMock, Mock, patch
 
 from aiowebostv import WebOsTvInfo, WebOsTvState
@@ -64,7 +65,10 @@ def client_fixture():
         client.is_connected = Mock(return_value=True)
 
         async def mock_state_update_callback():
-            await client.register_state_update_callback.call_args[0][0](client.tv_state)
+            for call in client.register_state_update_callback.call_args_list:
+                res = call[0][0](client.tv_state)
+                if inspect.isawaitable(res):
+                    await res
 
         client.mock_state_update = AsyncMock(side_effect=mock_state_update_callback)
 

--- a/tests/components/webostv/test_switch.py
+++ b/tests/components/webostv/test_switch.py
@@ -1,13 +1,11 @@
 """Tests for LG webOS TV switch platform."""
 
-import inspect
 from unittest.mock import AsyncMock
 
 from aiowebostv import WebOsTvCommandError
 import pytest
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.webostv.const import DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_TURN_OFF,
@@ -57,6 +55,7 @@ async def test_screen_switch_state_updates(
     await setup_webostv(hass)
 
     state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
     assert state.state == STATE_OFF
 
     # Update TV state to screen on
@@ -65,6 +64,7 @@ async def test_screen_switch_state_updates(
     await hass.async_block_till_done()
 
     state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
     assert state.state == STATE_ON
 
     # TV powered off makes switch unavailable
@@ -74,6 +74,7 @@ async def test_screen_switch_state_updates(
     await hass.async_block_till_done()
 
     state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
     assert state.state == STATE_UNAVAILABLE
 
 

--- a/tests/components/webostv/test_switch.py
+++ b/tests/components/webostv/test_switch.py
@@ -58,7 +58,6 @@ async def test_screen_switch_state_updates(
     assert state is not None
     assert state.state == STATE_OFF
 
-    # Update TV state to screen on
     client.tv_state.is_screen_on = True
     await fire_state_update(client)
     await hass.async_block_till_done()
@@ -67,7 +66,6 @@ async def test_screen_switch_state_updates(
     assert state is not None
     assert state.state == STATE_ON
 
-    # TV powered off makes switch unavailable
     client.tv_state.is_on = False
     client.tv_state.is_screen_on = False
     await fire_state_update(client)

--- a/tests/components/webostv/test_switch.py
+++ b/tests/components/webostv/test_switch.py
@@ -1,0 +1,132 @@
+"""Tests for LG webOS TV switch platform."""
+
+import inspect
+from unittest.mock import AsyncMock
+
+from aiowebostv import WebOsTvCommandError
+import pytest
+
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.webostv.const import DOMAIN
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_webostv
+from .const import FAKE_UUID
+
+SWITCH_ENTITY_ID = f"{SWITCH_DOMAIN}.lg_webos_tv_model_screen"
+
+
+async def fire_state_update(client: AsyncMock) -> None:
+    """Trigger all registered state update callbacks."""
+    for call in client.register_state_update_callback.call_args_list:
+        await call[0][0](client.tv_state)
+
+
+async def test_screen_switch_setup(
+    hass: HomeAssistant,
+    client: AsyncMock,
+) -> None:
+    """Test setup of LG webOS TV screen switch."""
+    await setup_webostv(hass)
+
+    entity_reg = er.async_get(hass)
+    entry = entity_reg.async_get(SWITCH_ENTITY_ID)
+    assert entry is not None
+    assert entry.unique_id == f"{FAKE_UUID}_screen"
+
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+
+async def test_screen_switch_state_updates(
+    hass: HomeAssistant,
+    client: AsyncMock,
+) -> None:
+    """Test screen switch state updates from client."""
+    await setup_webostv(hass)
+
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state.state == STATE_OFF
+
+    # Update TV state to screen on
+    client.tv_state.is_screen_on = True
+    await fire_state_update(client)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state.state == STATE_ON
+
+    # TV powered off makes switch unavailable
+    client.tv_state.is_on = False
+    client.tv_state.is_screen_on = False
+    await fire_state_update(client)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(SWITCH_ENTITY_ID)
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_screen_switch_turn_on(
+    hass: HomeAssistant,
+    client: AsyncMock,
+) -> None:
+    """Test turning on the screen switch."""
+    await setup_webostv(hass)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: SWITCH_ENTITY_ID},
+        blocking=True,
+    )
+
+    client.request.assert_called_once_with(
+        "com.webos.service.tvpower/power/turnOnScreen"
+    )
+
+
+async def test_screen_switch_turn_off(
+    hass: HomeAssistant,
+    client: AsyncMock,
+) -> None:
+    """Test turning off the screen switch."""
+    await setup_webostv(hass)
+
+    await hass.services.async_call(
+        SWITCH_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: SWITCH_ENTITY_ID},
+        blocking=True,
+    )
+
+    client.request.assert_called_once_with(
+        "com.webos.service.tvpower/power/turnOffScreen"
+    )
+
+
+async def test_screen_switch_command_error(
+    hass: HomeAssistant,
+    client: AsyncMock,
+) -> None:
+    """Test error handling when turning on screen fails."""
+    await setup_webostv(hass)
+    client.request.side_effect = WebOsTvCommandError("Communication error")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: SWITCH_ENTITY_ID},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR adds a native `switch` platform entity to the `webostv` integration (`switch.<tv_name>_screen`) for toggling and tracking LG webOS TV screen power state independently of the main TV power.

- **State Tracking:** Subscribes to real-time `tv_state.is_screen_on` WebSocket notifications from `aiowebostv`, eliminating the need for custom polling.
- **Actions:** Implements `turnOnScreen` (`com.webos.service.tvpower/power/turnOnScreen`) and `turnOffScreen` (`com.webos.service.tvpower/power/turnOffScreen`) service requests.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

