### PR TITLE
Add a 'copy previous day' shorthand to schedule

### DIFF
--- a/homeassistant/components/schedule/__init__.py
+++ b/homeassistant/components/schedule/__init__.py
@@ -1,6 +1,7 @@
 """Support for schedules in Home Assistant."""
 
 from collections.abc import Callable
+from copy import deepcopy
 from datetime import datetime, time, timedelta
 import itertools
 from typing import Any, Literal, override
@@ -45,6 +46,7 @@ from .const import (  # noqa: F401
     CONF_ALL_DAYS,
     CONF_DATA,
     CONF_FROM,
+    CONF_PREVIOUS,
     CONF_TO,
     DOMAIN,
     LOGGER,
@@ -87,6 +89,13 @@ def valid_schedule(schedule: list[dict[str, str]]) -> list[dict[str, str]]:
         previous_to = time_range[CONF_TO]
 
     return schedule
+
+
+def validate_not_all_previous(value: dict) -> dict:
+    """Ensure the schedule is not made entirely of 'previous'."""
+    if all(value[day] == CONF_PREVIOUS for day in CONF_ALL_DAYS):
+        raise vol.Invalid("Schedule cannot have all days set to 'previous'")
+    return value
 
 
 def deserialize_to_time(value: Any) -> Any:
@@ -136,31 +145,59 @@ STORAGE_TIME_RANGE_SCHEMA = vol.Schema(
     }
 )
 
+
+def _validate_schedule_day(value: Any) -> Any:
+    if value == CONF_PREVIOUS:
+        return value
+    return vol.All(cv.ensure_list, [TIME_RANGE_SCHEMA], valid_schedule)(value)
+
+
+def _validate_storage_schedule_day(value: Any) -> Any:
+    if value == CONF_PREVIOUS:
+        return value
+    return vol.All(
+        cv.ensure_list,
+        [TIME_RANGE_SCHEMA],
+        valid_schedule,
+        [STORAGE_TIME_RANGE_SCHEMA],
+    )(value)
+
+
 SCHEDULE_SCHEMA: VolDictType = {
-    vol.Optional(day, default=[]): vol.All(
-        cv.ensure_list, [TIME_RANGE_SCHEMA], valid_schedule
-    )
-    for day in CONF_ALL_DAYS
+    vol.Optional(day, default=[]): _validate_schedule_day for day in CONF_ALL_DAYS
 }
+
 STORAGE_SCHEDULE_SCHEMA: VolDictType = {
-    vol.Optional(day, default=[]): vol.All(
-        cv.ensure_list, [TIME_RANGE_SCHEMA], valid_schedule, [STORAGE_TIME_RANGE_SCHEMA]
-    )
+    vol.Optional(day, default=[]): _validate_storage_schedule_day
     for day in CONF_ALL_DAYS
 }
 
+
 # Validate YAML config
 CONFIG_SCHEMA = vol.Schema(
-    {DOMAIN: cv.schema_with_slug_keys(vol.All(BASE_SCHEMA | SCHEDULE_SCHEMA))},
+    {
+        DOMAIN: cv.schema_with_slug_keys(
+            vol.All(
+                BASE_SCHEMA | SCHEDULE_SCHEMA,
+                validate_not_all_previous,
+            )
+        )
+    },
     extra=vol.ALLOW_EXTRA,
 )
 # Validate storage config
 STORAGE_SCHEMA = vol.Schema(
-    {vol.Required(CONF_ID): cv.string} | BASE_SCHEMA | STORAGE_SCHEDULE_SCHEMA
+    vol.All(
+        {vol.Required(CONF_ID): cv.string} | BASE_SCHEMA | STORAGE_SCHEDULE_SCHEMA,
+        validate_not_all_previous,
+    )
 )
 # Validate + transform entity config
 ENTITY_SCHEMA = vol.Schema(
-    {vol.Required(CONF_ID): cv.string} | BASE_SCHEMA | SCHEDULE_SCHEMA
+    vol.All(
+        {vol.Required(CONF_ID): cv.string} | BASE_SCHEMA | SCHEDULE_SCHEMA,
+        validate_not_all_previous,
+    )
 )
 
 
@@ -325,14 +362,34 @@ class Schedule(CollectionEntity):
         self._update()
 
     def get_schedule(self) -> ConfigType:
-        """Return the schedule."""
-        return {d: self._config[d] for d in WEEKDAY_TO_CONF.values()}
+        """Return the schedule, expanding 'previous' entries."""
+        days = list(WEEKDAY_TO_CONF.values())
+
+        expanded: ConfigType = {}
+
+        for i, day in enumerate(days):
+            value = self._config[day]
+
+            if value != CONF_PREVIOUS:
+                expanded[day] = value
+                continue
+
+            for offset in range(1, len(days) + 1):
+                prev_day = days[(i - offset) % len(days)]
+                prev_value = self._config[prev_day]
+
+                if prev_value != CONF_PREVIOUS:
+                    expanded[day] = deepcopy(prev_value)
+                    break
+
+        return expanded
 
     @callback
     def _update(self, _: datetime | None = None) -> None:
         """Update the states of the schedule."""
         now = dt_util.now()
-        todays_schedule = self._config.get(WEEKDAY_TO_CONF[now.weekday()], [])
+        schedule = self.get_schedule()
+        todays_schedule = schedule.get(WEEKDAY_TO_CONF[now.weekday()], [])
 
         # Determine current schedule state
         for time_range in todays_schedule:
@@ -353,9 +410,7 @@ class Schedule(CollectionEntity):
         # the current day) until the next event has been found.
         next_event = None
         for day in range(8):  # 8 because we need to search today's weekday next week
-            day_schedule = self._config.get(
-                WEEKDAY_TO_CONF[(now.weekday() + day) % 7], []
-            )
+            day_schedule = schedule.get(WEEKDAY_TO_CONF[(now.weekday() + day) % 7], [])
             times = sorted(
                 itertools.chain(
                     *[
@@ -406,9 +461,9 @@ class Schedule(CollectionEntity):
     def all_custom_data_keys(self) -> frozenset[str]:
         """Return the set of all currently used custom data attribute keys."""
         data_keys: set[str] = set()
-
+        schedule = self.get_schedule()
         for weekday in WEEKDAY_TO_CONF.values():
-            if not (weekday_config := self._config.get(weekday)):
+            if not (weekday_config := schedule.get(weekday)):
                 continue  # this weekday is not configured
 
             for time_range in weekday_config:

--- a/homeassistant/components/schedule/const.py
+++ b/homeassistant/components/schedule/const.py
@@ -39,6 +39,7 @@ CONF_ALL_DAYS: Final = {
     CONF_SATURDAY,
     CONF_SUNDAY,
 }
+CONF_PREVIOUS: Final = "previous"
 
 ATTR_NEXT_EVENT: Final = "next_event"
 

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -113,6 +113,32 @@ async def test_invalid_schedules(
     assert error in caplog.text
 
 
+async def test_invalid_previous(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test overlapping time ranges invalidate."""
+    assert not await schedule_setup(
+        config={
+            DOMAIN: {
+                "from_yaml": {
+                    CONF_NAME: "from yaml",
+                    CONF_ICON: "mdi:party-pooper",
+                    CONF_SUNDAY: "previous",
+                    CONF_MONDAY: "previous",
+                    CONF_TUESDAY: "previous",
+                    CONF_WEDNESDAY: "previous",
+                    CONF_THURSDAY: "previous",
+                    CONF_FRIDAY: "previous",
+                    CONF_SATURDAY: "previous",
+                }
+            }
+        }
+    )
+    assert "Schedule cannot have all days set to 'previous'" in caplog.text
+
+
 async def test_events_one_day(
     hass: HomeAssistant,
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
@@ -746,3 +772,92 @@ async def test_service_get(
 
     assert set(result) == CONF_ALL_DAYS
     assert result == snapshot(name=f"{entity_id}-get-after-update")
+
+
+async def test_previous(
+    hass: HomeAssistant,
+    schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
+    caplog: pytest.LogCaptureFixture,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test 'previous' feature."""
+
+    TUESDAY_1PM = "2022-08-30 13:20:00-07:00"
+    SATURDAY_7AM = "2022-09-03T07:00:00-07:00"
+    SATURDAY_11AM = "2022-09-03T11:00:00-07:00"
+    SUNDAY_7AM = "2022-09-04T07:00:00-07:00"
+    SUNDAY_11AM = "2022-09-04T11:00:00-07:00"
+    MONDAY_7AM = "2022-09-05T07:00:00-07:00"
+    MONDAY_11AM = "2022-09-05T11:00:00-07:00"
+    NEXT_SATURDAY_7AM = "2022-09-10T07:00:00-07:00"
+
+    freezer.move_to(TUESDAY_1PM)
+
+    assert await schedule_setup(
+        config={
+            DOMAIN: {
+                "from_yaml": {
+                    CONF_NAME: "from yaml",
+                    CONF_ICON: "mdi:party-popper",
+                    CONF_SATURDAY: {CONF_FROM: "07:00:00", CONF_TO: "11:00:00"},
+                    CONF_SUNDAY: "previous",
+                    CONF_MONDAY: "previous",
+                    CONF_THURSDAY: "previous",
+                }
+            }
+        },
+        items=[],
+    )
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == SATURDAY_7AM
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == SATURDAY_11AM
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == SUNDAY_7AM
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == SUNDAY_11AM
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == MONDAY_7AM
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == MONDAY_11AM
+
+    freezer.move_to(state.attributes[ATTR_NEXT_EVENT])
+    async_fire_time_changed(hass)
+
+    state = hass.states.get(f"{DOMAIN}.from_yaml")
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_NEXT_EVENT].isoformat() == NEXT_SATURDAY_7AM

--- a/tests/components/schedule/test_init.py
+++ b/tests/components/schedule/test_init.py
@@ -118,7 +118,7 @@ async def test_invalid_previous(
     schedule_setup: Callable[..., Coroutine[Any, Any, bool]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test overlapping time ranges invalidate."""
+    """Test schedules with every day set to 'previous' are invalid."""
     assert not await schedule_setup(
         config={
             DOMAIN: {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
For schedule helper, allow a shorthand entry format, where a day can be defined to copy the schedule of the previous day.

While this may slightly improve the ease of entry for YAML (and could mostly be replicated by yaml-anchors, though that is somewhat advanced), I think it would really be beneficial once supported into frontend UI, which would allow for much easier maintenance of day-agnostic or weekday/weekend schedules.

Currently if you want to repeat the same schedule every day, it is quite tedious to replicate the same event blocks 7 times, anytime you want to modify or create a schedule. If days could just be defined as following the previous day, that would allow for much more easy schedule entry.

Example schedule:

```yaml
  workweek_schedule:
    name: "Workweek schedule"
    sunday: previous
    monday:
      - from: "07:00:00"
        to: "08:00:00"
    tuesday: previous
    wednesday: previous
    thursday: previous
    friday: previous
    saturday:
      - from: "09:00:00"
        to: "10:00:00"
        data:
          "type": "weekend"
```

Expands to:
```yaml
schedule.workweek_schedule:
  monday:
    - from: '07:00:00'
      to: '08:00:00'
  tuesday:
    - from: '07:00:00'
      to: '08:00:00'
  wednesday:
    - from: '07:00:00'
      to: '08:00:00'
  thursday:
    - from: '07:00:00'
      to: '08:00:00'
  friday:
    - from: '07:00:00'
      to: '08:00:00'
  saturday:
    - from: '09:00:00'
      to: '10:00:00'
      data:
        type: weekend
  sunday:
    - from: '09:00:00'
      to: '10:00:00'
      data:
        type: weekend
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
https://github.com/orgs/home-assistant/discussions/241
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
