### PR TITLE
econet: expose Vacation as a real selectable water heater operation mode

### DIFF
--- a/homeassistant/components/econet/water_heater.py
+++ b/homeassistant/components/econet/water_heater.py
@@ -28,6 +28,13 @@ SCAN_INTERVAL = timedelta(hours=1)
 
 _LOGGER = logging.getLogger(__name__)
 
+# Not (yet) a shared homeassistant.components.water_heater constant - kept
+# local to this integration since Vacation is one of this device's own
+# native operation modes (its own app lists it alongside Off/Energy
+# Saver/Heat Pump/High Demand/Electric in the same selector), not a
+# separate away-mode concept.
+STATE_VACATION = "vacation"
+
 ECONET_STATE_TO_HA = {
     WaterHeaterOperationMode.ENERGY_SAVING: STATE_ECO,
     WaterHeaterOperationMode.HIGH_DEMAND: STATE_HIGH_DEMAND,
@@ -36,6 +43,7 @@ ECONET_STATE_TO_HA = {
     WaterHeaterOperationMode.ELECTRIC_MODE: STATE_ELECTRIC,
     WaterHeaterOperationMode.GAS: STATE_GAS,
     WaterHeaterOperationMode.PERFORMANCE: STATE_PERFORMANCE,
+    WaterHeaterOperationMode.VACATION: STATE_VACATION,
 }
 HA_STATE_TO_ECONET = {value: key for key, value in ECONET_STATE_TO_HA.items()}
 
@@ -47,7 +55,7 @@ SUPPORT_FLAGS_HEATER = (
 
 def _operation_mode_to_ha(mode: WaterHeaterOperationMode | None) -> str:
     """Translate an EcoNet operation mode to a Home Assistant state."""
-    if mode in (None, WaterHeaterOperationMode.VACATION):
+    if mode is None:
         return STATE_OFF
     return ECONET_STATE_TO_HA[mode]
 
@@ -99,11 +107,7 @@ class EcoNetWaterHeater(EcoNetEntity[WaterHeater], WaterHeaterEntity):
             dict.fromkeys(
                 ECONET_STATE_TO_HA[mode]
                 for mode in self.water_heater.modes
-                if mode
-                not in (
-                    WaterHeaterOperationMode.UNKNOWN,
-                    WaterHeaterOperationMode.VACATION,
-                )
+                if mode is not WaterHeaterOperationMode.UNKNOWN
             )
         )
 


### PR DESCRIPTION
## Proposed change

`pyeconet`'s `WaterHeaterOperationMode` enum has a real `VACATION` value — it's one of the device's own native operation modes (the Rheem app itself lists "Vacation" alongside Off/Energy Saver/Heat Pump/High Demand/Electric in the same mode selector, not as a separate concept). Currently this integration deliberately excludes it: `_operation_mode_to_ha()` maps it to `STATE_OFF`, and `operation_list` filters it out of what's selectable.

This means there is currently no way to put one of these water heaters into its own real Vacation mode from Home Assistant. The existing `AWAY_MODE` feature (`water_heater.set_away_mode` → `turn_away_mode_on`/`off`) does **not** substitute for this on real hardware — confirmed by live testing: setting `@AWAY` alone does not change `@MODE`, is not reflected in the Rheem app, and does not trigger the device's own vacation-specific behavior (schedule override, `@SCHEDULERESUME` confirmation flow, etc.). Only a genuine `@MODE = Vacation` change does.

This PR simply stops filtering `VACATION` out, mapping it to a new local `STATE_VACATION = "vacation"` state instead of `STATE_OFF`, so it becomes a normal, selectable `operation_mode` like any other.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Testing

Live-tested end-to-end against a real Rheem heat pump water heater:
- `water_heater.set_operation_mode` with `"vacation"` → device state becomes `vacation`, `@MODE` is set to the device's own Vacation enum value, **confirmed independently via the Rheem app showing Vacation Mode on** (not just via HA's own state).
- Exiting requires the companion fix in [`pyeconet` PR #77](https://github.com/w1ll1am23/pyeconet/pull/77) (`resume_schedule()` + confirmation-dialog handling) — not part of this PR since it's a `pyeconet`-side addition, but noted here since the two are meant to work together. **`pyeconet` #77 has since merged.** Confirmed the full round trip (enter vacation → exit via `resume_schedule()`) independently via the Rheem app both times.

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works. (No existing test coverage for this platform's operation-mode mapping that I could find to extend — happy to add if pointed at the right pattern/fixtures.)
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

This is a minimal, single-integration change (no shared `homeassistant.components.water_heater` constants touched) — `STATE_VACATION` is kept local to `econet` since I wasn't sure whether promoting it to a shared constant is something the water_heater domain maintainers would want; happy to move it if preferred.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
