### PR TITLE
Remove name field from HERE Travel Time config flow

### DIFF
--- a/homeassistant/components/here_travel_time/config_flow.py
+++ b/homeassistant/components/here_travel_time/config_flow.py
@@ -21,13 +21,7 @@ from homeassistant.config_entries import (
     ConfigFlowResult,
     OptionsFlow,
 )
-from homeassistant.const import (
-    CONF_API_KEY,
-    CONF_LATITUDE,
-    CONF_LONGITUDE,
-    CONF_MODE,
-    CONF_NAME,
-)
+from homeassistant.const import CONF_API_KEY, CONF_LATITUDE, CONF_LONGITUDE, CONF_MODE
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
@@ -88,11 +82,6 @@ def get_user_step_schema(data: Mapping[str, Any]) -> vol.Schema:
         travel_mode = TRAVEL_MODE_PUBLIC
     return vol.Schema(
         {
-            # Name field is no longer allowed in config flow schemas
-            # pylint: disable-next=home-assistant-config-flow-name-field
-            vol.Optional(
-                CONF_NAME, default=data.get(CONF_NAME, DEFAULT_NAME)
-            ): cv.string,
             vol.Required(CONF_API_KEY, default=data.get(CONF_API_KEY)): cv.string,
             vol.Optional(
                 CONF_MODE, default=data.get(CONF_MODE, TRAVEL_MODE_CAR)
@@ -136,7 +125,6 @@ class HERETravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             if not errors:
-                self._config[CONF_NAME] = user_input[CONF_NAME]
                 self._config[CONF_API_KEY] = user_input[CONF_API_KEY]
                 self._config[CONF_MODE] = user_input[CONF_MODE]
                 return await self.async_step_origin_menu()
@@ -237,11 +225,10 @@ class HERETravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
             if self.source == SOURCE_RECONFIGURE:
                 return self.async_update_reload_and_abort(
                     self._get_reconfigure_entry(),
-                    title=self._config[CONF_NAME],
                     data=self._config,
                 )
             return self.async_create_entry(
-                title=self._config[CONF_NAME],
+                title=DEFAULT_NAME,
                 data=self._config,
                 options=DEFAULT_OPTIONS,
             )
@@ -283,7 +270,7 @@ class HERETravelTimeConfigFlow(ConfigFlow, domain=DOMAIN):
                     self._get_reconfigure_entry(), data=self._config
                 )
             return self.async_create_entry(
-                title=self._config[CONF_NAME],
+                title=DEFAULT_NAME,
                 data=self._config,
                 options=DEFAULT_OPTIONS,
             )

--- a/homeassistant/components/here_travel_time/sensor.py
+++ b/homeassistant/components/here_travel_time/sensor.py
@@ -12,7 +12,6 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     CONF_MODE,
-    CONF_NAME,
     EntityStateAttribute,
     UnitOfLength,
     UnitOfTime,
@@ -83,7 +82,7 @@ async def async_setup_entry(
     """Add HERE travel time entities from a config_entry."""
 
     entry_id = config_entry.entry_id
-    name = config_entry.data[CONF_NAME]
+    name = config_entry.title
     coordinator = config_entry.runtime_data
 
     sensors: list[HERETravelTimeSensor] = [

--- a/homeassistant/components/here_travel_time/strings.json
+++ b/homeassistant/components/here_travel_time/strings.json
@@ -50,8 +50,7 @@
       "user": {
         "data": {
           "api_key": "[%key:common::config_flow::data::api_key%]",
-          "mode": "Travel mode",
-          "name": "[%key:common::config_flow::data::name%]"
+          "mode": "Travel mode"
         }
       }
     }

--- a/tests/components/here_travel_time/const.py
+++ b/tests/components/here_travel_time/const.py
@@ -7,7 +7,7 @@ from homeassistant.components.here_travel_time.const import (
     CONF_ORIGIN_LONGITUDE,
     TRAVEL_MODE_CAR,
 )
-from homeassistant.const import CONF_API_KEY, CONF_MODE, CONF_NAME
+from homeassistant.const import CONF_API_KEY, CONF_MODE
 
 API_KEY = "test"
 
@@ -23,5 +23,4 @@ DEFAULT_CONFIG = {
     CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
     CONF_API_KEY: API_KEY,
     CONF_MODE: TRAVEL_MODE_CAR,
-    CONF_NAME: "test",
 }

--- a/tests/components/here_travel_time/test_config_flow.py
+++ b/tests/components/here_travel_time/test_config_flow.py
@@ -21,13 +21,14 @@ from homeassistant.components.here_travel_time.const import (
     CONF_ORIGIN_LONGITUDE,
     CONF_ROUTE_MODE,
     CONF_TRAFFIC_MODE,
+    DEFAULT_NAME,
     DOMAIN,
     ROUTE_MODE_FASTEST,
     TRAVEL_MODE_BICYCLE,
     TRAVEL_MODE_CAR,
     TRAVEL_MODE_PUBLIC,
 )
-from homeassistant.const import CONF_API_KEY, CONF_MODE, CONF_NAME
+from homeassistant.const import CONF_API_KEY, CONF_MODE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
@@ -66,7 +67,6 @@ async def user_step_result_fixture(
         {
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_CAR,
-            CONF_NAME: "test",
         },
     )
     await hass.async_block_till_done()
@@ -88,7 +88,6 @@ async def option_init_result_fixture(
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_PUBLIC,
-            CONF_NAME: "test",
         },
         version=HERETravelTimeConfigFlow.VERSION,
         minor_version=HERETravelTimeConfigFlow.MINOR_VERSION,
@@ -144,7 +143,6 @@ async def test_step_user(hass: HomeAssistant, menu_options) -> None:
         {
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_CAR,
-            CONF_NAME: "test",
         },
     )
     await hass.async_block_till_done()
@@ -215,8 +213,8 @@ async def test_step_destination_coordinates(
     )
     assert location_selector_result["type"] is FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.title == DEFAULT_NAME
     assert entry.data == {
-        CONF_NAME: "test",
         CONF_API_KEY: API_KEY,
         CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
         CONF_ORIGIN_LONGITUDE: float(ORIGIN_LONGITUDE),
@@ -243,8 +241,8 @@ async def test_step_destination_entity(
     )
     assert entity_selector_result["type"] is FlowResultType.CREATE_ENTRY
     entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.title == DEFAULT_NAME
     assert entry.data == {
-        CONF_NAME: "test",
         CONF_API_KEY: API_KEY,
         CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
         CONF_ORIGIN_LONGITUDE: float(ORIGIN_LONGITUDE),
@@ -275,8 +273,8 @@ async def test_reconfigure_destination_entity(hass: HomeAssistant) -> None:
     assert destination_entity_selector_result["type"] is FlowResultType.ABORT
     assert destination_entity_selector_result["reason"] == "reconfigure_successful"
     entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.title == "Mock Title"
     assert entry.data == {
-        CONF_NAME: "test",
         CONF_API_KEY: API_KEY,
         CONF_ORIGIN_ENTITY_ID: "zone.home",
         CONF_DESTINATION_ENTITY_ID: "zone.home",
@@ -307,8 +305,8 @@ async def test_reconfigure_destination_coordinates(hass: HomeAssistant) -> None:
     assert destination_entity_selector_result["type"] is FlowResultType.ABORT
     assert destination_entity_selector_result["reason"] == "reconfigure_successful"
     entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.title == "Mock Title"
     assert entry.data == {
-        CONF_NAME: "test",
         CONF_API_KEY: API_KEY,
         CONF_ORIGIN_ENTITY_ID: "zone.home",
         CONF_DESTINATION_LATITUDE: 43.0,
@@ -341,7 +339,6 @@ async def do_common_reconfiguration_steps(hass: HomeAssistant) -> None:
         {
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_BICYCLE,
-            CONF_NAME: "test",
         },
     )
     await hass.async_block_till_done()
@@ -369,7 +366,6 @@ async def test_form_invalid_auth(hass: HomeAssistant) -> None:
             {
                 CONF_API_KEY: API_KEY,
                 CONF_MODE: TRAVEL_MODE_CAR,
-                CONF_NAME: "test",
             },
         )
 
@@ -392,7 +388,6 @@ async def test_form_unknown_error(hass: HomeAssistant) -> None:
             {
                 CONF_API_KEY: API_KEY,
                 CONF_MODE: TRAVEL_MODE_CAR,
-                CONF_NAME: "test",
             },
         )
 

--- a/tests/components/here_travel_time/test_sensor.py
+++ b/tests/components/here_travel_time/test_sensor.py
@@ -64,7 +64,6 @@ from homeassistant.const import (
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_API_KEY,
     CONF_MODE,
-    CONF_NAME,
     EVENT_HOMEASSISTANT_STARTED,
     UnitOfLength,
     UnitOfTime,
@@ -135,6 +134,7 @@ async def test_sensor(
     hass.set_state(CoreState.not_running)
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -143,7 +143,6 @@ async def test_sensor(
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: mode,
-            CONF_NAME: "test",
         },
         options={
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
@@ -200,6 +199,7 @@ async def test_circular_ref(
     hass.states.async_set("test.second", "test.first")
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_ENTITY_ID: "test.first",
@@ -207,7 +207,6 @@ async def test_circular_ref(
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_TRUCK,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -229,6 +228,7 @@ async def test_public_transport(hass: HomeAssistant) -> None:
     hass.set_state(CoreState.not_running)
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -237,7 +237,6 @@ async def test_public_transport(hass: HomeAssistant) -> None:
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_PUBLIC,
-            CONF_NAME: "test",
         },
         options={
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
@@ -268,6 +267,7 @@ async def test_no_attribution_response(hass: HomeAssistant) -> None:
     """Test that no_attribution is handled."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -276,7 +276,6 @@ async def test_no_attribution_response(hass: HomeAssistant) -> None:
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_PUBLIC,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -319,13 +318,13 @@ async def test_entity_ids(hass: HomeAssistant, valid_response: MagicMock) -> Non
     )
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_ENTITY_ID: "zone.origin",
             CONF_DESTINATION_ENTITY_ID: "device_tracker.test",
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_TRUCK,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -360,6 +359,7 @@ async def test_destination_entity_not_found(
     """Test that a not existing destination_entity_id is caught."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -367,7 +367,6 @@ async def test_destination_entity_not_found(
             CONF_DESTINATION_ENTITY_ID: "device_tracker.test",
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_TRUCK,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -390,6 +389,7 @@ async def test_origin_entity_not_found(
     """Test that a not existing origin_entity_id is caught."""
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_ENTITY_ID: "device_tracker.test",
@@ -397,7 +397,6 @@ async def test_origin_entity_not_found(
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_TRUCK,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -424,6 +423,7 @@ async def test_invalid_destination_entity_state(
     )
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -431,7 +431,6 @@ async def test_invalid_destination_entity_state(
             CONF_DESTINATION_ENTITY_ID: "device_tracker.test",
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_TRUCK,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -460,6 +459,7 @@ async def test_invalid_origin_entity_state(
     )
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_ENTITY_ID: "device_tracker.test",
@@ -467,7 +467,6 @@ async def test_invalid_origin_entity_state(
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_TRUCK,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,
@@ -497,6 +496,7 @@ async def test_route_not_found(
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,
+            title="test",
             unique_id="0123456789",
             data={
                 CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -505,7 +505,6 @@ async def test_route_not_found(
                 CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
                 CONF_API_KEY: API_KEY,
                 CONF_MODE: TRAVEL_MODE_TRUCK,
-                CONF_NAME: "test",
             },
             options=DEFAULT_OPTIONS,
             version=HERETravelTimeConfigFlow.VERSION,
@@ -622,6 +621,7 @@ async def test_restore_state(hass: HomeAssistant) -> None:
     # create and add entry
     mock_entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id=DOMAIN,
         data=DEFAULT_CONFIG,
         options=DEFAULT_OPTIONS,
@@ -684,6 +684,7 @@ async def test_transit_errors(
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,
+            title="test",
             unique_id="0123456789",
             data={
                 CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -692,7 +693,6 @@ async def test_transit_errors(
                 CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
                 CONF_API_KEY: API_KEY,
                 CONF_MODE: TRAVEL_MODE_PUBLIC,
-                CONF_NAME: "test",
             },
             options=DEFAULT_OPTIONS,
             version=HERETravelTimeConfigFlow.VERSION,
@@ -720,6 +720,7 @@ async def test_routing_rate_limit(
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,
+            title="test",
             unique_id="0123456789",
             data=DEFAULT_CONFIG,
             options=DEFAULT_OPTIONS,
@@ -771,6 +772,7 @@ async def test_transit_rate_limit(
     ):
         entry = MockConfigEntry(
             domain=DOMAIN,
+            title="test",
             unique_id="0123456789",
             data={
                 CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -779,7 +781,6 @@ async def test_transit_rate_limit(
                 CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
                 CONF_API_KEY: API_KEY,
                 CONF_MODE: TRAVEL_MODE_PUBLIC,
-                CONF_NAME: "test",
             },
             options=DEFAULT_OPTIONS,
             version=HERETravelTimeConfigFlow.VERSION,
@@ -825,6 +826,7 @@ async def test_multiple_sections(
     hass.set_state(CoreState.not_running)
     entry = MockConfigEntry(
         domain=DOMAIN,
+        title="test",
         unique_id="0123456789",
         data={
             CONF_ORIGIN_LATITUDE: float(ORIGIN_LATITUDE),
@@ -833,7 +835,6 @@ async def test_multiple_sections(
             CONF_DESTINATION_LONGITUDE: float(DESTINATION_LONGITUDE),
             CONF_API_KEY: API_KEY,
             CONF_MODE: TRAVEL_MODE_BICYCLE,
-            CONF_NAME: "test",
         },
         options=DEFAULT_OPTIONS,
         version=HERETravelTimeConfigFlow.VERSION,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the name field from the HERE Travel Time config flow, as tracked in #168929 (part of home-assistant/epics#47). Config flow schemas should not include a name field, which is enforced by the `home-assistant-config-flow-name-field` pylint rule.

New entries are created with the default title "HERE Travel Time", the same approach as #169998. The user step no longer stores `CONF_NAME`, and the reconfigure flow no longer changes the entry title. The sensors take their device name from the entry title instead of reading `CONF_NAME` from the entry data.

Existing entries are not affected. The entry title was already set from the name field on creation, so device and sensor names stay the same, and entity IDs are stored by unique_id in the registry. The `CONF_NAME` value in the data of existing entries is no longer read, so no migration is needed. The pylint disable comment was removed together with the field, and `pylint --disable=all --enable=home-assistant-config-flow-name-field` reports no violations for this integration.

The documentation does not mention the name field, so no documentation change is needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168929
- This PR is related to issue: home-assistant/epics#47
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
