### PR TITLE
Add reconfigure flow to Overkiz

### DIFF
--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -36,7 +36,11 @@ from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlowResult
+from homeassistant.config_entries import (
+    SOURCE_REAUTH,
+    SOURCE_RECONFIGURE,
+    ConfigFlowResult,
+)
 from homeassistant.const import (
     CONF_HOST,
     CONF_PASSWORD,
@@ -269,6 +273,15 @@ class OverkizConfigFlow(
                         self._get_reauth_entry(), data_updates=user_input
                     )
 
+                if self.source == SOURCE_RECONFIGURE:
+                    self._abort_if_unique_id_mismatch(
+                        reason="reconfigure_wrong_account"
+                    )
+
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(), data=user_input
+                    )
+
                 # Create new entry
                 self._abort_if_unique_id_configured()
 
@@ -337,6 +350,15 @@ class OverkizConfigFlow(
 
                     return self.async_update_reload_and_abort(
                         self._get_reauth_entry(), data_updates=user_input
+                    )
+
+                if self.source == SOURCE_RECONFIGURE:
+                    self._abort_if_unique_id_mismatch(
+                        reason="reconfigure_wrong_account"
+                    )
+
+                    return self.async_update_reload_and_abort(
+                        self._get_reconfigure_entry(), data=user_input
                     )
 
                 # Create new entry
@@ -433,6 +455,12 @@ class OverkizConfigFlow(
                 self._get_reauth_entry(), data=data
             )
 
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(reason="reconfigure_wrong_account")
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(), data=data
+            )
+
         self._abort_if_unique_id_configured()
 
         return self.async_create_entry(title=gateway.label or "Rexel", data=data)
@@ -482,10 +510,8 @@ class OverkizConfigFlow(
 
         return await self.async_step_user()
 
-    async def async_step_reauth(
-        self, entry_data: Mapping[str, Any]
-    ) -> ConfigFlowResult:
-        """Handle reauth."""
+    def _init_flow_from_entry(self, entry_data: Mapping[str, Any]) -> None:
+        """Initialize the flow's state from an existing entry for reauth/reconfigure."""
         # Overkiz entries always have unique IDs
         self.context["title_placeholders"] = {"gateway_id": cast(str, self.unique_id)}
         self._api_type = entry_data.get(CONF_API_TYPE, APIType.CLOUD)
@@ -498,4 +524,17 @@ class OverkizConfigFlow(
         elif self._server != Server.REXEL:
             self._user = entry_data[CONF_USERNAME]
 
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle reauth."""
+        self._init_flow_from_entry(entry_data)
+        return await self.async_step_user(dict(entry_data))
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        entry_data = self._get_reconfigure_entry().data
+        self._init_flow_from_entry(entry_data)
         return await self.async_step_user(dict(entry_data))

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -162,10 +162,6 @@ class OverkizConfigFlow(
             if self._server in SERVERS_WITH_LOCAL_API:
                 return await self.async_step_local_or_cloud()
 
-            # Rexel authenticates via OAuth2 (Azure AD B2C with PKCE).
-            if self._server == Server.REXEL:
-                return await self.async_step_pick_implementation()
-
             return await self.async_step_cloud()
 
         return self.async_show_form(

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -510,7 +510,6 @@ class OverkizConfigFlow(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauth."""
-        # Overkiz entries always have unique IDs; reauth context carries it.
         self._init_flow_from_entry(entry_data, cast(str, self.unique_id))
         return await self.async_step_user(dict(entry_data))
 

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -137,7 +137,7 @@ class OverkizConfigFlow(
         if self.source == SOURCE_REAUTH:
             self._abort_if_unique_id_mismatch(reason="reauth_wrong_account")
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), data_updates=user_input
+                self._get_reauth_entry(), data=user_input
             )
 
         if self.source == SOURCE_RECONFIGURE:

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -130,6 +130,25 @@ class OverkizConfigFlow(
 
         return user_input
 
+    def _async_finish_validated_entry(
+        self, user_input: dict[str, Any], title: str
+    ) -> ConfigFlowResult:
+        """Create or update the entry once credentials have been validated."""
+        if self.source == SOURCE_REAUTH:
+            self._abort_if_unique_id_mismatch(reason="reauth_wrong_account")
+            return self.async_update_reload_and_abort(
+                self._get_reauth_entry(), data_updates=user_input
+            )
+
+        if self.source == SOURCE_RECONFIGURE:
+            self._abort_if_unique_id_mismatch(reason="reconfigure_wrong_account")
+            return self.async_update_reload_and_abort(
+                self._get_reconfigure_entry(), data=user_input
+            )
+
+        self._abort_if_unique_id_configured()
+        return self.async_create_entry(title=title, data=user_input)
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -266,27 +285,8 @@ class OverkizConfigFlow(
                 errors["base"] = "unknown"
                 LOGGER.exception("Unknown error")
             else:
-                if self.source == SOURCE_REAUTH:
-                    self._abort_if_unique_id_mismatch(reason="reauth_wrong_account")
-
-                    return self.async_update_reload_and_abort(
-                        self._get_reauth_entry(), data_updates=user_input
-                    )
-
-                if self.source == SOURCE_RECONFIGURE:
-                    self._abort_if_unique_id_mismatch(
-                        reason="reconfigure_wrong_account"
-                    )
-
-                    return self.async_update_reload_and_abort(
-                        self._get_reconfigure_entry(), data=user_input
-                    )
-
-                # Create new entry
-                self._abort_if_unique_id_configured()
-
-                return self.async_create_entry(
-                    title=user_input[CONF_USERNAME], data=user_input
+                return self._async_finish_validated_entry(
+                    user_input, title=user_input[CONF_USERNAME]
                 )
 
         return self.async_show_form(
@@ -345,27 +345,8 @@ class OverkizConfigFlow(
                 errors["base"] = "unknown"
                 LOGGER.exception("Unknown error")
             else:
-                if self.source == SOURCE_REAUTH:
-                    self._abort_if_unique_id_mismatch(reason="reauth_wrong_account")
-
-                    return self.async_update_reload_and_abort(
-                        self._get_reauth_entry(), data_updates=user_input
-                    )
-
-                if self.source == SOURCE_RECONFIGURE:
-                    self._abort_if_unique_id_mismatch(
-                        reason="reconfigure_wrong_account"
-                    )
-
-                    return self.async_update_reload_and_abort(
-                        self._get_reconfigure_entry(), data=user_input
-                    )
-
-                # Create new entry
-                self._abort_if_unique_id_configured()
-
-                return self.async_create_entry(
-                    title=user_input[CONF_HOST], data=user_input
+                return self._async_finish_validated_entry(
+                    user_input, title=user_input[CONF_HOST]
                 )
 
         return self.async_show_form(

--- a/homeassistant/components/overkiz/config_flow.py
+++ b/homeassistant/components/overkiz/config_flow.py
@@ -491,10 +491,11 @@ class OverkizConfigFlow(
 
         return await self.async_step_user()
 
-    def _init_flow_from_entry(self, entry_data: Mapping[str, Any]) -> None:
+    def _init_flow_from_entry(
+        self, entry_data: Mapping[str, Any], gateway_id: str
+    ) -> None:
         """Initialize the flow's state from an existing entry for reauth/reconfigure."""
-        # Overkiz entries always have unique IDs
-        self.context["title_placeholders"] = {"gateway_id": cast(str, self.unique_id)}
+        self.context["title_placeholders"] = {"gateway_id": gateway_id}
         self._api_type = entry_data.get(CONF_API_TYPE, APIType.CLOUD)
         self._server = entry_data[CONF_HUB]
 
@@ -509,13 +510,14 @@ class OverkizConfigFlow(
         self, entry_data: Mapping[str, Any]
     ) -> ConfigFlowResult:
         """Handle reauth."""
-        self._init_flow_from_entry(entry_data)
+        # Overkiz entries always have unique IDs; reauth context carries it.
+        self._init_flow_from_entry(entry_data, cast(str, self.unique_id))
         return await self.async_step_user(dict(entry_data))
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Handle reconfiguration of the integration."""
-        entry_data = self._get_reconfigure_entry().data
-        self._init_flow_from_entry(entry_data)
-        return await self.async_step_user(dict(entry_data))
+        entry = self._get_reconfigure_entry()
+        self._init_flow_from_entry(entry.data, cast(str, entry.unique_id))
+        return await self.async_step_user(dict(entry.data))

--- a/homeassistant/components/overkiz/quality_scale.yaml
+++ b/homeassistant/components/overkiz/quality_scale.yaml
@@ -55,7 +55,7 @@ rules:
   stale-devices: todo
   docs-supported-functions: todo
   repair-issues: todo
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   entity-category: done
   dynamic-devices: todo
   docs-troubleshooting: todo

--- a/homeassistant/components/overkiz/strings.json
+++ b/homeassistant/components/overkiz/strings.json
@@ -15,6 +15,8 @@
       "oauth_unauthorized": "[%key:common::config_flow::abort::oauth2_unauthorized%]",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reauth_wrong_account": "You can only reauthenticate this entry with the same Overkiz account and hub",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
+      "reconfigure_wrong_account": "You can only reconfigure this entry with the same Overkiz account and hub",
       "user_rejected_authorize": "[%key:common::config_flow::abort::oauth2_user_rejected_authorize%]"
     },
     "error": {

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -748,6 +748,9 @@ async def test_local_reauth_legacy(hass: HomeAssistant) -> None:
         assert mock_entry.data["host"] == TEST_HOST
         assert mock_entry.data["token"] == "new_token"
         assert mock_entry.data["verify_ssl"] is True
+        # The legacy username/password are dropped after migrating to a token.
+        assert "username" not in mock_entry.data
+        assert "password" not in mock_entry.data
 
 
 async def test_local_reauth_success(hass: HomeAssistant) -> None:

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -116,9 +116,12 @@ async def test_form_cloud(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> N
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -151,9 +154,12 @@ async def test_form_only_cloud_supported(
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -194,7 +200,7 @@ async def test_form_local_happy_flow(
     assert result["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -261,7 +267,10 @@ async def test_form_invalid_auth_cloud(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "cloud"
 
-    with patch("pyoverkiz.client.OverkizClient.login", side_effect=side_effect):
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+        side_effect=side_effect,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"username": TEST_EMAIL, "password": TEST_PASSWORD},
@@ -301,7 +310,10 @@ async def test_form_invalid_hardware_cloud(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "cloud"
 
-    with patch("pyoverkiz.client.OverkizClient.login", side_effect=side_effect):
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+        side_effect=side_effect,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"username": TEST_EMAIL, "password": TEST_PASSWORD},
@@ -348,7 +360,10 @@ async def test_form_invalid_hardware_cloud_local(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "cloud"
 
-    with patch("pyoverkiz.client.OverkizClient.login", side_effect=side_effect):
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+        side_effect=side_effect,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"username": TEST_EMAIL, "password": TEST_PASSWORD},
@@ -407,7 +422,10 @@ async def test_form_invalid_auth_local(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "local"
 
-    with patch("pyoverkiz.client.OverkizClient.login", side_effect=side_effect):
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+        side_effect=side_effect,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
@@ -447,7 +465,10 @@ async def test_form_invalid_cozytouch_auth(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "cloud"
 
-    with patch("pyoverkiz.client.OverkizClient.login", side_effect=side_effect):
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+        side_effect=side_effect,
+    ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {"username": TEST_EMAIL, "password": TEST_PASSWORD},
@@ -492,9 +513,12 @@ async def test_cloud_abort_on_duplicate_entry(hass: HomeAssistant) -> None:
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -546,7 +570,7 @@ async def test_local_abort_on_duplicate_entry(hass: HomeAssistant) -> None:
     assert result["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
         get_setup_option=AsyncMock(return_value=True),
@@ -597,9 +621,12 @@ async def test_cloud_allow_multiple_unique_entries(hass: HomeAssistant) -> None:
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -640,9 +667,12 @@ async def test_cloud_reauth_success(hass: HomeAssistant) -> None:
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -682,9 +712,12 @@ async def test_cloud_reauth_wrong_account(hass: HomeAssistant) -> None:
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY2_RESPONSE,
         ),
     ):
@@ -730,7 +763,7 @@ async def test_local_reauth_legacy(hass: HomeAssistant) -> None:
     assert result2["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -781,7 +814,7 @@ async def test_local_reauth_success(hass: HomeAssistant) -> None:
     assert result2["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -832,7 +865,7 @@ async def test_local_reauth_wrong_account(hass: HomeAssistant) -> None:
     assert result2["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -870,9 +903,12 @@ async def test_cloud_reconfigure_success(hass: HomeAssistant) -> None:
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -911,9 +947,12 @@ async def test_cloud_reconfigure_wrong_account(hass: HomeAssistant) -> None:
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY2_RESPONSE,
         ),
     ):
@@ -957,7 +996,7 @@ async def test_local_reconfigure_success(hass: HomeAssistant) -> None:
     assert result["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -1005,7 +1044,7 @@ async def test_local_reconfigure_wrong_account(hass: HomeAssistant) -> None:
     assert result["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -1049,7 +1088,7 @@ async def test_reconfigure_switch_cloud_to_local(hass: HomeAssistant) -> None:
     assert result["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):
@@ -1101,8 +1140,14 @@ async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> No
     )
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
-        patch("pyoverkiz.client.OverkizClient.get_gateways", return_value=None),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
+            return_value=None,
+        ),
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -1175,9 +1220,12 @@ async def test_zeroconf_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -
     assert result["step_id"] == "cloud"
 
     with (
-        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
         patch(
-            "pyoverkiz.client.OverkizClient.get_gateways",
+            "homeassistant.components.overkiz.config_flow.OverkizClient.login",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.overkiz.config_flow.OverkizClient.get_gateways",
             return_value=MOCK_GATEWAY_RESPONSE,
         ),
     ):
@@ -1228,7 +1276,7 @@ async def test_local_zeroconf_flow(
     assert result["step_id"] == "local"
 
     with patch.multiple(
-        "pyoverkiz.client.OverkizClient",
+        "homeassistant.components.overkiz.config_flow.OverkizClient",
         login=AsyncMock(return_value=True),
         get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
     ):

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -977,6 +977,51 @@ async def test_local_reconfigure_success(hass: HomeAssistant) -> None:
     assert mock_entry.data["verify_ssl"] is True
 
 
+async def test_local_reconfigure_wrong_account(hass: HomeAssistant) -> None:
+    """Test local reconfiguration aborts when the gateway account differs."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID2,
+        version=2,
+        data={
+            "host": TEST_HOST,
+            "token": "old_token",
+            "verify_ssl": True,
+            "hub": TEST_SERVER,
+            "api_type": "local",
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "local_or_cloud"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"api_type": "local"},
+    )
+
+    assert result["step_id"] == "local"
+
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        login=AsyncMock(return_value=True),
+        get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": TEST_HOST,
+                "token": "new_token",
+                "verify_ssl": True,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_wrong_account"
+
+
 async def test_reconfigure_switch_cloud_to_local(hass: HomeAssistant) -> None:
     """Test reconfiguring a cloud entry to use the local API."""
     mock_entry = MockConfigEntry(
@@ -1525,4 +1570,73 @@ async def test_rexel_reauth_success(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
+    assert mock_rexel_config_entry.data["token"]["access_token"] == "mock-access-token"
+
+
+@pytest.mark.usefixtures("current_request_with_host", "setup_rexel_credentials")
+async def test_rexel_reconfigure_wrong_account(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_rexel_config_entry: MockConfigEntry,
+) -> None:
+    """Reconfigure with a different Rexel gateway aborts."""
+    mock_rexel_config_entry.add_to_hass(hass)
+
+    # Reconfigure carries the stored hub, so the flow skips the server picker
+    # and goes to the local/cloud choice before re-running the OAuth2 flow.
+    result = await mock_rexel_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "local_or_cloud"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_type": "cloud"}
+    )
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    await _async_rexel_oauth_external_step(
+        hass, hass_client_no_auth, aioclient_mock, result["flow_id"]
+    )
+
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.discover_gateways",
+        return_value=[GatewayCandidate(gateway_id=TEST_GATEWAY_ID2, label="Other")],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_wrong_account"
+
+
+@pytest.mark.usefixtures("current_request_with_host", "setup_rexel_credentials")
+async def test_rexel_reconfigure_success(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+    mock_rexel_config_entry: MockConfigEntry,
+) -> None:
+    """Reconfigure with the same Rexel gateway updates the entry and reloads."""
+    mock_rexel_config_entry.add_to_hass(hass)
+
+    result = await mock_rexel_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "local_or_cloud"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"api_type": "cloud"}
+    )
+    assert result["type"] is FlowResultType.EXTERNAL_STEP
+
+    await _async_rexel_oauth_external_step(
+        hass, hass_client_no_auth, aioclient_mock, result["flow_id"]
+    )
+
+    with patch(
+        "homeassistant.components.overkiz.config_flow.OverkizClient.discover_gateways",
+        return_value=[GatewayCandidate(gateway_id=TEST_GATEWAY_ID, label="My Home")],
+    ):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
     assert mock_rexel_config_entry.data["token"]["access_token"] == "mock-access-token"

--- a/tests/components/overkiz/test_config_flow.py
+++ b/tests/components/overkiz/test_config_flow.py
@@ -846,6 +846,184 @@ async def test_local_reauth_wrong_account(hass: HomeAssistant) -> None:
         assert result3["reason"] == "reauth_wrong_account"
 
 
+async def test_cloud_reconfigure_success(hass: HomeAssistant) -> None:
+    """Test reconfiguration flow on a cloud entry."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID,
+        version=2,
+        data={
+            "username": TEST_EMAIL,
+            "password": TEST_PASSWORD,
+            "hub": TEST_SERVER2,
+            "api_type": "cloud",
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cloud"
+
+    with (
+        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
+        patch(
+            "pyoverkiz.client.OverkizClient.get_gateways",
+            return_value=MOCK_GATEWAY_RESPONSE,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                "username": TEST_EMAIL,
+                "password": TEST_PASSWORD2,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data["username"] == TEST_EMAIL
+    assert mock_entry.data["password"] == TEST_PASSWORD2
+
+
+async def test_cloud_reconfigure_wrong_account(hass: HomeAssistant) -> None:
+    """Test reconfiguration aborts when the gateway account differs."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID,
+        version=2,
+        data={
+            "username": TEST_EMAIL,
+            "password": TEST_PASSWORD,
+            "hub": TEST_SERVER2,
+            "api_type": "cloud",
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "cloud"
+
+    with (
+        patch("pyoverkiz.client.OverkizClient.login", return_value=True),
+        patch(
+            "pyoverkiz.client.OverkizClient.get_gateways",
+            return_value=MOCK_GATEWAY2_RESPONSE,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                "username": TEST_EMAIL,
+                "password": TEST_PASSWORD2,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_wrong_account"
+
+
+async def test_local_reconfigure_success(hass: HomeAssistant) -> None:
+    """Test reconfiguration flow on a local entry."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID,
+        version=2,
+        data={
+            "host": TEST_HOST,
+            "token": "old_token",
+            "verify_ssl": True,
+            "hub": TEST_SERVER,
+            "api_type": "local",
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "local_or_cloud"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"api_type": "local"},
+    )
+
+    assert result["step_id"] == "local"
+
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        login=AsyncMock(return_value=True),
+        get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": TEST_HOST,
+                "token": "new_token",
+                "verify_ssl": True,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data["host"] == TEST_HOST
+    assert mock_entry.data["token"] == "new_token"
+    assert mock_entry.data["verify_ssl"] is True
+
+
+async def test_reconfigure_switch_cloud_to_local(hass: HomeAssistant) -> None:
+    """Test reconfiguring a cloud entry to use the local API."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_ID,
+        version=2,
+        data={
+            "username": TEST_EMAIL,
+            "password": TEST_PASSWORD,
+            "hub": TEST_SERVER,
+            "api_type": "cloud",
+        },
+    )
+    mock_entry.add_to_hass(hass)
+
+    result = await mock_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "local_or_cloud"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"api_type": "local"},
+    )
+
+    assert result["step_id"] == "local"
+
+    with patch.multiple(
+        "pyoverkiz.client.OverkizClient",
+        login=AsyncMock(return_value=True),
+        get_gateways=AsyncMock(return_value=MOCK_GATEWAY_RESPONSE),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "host": TEST_HOST,
+                "token": TEST_TOKEN,
+                "verify_ssl": True,
+            },
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_entry.data["api_type"] == "local"
+    assert mock_entry.data["host"] == TEST_HOST
+    assert mock_entry.data["token"] == TEST_TOKEN
+    # Full data replace drops the previous cloud credentials.
+    assert "username" not in mock_entry.data
+    assert "password" not in mock_entry.data
+
+
 async def test_dhcp_flow(hass: HomeAssistant, mock_setup_entry: AsyncMock) -> None:
     """Test that DHCP discovery for new bridge works."""
     result = await hass.config_entries.flow.async_init(


### PR DESCRIPTION
## Proposed change

Add a reconfigure flow to Overkiz, so users can update an existing entry (switch local/cloud API, update the local token, change cloud credentials, or re-run the Rexel OAuth2 flow) without removing and re-adding it. It enforces the same gateway (`reconfigure_wrong_account`), mirroring the existing reauth guard.

Supporting cleanups:
- Extract the shared create/update branching into `_async_finish_validated_entry`, and the reauth/reconfigure state priming into `_init_flow_from_entry`.
- Reauth now fully replaces `data` instead of using `data_updates`, dropping stale keys (e.g. legacy `username`/`password` after migrating a local entry to a token).
- Remove an unreachable Rexel branch in `async_step_user` (`Server.REXEL` is in `SERVERS_WITH_LOCAL_API`, so it always routes through the local/cloud step).
- Config flow tests patch `OverkizClient` at the usage site, matching the existing Rexel patches.

`config_flow.py` is at 100% test coverage.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
