### PR TITLE
Bump knx-telegram-store to 0.10.2

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -14,7 +14,7 @@
     "xknx==3.16.0",
     "xknxproject==3.9.0",
     "knx-frontend==2026.6.23.203726",
-    "knx-telegram-store[sqlite,postgres]==0.10.1"
+    "knx-telegram-store[sqlite,postgres]==0.10.2"
   ],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1441,7 +1441,7 @@ knocki==0.4.2
 knx-frontend==2026.6.23.203726
 
 # homeassistant.components.knx
-knx-telegram-store[sqlite,postgres]==0.10.1
+knx-telegram-store[sqlite,postgres]==0.10.2
 
 # homeassistant.components.kraken
 krakenex==2.2.2


### PR DESCRIPTION
## Proposed change

Bump knx-telegram-store from 0.10.1 to 0.10.2.

Bugfix release: the library's `needs_migration()` legacy null-value probe and the corresponding startup backfill filtered on unindexed columns and, with no matching legacy rows (the common case), scanned the entire telegrams table on every startup. On large databases on low-power hardware this made KNX telegram store initialization time grow with database size and could exceed the 10 s `STORE_INIT_TIMEOUT`, disabling telegram history until reload. The recovery is now recorded in `store_metadata` and both scans are skipped once complete, making steady-state store initialization independent of database size.

Diff: https://github.com/XKNX/knx-telegram-store/compare/v0.10.1...v0.10.2
Related to: #176542 (retry on init timeout — complementary; this release removes the main cause of those timeouts)

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file](https://developers.home-assistant.io/docs/creating_integration_manifest/) has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.