### PR TITLE
Bump pyintesishome to 2.0.3

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -899,6 +899,7 @@ CLAUDE.md @home-assistant/core
 /homeassistant/components/intent_script/ @arturpragacz
 /tests/components/intent_script/ @arturpragacz
 /homeassistant/components/intesishome/ @jnimmo
+/tests/components/intesishome/ @jnimmo
 /homeassistant/components/iometer/ @jukrebs
 /tests/components/iometer/ @jukrebs
 /homeassistant/components/ios/ @robbiet480

--- a/homeassistant/components/intesishome/climate.py
+++ b/homeassistant/components/intesishome/climate.py
@@ -209,7 +209,7 @@ class IntesisAC(ClimateEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to event updates."""
         _LOGGER.debug("Added climate device with state: %s", repr(self._ih_device))
-        await self._controller.add_update_callback(self.async_update_callback)
+        self._controller.add_update_callback(self.async_update_callback)
         try:
             await self._controller.connect()
         except IHConnectionError as ex:

--- a/homeassistant/components/intesishome/manifest.json
+++ b/homeassistant/components/intesishome/manifest.json
@@ -6,5 +6,5 @@
   "iot_class": "cloud_push",
   "loggers": ["pyintesishome"],
   "quality_scale": "legacy",
-  "requirements": ["pyintesishome==1.8.8"]
+  "requirements": ["pyintesishome==2.0.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2267,7 +2267,7 @@ pyinsteon==1.6.4
 pyintelliclima==0.3.1
 
 # homeassistant.components.intesishome
-pyintesishome==1.8.8
+pyintesishome==2.0.3
 
 # homeassistant.components.ipma
 pyipma==3.0.10

--- a/tests/components/intesishome/__init__.py
+++ b/tests/components/intesishome/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the IntesisHome integration."""

--- a/tests/components/intesishome/test_climate.py
+++ b/tests/components/intesishome/test_climate.py
@@ -1,0 +1,25 @@
+"""Tests for the IntesisHome climate platform."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from homeassistant.components.intesishome.climate import IntesisAC
+
+
+async def test_async_added_to_hass_registers_callback() -> None:
+    """Test registering the synchronous library update callback."""
+    controller = MagicMock()
+    controller.device_type = "IntesisHome"
+    controller.has_setpoint_control.return_value = False
+    controller.has_vertical_swing.return_value = False
+    controller.has_horizontal_swing.return_value = False
+    controller.get_fan_speed_list.return_value = []
+    controller.get_mode_list.return_value = []
+    controller.add_update_callback = MagicMock()
+    controller.connect = AsyncMock()
+
+    entity = IntesisAC("device-id", {"name": "Office"}, controller)
+
+    await entity.async_added_to_hass()
+
+    controller.add_update_callback.assert_called_once_with(entity.async_update_callback)
+    controller.connect.assert_awaited_once_with()

--- a/tests/components/intesishome/test_climate.py
+++ b/tests/components/intesishome/test_climate.py
@@ -1,25 +1,58 @@
 """Tests for the IntesisHome climate platform."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock, patch
 
-from homeassistant.components.intesishome.climate import IntesisAC
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.const import CONF_PASSWORD, CONF_PLATFORM, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
 
-async def test_async_added_to_hass_registers_callback() -> None:
-    """Test registering the synchronous library update callback."""
-    controller = MagicMock()
-    controller.device_type = "IntesisHome"
-    controller.has_setpoint_control.return_value = False
-    controller.has_vertical_swing.return_value = False
-    controller.has_horizontal_swing.return_value = False
-    controller.get_fan_speed_list.return_value = []
-    controller.get_mode_list.return_value = []
-    controller.add_update_callback = MagicMock()
-    controller.connect = AsyncMock()
+async def test_setup_platform_registers_callback(hass: HomeAssistant) -> None:
+    """Test registering the synchronous library update callback during setup."""
+    with patch(
+        "homeassistant.components.intesishome.climate.IntesisHome", autospec=True
+    ) as intesis_home:
+        controller = intesis_home.return_value
+        controller.device_type = "IntesisHome"
+        controller.get_devices.return_value = {"device-id": {"name": "Office"}}
+        controller.has_setpoint_control.return_value = False
+        controller.has_vertical_swing.return_value = False
+        controller.has_horizontal_swing.return_value = False
+        controller.get_fan_speed_list.return_value = []
+        controller.get_mode_list.return_value = []
+        controller.add_update_callback = MagicMock()
+        controller.is_connected = True
+        controller.get_temperature.return_value = 22
+        controller.get_fan_speed.return_value = None
+        controller.is_on.return_value = False
+        controller.get_min_setpoint.return_value = 16
+        controller.get_max_setpoint.return_value = 30
+        controller.get_rssi.return_value = None
+        controller.get_run_hours.return_value = None
+        controller.get_setpoint.return_value = 21
+        controller.get_outdoor_temperature.return_value = None
+        controller.get_mode.return_value = "cool"
+        controller.get_preset_mode.return_value = None
+        controller.get_vertical_swing.return_value = "auto/stop"
+        controller.get_horizontal_swing.return_value = "auto/stop"
+        controller.get_heat_power_consumption.return_value = None
+        controller.get_cool_power_consumption.return_value = None
 
-    entity = IntesisAC("device-id", {"name": "Office"}, controller)
+        assert await async_setup_component(
+            hass,
+            CLIMATE_DOMAIN,
+            {
+                CLIMATE_DOMAIN: {
+                    CONF_PLATFORM: "intesishome",
+                    CONF_USERNAME: "user",
+                    CONF_PASSWORD: "password",
+                }
+            },
+        )
+        await hass.async_block_till_done()
 
-    await entity.async_added_to_hass()
-
-    controller.add_update_callback.assert_called_once_with(entity.async_update_callback)
+    assert hass.states.get("climate.office") is not None
+    controller.add_update_callback.assert_called_once()
+    assert callable(controller.add_update_callback.call_args.args[0])
     controller.connect.assert_awaited_once_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump `pyintesishome` from `1.8.8` to `2.0.3`.

The `2.x` releases fix the `KeyError` reported in #173153. They also make `add_update_callback` synchronous, so the integration must no longer await it. This PR also adds a regression test for that callback registration.

#174708 contains the same underlying fix but is currently blocked on its contributor CLA.

I tested it with IntesisHome climate entities on Home Assistant Core `2026.7.2` using `pyintesishome==2.0.3`. The entities loaded and accepted commands normally.

Dependency diff: [`1.8.8...v2.0.3`](https://github.com/jnimmo/pyIntesisHome/compare/1.8.8...v2.0.3)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173153
- This PR is related to issue: #171209, #174708

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging the code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
