### PR TITLE
Add port validation to ws http config command

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -231,6 +231,52 @@ async def _async_fallback_config(
     return _DEFAULT_CONFIG
 
 
+def _make_server(
+    hass: HomeAssistant,
+    conf: ConfData,
+    supervisor_unix_socket_path: Path | None = None,
+) -> HomeAssistantHTTP:
+    """Create a server instance for the given config."""
+    return HomeAssistantHTTP(
+        hass,
+        server_host=conf.get(CONF_SERVER_HOST, _DEFAULT_BIND),
+        server_port=conf[CONF_SERVER_PORT],
+        ssl_certificate=conf.get(CONF_SSL_CERTIFICATE),
+        ssl_peer_certificate=conf.get(CONF_SSL_PEER_CERTIFICATE),
+        ssl_key=conf.get(CONF_SSL_KEY),
+        # The loaded config stores trusted proxies as strings
+        # (JSON-serializable); the forwarded middleware needs
+        # IPv4Network/IPv6Network objects.
+        trusted_proxies=[
+            ip_network(proxy) for proxy in conf.get(CONF_TRUSTED_PROXIES) or []
+        ],
+        ssl_profile=conf[CONF_SSL_PROFILE],
+        supervisor_unix_socket_path=supervisor_unix_socket_path,
+    )
+
+
+async def async_verify_can_bind(hass: HomeAssistant, conf: ConfData) -> None:
+    """Verify a server for ``conf`` can be created and its address bound.
+
+    Used to validate a new user-supplied config before it is stored and
+    applied via a restart; the sockets are released right away. Best effort:
+    the address can still be taken by another process before the restart, so
+    the setup fallback chain remains the safety net.
+
+    Raises ``HomeAssistantError`` if the SSL configuration is unusable or the
+    configured address cannot be bound.
+    """
+    server = _make_server(hass, conf)
+    try:
+        await server.async_bind()
+    except OSError as err:
+        raise HomeAssistantError(
+            f"Failed to create HTTP server at port {conf[CONF_SERVER_PORT]}: {err}"
+        ) from err
+    finally:
+        await server.stop()
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the HTTP API and debug interface."""
     # Late import to ensure isal is updated before
@@ -262,25 +308,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
                 socket_env,
             )
 
-    def _make_server(conf: ConfData) -> HomeAssistantHTTP:
-        return HomeAssistantHTTP(
-            hass,
-            server_host=conf.get(CONF_SERVER_HOST, _DEFAULT_BIND),
-            server_port=conf[CONF_SERVER_PORT],
-            ssl_certificate=conf.get(CONF_SSL_CERTIFICATE),
-            ssl_peer_certificate=conf.get(CONF_SSL_PEER_CERTIFICATE),
-            ssl_key=conf.get(CONF_SSL_KEY),
-            # The loaded config stores trusted proxies as strings
-            # (JSON-serializable); the forwarded middleware needs
-            # IPv4Network/IPv6Network objects.
-            trusted_proxies=[
-                ip_network(proxy) for proxy in conf.get(CONF_TRUSTED_PROXIES) or []
-            ],
-            ssl_profile=conf[CONF_SSL_PROFILE],
-            supervisor_unix_socket_path=supervisor_unix_socket_path,
-        )
-
-    server = _make_server(conf)
+    server = _make_server(hass, conf, supervisor_unix_socket_path)
     trial_reverted = False
     while True:
         try:
@@ -289,7 +317,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
             store = await async_get_and_load_store(hass)
             trial_reverted = store.revert_deadline is not None
             conf = await _async_fallback_config(hass, store, conf, err)
-            server = _make_server(conf)
+            server = _make_server(hass, conf, supervisor_unix_socket_path)
             continue
         if trial_reverted:
             _LOGGER.warning(

--- a/homeassistant/components/http/websocket_api.py
+++ b/homeassistant/components/http/websocket_api.py
@@ -1,6 +1,6 @@
 """WebSocket API for the HTTP integration user config."""
 
-from typing import Any
+from typing import Any, Final
 
 import voluptuous as vol
 
@@ -12,8 +12,11 @@ from homeassistant.components.homeassistant import (
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
-from .config import HTTP_STORAGE_SCHEMA, async_get_and_load_store
-from .const import ATTR_CONFIG
+from . import async_verify_can_bind
+from .config import HTTP_STORAGE_SCHEMA, ConfData, async_get_and_load_store
+from .const import ATTR_CONFIG, CONF_SERVER_PORT
+
+ERR_BIND_FAILED: Final = "bind_failed"
 
 
 @callback
@@ -65,13 +68,28 @@ async def websocket_set_config(
 ) -> None:
     """Store a new pending HTTP configuration and restart to apply it.
 
+    A new config is first verified to be applicable by binding its
+    configured address, so an unusable config is rejected here instead of
+    being discovered after the restart. The check is skipped when the port
+    matches the currently bound one: the running server holds that port
+    until the restart releases it, so a probe would always fail against
+    ourselves.
+
     Restart whenever the pending slot changes, so the runtime config is
     refreshed. The result reports whether a restart was triggered via
     ``{"restart": bool}``.
     """
+    config: ConfData | None = msg[ATTR_CONFIG]
+    if config is not None and config[CONF_SERVER_PORT] != hass.http.server_port:
+        try:
+            await async_verify_can_bind(hass, config)
+        except HomeAssistantError as err:
+            connection.send_error(msg["id"], ERR_BIND_FAILED, str(err))
+            return
+
     store = await async_get_and_load_store(hass)
     previous_pending = store.pending
-    await store.async_set_pending(msg[ATTR_CONFIG])
+    await store.async_set_pending(config)
     restart = store.pending != previous_pending
     connection.send_result(msg["id"], {"restart": restart})
 

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1438,6 +1438,152 @@ async def test_websocket_http_config(
     assert len(restart_calls) == 3
 
 
+async def test_websocket_configure_verifies_new_port(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_create_server: Mock,
+) -> None:
+    """Configuring a new port probes that it can be bound before restarting."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await async_setup_component(hass, "websocket_api", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id(
+        {"type": "http/config/configure", "config": {"server_port": 9123}}
+    )
+    response = await ws_client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"restart": True}
+
+    # One bind for setup, one for the probe of the new config.
+    assert mock_create_server.call_count == 2
+    assert mock_create_server.call_args_list[1].args[0].server_port == 9123
+
+    await hass.async_block_till_done()
+    assert len(restart_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "bind_error",
+    [
+        OSError(errno.EADDRINUSE, "Address already in use"),
+        PermissionError(errno.EACCES, "Permission denied"),
+        socket.gaierror(socket.EAI_NONAME, "Name or service not known"),
+    ],
+    ids=["address-in-use", "permission-denied", "unresolvable-host"],
+)
+async def test_websocket_configure_rejects_unbindable_config(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+    mock_create_server: Mock,
+    bind_error: OSError,
+) -> None:
+    """A new config whose address cannot be bound is rejected without a restart."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await async_setup_component(hass, "websocket_api", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+    mock_create_server.side_effect = bind_error
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id(
+        {"type": "http/config/configure", "config": {"server_port": 9123}}
+    )
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "bind_failed"
+    assert response["error"]["message"] == (
+        f"Failed to create HTTP server at port 9123: {bind_error}"
+    )
+
+    # The rejected config is not stored and no restart is triggered.
+    assert hass_storage[DOMAIN]["data"]["pending"] is None
+    assert len(restart_calls) == 0
+
+
+async def test_websocket_configure_rejects_unusable_ssl(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+    tmp_path: Path,
+) -> None:
+    """A new config whose SSL certificate cannot be loaded is rejected."""
+    cert_path, key_path = _setup_broken_ssl_pem_files(tmp_path)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await async_setup_component(hass, "websocket_api", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id(
+        {
+            "type": "http/config/configure",
+            "config": {
+                "server_port": 9123,
+                "ssl_certificate": str(cert_path),
+                "ssl_key": str(key_path),
+            },
+        }
+    )
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "bind_failed"
+    assert "Could not use SSL certificate" in response["error"]["message"]
+
+    assert hass_storage[DOMAIN]["data"]["pending"] is None
+    assert len(restart_calls) == 0
+
+
+async def test_websocket_configure_same_port_skips_bind_check(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+    mock_create_server: Mock,
+) -> None:
+    """No bind probe runs when the new config keeps the currently bound port.
+
+    The running server holds the port until the restart releases it, so a
+    probe would always fail against ourselves.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await async_setup_component(hass, "websocket_api", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+    # Any probe would fail; success proves the check was skipped.
+    mock_create_server.side_effect = OSError(errno.EADDRINUSE, "Address already in use")
+
+    current_port = default_server_port()
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json_auto_id(
+        {
+            "type": "http/config/configure",
+            "config": {
+                "server_port": current_port,
+                "cors_allowed_origins": ["https://example.com"],
+            },
+        }
+    )
+    response = await ws_client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"restart": True}
+    assert hass_storage[DOMAIN]["data"]["pending"]["server_port"] == current_port
+
+    await hass.async_block_till_done()
+    assert len(restart_calls) == 1
+
+
 async def test_pending_config_auto_reverts_to_stable(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add port validation to ws http config command

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
