### PR TITLE
Minor improvement of async_remove_helper_devices

### DIFF
--- a/homeassistant/helpers/helper_integration.py
+++ b/homeassistant/helpers/helper_integration.py
@@ -225,20 +225,27 @@ def _composite_source_split_id(
     """Return the source split of a composite device.
 
     This is the split owned by the composite's recorded primary config entry - the rule
-    _restore_composite_device uses - rather than an arbitrary non-helper split. None when
-    source_device_id is not a composite id or no such split exists.
+    _restore_composite_device uses. Devices migrated from before 2024.7 have no recorded
+    primary (primary_config_entry, and thus composite_primary_config_entry, is None), so
+    fall back to a surviving non-helper split, mirroring _restore_composite_device's
+    fallback to the first split. None when source_device_id is not a composite id or the
+    helper owns every split.
     """
-    if not split_devices:
+    non_helper_splits = [
+        device
+        for device in split_devices
+        if device.config_entry_id != helper_config_entry_id
+    ]
+    if not non_helper_splits:
         return None
     primary_config_entry_id = split_devices[0].composite_primary_config_entry
     return next(
         (
             device.id
-            for device in split_devices
+            for device in non_helper_splits
             if device.config_entry_id == primary_config_entry_id
-            and device.config_entry_id != helper_config_entry_id
         ),
-        None,
+        non_helper_splits[0].id,
     )
 
 

--- a/tests/helpers/test_helper_integration.py
+++ b/tests/helpers/test_helper_integration.py
@@ -526,6 +526,16 @@ async def test_async_handle_source_entity_new_entity_id(
     "source_via_composite_id",
     [pytest.param(True, id="composite_id"), pytest.param(False, id="source_split")],
 )
+@pytest.mark.parametrize(
+    "record_composite_primary",
+    [
+        pytest.param(True, id="recorded_primary"),
+        # Devices migrated from before 2024.7 have no primary_config_entry, so their splits
+        # carry composite_primary_config_entry=None; the source split is then found by
+        # falling back to the surviving non-helper split.
+        pytest.param(False, id="no_recorded_primary"),
+    ],
+)
 async def test_async_remove_helper_devices(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -533,6 +543,7 @@ async def test_async_remove_helper_devices(
     helper_identifiers: set[tuple[str, str]],
     helper_has_composite_identifiers: bool,
     source_via_composite_id: bool,
+    record_composite_primary: bool,
 ) -> None:
     """Test migrating a helper off a device it co-owned before the migration split.
 
@@ -548,6 +559,9 @@ async def test_async_remove_helper_devices(
     helper_config_entry = MockConfigEntry(domain=HELPER_DOMAIN)
     helper_config_entry.add_to_hass(hass)
     composite_id = "pre_split_composite_id"
+    composite_primary = (
+        source_config_entry.entry_id if record_composite_primary else None
+    )
 
     source_split = device_registry.async_get_or_create(
         config_entry_id=source_config_entry.entry_id,
@@ -561,12 +575,12 @@ async def test_async_remove_helper_devices(
     device_registry.devices[source_split.id] = attr.evolve(
         source_split,
         composite_device_id=composite_id,
-        composite_primary_config_entry=source_config_entry.entry_id,
+        composite_primary_config_entry=composite_primary,
     )
     device_registry.devices[helper_split.id] = attr.evolve(
         helper_split,
         composite_device_id=composite_id,
-        composite_primary_config_entry=source_config_entry.entry_id,
+        composite_primary_config_entry=composite_primary,
         has_composite_identifiers=helper_has_composite_identifiers,
     )
     # A helper entity on the helper's split, plus one not linked to any device


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Minor improvement of `async_remove_helper_devices` for devices which don't have a primary config entry.

Fixes this comment: https://github.com/home-assistant/core/pull/176714#discussion_r3610420604

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
