### PR TITLE
Bump gcal-sync to 9.1.0

### DIFF
--- a/homeassistant/components/google/manifest.json
+++ b/homeassistant/components/google/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "service",
   "iot_class": "cloud_polling",
   "loggers": ["googleapiclient"],
-  "requirements": ["gcal-sync==8.0.0", "oauth2client==4.1.3", "ical==13.3.0"]
+  "requirements": ["gcal-sync==9.1.0", "oauth2client==4.1.3", "ical==13.3.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1081,7 +1081,7 @@ gassist-text==0.0.14
 gatus-api==1.0.3
 
 # homeassistant.components.google
-gcal-sync==8.0.0
+gcal-sync==9.1.0
 
 # homeassistant.components.aladdin_connect
 genie-partner-sdk==1.0.11

--- a/tests/components/google/snapshots/test_diagnostics.ambr
+++ b/tests/components/google/snapshots/test_diagnostics.ambr
@@ -8,6 +8,7 @@
           dict({
             'attendees': '**REDACTED**',
             'attendees_omitted': False,
+            'color_id': None,
             'description': '**REDACTED**',
             'end': dict({
               'date': None,
@@ -40,6 +41,7 @@
           dict({
             'attendees': '**REDACTED**',
             'attendees_omitted': False,
+            'color_id': None,
             'description': '**REDACTED**',
             'end': dict({
               'date': '2022-10-09',


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Bump `gcal-sync` to `9.1.0`.

- **Changelog**: https://github.com/allenporter/gcal_sync/releases/tag/9.1.0
- **Diff**: https://github.com/allenporter/gcal_sync/compare/8.0.0...9.1.0

This dependency bump is required to resolve a block on upgrading `ical` to `14.0.0` (PR #176745).

Without this upgrade, `gcal-sync` raises a validation error when cancelling recurring event instances because it attempts to set `count = 0` on the recurrence rule, which violates `ical` v14.0.0's positive integer validation constraint for `COUNT`. The `gcal-sync` library has been updated to set `count = None`.

## Type of change
- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176745
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
