### PR TITLE
Migrate KNX config store validation from voluptuous to probatio

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -14,7 +14,8 @@
     "xknx==3.16.0",
     "xknxproject==3.9.0",
     "knx-frontend==2026.6.23.203726",
-    "knx-telegram-store[sqlite,postgres]==0.10.1"
+    "knx-telegram-store[sqlite,postgres]==0.10.1",
+    "probatio==0.11.0"
   ],
   "single_config_entry": true
 }

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -2,6 +2,7 @@
 
 from enum import StrEnum, unique
 
+import probatio as prb
 import voluptuous as vol
 from xknx.dpt import DPTBase, DPTBinary, DPTNumeric
 from xknx.exceptions import ConversionError
@@ -29,9 +30,9 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
     Platform,
 )
-from homeassistant.helpers import config_validation as cv, selector
+from homeassistant.helpers import selector
 from homeassistant.helpers.entity import ENTITY_CATEGORIES_SCHEMA
-from homeassistant.helpers.typing import VolDictType, VolSchemaType
+from homeassistant.helpers.typing import VolDictType
 
 from ..const import (
     CONF_CONTEXT_TIMEOUT,
@@ -123,52 +124,59 @@ from .knx_selector import (
     KNXSectionFlat,
     SyncStateSelector,
 )
+from .vol_compat import VolValidator
 
-BASE_ENTITY_SCHEMA = vol.All(
+BASE_ENTITY_SCHEMA = prb.All(
     {
-        vol.Optional(CONF_NAME, default=None): vol.Maybe(str),
-        vol.Optional(CONF_DEVICE_INFO, default=None): vol.Maybe(str),
-        vol.Optional(CONF_ENTITY_CATEGORY, default=None): vol.Any(
-            ENTITY_CATEGORIES_SCHEMA, vol.SetTo(None)
+        prb.Optional(CONF_NAME, default=None): prb.Maybe(str),
+        prb.Optional(CONF_DEVICE_INFO, default=None): prb.Maybe(str),
+        prb.Optional(CONF_ENTITY_CATEGORY, default=None): prb.Any(
+            VolValidator(ENTITY_CATEGORIES_SCHEMA), prb.SetTo(None)
         ),
     },
-    vol.Any(
-        vol.Schema(
+    prb.Any(
+        prb.Schema(
             {
-                vol.Required(CONF_NAME): vol.All(str, vol.IsTrue()),
+                prb.Required(CONF_NAME): prb.All(str, prb.IsTrue()),
             },
-            extra=vol.ALLOW_EXTRA,
+            extra=prb.ALLOW_EXTRA,
         ),
-        vol.Schema(
+        prb.Schema(
             {
-                vol.Required(CONF_DEVICE_INFO): str,
+                prb.Required(CONF_DEVICE_INFO): str,
             },
-            extra=vol.ALLOW_EXTRA,
+            extra=prb.ALLOW_EXTRA,
         ),
         msg="One of `Device` or `Name` is required",
     ),
 )
 
 
-BINARY_SENSOR_KNX_SCHEMA = vol.Schema(
+BINARY_SENSOR_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_SENSOR): GASelector(
+        prb.Required(CONF_GA_SENSOR): GASelector(
             write=False, state_required=True, valid_dpt="1"
         ),
-        vol.Optional(CONF_INVERT): selector.BooleanSelector(),
+        prb.Optional(CONF_INVERT): VolValidator(selector.BooleanSelector()),
         "section_advanced_options": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_IGNORE_INTERNAL_STATE): selector.BooleanSelector(),
-        vol.Optional(CONF_CONTEXT_TIMEOUT): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0, max=10, step=0.1, unit_of_measurement="s"
+        prb.Optional(CONF_IGNORE_INTERNAL_STATE): VolValidator(
+            selector.BooleanSelector()
+        ),
+        prb.Optional(CONF_CONTEXT_TIMEOUT): VolValidator(
+            selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=10, step=0.1, unit_of_measurement="s"
+                )
             )
         ),
-        vol.Optional(CONF_RESET_AFTER): selector.NumberSelector(
-            selector.NumberSelectorConfig(
-                min=0, max=600, step=0.1, unit_of_measurement="s"
+        prb.Optional(CONF_RESET_AFTER): VolValidator(
+            selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=600, step=0.1, unit_of_measurement="s"
+                )
             )
         ),
-        vol.Required(CONF_SYNC_STATE, default=True): SyncStateSelector(
+        prb.Required(CONF_SYNC_STATE, default=True): SyncStateSelector(
             allow_false=True
         ),
     },
@@ -187,7 +195,7 @@ def _button_data_sub_validator(config: dict) -> dict:
             try:
                 transcoder.to_knx(config[CONF_DATA][CONF_VALUE])
             except ConversionError as ex:
-                raise vol.Invalid(
+                raise prb.Invalid(
                     f"Value invalid for DPT {transcoder.dpt_number_str()}",
                     path=([CONF_DATA]),
                 ) from ex
@@ -196,7 +204,7 @@ def _button_data_sub_validator(config: dict) -> dict:
             if length != transcoder.payload_length or (
                 length != 0 and transcoder.payload_type is DPTBinary
             ):
-                raise vol.Invalid(
+                raise prb.Invalid(
                     f"Payload length invalid for DPT {transcoder.dpt_number_str()}",
                     path=([CONF_DATA]),
                 )
@@ -204,78 +212,84 @@ def _button_data_sub_validator(config: dict) -> dict:
     # without DPT only raw allowed -> payload + payload_length (checked by KnxPayloadSelector)
     if CONF_PAYLOAD_LENGTH in config[CONF_DATA]:
         return config
-    raise vol.Invalid("Invalid configuration for button entity")
+    raise prb.Invalid("Invalid configuration for button entity")
 
 
 BUTTON_KNX_SCHEMA = AllSerializeFirst(
-    vol.Schema(
+    prb.Schema(
         {
-            vol.Required(CONF_GA_SEND): GASelector(
+            prb.Required(CONF_GA_SEND): GASelector(
                 state=False,
                 write_required=True,
                 passive=False,
                 dpt=["numeric", "enum", "complex", "string"],
                 dpt_required=False,  # for raw payload support
             ),
-            vol.Required(CONF_DATA): KnxPayloadSelector(ga_path=CONF_GA_SEND),
+            prb.Required(CONF_DATA): KnxPayloadSelector(ga_path=CONF_GA_SEND),
         },
     ),
     _button_data_sub_validator,
 )
 
 COVER_KNX_SCHEMA = AllSerializeFirst(
-    vol.Schema(
+    prb.Schema(
         {
-            vol.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
-            vol.Optional(CoverConf.INVERT_UPDOWN): selector.BooleanSelector(),
-            vol.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
-            vol.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
+            prb.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
+            prb.Optional(CoverConf.INVERT_UPDOWN): VolValidator(
+                selector.BooleanSelector()
+            ),
+            prb.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
+            prb.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
             "section_position_control": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_POSITION_SET): GASelector(
+            prb.Optional(CONF_GA_POSITION_SET): GASelector(
                 state=False, valid_dpt="5.001"
             ),
-            vol.Optional(CONF_GA_POSITION_STATE): GASelector(
+            prb.Optional(CONF_GA_POSITION_STATE): GASelector(
                 write=False, valid_dpt="5.001"
             ),
-            vol.Optional(CoverConf.INVERT_POSITION): selector.BooleanSelector(),
+            prb.Optional(CoverConf.INVERT_POSITION): VolValidator(
+                selector.BooleanSelector()
+            ),
             "section_tilt_control": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
-            vol.Optional(CoverConf.INVERT_ANGLE): selector.BooleanSelector(),
+            prb.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
+            prb.Optional(CoverConf.INVERT_ANGLE): VolValidator(
+                selector.BooleanSelector()
+            ),
             "section_travel_time": KNXSectionFlat(),
-            vol.Required(
-                CoverConf.TRAVELLING_TIME_UP, default=25
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0, max=1000, step=0.1, unit_of_measurement="s"
+            prb.Required(CoverConf.TRAVELLING_TIME_UP, default=25): VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0, max=1000, step=0.1, unit_of_measurement="s"
+                    )
                 )
             ),
-            vol.Required(
-                CoverConf.TRAVELLING_TIME_DOWN, default=25
-            ): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0, max=1000, step=0.1, unit_of_measurement="s"
+            prb.Required(CoverConf.TRAVELLING_TIME_DOWN, default=25): VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0, max=1000, step=0.1, unit_of_measurement="s"
+                    )
                 )
             ),
-            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+            prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
         },
-        extra=vol.REMOVE_EXTRA,
+        extra=prb.REMOVE_EXTRA,
     ),
-    vol.Any(
-        vol.Schema(
+    prb.Any(
+        prb.Schema(
             {
-                vol.Required(CONF_GA_UP_DOWN): GASelector(
+                prb.Required(CONF_GA_UP_DOWN): GASelector(
                     state=False, write_required=True
                 )
             },
-            extra=vol.ALLOW_EXTRA,
+            extra=prb.ALLOW_EXTRA,
         ),
-        vol.Schema(
+        prb.Schema(
             {
-                vol.Required(CONF_GA_POSITION_SET): GASelector(
+                prb.Required(CONF_GA_POSITION_SET): GASelector(
                     state=False, write_required=True
                 )
             },
-            extra=vol.ALLOW_EXTRA,
+            extra=prb.ALLOW_EXTRA,
         ),
         msg=(
             "At least one of 'Open/Close control' or"
@@ -284,35 +298,39 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
     ),
 )
 
-DATE_KNX_SCHEMA = vol.Schema(
+DATE_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_DATE): GASelector(write_required=True, valid_dpt="11.001"),
-        vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        prb.Required(CONF_GA_DATE): GASelector(write_required=True, valid_dpt="11.001"),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
+            selector.BooleanSelector()
+        ),
+        prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     }
 )
 
-DATETIME_KNX_SCHEMA = vol.Schema(
+DATETIME_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_DATETIME): GASelector(
+        prb.Required(CONF_GA_DATETIME): GASelector(
             write_required=True, valid_dpt="19.001"
         ),
-        vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
+            selector.BooleanSelector()
+        ),
+        prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     }
 )
 
 FAN_KNX_SCHEMA = AllSerializeFirst(
-    vol.Schema(
+    prb.Schema(
         {
-            vol.Optional(CONF_GA_SWITCH): GASelector(
+            prb.Optional(CONF_GA_SWITCH): GASelector(
                 write_required=True, valid_dpt="1"
             ),
-            vol.Optional(CONF_SPEED): GroupSelect(
+            prb.Optional(CONF_SPEED): GroupSelect(
                 GroupSelectOption(
                     translation_key="percentage_mode",
                     schema={
-                        vol.Required(CONF_GA_SPEED): GASelector(
+                        prb.Required(CONF_GA_SPEED): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
                     },
@@ -320,37 +338,37 @@ FAN_KNX_SCHEMA = AllSerializeFirst(
                 GroupSelectOption(
                     translation_key="step_mode",
                     schema={
-                        vol.Required(CONF_GA_STEP): GASelector(
+                        prb.Required(CONF_GA_STEP): GASelector(
                             write_required=True, valid_dpt="5.010"
                         ),
-                        vol.Required(
-                            FanConf.MAX_STEP, default=3
-                        ): selector.NumberSelector(
-                            selector.NumberSelectorConfig(
-                                min=1,
-                                max=100,
-                                step=1,
-                                mode=selector.NumberSelectorMode.BOX,
+                        prb.Required(FanConf.MAX_STEP, default=3): VolValidator(
+                            selector.NumberSelector(
+                                selector.NumberSelectorConfig(
+                                    min=1,
+                                    max=100,
+                                    step=1,
+                                    mode=selector.NumberSelectorMode.BOX,
+                                )
                             )
                         ),
                     },
                 ),
                 collapsible=False,
             ),
-            vol.Optional(CONF_GA_OSCILLATION): GASelector(
+            prb.Optional(CONF_GA_OSCILLATION): GASelector(
                 write_required=True, valid_dpt="1"
             ),
-            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+            prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
         }
     ),
-    vol.Any(
-        vol.Schema(
-            {vol.Required(CONF_GA_SWITCH): object},
-            extra=vol.ALLOW_EXTRA,
+    prb.Any(
+        prb.Schema(
+            {prb.Required(CONF_GA_SWITCH): object},
+            extra=prb.ALLOW_EXTRA,
         ),
-        vol.Schema(
-            {vol.Required(CONF_SPEED): object},
-            extra=vol.ALLOW_EXTRA,
+        prb.Schema(
+            {prb.Required(CONF_SPEED): object},
+            extra=prb.ALLOW_EXTRA,
         ),
         msg=("At least one of 'Switch' or 'Fan speed' is required."),
     ),
@@ -372,33 +390,37 @@ _hs_color_inclusion_msg = (
 
 
 LIGHT_KNX_SCHEMA = AllSerializeFirst(
-    vol.Schema(
+    prb.Schema(
         {
-            vol.Optional(CONF_GA_SWITCH): GASelector(
+            prb.Optional(CONF_GA_SWITCH): GASelector(
                 write_required=True, valid_dpt="1"
             ),
-            vol.Optional(CONF_GA_BRIGHTNESS): GASelector(
+            prb.Optional(CONF_GA_BRIGHTNESS): GASelector(
                 write_required=True, valid_dpt="5.001"
             ),
             "section_color_temp": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_GA_COLOR_TEMP): GASelector(
+            prb.Optional(CONF_GA_COLOR_TEMP): GASelector(
                 write_required=True, dpt=ColorTempModes
             ),
-            vol.Required(CONF_COLOR_TEMP_MIN, default=2700): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=1, max=10000, step=1, unit_of_measurement="K"
+            prb.Required(CONF_COLOR_TEMP_MIN, default=2700): VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1, max=10000, step=1, unit_of_measurement="K"
+                    )
                 )
             ),
-            vol.Required(CONF_COLOR_TEMP_MAX, default=6000): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=1, max=10000, step=1, unit_of_measurement="K"
+            prb.Required(CONF_COLOR_TEMP_MAX, default=6000): VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1, max=10000, step=1, unit_of_measurement="K"
+                    )
                 )
             ),
-            vol.Optional(CONF_COLOR): GroupSelect(
+            prb.Optional(CONF_COLOR): GroupSelect(
                 GroupSelectOption(
                     translation_key="single_address",
                     schema={
-                        vol.Optional(CONF_GA_COLOR): GASelector(
+                        prb.Optional(CONF_GA_COLOR): GASelector(
                             write_required=True, dpt=LightColorMode
                         )
                     },
@@ -406,28 +428,28 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
                 GroupSelectOption(
                     translation_key="individual_addresses",
                     schema={
-                        vol.Optional(CONF_GA_RED_SWITCH): GASelector(
+                        prb.Optional(CONF_GA_RED_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
-                        vol.Required(CONF_GA_RED_BRIGHTNESS): GASelector(
+                        prb.Required(CONF_GA_RED_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
-                        vol.Optional(CONF_GA_GREEN_SWITCH): GASelector(
+                        prb.Optional(CONF_GA_GREEN_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
-                        vol.Required(CONF_GA_GREEN_BRIGHTNESS): GASelector(
+                        prb.Required(CONF_GA_GREEN_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
-                        vol.Optional(CONF_GA_BLUE_SWITCH): GASelector(
+                        prb.Optional(CONF_GA_BLUE_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
-                        vol.Required(CONF_GA_BLUE_BRIGHTNESS): GASelector(
+                        prb.Required(CONF_GA_BLUE_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
-                        vol.Optional(CONF_GA_WHITE_SWITCH): GASelector(
+                        prb.Optional(CONF_GA_WHITE_SWITCH): GASelector(
                             write_required=False, valid_dpt="1"
                         ),
-                        vol.Optional(CONF_GA_WHITE_BRIGHTNESS): GASelector(
+                        prb.Optional(CONF_GA_WHITE_BRIGHTNESS): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
                     },
@@ -435,50 +457,50 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
                 GroupSelectOption(
                     translation_key="hsv_addresses",
                     schema={
-                        vol.Required(CONF_GA_HUE): GASelector(
+                        prb.Required(CONF_GA_HUE): GASelector(
                             write_required=True, valid_dpt="5.003"
                         ),
-                        vol.Required(CONF_GA_SATURATION): GASelector(
+                        prb.Required(CONF_GA_SATURATION): GASelector(
                             write_required=True, valid_dpt="5.001"
                         ),
                     },
                 ),
             ),
-            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+            prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
         }
     ),
-    vol.Any(
-        vol.Schema(
-            {vol.Required(CONF_GA_SWITCH): object},
-            extra=vol.ALLOW_EXTRA,
+    prb.Any(
+        prb.Schema(
+            {prb.Required(CONF_GA_SWITCH): object},
+            extra=prb.ALLOW_EXTRA,
         ),
-        vol.Schema(  # brightness addresses are required in INDIVIDUAL_COLOR_SCHEMA
-            {vol.Required(CONF_COLOR): {vol.Required(CONF_GA_RED_BRIGHTNESS): object}},
-            extra=vol.ALLOW_EXTRA,
+        prb.Schema(  # brightness addresses are required in INDIVIDUAL_COLOR_SCHEMA
+            {prb.Required(CONF_COLOR): {prb.Required(CONF_GA_RED_BRIGHTNESS): object}},
+            extra=prb.ALLOW_EXTRA,
         ),
         msg="either 'address' or 'individual_colors' is required",
     ),
-    vol.Any(
-        vol.Schema(  # 'brightness' is non-optional for hs-color
+    prb.Any(
+        prb.Schema(  # 'brightness' is non-optional for hs-color
             {
-                vol.Required(CONF_GA_BRIGHTNESS, msg=_hs_color_inclusion_msg): object,
-                vol.Required(CONF_COLOR): {
-                    vol.Required(CONF_GA_HUE, msg=_hs_color_inclusion_msg): object,
-                    vol.Required(
+                prb.Required(CONF_GA_BRIGHTNESS, msg=_hs_color_inclusion_msg): object,
+                prb.Required(CONF_COLOR): {
+                    prb.Required(CONF_GA_HUE, msg=_hs_color_inclusion_msg): object,
+                    prb.Required(
                         CONF_GA_SATURATION, msg=_hs_color_inclusion_msg
                     ): object,
                 },
             },
-            extra=vol.ALLOW_EXTRA,
+            extra=prb.ALLOW_EXTRA,
         ),
-        vol.Schema(  # hs-colors not used
+        prb.Schema(  # hs-colors not used
             {
-                vol.Optional(CONF_COLOR): {
-                    vol.Optional(CONF_GA_HUE): None,
-                    vol.Optional(CONF_GA_SATURATION): None,
+                prb.Optional(CONF_COLOR): {
+                    prb.Optional(CONF_GA_HUE): None,
+                    prb.Optional(CONF_GA_SATURATION): None,
                 },
             },
-            extra=vol.ALLOW_EXTRA,
+            extra=prb.ALLOW_EXTRA,
         ),
         msg=_hs_color_inclusion_msg,
     ),
@@ -494,103 +516,123 @@ def _number_limit_sub_validator(config: dict) -> dict:
 
 
 NUMBER_KNX_SCHEMA = AllSerializeFirst(
-    vol.Schema(
+    prb.Schema(
         {
-            vol.Required(CONF_GA_SENSOR): GASelector(
+            prb.Required(CONF_GA_SENSOR): GASelector(
                 write_required=True, dpt=["numeric"]
             ),
-            vol.Optional(
-                CONF_RESPOND_TO_READ, default=False
-            ): selector.BooleanSelector(),
+            prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
+                selector.BooleanSelector()
+            ),
             "section_advanced_options": KNXSectionFlat(collapsible=True),
-            vol.Required(CONF_MODE, default=NumberMode.AUTO): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=list(NumberMode),
-                    translation_key="component.knx.config_panel.entities.create.number.knx.mode",
-                ),
-            ),
-            vol.Optional(NumberConf.MIN): selector.NumberSelector(),
-            vol.Optional(NumberConf.MAX): selector.NumberSelector(),
-            vol.Optional(NumberConf.STEP): selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=0, step="any", mode=selector.NumberSelectorMode.BOX
-                )
-            ),
-            vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=sorted(
-                        {
-                            str(unit)
-                            for units in NUMBER_DEVICE_CLASS_UNITS.values()
-                            for unit in units
-                            if unit is not None
-                        }
+            prb.Required(CONF_MODE, default=NumberMode.AUTO): VolValidator(
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=list(NumberMode),
+                        translation_key="component.knx.config_panel.entities.create.number.knx.mode",
                     ),
-                    mode=selector.SelectSelectorMode.DROPDOWN,
-                    custom_value=True,
-                ),
-            ),
-            vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=[cls.value for cls in NumberDeviceClass],
-                    # should align with sensor
-                    translation_key="component.knx.selector.sensor_device_class",
-                    sort=True,
                 )
             ),
-            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+            prb.Optional(NumberConf.MIN): VolValidator(selector.NumberSelector()),
+            prb.Optional(NumberConf.MAX): VolValidator(selector.NumberSelector()),
+            prb.Optional(NumberConf.STEP): VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=0, step="any", mode=selector.NumberSelectorMode.BOX
+                    )
+                )
+            ),
+            prb.Optional(CONF_UNIT_OF_MEASUREMENT): VolValidator(
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=sorted(
+                            {
+                                str(unit)
+                                for units in NUMBER_DEVICE_CLASS_UNITS.values()
+                                for unit in units
+                                if unit is not None
+                            }
+                        ),
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        custom_value=True,
+                    ),
+                )
+            ),
+            prb.Optional(CONF_DEVICE_CLASS): VolValidator(
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[cls.value for cls in NumberDeviceClass],
+                        # should align with sensor
+                        translation_key="component.knx.selector.sensor_device_class",
+                        sort=True,
+                    )
+                )
+            ),
+            prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
         },
     ),
-    _number_limit_sub_validator,
+    VolValidator(_number_limit_sub_validator),
 )
 
-SCENE_KNX_SCHEMA = vol.Schema(
+SCENE_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_SCENE): GASelector(
+        prb.Required(CONF_GA_SCENE): GASelector(
             state=False,
             passive=False,
             write_required=True,
             valid_dpt=["17.001", "18.001"],
         ),
-        vol.Required(SceneConf.SCENE_NUMBER): AllSerializeFirst(
-            selector.NumberSelector(
-                selector.NumberSelectorConfig(
-                    min=1, max=64, step=1, mode=selector.NumberSelectorMode.BOX
+        prb.Required(SceneConf.SCENE_NUMBER): AllSerializeFirst(
+            VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=1, max=64, step=1, mode=selector.NumberSelectorMode.BOX
+                    )
                 )
             ),
-            vol.Coerce(int),
+            prb.Coerce(int),
         ),
     },
 )
 
-SWITCH_KNX_SCHEMA = vol.Schema(
+SWITCH_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
-        vol.Optional(CONF_INVERT, default=False): selector.BooleanSelector(),
-        vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
-    },
-)
-
-TEXT_KNX_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_GA_TEXT): GASelector(write_required=True, dpt=["string"]),
-        vol.Required(CONF_MODE, default=TextMode.TEXT): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=list(TextMode),
-                translation_key="component.knx.config_panel.entities.create.text.knx.mode",
-            ),
+        prb.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
+        prb.Optional(CONF_INVERT, default=False): VolValidator(
+            selector.BooleanSelector()
         ),
-        vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
+            selector.BooleanSelector()
+        ),
+        prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     },
 )
 
-TIME_KNX_SCHEMA = vol.Schema(
+TEXT_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_TIME): GASelector(write_required=True, valid_dpt="10.001"),
-        vol.Optional(CONF_RESPOND_TO_READ, default=False): selector.BooleanSelector(),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        prb.Required(CONF_GA_TEXT): GASelector(write_required=True, dpt=["string"]),
+        prb.Required(CONF_MODE, default=TextMode.TEXT): VolValidator(
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=list(TextMode),
+                    translation_key="component.knx.config_panel.entities.create.text.knx.mode",
+                ),
+            )
+        ),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
+            selector.BooleanSelector()
+        ),
+        prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+    },
+)
+
+TIME_KNX_SCHEMA = prb.Schema(
+    {
+        prb.Required(CONF_GA_TIME): GASelector(write_required=True, valid_dpt="10.001"),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
+            selector.BooleanSelector()
+        ),
+        prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     }
 )
 
@@ -611,128 +653,142 @@ class ConfClimateFanSpeedMode(StrEnum):
     STEPS = "5.010"
 
 
-CLIMATE_KNX_SCHEMA = vol.Schema(
+CLIMATE_KNX_SCHEMA = prb.Schema(
     {
-        vol.Required(CONF_GA_TEMPERATURE_CURRENT): GASelector(
+        prb.Required(CONF_GA_TEMPERATURE_CURRENT): GASelector(
             write=False, state_required=True, valid_dpt="9.001"
         ),
-        vol.Optional(CONF_GA_HUMIDITY_CURRENT): GASelector(
+        prb.Optional(CONF_GA_HUMIDITY_CURRENT): GASelector(
             write=False, valid_dpt="9.007"
         ),
-        vol.Required(CONF_TARGET_TEMPERATURE): GroupSelect(
+        prb.Required(CONF_TARGET_TEMPERATURE): GroupSelect(
             GroupSelectOption(
                 translation_key="group_direct_temp",
                 schema={
-                    vol.Required(CONF_GA_TEMPERATURE_TARGET): GASelector(
+                    prb.Required(CONF_GA_TEMPERATURE_TARGET): GASelector(
                         write_required=True, valid_dpt="9.001"
                     ),
-                    vol.Required(
-                        ClimateConf.MIN_TEMP, default=7
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=-20, max=80, step=1, unit_of_measurement="°C"
+                    prb.Required(ClimateConf.MIN_TEMP, default=7): VolValidator(
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=-20, max=80, step=1, unit_of_measurement="°C"
+                            )
                         )
                     ),
-                    vol.Required(
-                        ClimateConf.MAX_TEMP, default=28
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=0, max=100, step=1, unit_of_measurement="°C"
+                    prb.Required(ClimateConf.MAX_TEMP, default=28): VolValidator(
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=0, max=100, step=1, unit_of_measurement="°C"
+                            )
                         )
                     ),
-                    vol.Required(
+                    prb.Required(
                         ClimateConf.TEMPERATURE_STEP, default=0.1
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=0.1, max=2, step=0.1, unit_of_measurement="K"
-                        ),
+                    ): VolValidator(
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=0.1, max=2, step=0.1, unit_of_measurement="K"
+                            ),
+                        )
                     ),
                 },
             ),
             GroupSelectOption(
                 translation_key="group_setpoint_shift",
                 schema={
-                    vol.Required(CONF_GA_TEMPERATURE_TARGET): GASelector(
+                    prb.Required(CONF_GA_TEMPERATURE_TARGET): GASelector(
                         write=False, state_required=True, valid_dpt="9.001"
                     ),
-                    vol.Required(CONF_GA_SETPOINT_SHIFT): GASelector(
+                    prb.Required(CONF_GA_SETPOINT_SHIFT): GASelector(
                         write_required=True,
                         state_required=True,
                         dpt=ConfSetpointShiftMode,
                     ),
-                    vol.Required(
+                    prb.Required(
                         ClimateConf.SETPOINT_SHIFT_MIN, default=-6
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=-32, max=0, step=1, unit_of_measurement="K"
+                    ): VolValidator(
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=-32, max=0, step=1, unit_of_measurement="K"
+                            )
                         )
                     ),
-                    vol.Required(
+                    prb.Required(
                         ClimateConf.SETPOINT_SHIFT_MAX, default=6
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=0, max=32, step=1, unit_of_measurement="K"
+                    ): VolValidator(
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=0, max=32, step=1, unit_of_measurement="K"
+                            )
                         )
                     ),
-                    vol.Required(
+                    prb.Required(
                         ClimateConf.TEMPERATURE_STEP, default=0.1
-                    ): selector.NumberSelector(
-                        selector.NumberSelectorConfig(
-                            min=0.1, max=2, step=0.1, unit_of_measurement="K"
-                        ),
+                    ): VolValidator(
+                        selector.NumberSelector(
+                            selector.NumberSelectorConfig(
+                                min=0.1, max=2, step=0.1, unit_of_measurement="K"
+                            ),
+                        )
                     ),
                 },
             ),
             collapsible=False,
         ),
         "section_activity": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_ACTIVE): GASelector(write=False, valid_dpt="1"),
-        vol.Optional(CONF_GA_VALVE): GASelector(write=False, valid_dpt="5.001"),
+        prb.Optional(CONF_GA_ACTIVE): GASelector(write=False, valid_dpt="1"),
+        prb.Optional(CONF_GA_VALVE): GASelector(write=False, valid_dpt="5.001"),
         "section_operation_mode": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_OPERATION_MODE): GASelector(valid_dpt="20.102"),
-        vol.Optional(CONF_IGNORE_AUTO_MODE): selector.BooleanSelector(),
+        prb.Optional(CONF_GA_OPERATION_MODE): GASelector(valid_dpt="20.102"),
+        prb.Optional(CONF_IGNORE_AUTO_MODE): VolValidator(selector.BooleanSelector()),
         "section_operation_mode_individual": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_OP_MODE_COMFORT): GASelector(state=False, valid_dpt="1"),
-        vol.Optional(CONF_GA_OP_MODE_ECO): GASelector(state=False, valid_dpt="1"),
-        vol.Optional(CONF_GA_OP_MODE_STANDBY): GASelector(state=False, valid_dpt="1"),
-        vol.Optional(CONF_GA_OP_MODE_PROTECTION): GASelector(
+        prb.Optional(CONF_GA_OP_MODE_COMFORT): GASelector(state=False, valid_dpt="1"),
+        prb.Optional(CONF_GA_OP_MODE_ECO): GASelector(state=False, valid_dpt="1"),
+        prb.Optional(CONF_GA_OP_MODE_STANDBY): GASelector(state=False, valid_dpt="1"),
+        prb.Optional(CONF_GA_OP_MODE_PROTECTION): GASelector(
             state=False, valid_dpt="1"
         ),
         "section_heat_cool": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_HEAT_COOL): GASelector(valid_dpt="1.100"),
+        prb.Optional(CONF_GA_HEAT_COOL): GASelector(valid_dpt="1.100"),
         "section_on_off": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_ON_OFF): GASelector(valid_dpt="1"),
-        vol.Optional(ClimateConf.ON_OFF_INVERT): selector.BooleanSelector(),
+        prb.Optional(CONF_GA_ON_OFF): GASelector(valid_dpt="1"),
+        prb.Optional(ClimateConf.ON_OFF_INVERT): VolValidator(
+            selector.BooleanSelector()
+        ),
         "section_controller_mode": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_CONTROLLER_MODE): GASelector(valid_dpt="20.105"),
-        vol.Optional(CONF_GA_CONTROLLER_STATUS): GASelector(write=False),
-        vol.Required(
+        prb.Optional(CONF_GA_CONTROLLER_MODE): GASelector(valid_dpt="20.105"),
+        prb.Optional(CONF_GA_CONTROLLER_STATUS): GASelector(write=False),
+        prb.Required(
             ClimateConf.DEFAULT_CONTROLLER_MODE, default=HVACMode.HEAT
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=list(HVACMode),
-                translation_key="component.climate.selector.hvac_mode",
+        ): VolValidator(
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=list(HVACMode),
+                    translation_key="component.climate.selector.hvac_mode",
+                )
             )
         ),
         "section_fan": KNXSectionFlat(collapsible=True),
-        vol.Optional(CONF_GA_FAN_SPEED): GASelector(dpt=ConfClimateFanSpeedMode),
-        vol.Required(ClimateConf.FAN_MAX_STEP, default=3): AllSerializeFirst(
-            selector.NumberSelector(
-                selector.NumberSelectorConfig(min=1, max=100, step=1)
+        prb.Optional(CONF_GA_FAN_SPEED): GASelector(dpt=ConfClimateFanSpeedMode),
+        prb.Required(ClimateConf.FAN_MAX_STEP, default=3): AllSerializeFirst(
+            VolValidator(
+                selector.NumberSelector(
+                    selector.NumberSelectorConfig(min=1, max=100, step=1)
+                )
             ),
-            vol.Coerce(int),
+            prb.Coerce(int),
         ),
-        vol.Required(
-            ClimateConf.FAN_ZERO_MODE, default=FanZeroMode.OFF
-        ): selector.SelectSelector(
-            selector.SelectSelectorConfig(
-                options=list(FanZeroMode),
-                translation_key="component.knx.config_panel.entities.create.climate.knx.fan_zero_mode",
+        prb.Required(ClimateConf.FAN_ZERO_MODE, default=FanZeroMode.OFF): VolValidator(
+            selector.SelectSelector(
+                selector.SelectSelectorConfig(
+                    options=list(FanZeroMode),
+                    translation_key="component.knx.config_panel.entities.create.climate.knx.fan_zero_mode",
+                )
             )
         ),
-        vol.Optional(CONF_GA_FAN_SWING): GASelector(valid_dpt="1"),
-        vol.Optional(CONF_GA_FAN_SWING_HORIZONTAL): GASelector(valid_dpt="1"),
-        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        prb.Optional(CONF_GA_FAN_SWING): GASelector(valid_dpt="1"),
+        prb.Optional(CONF_GA_FAN_SWING_HORIZONTAL): GASelector(valid_dpt="1"),
+        prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     },
 )
 
@@ -745,52 +801,60 @@ def _sensor_attribute_sub_validator(config: dict) -> dict:
 
 
 SENSOR_KNX_SCHEMA = AllSerializeFirst(
-    vol.Schema(
+    prb.Schema(
         {
-            vol.Required(CONF_GA_SENSOR): GASelector(
+            prb.Required(CONF_GA_SENSOR): GASelector(
                 write=False, state_required=True, dpt=["numeric", "string"]
             ),
             "section_advanced_options": KNXSectionFlat(collapsible=True),
-            vol.Optional(CONF_UNIT_OF_MEASUREMENT): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=sorted(
-                        {
-                            str(unit)
-                            for units in SENSOR_DEVICE_CLASS_UNITS.values()
-                            for unit in units
-                            if unit is not None
-                        }
+            prb.Optional(CONF_UNIT_OF_MEASUREMENT): VolValidator(
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=sorted(
+                            {
+                                str(unit)
+                                for units in SENSOR_DEVICE_CLASS_UNITS.values()
+                                for unit in units
+                                if unit is not None
+                            }
+                        ),
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                        translation_key="component.knx.selector.sensor_unit_of_measurement",
+                        custom_value=True,
                     ),
-                    mode=selector.SelectSelectorMode.DROPDOWN,
-                    translation_key="component.knx.selector.sensor_unit_of_measurement",
-                    custom_value=True,
-                ),
-            ),
-            vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=[
-                        cls.value
-                        for cls in SensorDeviceClass
-                        if cls != SensorDeviceClass.ENUM
-                    ],
-                    translation_key="component.knx.selector.sensor_device_class",
-                    sort=True,
                 )
             ),
-            vol.Optional(CONF_SENSOR_STATE_CLASS): selector.SelectSelector(
-                selector.SelectSelectorConfig(
-                    options=list(SensorStateClass),
-                    translation_key="component.knx.selector.sensor_state_class",
-                    mode=selector.SelectSelectorMode.DROPDOWN,
+            prb.Optional(CONF_DEVICE_CLASS): VolValidator(
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=[
+                            cls.value
+                            for cls in SensorDeviceClass
+                            if cls != SensorDeviceClass.ENUM
+                        ],
+                        translation_key="component.knx.selector.sensor_device_class",
+                        sort=True,
+                    )
                 )
             ),
-            vol.Optional(CONF_ALWAYS_CALLBACK): selector.BooleanSelector(),
-            vol.Required(CONF_SYNC_STATE, default=True): SyncStateSelector(
+            prb.Optional(CONF_SENSOR_STATE_CLASS): VolValidator(
+                selector.SelectSelector(
+                    selector.SelectSelectorConfig(
+                        options=list(SensorStateClass),
+                        translation_key="component.knx.selector.sensor_state_class",
+                        mode=selector.SelectSelectorMode.DROPDOWN,
+                    )
+                )
+            ),
+            prb.Optional(CONF_ALWAYS_CALLBACK): VolValidator(
+                selector.BooleanSelector()
+            ),
+            prb.Required(CONF_SYNC_STATE, default=True): SyncStateSelector(
                 allow_false=True
             ),
         },
     ),
-    _sensor_attribute_sub_validator,
+    VolValidator(_sensor_attribute_sub_validator),
 )
 
 KNX_SCHEMA_FOR_PLATFORM = {
@@ -810,28 +874,28 @@ KNX_SCHEMA_FOR_PLATFORM = {
     Platform.TIME: TIME_KNX_SCHEMA,
 }
 
-ENTITY_STORE_DATA_SCHEMA: VolSchemaType = vol.All(
-    vol.Schema(
+ENTITY_STORE_DATA_SCHEMA: prb.All = prb.All(
+    prb.Schema(
         {
-            vol.Required(CONF_PLATFORM): vol.All(
-                vol.Coerce(Platform),
-                vol.In(SUPPORTED_PLATFORMS_UI),
+            prb.Required(CONF_PLATFORM): prb.All(
+                prb.Coerce(Platform),
+                prb.In(SUPPORTED_PLATFORMS_UI),
             ),
-            vol.Required(CONF_DATA): dict,
+            prb.Required(CONF_DATA): dict,
         },
-        extra=vol.ALLOW_EXTRA,
+        extra=prb.ALLOW_EXTRA,
     ),
-    cv.key_value_schemas(
+    prb.TaggedUnion(
         CONF_PLATFORM,
         {
-            platform: vol.Schema(
+            platform: prb.Schema(
                 {
-                    vol.Required(CONF_DATA): {
-                        vol.Required(CONF_ENTITY): BASE_ENTITY_SCHEMA,
-                        vol.Required(DOMAIN): knx_schema,
+                    prb.Required(CONF_DATA): {
+                        prb.Required(CONF_ENTITY): BASE_ENTITY_SCHEMA,
+                        prb.Required(DOMAIN): knx_schema,
                     },
                 },
-                extra=vol.ALLOW_EXTRA,
+                extra=prb.ALLOW_EXTRA,
             )
             for platform, knx_schema in KNX_SCHEMA_FOR_PLATFORM.items()
         },

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -3,7 +3,6 @@
 from enum import StrEnum, unique
 
 import probatio as prb
-import voluptuous as vol
 from xknx.dpt import DPTBase, DPTBinary, DPTNumeric
 from xknx.exceptions import ConversionError
 
@@ -23,7 +22,6 @@ from homeassistant.components.text import TextMode
 from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_CATEGORY,
-    CONF_ENTITY_ID,
     CONF_MODE,
     CONF_NAME,
     CONF_PLATFORM,
@@ -32,7 +30,6 @@ from homeassistant.const import (
 )
 from homeassistant.helpers import selector
 from homeassistant.helpers.entity import ENTITY_CATEGORIES_SCHEMA
-from homeassistant.helpers.typing import VolDictType
 
 from ..const import (
     CONF_CONTEXT_TIMEOUT,
@@ -126,6 +123,8 @@ from .knx_selector import (
 )
 from .vol_compat import VolValidator
 
+BOOLEAN_SELECTOR = VolValidator(selector.BooleanSelector())
+
 BASE_ENTITY_SCHEMA = prb.All(
     {
         prb.Optional(CONF_NAME, default=None): prb.Maybe(str),
@@ -157,11 +156,9 @@ BINARY_SENSOR_KNX_SCHEMA = prb.Schema(
         prb.Required(CONF_GA_SENSOR): GASelector(
             write=False, state_required=True, valid_dpt="1"
         ),
-        prb.Optional(CONF_INVERT): VolValidator(selector.BooleanSelector()),
+        prb.Optional(CONF_INVERT): BOOLEAN_SELECTOR,
         "section_advanced_options": KNXSectionFlat(collapsible=True),
-        prb.Optional(CONF_IGNORE_INTERNAL_STATE): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(CONF_IGNORE_INTERNAL_STATE): BOOLEAN_SELECTOR,
         prb.Optional(CONF_CONTEXT_TIMEOUT): VolValidator(
             selector.NumberSelector(
                 selector.NumberSelectorConfig(
@@ -235,9 +232,7 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
     prb.Schema(
         {
             prb.Optional(CONF_GA_UP_DOWN): GASelector(state=False, valid_dpt="1"),
-            prb.Optional(CoverConf.INVERT_UPDOWN): VolValidator(
-                selector.BooleanSelector()
-            ),
+            prb.Optional(CoverConf.INVERT_UPDOWN): BOOLEAN_SELECTOR,
             prb.Optional(CONF_GA_STOP): GASelector(state=False, valid_dpt="1"),
             prb.Optional(CONF_GA_STEP): GASelector(state=False, valid_dpt="1"),
             "section_position_control": KNXSectionFlat(collapsible=True),
@@ -247,14 +242,10 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
             prb.Optional(CONF_GA_POSITION_STATE): GASelector(
                 write=False, valid_dpt="5.001"
             ),
-            prb.Optional(CoverConf.INVERT_POSITION): VolValidator(
-                selector.BooleanSelector()
-            ),
+            prb.Optional(CoverConf.INVERT_POSITION): BOOLEAN_SELECTOR,
             "section_tilt_control": KNXSectionFlat(collapsible=True),
             prb.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
-            prb.Optional(CoverConf.INVERT_ANGLE): VolValidator(
-                selector.BooleanSelector()
-            ),
+            prb.Optional(CoverConf.INVERT_ANGLE): BOOLEAN_SELECTOR,
             "section_travel_time": KNXSectionFlat(),
             prb.Required(CoverConf.TRAVELLING_TIME_UP, default=25): VolValidator(
                 selector.NumberSelector(
@@ -301,9 +292,7 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
 DATE_KNX_SCHEMA = prb.Schema(
     {
         prb.Required(CONF_GA_DATE): GASelector(write_required=True, valid_dpt="11.001"),
-        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): BOOLEAN_SELECTOR,
         prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     }
 )
@@ -313,9 +302,7 @@ DATETIME_KNX_SCHEMA = prb.Schema(
         prb.Required(CONF_GA_DATETIME): GASelector(
             write_required=True, valid_dpt="19.001"
         ),
-        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): BOOLEAN_SELECTOR,
         prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     }
 )
@@ -521,9 +508,7 @@ NUMBER_KNX_SCHEMA = AllSerializeFirst(
             prb.Required(CONF_GA_SENSOR): GASelector(
                 write_required=True, dpt=["numeric"]
             ),
-            prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
-                selector.BooleanSelector()
-            ),
+            prb.Optional(CONF_RESPOND_TO_READ, default=False): BOOLEAN_SELECTOR,
             "section_advanced_options": KNXSectionFlat(collapsible=True),
             prb.Required(CONF_MODE, default=NumberMode.AUTO): VolValidator(
                 selector.SelectSelector(
@@ -598,12 +583,8 @@ SCENE_KNX_SCHEMA = prb.Schema(
 SWITCH_KNX_SCHEMA = prb.Schema(
     {
         prb.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
-        prb.Optional(CONF_INVERT, default=False): VolValidator(
-            selector.BooleanSelector()
-        ),
-        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(CONF_INVERT, default=False): BOOLEAN_SELECTOR,
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): BOOLEAN_SELECTOR,
         prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     },
 )
@@ -619,9 +600,7 @@ TEXT_KNX_SCHEMA = prb.Schema(
                 ),
             )
         ),
-        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): BOOLEAN_SELECTOR,
         prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     },
 )
@@ -629,9 +608,7 @@ TEXT_KNX_SCHEMA = prb.Schema(
 TIME_KNX_SCHEMA = prb.Schema(
     {
         prb.Required(CONF_GA_TIME): GASelector(write_required=True, valid_dpt="10.001"),
-        prb.Optional(CONF_RESPOND_TO_READ, default=False): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(CONF_RESPOND_TO_READ, default=False): BOOLEAN_SELECTOR,
         prb.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
     }
 )
@@ -740,7 +717,7 @@ CLIMATE_KNX_SCHEMA = prb.Schema(
         prb.Optional(CONF_GA_VALVE): GASelector(write=False, valid_dpt="5.001"),
         "section_operation_mode": KNXSectionFlat(collapsible=True),
         prb.Optional(CONF_GA_OPERATION_MODE): GASelector(valid_dpt="20.102"),
-        prb.Optional(CONF_IGNORE_AUTO_MODE): VolValidator(selector.BooleanSelector()),
+        prb.Optional(CONF_IGNORE_AUTO_MODE): BOOLEAN_SELECTOR,
         "section_operation_mode_individual": KNXSectionFlat(collapsible=True),
         prb.Optional(CONF_GA_OP_MODE_COMFORT): GASelector(state=False, valid_dpt="1"),
         prb.Optional(CONF_GA_OP_MODE_ECO): GASelector(state=False, valid_dpt="1"),
@@ -752,9 +729,7 @@ CLIMATE_KNX_SCHEMA = prb.Schema(
         prb.Optional(CONF_GA_HEAT_COOL): GASelector(valid_dpt="1.100"),
         "section_on_off": KNXSectionFlat(collapsible=True),
         prb.Optional(CONF_GA_ON_OFF): GASelector(valid_dpt="1"),
-        prb.Optional(ClimateConf.ON_OFF_INVERT): VolValidator(
-            selector.BooleanSelector()
-        ),
+        prb.Optional(ClimateConf.ON_OFF_INVERT): BOOLEAN_SELECTOR,
         "section_controller_mode": KNXSectionFlat(collapsible=True),
         prb.Optional(CONF_GA_CONTROLLER_MODE): GASelector(valid_dpt="20.105"),
         prb.Optional(CONF_GA_CONTROLLER_STATUS): GASelector(write=False),
@@ -846,9 +821,7 @@ SENSOR_KNX_SCHEMA = AllSerializeFirst(
                     )
                 )
             ),
-            prb.Optional(CONF_ALWAYS_CALLBACK): VolValidator(
-                selector.BooleanSelector()
-            ),
+            prb.Optional(CONF_ALWAYS_CALLBACK): BOOLEAN_SELECTOR,
             prb.Required(CONF_SYNC_STATE, default=True): SyncStateSelector(
                 allow_false=True
             ),
@@ -874,7 +847,7 @@ KNX_SCHEMA_FOR_PLATFORM = {
     Platform.TIME: TIME_KNX_SCHEMA,
 }
 
-ENTITY_STORE_DATA_SCHEMA: prb.All = prb.All(
+ENTITY_STORE_DATA_SCHEMA = prb.All(
     prb.Schema(
         {
             prb.Required(CONF_PLATFORM): prb.All(
@@ -901,13 +874,3 @@ ENTITY_STORE_DATA_SCHEMA: prb.All = prb.All(
         },
     ),
 )
-
-CREATE_ENTITY_BASE_SCHEMA: VolDictType = {
-    vol.Required(CONF_PLATFORM): str,
-    vol.Required(CONF_DATA): dict,  # validated by ENTITY_STORE_DATA_SCHEMA for platform
-}
-
-UPDATE_ENTITY_BASE_SCHEMA = {
-    vol.Required(CONF_ENTITY_ID): str,
-    **CREATE_ENTITY_BASE_SCHEMA,
-}

--- a/homeassistant/components/knx/storage/entity_store_validation.py
+++ b/homeassistant/components/knx/storage/entity_store_validation.py
@@ -1,18 +1,21 @@
 """KNX entity store validation."""
 
-from typing import Literal, TypedDict
+from collections.abc import Callable
+from typing import Any, Literal, TypedDict
 
-import voluptuous as vol
-
-from homeassistant.helpers.typing import VolSchemaType
+import probatio as prb
 
 from .entity_store_schema import ENTITY_STORE_DATA_SCHEMA
 
 
 class _ErrorDescription(TypedDict):
-    path: list[str] | None
-    error_message: str
-    error_class: str
+    code: str | None
+    message: str
+    path: list[str]
+    secret: bool
+    context: dict[str, Any]
+    translation_key: str | None
+    placeholders: dict[str, Any]
 
 
 class EntityStoreValidationError(TypedDict):
@@ -30,24 +33,24 @@ class EntityStoreValidationSuccess(TypedDict):
     entity_id: str | None
 
 
-def parse_invalid(exc: vol.Invalid) -> _ErrorDescription:
-    """Parse a vol.Invalid exception."""
-    return _ErrorDescription(
-        path=[str(path) for path in exc.path],  # exc.path: str | vol.Required
-        error_message=exc.msg,
-        error_class=type(exc).__name__,
-    )
+def parse_invalid(exc: prb.Invalid) -> _ErrorDescription:
+    """Parse a probatio.Invalid exception."""
+    description = exc.as_dict()
+    description["path"] = [str(path) for path in description["path"]]
+    return description  # type: ignore[return-value]
 
 
-def validate_config_store_data(schema: VolSchemaType, entity_data: dict) -> dict:
+def validate_config_store_data(
+    schema: Callable[[dict], dict], entity_data: dict
+) -> dict:
     """Validate data for config store.
 
     Return validated data or raise EntityStoreValidationException.
     """
     try:
         # return so defaults are applied
-        return schema(entity_data)  # type: ignore[no-any-return]
-    except vol.MultipleInvalid as exc:
+        return schema(entity_data)
+    except prb.MultipleInvalid as exc:
         raise EntityStoreValidationException(
             validation_error={
                 "success": False,
@@ -55,7 +58,7 @@ def validate_config_store_data(schema: VolSchemaType, entity_data: dict) -> dict
                 "errors": [parse_invalid(invalid) for invalid in exc.errors],
             }
         ) from exc
-    except vol.Invalid as exc:
+    except prb.Invalid as exc:
         raise EntityStoreValidationException(
             validation_error={
                 "success": False,

--- a/homeassistant/components/knx/storage/entity_store_validation.py
+++ b/homeassistant/components/knx/storage/entity_store_validation.py
@@ -50,20 +50,13 @@ def validate_config_store_data(
     try:
         # return so defaults are applied
         return schema(entity_data)
-    except prb.MultipleInvalid as exc:
-        raise EntityStoreValidationException(
-            validation_error={
-                "success": False,
-                "error_base": str(exc),
-                "errors": [parse_invalid(invalid) for invalid in exc.errors],
-            }
-        ) from exc
     except prb.Invalid as exc:
+        errors = exc.errors if isinstance(exc, prb.MultipleInvalid) else [exc]
         raise EntityStoreValidationException(
             validation_error={
                 "success": False,
                 "error_base": str(exc),
-                "errors": [parse_invalid(exc)],
+                "errors": [parse_invalid(invalid) for invalid in errors],
             }
         ) from exc
 

--- a/homeassistant/components/knx/storage/expose_controller.py
+++ b/homeassistant/components/knx/storage/expose_controller.py
@@ -2,6 +2,7 @@
 
 from typing import Any, NotRequired, TypedDict
 
+import probatio as prb
 import voluptuous as vol
 from xknx import XKNX
 from xknx.dpt import DPTBase
@@ -17,6 +18,7 @@ from homeassistant.helpers import (
 from ..expose import KnxExposeEntity, KnxExposeOptions
 from .entity_store_validation import validate_config_store_data
 from .knx_selector import GASelector
+from .vol_compat import VolValidator
 
 
 class KNXExposeStoreOptionModel(TypedDict):
@@ -60,34 +62,37 @@ def validate_expose_template_no_coerce(value: str) -> str:
     return value  # return original string for storage and later template creation
 
 
-EXPOSE_OPTION_SCHEMA = vol.Schema(
+EXPOSE_OPTION_SCHEMA = prb.Schema(
     {
-        vol.Required("ga"): GASelector(
+        prb.Required("ga"): GASelector(
             state=False,
             passive=False,
             write_required=True,
             dpt=["numeric", "enum", "complex", "string"],
         ),
-        vol.Optional("attribute"): str,
-        vol.Optional("default"): object,
-        vol.Optional("cooldown"): cv.positive_float,  # frontend renders to duration
-        vol.Optional("periodic_send"): cv.positive_float,
-        vol.Optional("respond_to_read"): bool,
-        vol.Optional("value_template"): validate_expose_template_no_coerce,
+        prb.Optional("attribute"): str,
+        prb.Optional("default"): object,
+        # frontend renders cooldown to duration
+        prb.Optional("cooldown"): VolValidator(cv.positive_float),
+        prb.Optional("periodic_send"): VolValidator(cv.positive_float),
+        prb.Optional("respond_to_read"): bool,
+        prb.Optional("value_template"): VolValidator(
+            validate_expose_template_no_coerce
+        ),
     }
 )
 
-EXPOSE_CONFIG_SCHEMA = vol.Schema(
+EXPOSE_CONFIG_SCHEMA = prb.Schema(
     {
-        vol.Required("entity_id"): selector.EntitySelector(),
-        vol.Required("data"): vol.Schema(
+        prb.Required("entity_id"): VolValidator(selector.EntitySelector()),
+        prb.Required("data"): prb.Schema(
             {
-                vol.Required("options"): [EXPOSE_OPTION_SCHEMA],
-                vol.Optional("notes"): str,
+                prb.Required("options"): [EXPOSE_OPTION_SCHEMA],
+                prb.Optional("notes"): str,
             }
         ),
     },
-    extra=vol.REMOVE_EXTRA,
+    extra=prb.REMOVE_EXTRA,
 )
 
 

--- a/homeassistant/components/knx/storage/knx_selector.py
+++ b/homeassistant/components/knx/storage/knx_selector.py
@@ -1,10 +1,10 @@
 """Selectors for KNX."""
 
-from collections.abc import Hashable, Iterable
+from collections.abc import Callable, Iterable
 from enum import Enum
 from typing import Any, override
 
-import voluptuous as vol
+import probatio as prb
 
 from homeassistant.const import CONF_PAYLOAD
 
@@ -13,12 +13,13 @@ from ..dpt import HaDptClass, get_supported_dpts
 from ..validation import ga_validator, maybe_ga_validator, sync_state_validator
 from .const import CONF_DPT, CONF_GA_PASSIVE, CONF_GA_STATE, CONF_GA_WRITE
 from .util import dpt_string_to_dict
+from .vol_compat import VolValidator
 
 
-class AllSerializeFirst(vol.All):
+class AllSerializeFirst(prb.All):
     """Use the first validated value for serialization.
 
-    This is a version of vol.All with custom error handling to
+    This is a version of probatio.All with custom error handling to
     show proper invalid markers for sub-schema items in the UI.
     """
 
@@ -26,7 +27,7 @@ class AllSerializeFirst(vol.All):
 class KNXSelectorBase:
     """Base class for KNX selectors supporting optional nested schemas."""
 
-    schema: vol.Schema | vol.Any | vol.All
+    schema: Callable[[Any], Any]
     selector_type: str
     # mark if self.schema should be serialized to `schema` key
     serialize_subschema: bool = False
@@ -49,7 +50,7 @@ class KNXSectionFlat(KNXSelectorBase):
     """Generate a schema-neutral section with title and description."""
 
     selector_type = "knx_section_flat"
-    schema = vol.Schema(None)
+    schema = prb.Schema(None)
 
     def __init__(
         self,
@@ -75,12 +76,12 @@ class KNXSection(KNXSelectorBase):
 
     def __init__(
         self,
-        schema: dict[str | vol.Marker, vol.Schemable],
+        schema: dict[str | prb.Marker, prb.Schemable],
         collapsible: bool = True,
     ) -> None:
         """Initialize the section."""
         self.collapsible = collapsible
-        self.schema = vol.Schema(schema)
+        self.schema = prb.Schema(schema)
 
     @override
     def serialize(self) -> dict[str, Any]:
@@ -97,10 +98,10 @@ class GroupSelectOption(KNXSelectorBase):
     selector_type = "knx_group_select_option"
     serialize_subschema: bool = True
 
-    def __init__(self, schema: vol.Schemable, translation_key: str) -> None:
+    def __init__(self, schema: prb.Schemable, translation_key: str) -> None:
         """Initialize the group select option schema."""
         self.translation_key = translation_key
-        self.schema = vol.Schema(schema)
+        self.schema = prb.Schema(schema)
 
     @override
     def serialize(self) -> dict[str, Any]:
@@ -111,30 +112,34 @@ class GroupSelectOption(KNXSelectorBase):
         }
 
 
-class GroupSelectSchema(vol.Any):
+class GroupSelectSchema:
     """Use the first validated value.
 
-    This is a version of vol.Any with custom error handling to
+    This is a version of probatio.Any with custom error handling to
     show proper invalid markers for sub-schema items in the UI.
     """
 
-    @override
-    def _exec(self, funcs: Iterable, v: Any, path: list[Hashable] | None = None) -> Any:
-        """Execute the validation functions."""
-        errors: list[vol.Invalid] = []
-        for func in funcs:
+    def __init__(self, *validators: Any, msg: str | None = None) -> None:
+        """Initialize the group select schema."""
+        self.validators = list(validators)
+        self.msg = msg
+
+    def __call__(self, value: Any) -> Any:
+        """Validate the passed data against any of the options."""
+        errors: list[prb.Invalid] = []
+        for validator in self.validators:
             try:
-                if path is None:
-                    return func(v)
-                return func(path, v)
-            except vol.Invalid as e:
-                errors.append(e)
+                return validator(value)
+            except prb.MultipleInvalid as exc:
+                errors.extend(exc.errors)
+            except prb.Invalid as exc:
+                errors.append(exc)
         if errors:
             raise next(
-                (err for err in errors if "extra keys not allowed" not in err.msg),
+                (err for err in errors if not isinstance(err, prb.ExtraKeysInvalid)),
                 errors[0],
             )
-        raise vol.AnyInvalid(self.msg or "no valid value found", path=path)
+        raise prb.AnyInvalid(self.msg or "no valid value found")
 
 
 class GroupSelect(KNXSelectorBase):
@@ -223,73 +228,75 @@ class GASelector(KNXSelectorBase):
             "options": options,
         }
 
-    def build_schema(self) -> vol.Schema:
+    def build_schema(self) -> prb.Schema:
         """Create the schema based on configuration."""
-        schema: dict[vol.Marker, Any] = {}  # will be modified in-place
+        schema: dict[prb.Marker, Any] = {}  # will be modified in-place
         self._add_group_addresses(schema)
         self._add_passive(schema)
         self._add_dpt(schema)
-        return vol.Schema(
-            vol.All(
+        return prb.Schema(
+            prb.All(
                 schema,
-                vol.Schema(  # one group address shall be included
-                    vol.Any(
-                        {vol.Required(CONF_GA_WRITE): vol.IsTrue()},
-                        {vol.Required(CONF_GA_STATE): vol.IsTrue()},
-                        {vol.Required(CONF_GA_PASSIVE): vol.IsTrue()},
+                prb.Schema(  # one group address shall be included
+                    prb.Any(
+                        {prb.Required(CONF_GA_WRITE): prb.IsTrue()},
+                        {prb.Required(CONF_GA_STATE): prb.IsTrue()},
+                        {prb.Required(CONF_GA_PASSIVE): prb.IsTrue()},
                         msg="At least one group address must be set",
                     ),
-                    extra=vol.ALLOW_EXTRA,
+                    extra=prb.ALLOW_EXTRA,
                 ),
             )
         )
 
-    def _add_group_addresses(self, schema: dict[vol.Marker, Any]) -> None:
+    def _add_group_addresses(self, schema: dict[prb.Marker, Any]) -> None:
         """Add basic group address items to the schema."""
 
         def add_ga_item(key: str, allowed: bool, required: bool) -> None:
             """Add a group address item validator to the schema."""
             if not allowed:
-                schema[vol.Remove(key)] = object
+                schema[prb.Remove(key)] = object
                 return
             if required:
-                schema[vol.Required(key)] = ga_validator
+                schema[prb.Required(key)] = VolValidator(ga_validator)
             else:
-                schema[vol.Optional(key, default=None)] = maybe_ga_validator
+                schema[prb.Optional(key, default=None)] = VolValidator(
+                    maybe_ga_validator
+                )
 
         add_ga_item(CONF_GA_WRITE, self.write, self.write_required)
         add_ga_item(CONF_GA_STATE, self.state, self.state_required)
 
-    def _add_passive(self, schema: dict[vol.Marker, Any]) -> None:
+    def _add_passive(self, schema: dict[prb.Marker, Any]) -> None:
         """Add passive group addresses validator to the schema."""
         if self.passive:
-            schema[vol.Optional(CONF_GA_PASSIVE, default=list)] = vol.Any(
-                [ga_validator],
-                vol.All(  # Coerce `None` to an empty list if passive is allowed
-                    vol.IsFalse(), vol.SetTo(list)
+            schema[prb.Optional(CONF_GA_PASSIVE, default=list)] = prb.Any(
+                [VolValidator(ga_validator)],
+                prb.All(  # Coerce `None` to an empty list if passive is allowed
+                    prb.IsFalse(), prb.SetTo(list)
                 ),
             )
         else:
-            schema[vol.Remove(CONF_GA_PASSIVE)] = object
+            schema[prb.Remove(CONF_GA_PASSIVE)] = object
 
-    def _add_dpt(self, schema: dict[vol.Marker, Any]) -> None:
+    def _add_dpt(self, schema: dict[prb.Marker, Any]) -> None:
         """Add DPT validator to the schema."""
         if self.dpt is not None:
             if isinstance(self.dpt, list):
-                marker = vol.Required if self.dpt_required else vol.Optional
-                schema[marker(CONF_DPT)] = vol.In(get_supported_dpts())
+                marker = prb.Required if self.dpt_required else prb.Optional
+                schema[marker(CONF_DPT)] = prb.In(get_supported_dpts())
             else:
-                schema[vol.Required(CONF_DPT)] = vol.In(
+                schema[prb.Required(CONF_DPT)] = prb.In(
                     {item.value for item in self.dpt}
                 )
         else:
-            schema[vol.Remove(CONF_DPT)] = object
+            schema[prb.Remove(CONF_DPT)] = object
 
 
 class SyncStateSelector(KNXSelectorBase):
     """Selector for knx sync state validation."""
 
-    schema = vol.Schema(sync_state_validator)
+    schema = prb.Schema(VolValidator(sync_state_validator))
     selector_type = "knx_sync_state"
 
     def __init__(self, allow_false: bool = False) -> None:
@@ -308,7 +315,7 @@ class SyncStateSelector(KNXSelectorBase):
     def __call__(self, data: Any) -> Any:
         """Validate the passed data."""
         if not self.allow_false and not data:
-            raise vol.Invalid(f"Sync state cannot be {data}")
+            raise prb.Invalid(f"Sync state cannot be {data}")
         return self.schema(data)
 
 
@@ -318,13 +325,13 @@ class KnxPayloadSelector(KNXSelectorBase):
     Raw payloads are stored as hex strings.
     """
 
-    schema = vol.Any(
+    schema = prb.Any(
         {
-            vol.Required(CONF_VALUE): object,
+            prb.Required(CONF_VALUE): object,
         },
         {
-            vol.Required(CONF_PAYLOAD): str,
-            vol.Required(CONF_PAYLOAD_LENGTH): vol.All(int, vol.Range(min=0, max=14)),
+            prb.Required(CONF_PAYLOAD): str,
+            prb.Required(CONF_PAYLOAD_LENGTH): prb.All(int, prb.Range(min=0, max=14)),
         },
     )
     selector_type = "knx_payload"
@@ -351,21 +358,21 @@ class KnxPayloadSelector(KNXSelectorBase):
             try:
                 int_payload = int(payload, 16)
             except ValueError as ex:
-                raise vol.Invalid(f"Invalid payload format: {payload}") from ex
+                raise prb.Invalid(f"Invalid payload format: {payload}") from ex
             validated[CONF_PAYLOAD] = hex(int_payload)  # prepends "0x" if not present
 
             if int_payload < 0:
-                raise vol.Invalid(f"Payload cannot be negative: {payload}")
+                raise prb.Invalid(f"Payload cannot be negative: {payload}")
             if payload_length == 0:
                 # DPT 1,2,3 is marked length 0, has 6 bit size
                 if int_payload > 63:
-                    raise vol.Invalid(
+                    raise prb.Invalid(
                         f"Payload exceeds DPT 1,2,3 limit of 0x3f (63): {payload}"
                     )
             else:
                 max_payload = (1 << (payload_length * 8)) - 1
                 if int_payload > max_payload:
-                    raise vol.Invalid(
+                    raise prb.Invalid(
                         f"Payload {payload} exceeds possible maximum for "
                         f"length {payload_length}: {hex(max_payload)}"
                     )

--- a/homeassistant/components/knx/storage/knx_selector.py
+++ b/homeassistant/components/knx/storage/knx_selector.py
@@ -119,10 +119,9 @@ class GroupSelectSchema:
     show proper invalid markers for sub-schema items in the UI.
     """
 
-    def __init__(self, *validators: Any, msg: str | None = None) -> None:
+    def __init__(self, *validators: Any) -> None:
         """Initialize the group select schema."""
         self.validators = list(validators)
-        self.msg = msg
 
     def __call__(self, value: Any) -> Any:
         """Validate the passed data against any of the options."""
@@ -139,7 +138,7 @@ class GroupSelectSchema:
                 (err for err in errors if not isinstance(err, prb.ExtraKeysInvalid)),
                 errors[0],
             )
-        raise prb.AnyInvalid(self.msg or "no valid value found")
+        raise prb.AnyInvalid("no valid value found")
 
 
 class GroupSelect(KNXSelectorBase):

--- a/homeassistant/components/knx/storage/knx_selector.py
+++ b/homeassistant/components/knx/storage/knx_selector.py
@@ -112,6 +112,12 @@ class GroupSelectOption(KNXSelectorBase):
         }
 
 
+def _has_extra_keys_error(exc: prb.Invalid) -> bool:
+    """Check if any of the errors is about extra keys."""
+    errors = exc.errors if isinstance(exc, prb.MultipleInvalid) else [exc]
+    return any(isinstance(error, prb.ExtraKeysInvalid) for error in errors)
+
+
 class GroupSelectSchema:
     """Use the first validated value.
 
@@ -129,13 +135,13 @@ class GroupSelectSchema:
         for validator in self.validators:
             try:
                 return validator(value)
-            except prb.MultipleInvalid as exc:
-                errors.extend(exc.errors)
             except prb.Invalid as exc:
                 errors.append(exc)
         if errors:
+            # an option failing on extra keys wasn't the one configured by the
+            # user - prefer errors of an option matching the given keys
             raise next(
-                (err for err in errors if not isinstance(err, prb.ExtraKeysInvalid)),
+                (err for err in errors if not _has_extra_keys_error(err)),
                 errors[0],
             )
         raise prb.AnyInvalid("no valid value found")

--- a/homeassistant/components/knx/storage/serialize.py
+++ b/homeassistant/components/knx/storage/serialize.py
@@ -2,36 +2,38 @@
 
 from typing import Any, cast
 
-import voluptuous as vol
-from voluptuous_serialize import UNSUPPORTED, UnsupportedType, convert
+from probatio import UNSUPPORTED, to_field_list
 
 from homeassistant.const import Platform
 from homeassistant.helpers import selector
 
 from .entity_store_schema import KNX_SCHEMA_FOR_PLATFORM
 from .knx_selector import AllSerializeFirst, GroupSelectSchema, KNXSelectorBase
+from .vol_compat import VolValidator
 
 
-def knx_serializer(
-    schema: vol.Schema,
-) -> dict[str, Any] | list[dict[str, Any]] | UnsupportedType:
+def knx_serializer(schema: Any) -> dict[str, Any] | list[dict[str, Any]] | object:
     """Serialize KNX schema."""
     if isinstance(schema, GroupSelectSchema):
         return [
             cast(
                 dict[str, Any],  # GroupSelectOption converts to a dict with subschema
-                convert(option, custom_serializer=knx_serializer),
+                to_field_list(option, custom_serializer=knx_serializer),
             )
             for option in schema.validators
         ]
     if isinstance(schema, KNXSelectorBase):
         result = schema.serialize()
         if schema.serialize_subschema:
-            result["schema"] = convert(schema.schema, custom_serializer=knx_serializer)
+            result["schema"] = to_field_list(
+                schema.schema, custom_serializer=knx_serializer
+            )
         return result
     if isinstance(schema, AllSerializeFirst):
-        return convert(schema.validators[0], custom_serializer=knx_serializer)
+        return to_field_list(schema.validators[0], custom_serializer=knx_serializer)
 
+    if isinstance(schema, VolValidator):
+        schema = schema.validator
     if isinstance(schema, selector.Selector):
         return schema.serialize() | {"type": "ha_selector"}
 
@@ -43,5 +45,5 @@ def get_serialized_schema(
 ) -> dict[str, Any] | list[dict[str, Any]] | None:
     """Get the schema for a specific platform."""
     if knx_schema := KNX_SCHEMA_FOR_PLATFORM.get(platform):
-        return convert(knx_schema, custom_serializer=knx_serializer)
+        return to_field_list(knx_schema, custom_serializer=knx_serializer)
     return None

--- a/homeassistant/components/knx/storage/time_server.py
+++ b/homeassistant/components/knx/storage/time_server.py
@@ -2,7 +2,7 @@
 
 from typing import Any, TypedDict
 
-import voluptuous as vol
+import probatio as prb
 from xknx import XKNX
 
 from ..expose import KnxExposeTime, create_time_server_exposures
@@ -18,15 +18,15 @@ class KNXTimeServerStoreModel(TypedDict, total=False):
     datetime: dict[str, Any] | None
 
 
-TIME_SERVER_CONFIG_SCHEMA = vol.Schema(
+TIME_SERVER_CONFIG_SCHEMA = prb.Schema(
     {
-        vol.Optional("time"): GASelector(
+        prb.Optional("time"): GASelector(
             state=False, passive=False, valid_dpt="10.001"
         ),
-        vol.Optional("date"): GASelector(
+        prb.Optional("date"): GASelector(
             state=False, passive=False, valid_dpt="11.001"
         ),
-        vol.Optional("datetime"): GASelector(
+        prb.Optional("datetime"): GASelector(
             state=False, passive=False, valid_dpt="19.001"
         ),
     }

--- a/homeassistant/components/knx/storage/vol_compat.py
+++ b/homeassistant/components/knx/storage/vol_compat.py
@@ -1,0 +1,33 @@
+"""Adapter to use voluptuous based validators in probatio schemas."""
+
+from collections.abc import Callable
+from typing import Any
+
+import probatio as prb
+import voluptuous as vol
+
+
+def _convert(exc: vol.Invalid) -> prb.Invalid:
+    """Convert a voluptuous error to its probatio counterpart."""
+    if isinstance(exc, vol.MultipleInvalid):
+        return prb.MultipleInvalid([_convert(error) for error in exc.errors])
+    return prb.Invalid(exc.msg, path=list(exc.path))
+
+
+class VolValidator:
+    """Wrap a voluptuous based validator for use in a probatio schema.
+
+    probatio only handles its own `Invalid` (and `ValueError`) raised from
+    validator callables, so voluptuous errors need to be translated.
+    """
+
+    def __init__(self, validator: Callable[[Any], Any]) -> None:
+        """Initialize the wrapper."""
+        self.validator = validator
+
+    def __call__(self, value: Any) -> Any:
+        """Validate the value with the wrapped validator."""
+        try:
+            return self.validator(value)
+        except vol.Invalid as exc:
+            raise _convert(exc) from exc

--- a/homeassistant/components/knx/websocket.py
+++ b/homeassistant/components/knx/websocket.py
@@ -25,7 +25,7 @@ from homeassistant.const import CONF_ENTITY_ID, CONF_PLATFORM, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.typing import UNDEFINED
+from homeassistant.helpers.typing import UNDEFINED, VolDictType
 from homeassistant.util import dt as dt_util
 from homeassistant.util.ulid import ulid_now
 
@@ -40,10 +40,6 @@ from .const import (
 from .dpt import get_supported_dpts
 from .storage.config_store import ConfigStoreException
 from .storage.const import CONF_DATA
-from .storage.entity_store_schema import (
-    CREATE_ENTITY_BASE_SCHEMA,
-    UPDATE_ENTITY_BASE_SCHEMA,
-)
 from .storage.entity_store_validation import (
     EntityStoreValidationException,
     EntityStoreValidationSuccess,
@@ -487,6 +483,17 @@ def ws_subscribe_telegram(
 
     connection.subscriptions[msg["id"]] = stack.close
     connection.send_result(msg["id"])
+
+
+CREATE_ENTITY_BASE_SCHEMA: VolDictType = {
+    vol.Required(CONF_PLATFORM): str,
+    vol.Required(CONF_DATA): dict,  # validated by ENTITY_STORE_DATA_SCHEMA for platform
+}
+
+UPDATE_ENTITY_BASE_SCHEMA = {
+    vol.Required(CONF_ENTITY_ID): str,
+    **CREATE_ENTITY_BASE_SCHEMA,
+}
 
 
 @websocket_api.require_admin

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1890,6 +1890,9 @@ praw==7.5.0
 # homeassistant.components.islamic_prayer_times
 prayer-times-calculator-offline==1.0.3
 
+# homeassistant.components.knx
+probatio==0.11.0
+
 # homeassistant.components.proliphix
 proliphix==0.4.1
 

--- a/tests/components/knx/test_config_store.py
+++ b/tests/components/knx/test_config_store.py
@@ -418,7 +418,8 @@ async def test_validate_entity(
     assert res["success"], res
     assert res["result"]["success"] is False
     assert res["result"]["errors"][0]["path"] == ["data", "knx", "ga_switch", "write"]
-    assert res["result"]["errors"][0]["error_message"] == "required key not provided"
+    assert res["result"]["errors"][0]["code"] == "required"
+    assert res["result"]["errors"][0]["message"] == "required key not provided"
     assert res["result"]["error_base"].startswith("required key not provided")
 
     # invalid group_select data
@@ -449,7 +450,8 @@ async def test_validate_entity(
         "color",
         "ga_blue_brightness",
     ]
-    assert res["result"]["errors"][0]["error_message"] == "required key not provided"
+    assert res["result"]["errors"][0]["code"] == "required"
+    assert res["result"]["errors"][0]["message"] == "required key not provided"
     assert res["result"]["error_base"].startswith("required key not provided")
 
 
@@ -478,7 +480,8 @@ async def test_update_expose_error(
     assert res["success"], res
     assert res["result"]["success"] is False
     assert res["result"]["errors"][0]["path"] == ["data", "options", "0", "ga", "write"]
-    assert res["result"]["errors"][0]["error_message"] == "required key not provided"
+    assert res["result"]["errors"][0]["code"] == "required"
+    assert res["result"]["errors"][0]["message"] == "required key not provided"
 
 
 async def test_validate_expose(

--- a/tests/components/knx/test_config_store.py
+++ b/tests/components/knx/test_config_store.py
@@ -454,6 +454,35 @@ async def test_validate_entity(
     assert res["result"]["errors"][0]["message"] == "required key not provided"
     assert res["result"]["error_base"].startswith("required key not provided")
 
+    # partially configured group_select option
+    await client.send_json_auto_id(
+        {
+            "type": "knx/validate_entity",
+            "platform": Platform.LIGHT,
+            "data": {
+                "entity": {"name": "test_name"},
+                "knx": {
+                    "color": {
+                        "ga_hue": {"write": "1/2/3"},
+                        # ga_saturation is missing - which is required
+                    }
+                },
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    # This shall test that the error of the partially configured GroupSelect
+    # option is reported instead of "required key" errors of other options
+    assert res["result"]["errors"][0]["path"] == [
+        "data",
+        "knx",
+        "color",
+        "ga_saturation",
+    ]
+    assert res["result"]["errors"][0]["code"] == "required"
+
 
 ########
 # EXPOSE

--- a/tests/components/knx/test_knx_selectors.py
+++ b/tests/components/knx/test_knx_selectors.py
@@ -2,9 +2,8 @@
 
 from typing import Any
 
+import probatio as prb
 import pytest
-import voluptuous as vol
-from voluptuous_serialize import convert
 
 from homeassistant.components.knx.const import ColorTempModes
 from homeassistant.components.knx.storage.knx_selector import (
@@ -177,7 +176,7 @@ def test_ga_selector_invalid(
 ) -> None:
     """Test GASelector."""
     selector = GASelector(**selector_config)
-    with pytest.raises(vol.Invalid, match=error_str):
+    with pytest.raises(prb.Invalid, match=error_str):
         selector(data)
 
 
@@ -186,10 +185,10 @@ def test_sync_state_selector() -> None:
     selector = SyncStateSelector()
     assert selector("expire 50") == "expire 50"
 
-    with pytest.raises(vol.Invalid):
+    with pytest.raises(prb.Invalid):
         selector("invalid")
 
-    with pytest.raises(vol.Invalid, match="Sync state cannot be False"):
+    with pytest.raises(prb.Invalid, match="Sync state cannot be False"):
         selector(False)
 
     false_allowed = SyncStateSelector(allow_false=True)
@@ -265,7 +264,7 @@ def test_ga_selector_serialization(
     ("schema", "serialized"),
     [
         (
-            AllSerializeFirst(vol.Schema({"key": int}), vol.Schema({"ignored": str})),
+            AllSerializeFirst(prb.Schema({"key": int}), prb.Schema({"ignored": str})),
             [{"name": "key", "required": False, "type": "integer"}],
         ),
         (
@@ -324,10 +323,10 @@ def test_ga_selector_serialization(
             },
         ),
         (  # in a dict schema `name` and `required` keys are added
-            vol.Schema(
+            prb.Schema(
                 {
                     "section_test": KNXSectionFlat(),
-                    vol.Optional("key"): selector.BooleanSelector(),
+                    prb.Optional("key"): selector.BooleanSelector(),
                 }
             ),
             [
@@ -350,4 +349,4 @@ def test_ga_selector_serialization(
 )
 def test_serialization(schema: Any, serialized: dict[str, Any]) -> None:
     """Test serialization of the selector."""
-    assert convert(schema, custom_serializer=knx_serializer) == serialized
+    assert prb.to_field_list(schema, custom_serializer=knx_serializer) == serialized


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate the KNX UI config store validation (`knx/storage/`) from voluptuous to [probatio](https://pypi.org/project/probatio/). YAML schemas, services, triggers and config flow stay on voluptuous — shared validators in `validation.py` are unchanged and bridged with a small `VolValidator` adapter (`storage/vol_compat.py`) that translates `vol.Invalid` to `probatio.Invalid`.

Highlights:

- `GroupSelectSchema` no longer overrides voluptuous private API (`vol.Any._exec`) — it is now a plain callable with `isinstance`-based error selection.
- `cv.key_value_schemas` is replaced by `probatio.TaggedUnion`, probatio's built-in equivalent.
- Schema serialization for the frontend uses `probatio.to_field_list` — output verified byte-identical to `voluptuous_serialize.convert` for all 14 platforms.
- Validation behavior verified identical (validated output incl. defaults, error paths and messages) against all stored-config test fixtures.
- Websocket validation errors now use probatio's structured `as_dict()` format: `message`/`code` plus `translation_key`/`placeholders` — groundwork for localized validation errors in a follow-up. This is the only intentional behavior change; the matching frontend update is linked below and will be released together with this change (no config store migration needed).

probatio is added as a new integration requirement, pinned to 0.11.0 ([release notes](https://github.com/frenck/probatio/releases)).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/XKNX/knx-frontend/pull/410

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)