### PR TITLE
Add the ability to select clean mode for V1 Roborock vacuums

### DIFF
--- a/homeassistant/components/roborock/select.py
+++ b/homeassistant/components/roborock/select.py
@@ -268,6 +268,8 @@ async def async_setup_entry(
                 if (options := description.options_lambda(coordinator.properties_api))
                 is not None
             )
+            if coordinator.properties_api.status.cleaning_mode_options:
+                entities.append(RoborockCleaningModeSelectEntity(coordinator))
             if (
                 coordinator.properties_api.home is not None
                 and coordinator.properties_api.maps is not None
@@ -384,6 +386,47 @@ class RoborockSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
     def current_option(self) -> str | None:
         """Get the current status of the select entity from device props."""
         return self.entity_description.value_fn(self.coordinator.properties_api)
+
+
+class RoborockCleaningModeSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):
+    """A class to let you set the high-level cleaning mode on a Roborock vacuum.
+
+    This bundles the fan speed, water flow, and mop route settings into a
+    single choice, e.g. vacuum only, mop only, or vacuum and mop.
+    """
+
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "cleaning_mode"
+
+    def __init__(
+        self,
+        coordinator: RoborockDataUpdateCoordinator,
+    ) -> None:
+        """Create a select entity for the high-level cleaning mode."""
+        super().__init__(f"cleaning_mode_{coordinator.duid_slug}", coordinator)
+        self._status_trait = coordinator.properties_api.status
+        self._attr_options = [
+            mode.value for mode in self._status_trait.cleaning_mode_options
+        ]
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Get the current high-level cleaning mode."""
+        return self._status_trait.current_cleaning_mode_name
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Set the high-level cleaning mode."""
+        try:
+            await self._status_trait.set_cleaning_mode(option)
+        except RoborockException as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="command_failed",
+                translation_placeholders={"command": "cleaning_mode"},
+            ) from err
+        await self.coordinator.async_refresh()
 
 
 class RoborockCurrentMapSelectEntity(RoborockCoordinatedEntityV1, SelectEntity):

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -139,7 +139,9 @@
       "cleaning_mode": {
         "name": "Cleaning mode",
         "state": {
+          "custom": "Custom",
           "mop": "Mop only",
+          "smart_mode": "Smart",
           "vac_and_mop": "Vacuum and mop",
           "vacuum": "Vacuum only"
         }

--- a/tests/components/roborock/conftest.py
+++ b/tests/components/roborock/conftest.py
@@ -12,6 +12,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, PropertyMock, patch
 
 import pytest
 from roborock import (
+    CleaningMode,
     CleanRoutes,
     HomeDataRoom,
     MultiMapsListMapInfo,
@@ -452,6 +453,8 @@ def create_v1_properties(network_info: NetworkInfo) -> AsyncMock:
     v1_properties.status.mop_route_options = list(CleanRoutes)
     v1_properties.status.mop_route_mapping = _mop_route_mapping
     v1_properties.status.mop_route_name = _mop_route_mapping.get(STATUS.mop_mode)
+    v1_properties.status.cleaning_mode_options = list(CleaningMode)
+    v1_properties.status.current_cleaning_mode_name = CleaningMode.VAC_AND_MOP.value
     v1_properties.dnd = make_dnd_timer(dataclass_template=DND_TIMER)
     v1_properties.clean_summary = make_mock_trait(
         trait_spec=CleanSummaryTrait,

--- a/tests/components/roborock/test_select.py
+++ b/tests/components/roborock/test_select.py
@@ -170,6 +170,63 @@ async def test_selected_map_without_name(
     assert select_entity.state == "Map 0"
 
 
+async def test_cleaning_mode_select_current_option(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test the V1 cleaning mode select entity current option."""
+    entity_id = "select.roborock_s7_maxv_cleaning_mode"
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "vac_and_mop"
+    options = state.attributes.get("options")
+    assert options is not None
+    assert set(options) == {"vacuum", "vac_and_mop", "mop", "custom", "smart_mode"}
+
+
+async def test_cleaning_mode_select_update_success(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test setting the V1 cleaning mode select option."""
+    entity_id = "select.roborock_s7_maxv_cleaning_mode"
+    assert hass.states.get(entity_id) is not None
+
+    await hass.services.async_call(
+        "select",
+        SERVICE_SELECT_OPTION,
+        service_data={"option": "vacuum"},
+        blocking=True,
+        target={"entity_id": entity_id},
+    )
+
+    assert fake_vacuum.v1_properties
+    fake_vacuum.v1_properties.status.set_cleaning_mode.assert_called_once_with("vacuum")
+
+
+async def test_cleaning_mode_select_update_failure(
+    hass: HomeAssistant,
+    setup_entry: MockConfigEntry,
+    fake_vacuum: FakeDevice,
+) -> None:
+    """Test failure when setting the V1 cleaning mode."""
+    assert fake_vacuum.v1_properties
+    fake_vacuum.v1_properties.status.set_cleaning_mode.side_effect = RoborockException
+    entity_id = "select.roborock_s7_maxv_cleaning_mode"
+    assert hass.states.get(entity_id) is not None
+
+    with pytest.raises(HomeAssistantError, match="cleaning_mode"):
+        await hass.services.async_call(
+            "select",
+            SERVICE_SELECT_OPTION,
+            service_data={"option": "vacuum"},
+            blocking=True,
+            target={"entity_id": entity_id},
+        )
+
+
 @pytest.mark.parametrize(
     ("dust_collection_mode", "expected_state"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Historically, users would have to select each individual cleaning attribute (i.e. fan speed, then mop intensity, etc.) This allows the user to just select the cleaning mode similar to how the app allows them to do it.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
