### PR TITLE
Add cleanup of unused devices in NINA

### DIFF
--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -13,7 +13,11 @@ from homeassistant.config_entries import (
 )
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import VolDictType
 
@@ -245,6 +249,7 @@ class OptionsFlowHandler(OptionsFlowWithReload):
                 )
 
                 await self.remove_unused_entities(user_input)
+                await self.remove_unused_devices(user_input)
 
                 self.hass.config_entries.async_update_entry(
                     self.config_entry, data=user_input
@@ -263,6 +268,18 @@ class OptionsFlowHandler(OptionsFlowWithReload):
             data_schema=schema_with_suggested,
             errors=errors,
         )
+
+    async def remove_unused_devices(self, user_input: dict[str, Any]) -> None:
+        """Remove devices from regions that are not selected."""
+        device_registry = dr.async_get(self.hass)
+
+        removed_regions = set(self.data[CONF_REGIONS]) - set(user_input[CONF_REGIONS])
+
+        for region in removed_regions:
+            if device := device_registry.async_get_device(
+                identifiers={(DOMAIN, region)}
+            ):
+                device_registry.async_remove_device(device.id)
 
     async def remove_unused_entities(self, user_input: dict[str, Any]) -> None:
         """Remove entities which are not used anymore."""

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -279,7 +279,9 @@ class OptionsFlowHandler(OptionsFlowWithReload):
             if device := device_registry.async_get_device(
                 identifiers={(DOMAIN, region)}
             ):
-                device_registry.async_remove_device(device.id)
+                device_registry.async_update_device(
+                    device.id, remove_config_entry_id=self.config_entry.entry_id
+                )
 
     async def remove_unused_entities(self, user_input: dict[str, Any]) -> None:
         """Remove entities which are not used anymore."""

--- a/tests/components/nina/conftest.py
+++ b/tests/components/nina/conftest.py
@@ -14,6 +14,7 @@ from .const import (
     DUMMY_CONFIG_ENTRY,
     DUMMY_CONFIG_ENTRY_AREA_FILTERS,
     DUMMY_CONFIG_ENTRY_DEFAULT_FILTERS,
+    DUMMY_CONFIG_ENTRY_MULTIPLE_REGIONS,
 )
 
 from tests.common import (
@@ -71,6 +72,22 @@ def mock_config_entry_area_filter(hass: HomeAssistant) -> MockConfigEntry:
         domain=DOMAIN,
         title="NINA",
         data=deepcopy(DUMMY_CONFIG_ENTRY_AREA_FILTERS),
+        version=1,
+        minor_version=3,
+    )
+
+    config_entry.add_to_hass(hass)
+
+    return config_entry
+
+
+@pytest.fixture
+def mock_config_entry_multiple_regions(hass: HomeAssistant) -> MockConfigEntry:
+    """Provide a common mock config entry with an area filter."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="NINA",
+        data=deepcopy(DUMMY_CONFIG_ENTRY_MULTIPLE_REGIONS),
         version=1,
         minor_version=3,
     )

--- a/tests/components/nina/const.py
+++ b/tests/components/nina/const.py
@@ -55,3 +55,12 @@ DUMMY_CONFIG_ENTRY_AREA_FILTERS: dict[str, Any] = {
         CONF_AREA_FILTER: ".*nagold.*",
     },
 }
+
+DUMMY_CONFIG_ENTRY_MULTIPLE_REGIONS: dict[str, Any] = {
+    CONF_MESSAGE_SLOTS: 5,
+    CONF_REGIONS: {"083350000000": "Aach, Stadt", "010590000000": "Test, Stadt"},
+    CONF_FILTERS: {
+        CONF_HEADLINE_FILTER: "/(?!)/",
+        CONF_AREA_FILTER: ".*nagold.*",
+    },
+}

--- a/tests/components/nina/test_config_flow.py
+++ b/tests/components/nina/test_config_flow.py
@@ -25,7 +25,7 @@ from homeassistant.components.nina.const import (
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_platform
 from .const import DUMMY_USER_INPUT
@@ -320,3 +320,52 @@ async def test_options_flow_entity_removal(
     )
 
     assert len(entries) == new_slot_count * entities_per_slot
+
+
+async def test_options_flow_device_removal(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry_multiple_regions: MockConfigEntry,
+    mock_nina_class: AsyncMock,
+    nina_warnings: list[Warning],
+) -> None:
+    """Test if old devices are removed."""
+    await setup_platform(
+        hass, mock_config_entry_multiple_regions, mock_nina_class, nina_warnings
+    )
+
+    old_devices = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry_multiple_regions.entry_id
+    )
+
+    assert len(old_devices) == len(
+        mock_config_entry_multiple_regions.data.get(CONF_REGIONS, [])
+    )
+
+    result = await hass.config_entries.options.async_init(
+        mock_config_entry_multiple_regions.entry_id
+    )
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            CONF_MESSAGE_SLOTS: 5,
+            CONST_REGION_A_TO_D: ["095760000000_0"],
+            CONST_REGION_E_TO_H: [],
+            CONST_REGION_I_TO_L: [],
+            CONST_REGION_M_TO_Q: [],
+            CONST_REGION_R_TO_U: [],
+            CONST_REGION_V_TO_Z: [],
+            CONF_FILTERS: {},
+        },
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    devices = dr.async_entries_for_config_entry(
+        device_registry, mock_config_entry_multiple_regions.entry_id
+    )
+
+    assert not any(
+        old_device.id in (device.id for device in devices) for old_device in old_devices
+    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This pr adds the clean up of old devices after a region is not longer selected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
