### PR TITLE
aliases() template function

### DIFF
--- a/homeassistant/helpers/template/__init__.py
+++ b/homeassistant/helpers/template/__init__.py
@@ -43,6 +43,7 @@ from .context import (
     template_cv,
 )
 from .extensions import (
+    AliasExtension,
     AreaExtension,
     Base64Extension,
     CollectionExtension,
@@ -805,6 +806,7 @@ class TemplateEnvironment(ImmutableSandboxedEnvironment):
         )
         self.add_extension("jinja2.ext.loopcontrols")
         self.add_extension("jinja2.ext.do")
+        self.add_extension(AliasExtension)
         self.add_extension(AreaExtension)
         self.add_extension(Base64Extension)
         self.add_extension(CollectionExtension)

--- a/homeassistant/helpers/template/extensions/__init__.py
+++ b/homeassistant/helpers/template/extensions/__init__.py
@@ -1,5 +1,6 @@
 """Home Assistant template extensions."""
 
+from .aliases import AliasExtension
 from .areas import AreaExtension
 from .base64 import Base64Extension
 from .collection import CollectionExtension
@@ -21,6 +22,7 @@ from .type_cast import TypeCastExtension
 from .version import VersionExtension
 
 __all__ = [
+    "AliasExtension",
     "AreaExtension",
     "Base64Extension",
     "CollectionExtension",

--- a/homeassistant/helpers/template/extensions/aliases.py
+++ b/homeassistant/helpers/template/extensions/aliases.py
@@ -1,0 +1,66 @@
+"""Alias functions for Home Assistant templates."""
+
+from typing import TYPE_CHECKING, Any
+
+import voluptuous as vol
+
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    floor_registry as fr,
+)
+
+from .base import BaseTemplateExtension, TemplateFunction
+
+if TYPE_CHECKING:
+    from homeassistant.helpers.template import TemplateEnvironment
+
+
+class AliasExtension(BaseTemplateExtension):
+    """Extension for alias-related template functions."""
+
+    def __init__(self, environment: TemplateEnvironment) -> None:
+        """Initialize the alias extension."""
+        super().__init__(
+            environment,
+            functions=[
+                TemplateFunction(
+                    "aliases",
+                    self.aliases,
+                    as_global=True,
+                    as_filter=True,
+                    requires_hass=True,
+                ),
+            ],
+        )
+
+    def aliases(self, lookup_value: Any) -> list[str]:
+        """Return the aliases of an entity, area, or floor ID.
+
+        Dispatch mirrors ``labels()``: the entity ID is shape-checked with
+        ``cv.entity_id`` first, then the value is tried as an area ID and finally
+        a floor ID, first hit wins. Area and floor IDs are both bare slugs and
+        cannot be told apart by shape, so area-before-floor is the deterministic
+        tiebreak. Returns an empty list when nothing matches.
+        """
+        lookup_value = str(lookup_value)
+
+        # Import here, not at top-level to avoid circular import
+        from homeassistant.helpers import config_validation as cv  # noqa: PLC0415
+
+        try:
+            cv.entity_id(lookup_value)
+        except vol.Invalid:
+            pass
+        else:
+            if entity := er.async_get(self.hass).async_get(lookup_value):
+                # entity.aliases may hold a non-str ComputedNameType sentinel
+                return sorted(a for a in entity.aliases if isinstance(a, str))
+
+        if area := ar.async_get(self.hass).async_get_area(lookup_value):
+            return sorted(area.aliases)
+
+        if floor := fr.async_get(self.hass).async_get_floor(lookup_value):
+            return sorted(floor.aliases)
+
+        return []

--- a/homeassistant/helpers/template/extensions/aliases.py
+++ b/homeassistant/helpers/template/extensions/aliases.py
@@ -1,6 +1,7 @@
 """Alias function for Home Assistant templates."""
 
 from collections.abc import Iterable
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -15,6 +16,14 @@ from .base import BaseTemplateExtension, TemplateFunction
 
 if TYPE_CHECKING:
     from homeassistant.helpers.template import TemplateEnvironment
+
+
+class AliasType(StrEnum):
+    """Registry selector for the optional second argument of aliases()."""
+
+    ENTITY = "entity"
+    AREA = "area"
+    FLOOR = "floor"
 
 
 class AliasExtension(BaseTemplateExtension):
@@ -35,30 +44,47 @@ class AliasExtension(BaseTemplateExtension):
             ],
         )
 
-    def aliases(self, lookup_value: Any) -> Iterable[str]:
+    def aliases(self, lookup_value: Any, alias_type: Any = None) -> Iterable[str]:
         """Return the sorted aliases of an entity, area, or floor ID ([] if unknown).
 
+        Without ``alias_type`` the registries are tried entity → area → floor.
         Area is tried before floor because their IDs are indistinguishable bare
         slugs, so the order is the deterministic tiebreak.
+        Pass ``alias_type`` ("entity", "area", or "floor") to restrict the lookup to
+        one registry — this makes the result unambiguous and, in the colliding
+        area/floor case, is the only way to reach the floor.
         """
         lookup_value = str(lookup_value)
+
+        if alias_type is not None:
+            try:
+                alias_type = AliasType(str(alias_type))
+            except ValueError:
+                valid = ", ".join(repr(member.value) for member in AliasType)
+                raise ValueError(
+                    f"aliases(): alias_type must be omitted or one of {valid}, "
+                    f"got {alias_type!r}"
+                ) from None
 
         # Import here, not at top-level to avoid circular import
         from homeassistant.helpers import config_validation as cv  # noqa: PLC0415
 
-        try:
-            entity_id = cv.entity_id(lookup_value)
-        except vol.Invalid:
-            pass
-        else:
-            if entity := er.async_get(self.hass).async_get(entity_id):
-                # entity.aliases may hold a non-str ComputedNameType sentinel
-                return sorted(a for a in entity.aliases if isinstance(a, str))
+        if alias_type in (None, AliasType.ENTITY):
+            try:
+                entity_id = cv.entity_id(lookup_value)
+            except vol.Invalid:
+                pass
+            else:
+                if entity := er.async_get(self.hass).async_get(entity_id):
+                    # entity.aliases may hold a non-str ComputedNameType sentinel
+                    return sorted(a for a in entity.aliases if isinstance(a, str))
 
-        if area := ar.async_get(self.hass).async_get_area(lookup_value):
-            return sorted(area.aliases)
+        if alias_type in (None, AliasType.AREA):
+            if area := ar.async_get(self.hass).async_get_area(lookup_value):
+                return sorted(area.aliases)
 
-        if floor := fr.async_get(self.hass).async_get_floor(lookup_value):
-            return sorted(floor.aliases)
+        if alias_type in (None, AliasType.FLOOR):
+            if floor := fr.async_get(self.hass).async_get_floor(lookup_value):
+                return sorted(floor.aliases)
 
         return []

--- a/homeassistant/helpers/template/extensions/aliases.py
+++ b/homeassistant/helpers/template/extensions/aliases.py
@@ -1,4 +1,4 @@
-"""Alias functions for Home Assistant templates."""
+"""Alias function for Home Assistant templates."""
 
 from typing import TYPE_CHECKING, Any
 
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 
 class AliasExtension(BaseTemplateExtension):
-    """Extension for alias-related template functions."""
+    """Extension for the alias template function."""
 
     def __init__(self, environment: TemplateEnvironment) -> None:
         """Initialize the alias extension."""
@@ -35,13 +35,10 @@ class AliasExtension(BaseTemplateExtension):
         )
 
     def aliases(self, lookup_value: Any) -> list[str]:
-        """Return the aliases of an entity, area, or floor ID.
+        """Return the sorted aliases of an entity, area, or floor ID ([] if unknown).
 
-        Dispatch mirrors ``labels()``: the entity ID is shape-checked with
-        ``cv.entity_id`` first, then the value is tried as an area ID and finally
-        a floor ID, first hit wins. Area and floor IDs are both bare slugs and
-        cannot be told apart by shape, so area-before-floor is the deterministic
-        tiebreak. Returns an empty list when nothing matches.
+        Area is tried before floor because their IDs are indistinguishable bare
+        slugs, so the order is the deterministic tiebreak.
         """
         lookup_value = str(lookup_value)
 

--- a/homeassistant/helpers/template/extensions/aliases.py
+++ b/homeassistant/helpers/template/extensions/aliases.py
@@ -47,11 +47,11 @@ class AliasExtension(BaseTemplateExtension):
         from homeassistant.helpers import config_validation as cv  # noqa: PLC0415
 
         try:
-            cv.entity_id(lookup_value)
+            entity_id = cv.entity_id(lookup_value)
         except vol.Invalid:
             pass
         else:
-            if entity := er.async_get(self.hass).async_get(lookup_value):
+            if entity := er.async_get(self.hass).async_get(entity_id):
                 # entity.aliases may hold a non-str ComputedNameType sentinel
                 return sorted(a for a in entity.aliases if isinstance(a, str))
 

--- a/homeassistant/helpers/template/extensions/aliases.py
+++ b/homeassistant/helpers/template/extensions/aliases.py
@@ -1,5 +1,6 @@
 """Alias function for Home Assistant templates."""
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any
 
 import voluptuous as vol
@@ -34,7 +35,7 @@ class AliasExtension(BaseTemplateExtension):
             ],
         )
 
-    def aliases(self, lookup_value: Any) -> list[str]:
+    def aliases(self, lookup_value: Any) -> Iterable[str]:
         """Return the sorted aliases of an entity, area, or floor ID ([] if unknown).
 
         Area is tried before floor because their IDs are indistinguishable bare

--- a/tests/helpers/template/extensions/test_aliases.py
+++ b/tests/helpers/template/extensions/test_aliases.py
@@ -12,18 +12,18 @@ from homeassistant.helpers import (
 from homeassistant.helpers.entity_registry import COMPUTED_NAME
 
 from tests.common import MockConfigEntry
-from tests.helpers.template.helpers import assert_result_info, render_to_info
+from tests.helpers.template.helpers import assert_result_info, render, render_to_info
 
 
 @pytest.mark.parametrize(
     "template",
     [
-        "{{ aliases('sensor.fake') }}",
-        "{{ 'sensor.fake' | aliases }}",
-        "{{ aliases('unknown_slug') }}",
-        "{{ 'unknown_slug' | aliases }}",
-        "{{ aliases(42) }}",
-        "{{ 42 | aliases }}",
+        pytest.param("{{ aliases('sensor.fake') }}", id="unknown-entity-global"),
+        pytest.param("{{ 'sensor.fake' | aliases }}", id="unknown-entity-filter"),
+        pytest.param("{{ aliases('unknown_slug') }}", id="unknown-slug-global"),
+        pytest.param("{{ 'unknown_slug' | aliases }}", id="unknown-slug-filter"),
+        pytest.param("{{ aliases(42) }}", id="non-string-global"),
+        pytest.param("{{ 42 | aliases }}", id="non-string-filter"),
     ],
 )
 async def test_aliases_unknown(hass: HomeAssistant, template: str) -> None:
@@ -146,6 +146,10 @@ async def test_aliases_area_before_floor(
     assert_result_info(info, ["Area Alias"])
     assert info.rate_limit is None
 
+    info = render_to_info(hass, f"{{{{ '{area.id}' | aliases }}}}")
+    assert_result_info(info, ["Area Alias"])
+    assert info.rate_limit is None
+
 
 async def test_aliases_type_reaches_colliding_floor(
     hass: HomeAssistant,
@@ -182,6 +186,10 @@ async def test_aliases_type_restricts_registry(
     assert_result_info(info, [])
     assert info.rate_limit is None
 
+    info = render_to_info(hass, f"{{{{ '{area.id}' | aliases('entity') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
     info = render_to_info(hass, f"{{{{ aliases('{area.id}', 'floor') }}}}")
     assert_result_info(info, [])
     assert info.rate_limit is None
@@ -190,11 +198,13 @@ async def test_aliases_type_restricts_registry(
 @pytest.mark.parametrize(
     "template",
     [
-        "{{ aliases('sensor.fake', 'device') }}",
-        "{{ 'sensor.fake' | aliases('') }}",
+        pytest.param("{{ aliases('sensor.fake', 'device') }}", id="global-unknown"),
+        pytest.param("{{ 'sensor.fake' | aliases('device') }}", id="filter-unknown"),
+        pytest.param("{{ aliases('sensor.fake', '') }}", id="global-empty"),
+        pytest.param("{{ 'sensor.fake' | aliases('') }}", id="filter-empty"),
     ],
 )
 async def test_aliases_invalid_type(hass: HomeAssistant, template: str) -> None:
-    """Test an unknown alias_type raises a template error."""
-    with pytest.raises(TemplateError):
-        render_to_info(hass, template).result()
+    """Test an unknown alias_type raises a template error naming the valid values."""
+    with pytest.raises(TemplateError, match="alias_type must be omitted or one of"):
+        render(hass, template)

--- a/tests/helpers/template/extensions/test_aliases.py
+++ b/tests/helpers/template/extensions/test_aliases.py
@@ -3,6 +3,7 @@
 import pytest
 
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import (
     area_registry as ar,
     entity_registry as er,
@@ -144,3 +145,56 @@ async def test_aliases_area_before_floor(
     info = render_to_info(hass, f"{{{{ aliases('{area.id}') }}}}")
     assert_result_info(info, ["Area Alias"])
     assert info.rate_limit is None
+
+
+async def test_aliases_type_reaches_colliding_floor(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test the 'floor' selector reaches a floor whose ID collides with an area."""
+    area = area_registry.async_create("Shared", aliases={"Area Alias"})
+    floor = floor_registry.async_create("Shared", aliases={"Floor Alias"})
+    assert area.id == floor.floor_id
+
+    info = render_to_info(hass, f"{{{{ aliases('{area.id}', 'area') }}}}")
+    assert_result_info(info, ["Area Alias"])
+    assert info.rate_limit is None
+
+    # Without the selector the area wins; 'floor' is the only way to reach it
+    info = render_to_info(hass, f"{{{{ aliases('{floor.floor_id}', 'floor') }}}}")
+    assert_result_info(info, ["Floor Alias"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{floor.floor_id}' | aliases('floor') }}}}")
+    assert_result_info(info, ["Floor Alias"])
+    assert info.rate_limit is None
+
+
+async def test_aliases_type_restricts_registry(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test a selector that does not match the target registry returns []."""
+    area = area_registry.async_create("Bedroom", aliases={"Sleeping Room"})
+
+    info = render_to_info(hass, f"{{{{ aliases('{area.id}', 'entity') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ aliases('{area.id}', 'floor') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{{ aliases('sensor.fake', 'device') }}",
+        "{{ 'sensor.fake' | aliases('') }}",
+    ],
+)
+async def test_aliases_invalid_type(hass: HomeAssistant, template: str) -> None:
+    """Test an unknown alias_type raises a template error."""
+    with pytest.raises(TemplateError):
+        render_to_info(hass, template).result()

--- a/tests/helpers/template/extensions/test_aliases.py
+++ b/tests/helpers/template/extensions/test_aliases.py
@@ -66,6 +66,28 @@ async def test_aliases_entity(
     assert info.rate_limit is None
 
 
+async def test_aliases_entity_case_insensitive(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a mixed-case entity ID is normalized before the registry lookup."""
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    entity_entry = entity_registry.async_get_or_create(
+        "light", "hue", "5678", config_entry=config_entry
+    )
+    entity_registry.async_update_entity(entity_entry.entity_id, aliases=["Kitchen"])
+
+    upper_entity_id = entity_entry.entity_id.upper()
+    info = render_to_info(hass, f"{{{{ aliases('{upper_entity_id}') }}}}")
+    assert_result_info(info, ["Kitchen"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{upper_entity_id}' | aliases }}}}")
+    assert_result_info(info, ["Kitchen"])
+    assert info.rate_limit is None
+
+
 async def test_aliases_area(
     hass: HomeAssistant,
     area_registry: ar.AreaRegistry,

--- a/tests/helpers/template/extensions/test_aliases.py
+++ b/tests/helpers/template/extensions/test_aliases.py
@@ -1,0 +1,124 @@
+"""Test alias template functions."""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import (
+    area_registry as ar,
+    entity_registry as er,
+    floor_registry as fr,
+)
+from homeassistant.helpers.entity_registry import COMPUTED_NAME
+
+from tests.common import MockConfigEntry
+from tests.helpers.template.helpers import assert_result_info, render_to_info
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "{{ aliases('sensor.fake') }}",
+        "{{ 'sensor.fake' | aliases }}",
+        "{{ aliases('unknown_slug') }}",
+        "{{ 'unknown_slug' | aliases }}",
+        "{{ aliases(42) }}",
+        "{{ 42 | aliases }}",
+    ],
+)
+async def test_aliases_unknown(hass: HomeAssistant, template: str) -> None:
+    """Test aliases returns an empty list for unknown or invalid lookups."""
+    info = render_to_info(hass, template)
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+
+async def test_aliases_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test aliases for an entity, sorted and with the sentinel filtered out."""
+    config_entry = MockConfigEntry(domain="light")
+    config_entry.add_to_hass(hass)
+    entity_entry = entity_registry.async_get_or_create(
+        "light", "hue", "5678", config_entry=config_entry
+    )
+    entity_id = entity_entry.entity_id
+
+    # No aliases yet
+    info = render_to_info(hass, f"{{{{ aliases('{entity_id}') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{entity_id}' | aliases }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    # The COMPUTED_NAME sentinel is not a str and must be filtered out
+    entity_registry.async_update_entity(
+        entity_id, aliases=["Office Light Switch", COMPUTED_NAME, "Another Alias"]
+    )
+    info = render_to_info(hass, f"{{{{ aliases('{entity_id}') }}}}")
+    assert_result_info(info, ["Another Alias", "Office Light Switch"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{entity_id}' | aliases }}}}")
+    assert_result_info(info, ["Another Alias", "Office Light Switch"])
+    assert info.rate_limit is None
+
+
+async def test_aliases_area(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+) -> None:
+    """Test aliases for an area by ID, returned sorted."""
+    area = area_registry.async_create("Bedroom")
+
+    info = render_to_info(hass, f"{{{{ aliases('{area.id}') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    area_registry.async_update(area.id, aliases={"Sleeping Room", "Bedchamber"})
+    info = render_to_info(hass, f"{{{{ aliases('{area.id}') }}}}")
+    assert_result_info(info, ["Bedchamber", "Sleeping Room"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{area.id}' | aliases }}}}")
+    assert_result_info(info, ["Bedchamber", "Sleeping Room"])
+    assert info.rate_limit is None
+
+
+async def test_aliases_floor(
+    hass: HomeAssistant,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test aliases for a floor by ID, returned sorted."""
+    floor = floor_registry.async_create("Ground Floor")
+
+    info = render_to_info(hass, f"{{{{ aliases('{floor.floor_id}') }}}}")
+    assert_result_info(info, [])
+    assert info.rate_limit is None
+
+    floor_registry.async_update(floor.floor_id, aliases={"Erdgeschoss", "Downstairs"})
+    info = render_to_info(hass, f"{{{{ aliases('{floor.floor_id}') }}}}")
+    assert_result_info(info, ["Downstairs", "Erdgeschoss"])
+    assert info.rate_limit is None
+
+    info = render_to_info(hass, f"{{{{ '{floor.floor_id}' | aliases }}}}")
+    assert_result_info(info, ["Downstairs", "Erdgeschoss"])
+    assert info.rate_limit is None
+
+
+async def test_aliases_area_before_floor(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+) -> None:
+    """Test an ID that is both an area and a floor resolves to the area."""
+    area = area_registry.async_create("Shared", aliases={"Area Alias"})
+    floor = floor_registry.async_create("Shared", aliases={"Floor Alias"})
+    # Both slugs collide; area must win the tiebreak
+    assert area.id == floor.floor_id
+
+    info = render_to_info(hass, f"{{{{ aliases('{area.id}') }}}}")
+    assert_result_info(info, ["Area Alias"])
+    assert info.rate_limit is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an `aliases()` template function/filter returning the aliases of an entity, area, or
floor — a sibling of the existing `labels()` function.

```jinja
{{ aliases('switch.office_shelly') }}      → ['Office Light Switch']
{{ aliases(area_id('Bedroom')) }}          → ['Sleeping Room']
{{ aliases(floor_id('Basement')) }}        → ['Keller', 'Unten', 'Untergeschoss']

{{ aliases(floor_id('Garage'), 'floor') }} → ['Annex', 'Outbuilding', 'Outhouse']
{{ aliases(area_id('Garage'), 'area') }}   → ['Workshop']
```
Aliases are a first-class registry field on entities, areas, and floors, and they are already
user-facing: Assist uses them to match spoken/typed alternate names. But they are readable
**everywhere except from a template**. Core already exposes the neighbouring registry
metadata template authors rely on — `labels()`, `area_id()`, `area_name()`, `floor_id()`,
`floor_name()` — so the alias field is the one obvious gap in that set. `aliases()` closes it.

The function returns a sorted `list[str]` (`[]` when the target is unknown or has no aliases),
registered as both a global and a filter. Dispatch mirrors `labels()`: entity → area → floor —
the three registries that carry an aliases field.

<details>
<summary>Example: alias-review dashboard — new <code>aliases()</code></summary>
... next to the <code>labels()</code> it mirrors

```yaml
type: markdown
content: |-
  ## Alias overview
  <table>
    <tr><th colspan="3">Name</th><th>ID</th><th>Aliases</th><th>Labels</th></tr>
    {% for floor in floors() %}
    <tr>
      <td colspan="3"><b>{{ floor_name(floor) }}</b></td>
      <td>{{ floor }}</td>
      <td>{{ aliases(floor) }}</td>
      <td>{{ labels(floor) }}</td>
    </tr>
    {% for area in floor_areas(floor) %}
    <tr>
      <td>↳</td>
      <td colspan="2"><b>{{ area_name(area) }}</b></td>
      <td>{{ area }}</td>
      <td>{{ aliases(area) }}</td>
      <td>{{ labels(area) }}</td>
    </tr>
    {% for entity in area_entities(area) %}
    <tr>
      <td>&#160;</td>
      <td>↳</td>
      <td>{{ state_attr(entity, 'friendly_name') or entity }}</td>
      <td>{{ entity }}</td>
      <td>{{ aliases(entity) }}</td>
      <td>{{ labels(entity) }}</td>
    </tr>
    {% endfor %}
    {% endfor %}
    {% endfor %}
  </table>
```
</details>

**Deliberately out of scope**:
- **No name/alias resolution** — id-only, like `labels()`. Compose with existing resolvers:
  `aliases(area_id('Bedroom'))`.

**Three intentional deviations from `labels()`:**
1. `aliases()` returns the list **sorted**; `labels()` returns it unsorted (`list(set)`). Sorting
makes the output reproducible and matches the alphabetical order the settings UI already
shows.
2. For `labels()` the one parameter given is sufficient to clearly determine what to search
for. In contrast, for `aliases()`, an `id` might be ambiguous. For that reason, and because
at the same time it might easily be considered a rare edge case, `aliases()` introduces an
optional second parameter to specify the registry to search in. If a second param is given
but not in the range of the expected values, a TemplateError is raised
3. `labels()` can be called without any parameter to list all available labels. That doesn't
make sense for `aliases()` and accordingly, it's not implemented. The first parameter is
mandatory

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: [home-assistant/core discussions#1394](https://github.com/orgs/home-assistant/discussions/1394)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
