### PR TITLE
Fix mobile_app local push failing permanently after a missed confirmation

### DIFF
--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -106,8 +106,10 @@ class MobileAppNotifyEntity(NotifyEntity):
 
         # Sends notification via local push if available
         # and fallback to cloud push if fails; a degraded channel is
-        # bypassed for cloud-capable targets until a probe is confirmed
-        if push_channel is not None and not (cloud_capable and push_channel.degraded):
+        # bypassed for cloud-capable targets except a single probe send
+        if push_channel is not None and (
+            not cloud_capable or push_channel.async_should_send_local()
+        ):
             push_channel.async_send_notification(
                 data,
                 partial(_send_message, self._session, self._config_entry),
@@ -223,9 +225,9 @@ class MobileAppNotificationService(BaseNotificationService):
             cloud_capable = ATTR_PUSH_URL in entry.data[ATTR_APP_DATA]
 
             # A degraded channel is bypassed for cloud-capable targets
-            # until a probe is confirmed
-            if push_channel is not None and not (
-                cloud_capable and push_channel.degraded
+            # except a single probe send
+            if push_channel is not None and (
+                not cloud_capable or push_channel.async_should_send_local()
             ):
                 push_channel.async_send_notification(
                     data,

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -98,20 +98,22 @@ class MobileAppNotifyEntity(NotifyEntity):
         if title is not None:
             data[ATTR_TITLE] = title
 
+        webhook_id = self._config_entry.data[ATTR_WEBHOOK_ID]
+        push_channel: PushChannel | None = self.hass.data[DOMAIN][
+            DATA_PUSH_CHANNEL
+        ].get(webhook_id)
+        cloud_capable = ATTR_PUSH_URL in self._config_entry.data[ATTR_APP_DATA]
+
         # Sends notification via local push if available
-        # and fallback to cloud push if fails
-        if (webhook_id := self._config_entry.data[ATTR_WEBHOOK_ID]) in self.hass.data[
-            DOMAIN
-        ][DATA_PUSH_CHANNEL]:
-            push_channel: PushChannel = self.hass.data[DOMAIN][DATA_PUSH_CHANNEL][
-                webhook_id
-            ]
+        # and fallback to cloud push if fails; a degraded channel is
+        # bypassed for cloud-capable targets until a probe is confirmed
+        if push_channel is not None and not (cloud_capable and push_channel.degraded):
             push_channel.async_send_notification(
                 data,
                 partial(_send_message, self._session, self._config_entry),
             )
         # Sends notification via cloud push notification service
-        elif ATTR_PUSH_URL in self._config_entry.data[ATTR_APP_DATA]:
+        elif cloud_capable:
             await _send_message(self._session, self._config_entry, data)
         else:
             raise HomeAssistantError(
@@ -217,8 +219,15 @@ class MobileAppNotificationService(BaseNotificationService):
         for target in targets:
             entry: ConfigEntry = self.hass.data[DOMAIN][DATA_CONFIG_ENTRIES][target]
 
-            if target in local_push_channels:
-                local_push_channels[target].async_send_notification(
+            push_channel = local_push_channels.get(target)
+            cloud_capable = ATTR_PUSH_URL in entry.data[ATTR_APP_DATA]
+
+            # A degraded channel is bypassed for cloud-capable targets
+            # until a probe is confirmed
+            if push_channel is not None and not (
+                cloud_capable and push_channel.degraded
+            ):
+                push_channel.async_send_notification(
                     data,
                     partial(self._async_send_remote_message_target, entry),
                 )
@@ -226,7 +235,7 @@ class MobileAppNotificationService(BaseNotificationService):
                 continue
 
             # Test if local push only.
-            if ATTR_PUSH_URL not in entry.data[ATTR_APP_DATA]:
+            if not cloud_capable:
                 failed_targets.append(target)
                 continue
 

--- a/homeassistant/components/mobile_app/notify.py
+++ b/homeassistant/components/mobile_app/notify.py
@@ -112,7 +112,9 @@ class MobileAppNotifyEntity(NotifyEntity):
         ):
             push_channel.async_send_notification(
                 data,
-                partial(_send_message, self._session, self._config_entry),
+                partial(_send_message, self._session, self._config_entry)
+                if cloud_capable
+                else None,
             )
         # Sends notification via cloud push notification service
         elif cloud_capable:
@@ -231,7 +233,9 @@ class MobileAppNotificationService(BaseNotificationService):
             ):
                 push_channel.async_send_notification(
                     data,
-                    partial(self._async_send_remote_message_target, entry),
+                    partial(self._async_send_remote_message_target, entry)
+                    if cloud_capable
+                    else None,
                 )
                 async_dispatcher_send(self.hass, SIGNAL_RECORD_NOTIFICATION, target)
                 continue

--- a/homeassistant/components/mobile_app/push_notification.py
+++ b/homeassistant/components/mobile_app/push_notification.py
@@ -40,12 +40,21 @@ class PushChannel:
         self.pending_confirms: dict[str, dict] = {}
         self._consecutive_timeouts = 0
         self._degraded = False
+        self._probe_permit = False
         self._unsub_degraded_probe: CALLBACK_TYPE | None = None
 
-    @property
-    def degraded(self) -> bool:
-        """Return if sends should be routed via cloud where possible."""
-        return self._degraded
+    @callback
+    def async_should_send_local(self) -> bool:
+        """Return if the next send should be delivered locally.
+
+        Consumes the single probe permit of a degraded channel.
+        """
+        if not self._degraded:
+            return True
+        if self._probe_permit:
+            self._probe_permit = False
+            return True
+        return False
 
     @callback
     def async_send_notification(self, data, fallback_send):
@@ -98,6 +107,7 @@ class PushChannel:
     def _async_mark_degraded(self) -> None:
         """Route cloud-capable sends via cloud until a probe is confirmed."""
         self._degraded = True
+        self._probe_permit = False
         if self._unsub_degraded_probe is None:
             self._unsub_degraded_probe = async_call_later(
                 self.hass, PUSH_DEGRADED_PROBE_INTERVAL, self._async_allow_probe
@@ -105,9 +115,9 @@ class PushChannel:
 
     @callback
     def _async_allow_probe(self, _now: datetime) -> None:
-        """Let the next send probe local delivery again."""
+        """Let a single next send probe local delivery again."""
         self._unsub_degraded_probe = None
-        self._degraded = False
+        self._probe_permit = True
 
     @callback
     def _async_clear_degraded(self) -> None:
@@ -115,6 +125,7 @@ class PushChannel:
         if self._unsub_degraded_probe is not None:
             self._unsub_degraded_probe()
             self._unsub_degraded_probe = None
+        self._probe_permit = False
         self._degraded = False
 
     async def async_teardown(self):

--- a/homeassistant/components/mobile_app/push_notification.py
+++ b/homeassistant/components/mobile_app/push_notification.py
@@ -2,12 +2,22 @@
 
 import asyncio
 from collections.abc import Callable
+from datetime import datetime
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.uuid import random_uuid_hex
 
 PUSH_CONFIRM_TIMEOUT = 10  # seconds
+
+# Consecutive confirm timeouts after which the channel is considered degraded
+# and cloud-capable targets are routed straight to cloud instead of waiting
+# out the confirm timeout for every message.
+PUSH_DEGRADED_AFTER_TIMEOUTS = 2
+
+# How long a degraded channel routes via cloud before the next send probes
+# local delivery again.
+PUSH_DEGRADED_PROBE_INTERVAL = 300  # seconds
 
 
 class PushChannel:
@@ -28,6 +38,14 @@ class PushChannel:
         self._send_message = send_message
         self.on_teardown = on_teardown
         self.pending_confirms: dict[str, dict] = {}
+        self._consecutive_timeouts = 0
+        self._degraded = False
+        self._unsub_degraded_probe: CALLBACK_TYPE | None = None
+
+    @property
+    def degraded(self) -> bool:
+        """Return if sends should be routed via cloud where possible."""
+        return self._degraded
 
     @callback
     def async_send_notification(self, data, fallback_send):
@@ -44,6 +62,12 @@ class PushChannel:
             # Already popped by a confirm or a teardown flush; nothing to fall back.
             if self.pending_confirms.pop(confirm_id, None) is None:
                 return
+
+            # A teardown flush is not a delivery failure of a live channel
+            if self.on_teardown is not None:
+                self._consecutive_timeouts += 1
+                if self._consecutive_timeouts >= PUSH_DEGRADED_AFTER_TIMEOUTS:
+                    self._async_mark_degraded()
 
             await fallback_send(data)
 
@@ -65,7 +89,33 @@ class PushChannel:
             return False
 
         self.pending_confirms.pop(confirm_id)["unsub_scheduled_push_failed"]()
+        # A timely confirm proves the channel delivers
+        self._consecutive_timeouts = 0
+        self._async_clear_degraded()
         return True
+
+    @callback
+    def _async_mark_degraded(self) -> None:
+        """Route cloud-capable sends via cloud until a probe is confirmed."""
+        self._degraded = True
+        if self._unsub_degraded_probe is None:
+            self._unsub_degraded_probe = async_call_later(
+                self.hass, PUSH_DEGRADED_PROBE_INTERVAL, self._async_allow_probe
+            )
+
+    @callback
+    def _async_allow_probe(self, _now: datetime) -> None:
+        """Let the next send probe local delivery again."""
+        self._unsub_degraded_probe = None
+        self._degraded = False
+
+    @callback
+    def _async_clear_degraded(self) -> None:
+        """Restore local delivery for all sends."""
+        if self._unsub_degraded_probe is not None:
+            self._unsub_degraded_probe()
+            self._unsub_degraded_probe = None
+        self._degraded = False
 
     async def async_teardown(self):
         """Tear down this channel."""
@@ -75,6 +125,7 @@ class PushChannel:
 
         self.on_teardown()
         self.on_teardown = None
+        self._async_clear_degraded()
 
         cancel_pending_local_tasks = [
             actions["handle_push_failed"]()

--- a/homeassistant/components/mobile_app/push_notification.py
+++ b/homeassistant/components/mobile_app/push_notification.py
@@ -40,16 +40,10 @@ class PushChannel:
         data["hass_confirm_id"] = confirm_id
 
         async def handle_push_failed(_=None):
-            """Handle a failed local push notification."""
-            # Remove this handler from the pending dict
-            # If it didn't exist we hit a race condition between call_later and another
-            # push failing and tearing down the connection.
+            """Fall back to cloud for a local push left unconfirmed in time."""
+            # Already popped by a confirm or a teardown flush; nothing to fall back.
             if self.pending_confirms.pop(confirm_id, None) is None:
                 return
-
-            # Drop local channel if it's still open
-            if self.on_teardown is not None:
-                await self.async_teardown()
 
             await fallback_send(data)
 

--- a/homeassistant/components/mobile_app/push_notification.py
+++ b/homeassistant/components/mobile_app/push_notification.py
@@ -3,10 +3,13 @@
 import asyncio
 from collections.abc import Callable
 from datetime import datetime
+import logging
 
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.event import async_call_later
 from homeassistant.util.uuid import random_uuid_hex
+
+_LOGGER = logging.getLogger(__name__)
 
 PUSH_CONFIRM_TIMEOUT = 10  # seconds
 
@@ -99,6 +102,8 @@ class PushChannel:
 
         self.pending_confirms.pop(confirm_id)["unsub_scheduled_push_failed"]()
         # A timely confirm proves the channel delivers
+        if self._degraded:
+            _LOGGER.debug("Push channel %s restored to local delivery", self.webhook_id)
         self._consecutive_timeouts = 0
         self._async_clear_degraded()
         return True
@@ -106,6 +111,13 @@ class PushChannel:
     @callback
     def _async_mark_degraded(self) -> None:
         """Route cloud-capable sends via cloud until a probe is confirmed."""
+        if not self._degraded:
+            _LOGGER.debug(
+                "Push channel %s degraded after %d consecutive confirm timeouts;"
+                " routing cloud-capable sends via cloud",
+                self.webhook_id,
+                self._consecutive_timeouts,
+            )
         self._degraded = True
         self._probe_permit = False
         if self._unsub_degraded_probe is None:
@@ -116,6 +128,9 @@ class PushChannel:
     @callback
     def _async_allow_probe(self, _now: datetime) -> None:
         """Let a single next send probe local delivery again."""
+        _LOGGER.debug(
+            "Allowing a local delivery probe for push channel %s", self.webhook_id
+        )
         self._unsub_degraded_probe = None
         self._probe_permit = True
 

--- a/homeassistant/components/mobile_app/push_notification.py
+++ b/homeassistant/components/mobile_app/push_notification.py
@@ -60,8 +60,12 @@ class PushChannel:
         return False
 
     @callback
-    def async_send_notification(self, data, fallback_send):
-        """Send a push notification."""
+    def async_send_notification(self, data, fallback_send: Callable | None):
+        """Send a push notification.
+
+        fallback_send is None for local-push-only registrations, which have no
+        cloud delivery to fall back to.
+        """
         if not self.support_confirm:
             self._send_message(data)
             return
@@ -80,6 +84,9 @@ class PushChannel:
                 self._consecutive_timeouts += 1
                 if self._consecutive_timeouts >= PUSH_DEGRADED_AFTER_TIMEOUTS:
                     self._async_mark_degraded()
+
+            if fallback_send is None:
+                return
 
             await fallback_send(data)
 

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -835,7 +835,8 @@ async def test_local_push_only_stays_local_when_degraded(
     assert msg_result["event"]["message"] == "Hello world 1"
     msg_result = await client.receive_json()
     assert msg_result["event"]["message"] == "Hello world 2"
-    assert len(mock_cloud_send.mock_calls) == 2
+    # A local-push-only registration has no cloud path to fall back to
+    assert len(mock_cloud_send.mock_calls) == 0
 
     # The channel reached the degraded threshold, but a local-push-only
     # target has no cloud path: the legacy service still delivers locally
@@ -880,6 +881,61 @@ async def test_local_push_only_stays_local_when_degraded(
     result = await client.receive_json()
     assert result["success"]
 
+    await client.send_json_auto_id(
+        {
+            "type": "unsubscribe_events",
+            "subscription": sub_id,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    await hass.async_block_till_done()
+
+
+@pytest.mark.usefixtures("setup_websocket_channel_only_push")
+async def test_local_push_only_missed_confirm(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a missed confirm without a cloud fallback keeps the channel working."""
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_channel",
+            "webhook_id": "websocket-push-webhook-id",
+            "support_confirm": True,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    sub_id = sub_result["id"]
+
+    # The confirm times out and there is no cloud delivery to fall back to
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
+        await hass.services.async_call(
+            "notify",
+            "mobile_app_websocket_push_name",
+            {"message": "Hello world 1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 1"
+
+    # The channel is still registered and keeps delivering locally
+    await hass.services.async_call(
+        "notify",
+        "mobile_app_websocket_push_name",
+        {"message": "Hello world 2"},
+        blocking=True,
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 2"
+
+    # The pending confirm of the second message is flushed by the teardown
     await client.send_json_auto_id(
         {
             "type": "unsubscribe_events",

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -520,6 +520,87 @@ async def test_notify_ws_not_confirming(
 
 
 @pytest.mark.usefixtures("setup_push_receiver")
+async def test_notify_ws_confirm_resets_timeout_count(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a timely confirm between two timeouts keeps the channel local."""
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_channel",
+            "webhook_id": "mock-webhook_id",
+            "support_confirm": True,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    sub_id = sub_result["id"]
+
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
+        await hass.services.async_call(
+            "notify", "mobile_app_test", {"message": "Hello world 1"}, blocking=True
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 1"
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # A timely confirm resets the consecutive timeout count
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 2"}, blocking=True
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 2"
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_confirm",
+            "webhook_id": "mock-webhook_id",
+            "confirm_id": msg_result["event"]["hass_confirm_id"],
+        }
+    )
+    result = await client.receive_json()
+    assert result["success"]
+
+    # The next timeout is an isolated one again and must not open the breaker
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
+        await hass.services.async_call(
+            "notify", "mobile_app_test", {"message": "Hello world 3"}, blocking=True
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 3"
+    assert len(aioclient_mock.mock_calls) == 2
+
+    # Local delivery continues
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 4"}, blocking=True
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 4"
+    assert len(aioclient_mock.mock_calls) == 2
+
+    await client.send_json_auto_id(
+        {
+            "type": "unsubscribe_events",
+            "subscription": sub_id,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 3
+
+
+@pytest.mark.usefixtures("setup_push_receiver")
 async def test_notify_ws_degraded_channel(
     hass: HomeAssistant,
     aioclient_mock: AiohttpClientMocker,

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -708,6 +708,108 @@ async def test_send_message_degraded_channel(
     assert len(aioclient_mock.mock_calls) == 3
 
 
+@pytest.mark.usefixtures("setup_websocket_channel_only_push")
+async def test_local_push_only_stays_local_when_degraded(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a degraded channel keeps local delivery for local-push-only targets."""
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_channel",
+            "webhook_id": "websocket-push-webhook-id",
+            "support_confirm": True,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    sub_id = sub_result["id"]
+
+    with (
+        patch(CONFIRM_TIMEOUT_PATCH, 0),
+        patch(
+            "homeassistant.components.mobile_app.notify._send_message"
+        ) as mock_cloud_send,
+    ):
+        await hass.services.async_call(
+            "notify",
+            "mobile_app_websocket_push_name",
+            {"message": "Hello world 1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            "notify",
+            "mobile_app_websocket_push_name",
+            {"message": "Hello world 2"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 1"
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 2"
+    assert len(mock_cloud_send.mock_calls) == 2
+
+    # The channel reached the degraded threshold, but a local-push-only
+    # target has no cloud path: the legacy service still delivers locally
+    await hass.services.async_call(
+        "notify",
+        "mobile_app_websocket_push_name",
+        {"message": "Hello world 3"},
+        blocking=True,
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 3"
+    confirm_id_3 = msg_result["event"]["hass_confirm_id"]
+
+    # The notify entity still delivers locally on the degraded channel as well
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        {ATTR_ENTITY_ID: "notify.websocket_push_name", ATTR_MESSAGE: "Hello world 4"},
+        blocking=True,
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 4"
+    confirm_id_4 = msg_result["event"]["hass_confirm_id"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_confirm",
+            "webhook_id": "websocket-push-webhook-id",
+            "confirm_id": confirm_id_3,
+        }
+    )
+    result = await client.receive_json()
+    assert result["success"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_confirm",
+            "webhook_id": "websocket-push-webhook-id",
+            "confirm_id": confirm_id_4,
+        }
+    )
+    result = await client.receive_json()
+    assert result["success"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "unsubscribe_events",
+            "subscription": sub_id,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    await hass.async_block_till_done()
+
+
 @pytest.mark.freeze_time("1970-01-01T00:00:00.000Z")
 async def test_local_push_only(
     hass: HomeAssistant,

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -25,7 +25,12 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, MockUser, snapshot_platform
+from tests.common import (
+    MockConfigEntry,
+    MockUser,
+    async_fire_time_changed,
+    snapshot_platform,
+)
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
 
@@ -412,6 +417,12 @@ async def test_notify_ws_confirming_works(
     result = await client.receive_json()
     assert result["success"]
 
+    # The timely confirm cancelled the fallback timer: advancing past the
+    # confirm timeout must not send anything via cloud
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=15))
+    await hass.async_block_till_done()
+    assert len(aioclient_mock.mock_calls) == 0
+
     # Drop local push channel and try to confirm another message
     await client.send_json_auto_id(
         {
@@ -444,7 +455,7 @@ async def test_notify_ws_not_confirming(
     setup_push_receiver,
     hass_ws_client: WebSocketGenerator,
 ) -> None:
-    """Test we go via cloud when failed to confirm."""
+    """Test a late confirm falls back via cloud without dropping the channel."""
     client = await hass_ws_client(hass)
 
     await client.send_json_auto_id(
@@ -457,10 +468,13 @@ async def test_notify_ws_not_confirming(
 
     sub_result = await client.receive_json()
     assert sub_result["success"]
+    sub_id = sub_result["id"]
 
     await hass.services.async_call(
         "notify", "mobile_app_test", {"message": "Hello world 1"}, blocking=True
     )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 1"
 
     with patch(
         "homeassistant.components.mobile_app.push_notification.PUSH_CONFIRM_TIMEOUT", 0
@@ -471,13 +485,31 @@ async def test_notify_ws_not_confirming(
         await hass.async_block_till_done()
         await hass.async_block_till_done()
 
-    # When we fail, all unconfirmed ones and failed one are sent via cloud
-    assert len(aioclient_mock.mock_calls) == 2
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 2"
 
-    # All future ones also go via cloud
+    # Only the message that missed its confirmation falls back via cloud;
+    # the channel stays registered instead of being torn down
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # Later messages keep being delivered locally
     await hass.services.async_call(
         "notify", "mobile_app_test", {"message": "Hello world 3"}, blocking=True
     )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 3"
+    assert len(aioclient_mock.mock_calls) == 1
+
+    # Dropping the channel still flushes the unconfirmed messages via cloud once
+    await client.send_json_auto_id(
+        {
+            "type": "unsubscribe_events",
+            "subscription": sub_id,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    await hass.async_block_till_done()
 
     assert len(aioclient_mock.mock_calls) == 3
 

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -603,6 +603,13 @@ async def test_notify_ws_degraded_channel(
     msg_result = await client.receive_json()
     assert msg_result["event"]["message"] == "Hello world 6"
 
+    # Only a single send probes: a message sent while the probe is still
+    # unconfirmed keeps routing via cloud
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 6b"}, blocking=True
+    )
+    assert len(aioclient_mock.mock_calls) == 6
+
     await client.send_json_auto_id(
         {
             "type": "mobile_app/push_notification_confirm",
@@ -619,7 +626,7 @@ async def test_notify_ws_degraded_channel(
     )
     msg_result = await client.receive_json()
     assert msg_result["event"]["message"] == "Hello world 7"
-    assert len(aioclient_mock.mock_calls) == 5
+    assert len(aioclient_mock.mock_calls) == 6
 
     # Dropping the channel still flushes the unconfirmed message via cloud
     await client.send_json_auto_id(
@@ -632,7 +639,7 @@ async def test_notify_ws_degraded_channel(
     assert sub_result["success"]
     await hass.async_block_till_done()
 
-    assert len(aioclient_mock.mock_calls) == 6
+    assert len(aioclient_mock.mock_calls) == 7
 
 
 @pytest.mark.usefixtures("setup_push_receiver")

--- a/tests/components/mobile_app/test_notify.py
+++ b/tests/components/mobile_app/test_notify.py
@@ -11,6 +11,9 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.mobile_app.const import DATA_LIVE_ACTIVITY_TOKENS, DOMAIN
+from homeassistant.components.mobile_app.push_notification import (
+    PUSH_DEGRADED_PROBE_INTERVAL,
+)
 from homeassistant.components.notify import (
     ATTR_MESSAGE,
     ATTR_TITLE,
@@ -33,6 +36,10 @@ from tests.common import (
 )
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import WebSocketGenerator
+
+CONFIRM_TIMEOUT_PATCH = (
+    "homeassistant.components.mobile_app.push_notification.PUSH_CONFIRM_TIMEOUT"
+)
 
 
 @pytest.fixture
@@ -476,9 +483,7 @@ async def test_notify_ws_not_confirming(
     msg_result = await client.receive_json()
     assert msg_result["event"]["message"] == "Hello world 1"
 
-    with patch(
-        "homeassistant.components.mobile_app.push_notification.PUSH_CONFIRM_TIMEOUT", 0
-    ):
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
         await hass.services.async_call(
             "notify", "mobile_app_test", {"message": "Hello world 2"}, blocking=True
         )
@@ -501,6 +506,188 @@ async def test_notify_ws_not_confirming(
     assert len(aioclient_mock.mock_calls) == 1
 
     # Dropping the channel still flushes the unconfirmed messages via cloud once
+    await client.send_json_auto_id(
+        {
+            "type": "unsubscribe_events",
+            "subscription": sub_id,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 3
+
+
+@pytest.mark.usefixtures("setup_push_receiver")
+async def test_notify_ws_degraded_channel(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test consecutive confirm timeouts degrade the channel to cloud routing."""
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_channel",
+            "webhook_id": "mock-webhook_id",
+            "support_confirm": True,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    sub_id = sub_result["id"]
+
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
+        await hass.services.async_call(
+            "notify", "mobile_app_test", {"message": "Hello world 1"}, blocking=True
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            "notify", "mobile_app_test", {"message": "Hello world 2"}, blocking=True
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 1"
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 2"
+
+    # Both messages were delivered locally and fell back via cloud unconfirmed
+    assert len(aioclient_mock.mock_calls) == 2
+
+    # Two consecutive timeouts degraded the channel: this send goes straight
+    # via cloud without waiting out the confirm timeout
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 3"}, blocking=True
+    )
+    assert len(aioclient_mock.mock_calls) == 3
+
+    # After the probe interval the next send tries local delivery again
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=PUSH_DEGRADED_PROBE_INTERVAL + 1)
+    )
+    await hass.async_block_till_done()
+
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
+        await hass.services.async_call(
+            "notify", "mobile_app_test", {"message": "Hello world 4"}, blocking=True
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    # The probe was delivered locally and fell back via cloud unconfirmed;
+    # the bypassed message never reached the websocket
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 4"
+    assert len(aioclient_mock.mock_calls) == 4
+
+    # The unconfirmed probe kept the channel degraded
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 5"}, blocking=True
+    )
+    assert len(aioclient_mock.mock_calls) == 5
+
+    # Allow another probe and confirm it in time
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + timedelta(seconds=PUSH_DEGRADED_PROBE_INTERVAL + 1)
+    )
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 6"}, blocking=True
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 6"
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_confirm",
+            "webhook_id": "mock-webhook_id",
+            "confirm_id": msg_result["event"]["hass_confirm_id"],
+        }
+    )
+    result = await client.receive_json()
+    assert result["success"]
+
+    # The confirmed probe restored local delivery
+    await hass.services.async_call(
+        "notify", "mobile_app_test", {"message": "Hello world 7"}, blocking=True
+    )
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 7"
+    assert len(aioclient_mock.mock_calls) == 5
+
+    # Dropping the channel still flushes the unconfirmed message via cloud
+    await client.send_json_auto_id(
+        {
+            "type": "unsubscribe_events",
+            "subscription": sub_id,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    await hass.async_block_till_done()
+
+    assert len(aioclient_mock.mock_calls) == 6
+
+
+@pytest.mark.usefixtures("setup_push_receiver")
+async def test_send_message_degraded_channel(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test notify.send_message bypasses a degraded channel via cloud."""
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id(
+        {
+            "type": "mobile_app/push_notification_channel",
+            "webhook_id": "mock-webhook_id",
+            "support_confirm": True,
+        }
+    )
+    sub_result = await client.receive_json()
+    assert sub_result["success"]
+    sub_id = sub_result["id"]
+
+    with patch(CONFIRM_TIMEOUT_PATCH, 0):
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            SERVICE_SEND_MESSAGE,
+            {ATTR_ENTITY_ID: "notify.test", ATTR_MESSAGE: "Hello world 1"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            SERVICE_SEND_MESSAGE,
+            {ATTR_ENTITY_ID: "notify.test", ATTR_MESSAGE: "Hello world 2"},
+            blocking=True,
+        )
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 1"
+    msg_result = await client.receive_json()
+    assert msg_result["event"]["message"] == "Hello world 2"
+    assert len(aioclient_mock.mock_calls) == 2
+
+    # The degraded channel is bypassed straight via cloud
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_SEND_MESSAGE,
+        {ATTR_ENTITY_ID: "notify.test", ATTR_MESSAGE: "Hello world 3"},
+        blocking=True,
+    )
+    assert len(aioclient_mock.mock_calls) == 3
+
     await client.send_json_auto_id(
         {
             "type": "unsubscribe_events",


### PR DESCRIPTION
## Proposed change

Local push is what lets a notification reach a device without ever touching a cloud — this change makes that local-first path resilient, so devices stay on it instead of being silently forced onto cloud delivery, or losing notifications entirely, because of a single late acknowledgment.

### What's broken

Local push notifications are expected to be acknowledged by the app within 10 seconds. When a phone confirms late — asleep, slow to wake, behind a buffering proxy — Home Assistant doesn't just give up on that one message. It silently kills the **entire push channel**. The app is never told: it keeps its socket open, believes it's still subscribed, and never re-subscribes.

For a device registered with local push only, the consequence is severe: **no notifications at all until the app is force-restarted**. Cloud-capable devices fare better but silently lose local delivery until an app restart. Both companion apps use confirmations, so both are exposed — iOS registrations virtually always include a cloud path (silent degradation), while Android builds without Google services are the typical local-push-only case (hard failure).

### The constraint: iOS misses confirmations on purpose

While the app is suspended, iOS deliberately leaves Live Activity updates unconfirmed (home-assistant/iOS#4857) so the confirm timeout forwards them through APNs — the only path that can start a Live Activity in the background. Prompt APNs routing for unconfirmed Live Activity updates is therefore a hard requirement, not an accident of the old behavior.

### The fix: a missed confirmation affects routing, never registration

| Event | New behavior |
|---|---|
| 1 missed confirm | The message was sent locally, but delivery is unknown — that is what the confirmation was for. The timeout triggers a safety copy via cloud for devices that have one. The channel stays registered |
| 2 misses in a row | Channel **degraded**: cloud-capable devices route straight to cloud, no 10 s wait (keeps iOS Live Activities fast); local-push-only devices keep local delivery |
| While degraded: one probe per 5 min | One message is sent locally as a test (all others stay on cloud). Confirmed in time → the channel returns to normal local delivery. Not confirmed → it stays degraded and the next probe comes ~5 min later |
| Any timely confirm | Immediately restores normal local delivery and zeroes the miss counter — so two misses only degrade the channel if no message got confirmed between them |

Everything else is untouched: when a device unsubscribes or disconnects, messages still awaiting confirmation are sent via cloud once, exactly as before; re-subscribing replaces the channel with a fresh one; and the confirmation messages the apps already send work unchanged. Genuinely dead sockets are still reaped by the server's 55 s websocket heartbeat, typically within a couple of minutes; a complementary client-side ping is proposed in home-assistant/android#7164. Degrade / probe / restore transitions are debug-logged.

### What changes in practice

| Scenario | Before | After |
|---|---|---|
| Local-push-only device, one late confirm | **Notifications dead** until force-restart | Cloud fallback cannot deliver (there is no cloud path), but the channel remains registered and later notifications continue trying local delivery |
| iOS Live Activity burst, app suspended | First update +10 s, rest instant via APNs | In-flight updates +10 s each, later ones instant via APNs; one 10 s probe per 5 min |
| Device delivers but confirms slowly (>10 s) | 1 duplicate, then cloud-only | Sequential sends: up to 2 duplicates, then cloud-only until a probe confirms. Messages already in flight when the channel degrades each keep their own timer and can each duplicate |

### Inherited limitations (unchanged by this PR)

These compromises predate the change:

- **Delivery is inferred, never reported.** The server guesses delivery from a 10 s timer; a client can't say "got it, don't resend" or "can't present this, use cloud now". Every duplicate and every 10 s wait — before and after this PR — stems from that inference.
- **Duplicates on a late confirm** already existed (exactly one, after which the channel was removed and everything went cloud-only); this PR bounds them at two per degrade cycle instead. Client-side tag matching usually collapses a duplicate into a re-alert rather than a second entry.
- **A local-push-only device with a silently dead socket loses the messages sent into the dead window** — they have no second path, and the cloud fallback can only log. Previously that window was permanent (the channel was gone until an app restart); it's now bounded by the 55 s heartbeat reap and the client's reconnect.

**Potential follow-up (not an alternative to this change):** an explicit client acknowledgement protocol — "delivered, don't resend" / "can't present this, route via cloud" — would remove the inference for clients that speak it. It would layer on top of this PR rather than replace it: the server must keep timeout-based inference for older apps indefinitely, and this change is that layer. Cross-repo (core + both companions), so it belongs in an architecture discussion if there's interest.

### Tests

New tests cover: a channel surviving a single missed confirmation · the full degrade → probe → recover cycle, for both ways Home Assistant sends notifications (the notify service and notify entities) · only one probe going local while the rest of a burst stays on cloud · a timely confirmation between two misses preventing degradation · local-push-only devices never being routed to cloud · unsubscribing still delivering unconfirmed messages via cloud once.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue:
  - fixes [#176371](https://github.com/home-assistant/core/issues/176371)
  - fixes [#174164](https://github.com/home-assistant/core/issues/174164)
- This PR is related to issue:
  - [#172669](https://github.com/home-assistant/core/issues/172669)
  - [android#7164](https://github.com/home-assistant/android/pull/7164)
  - [iOS#4857](https://github.com/home-assistant/iOS/issues/4857)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
This project is very active and we have a high turnover of pull requests.

Unfortunately, the number of incoming pull requests is higher than what our
reviewers can review and merge so there is a long backlog of pull requests
waiting for review. You can help here!

By reviewing another pull request, you will help raise the code quality of
that pull request and the final review will be faster. This way the general
pace of pull request reviews will go up and your wait time will go down.

When picking a pull request to review, try to choose one that hasn't yet
been reviewed.

Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

