### PR TITLE
Deprecate helpers async_remove_stale_devices_links_*

### DIFF
--- a/homeassistant/helpers/device.py
+++ b/homeassistant/helpers/device.py
@@ -84,16 +84,20 @@ def async_remove_stale_devices_links_keep_entity_device(
 ) -> None:
     """Remove entry_id from all devices except that of source_entity_id_or_uuid.
 
-    Also moves all entities linked to the entry_id to the device of
-    source_entity_id_or_uuid.
+    Deprecated, does nothing: a device belongs to a single config entry, so a helper no
+    longer adds its config entry to the source device and there is no stale config entry
+    link to remove. Call helper_integration.async_remove_helper_devices with
+    sweep_helper_devices=True to remove devices a helper created for previously selected
+    source devices.
     """
-
-    async_remove_stale_devices_links_keep_current_device(
-        hass=hass,
-        entry_id=entry_id,
-        current_device_id=async_entity_id_to_device_id(hass, source_entity_id_or_uuid)
-        if source_entity_id_or_uuid
-        else None,
+    report_usage(
+        "calls async_remove_stale_devices_links_keep_entity_device, which is deprecated "
+        "and does nothing: a device belongs to a single config entry, so a helper no "
+        "longer adds its config entry to the source device. Call "
+        "homeassistant.helpers.helper_integration.async_remove_helper_devices with "
+        "sweep_helper_devices=True instead",
+        core_behavior=ReportBehavior.LOG,
+        breaks_in_ha_version="2027.8.0",
     )
 
 
@@ -103,20 +107,20 @@ def async_remove_stale_devices_links_keep_current_device(
     entry_id: str,
     current_device_id: str | None,
 ) -> None:
-    """Remove entry_id from all devices except current_device_id."""
+    """Remove entry_id from all devices except current_device_id.
 
-    dev_reg = dr.async_get(hass)
-    ent_reg = er.async_get(hass)
-
-    # Make sure all entities are linked to the correct device
-    for entity in ent_reg.entities.get_entries_for_config_entry_id(entry_id):
-        if entity.device_id == current_device_id:
-            continue
-        ent_reg.async_update_entity(entity.entity_id, device_id=current_device_id)
-
-    # Removes all devices from the config entry that are not the same
-    # as the current device
-    for device in dev_reg.devices.get_devices_for_config_entry_id(entry_id):
-        if device.id == current_device_id:
-            continue
-        dev_reg.async_update_device(device.id, remove_config_entry_id=entry_id)
+    Deprecated, does nothing: a device belongs to a single config entry, so a helper no
+    longer adds its config entry to another device and there is no stale config entry link
+    to remove. Call helper_integration.async_remove_helper_devices with
+    sweep_helper_devices=True to remove devices a helper created for previously selected
+    source devices.
+    """
+    report_usage(
+        "calls async_remove_stale_devices_links_keep_current_device, which is deprecated "
+        "and does nothing: a device belongs to a single config entry, so a helper no "
+        "longer adds its config entry to another device. Call "
+        "homeassistant.helpers.helper_integration.async_remove_helper_devices with "
+        "sweep_helper_devices=True instead",
+        core_behavior=ReportBehavior.LOG,
+        breaks_in_ha_version="2027.8.0",
+    )

--- a/tests/helpers/test_device.py
+++ b/tests/helpers/test_device.py
@@ -168,8 +168,8 @@ async def test_remove_stale_devices_links_deprecated_noop(
     A device belongs to a single config entry, so a helper no longer adds its config
     entry to another device and there is no stale config entry link to remove. The
     helpers leave the devices and entities untouched and only report the deprecated
-    usage; helpers set entity.device_entry and migrate with async_remove_helper_device
-    instead.
+    usage; helpers set entity.device_entry and clean up devices with
+    async_remove_helper_devices instead.
     """
     helper_config_entry = MockConfigEntry(domain="helper_integration")
     helper_config_entry.add_to_hass(hass)

--- a/tests/helpers/test_device.py
+++ b/tests/helpers/test_device.py
@@ -158,36 +158,33 @@ async def test_device_info_to_link(
     assert async_device_info_to_link_from_device_id(hass, device_id=None) is None
 
 
-async def test_remove_stale_device_links_keep_entity_device(
+async def test_remove_stale_devices_links_deprecated_noop(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test cleaning works for entity."""
+    """The stale-device-link helpers are deprecated and do nothing.
+
+    A device belongs to a single config entry, so a helper no longer adds its config
+    entry to another device and there is no stale config entry link to remove. The
+    helpers leave the devices and entities untouched and only report the deprecated
+    usage; helpers set entity.device_entry and migrate with async_remove_helper_device
+    instead.
+    """
     helper_config_entry = MockConfigEntry(domain="helper_integration")
     helper_config_entry.add_to_hass(hass)
     host_config_entry = MockConfigEntry(domain="host_integration")
     host_config_entry.add_to_hass(hass)
 
+    # A device owned by another config entry, plus one owned by the helper config entry
     current_device = device_registry.async_get_or_create(
         identifiers={("test", "current_device")},
-        connections={("mac", "30:31:32:33:34:00")},
+        config_entry_id=host_config_entry.entry_id,
+    )
+    stale_device = device_registry.async_get_or_create(
+        identifiers={("test", "stale_device")},
         config_entry_id=helper_config_entry.entry_id,
     )
-
-    stale_device_1 = device_registry.async_get_or_create(
-        identifiers={("test", "stale_device_1")},
-        connections={("mac", "30:31:32:33:34:01")},
-        config_entry_id=helper_config_entry.entry_id,
-    )
-
-    device_registry.async_get_or_create(
-        identifiers={("test", "stale_device_2")},
-        connections={("mac", "30:31:32:33:34:02")},
-        config_entry_id=helper_config_entry.entry_id,
-    )
-
-    # Source entity
     source_entity = entity_registry.async_get_or_create(
         "sensor",
         "host_integration",
@@ -195,92 +192,31 @@ async def test_remove_stale_device_links_keep_entity_device(
         config_entry=host_config_entry,
         device_id=current_device.id,
     )
-    assert entity_registry.async_get(source_entity.entity_id) is not None
-
-    # Helper entity connected to a stale device
+    # Helper entity left on a device owned by the helper config entry
     helper_entity = entity_registry.async_get_or_create(
         "sensor",
         "helper_integration",
         "helper",
         config_entry=helper_config_entry,
-        device_id=stale_device_1.id,
-    )
-    assert entity_registry.async_get(helper_entity.entity_id) is not None
-
-    devices_helper_entry = device_registry.devices.get_devices_for_config_entry_id(
-        helper_config_entry.entry_id
+        device_id=stale_device.id,
     )
 
-    # 3 devices linked to the config entry are expected (1 current device + 2 stales)
-    assert len(devices_helper_entry) == 3
-
-    # Manual cleanup should unlink stale devices from the config entry
-    async_remove_stale_devices_links_keep_entity_device(
-        hass,
-        entry_id=helper_config_entry.entry_id,
-        source_entity_id_or_uuid=source_entity.entity_id,
-    )
-
+    with patch("homeassistant.helpers.device.report_usage") as report_usage:
+        async_remove_stale_devices_links_keep_current_device(
+            hass,
+            entry_id=helper_config_entry.entry_id,
+            current_device_id=current_device.id,
+        )
+        async_remove_stale_devices_links_keep_entity_device(
+            hass,
+            entry_id=helper_config_entry.entry_id,
+            source_entity_id_or_uuid=source_entity.entity_id,
+        )
     await hass.async_block_till_done()
 
-    devices_helper_entry = device_registry.devices.get_devices_for_config_entry_id(
-        helper_config_entry.entry_id
-    )
-
-    # After cleanup, only one device is expected to be linked to the config entry, and
-    # the entities should exist and be linked to the current device
-    assert len(devices_helper_entry) == 1
-    assert current_device in devices_helper_entry
-    assert entity_registry.async_get(source_entity.entity_id) is not None
-    assert entity_registry.async_get(helper_entity.entity_id) is not None
-
-
-async def test_remove_stale_devices_links_keep_current_device(
-    hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test cleanup works for device id."""
-    config_entry = MockConfigEntry(domain="hue")
-    config_entry.add_to_hass(hass)
-
-    current_device = device_registry.async_get_or_create(
-        identifiers={("test", "current_device")},
-        connections={("mac", "30:31:32:33:34:00")},
-        config_entry_id=config_entry.entry_id,
-    )
-    assert current_device is not None
-
-    device_registry.async_get_or_create(
-        identifiers={("test", "stale_device_1")},
-        connections={("mac", "30:31:32:33:34:01")},
-        config_entry_id=config_entry.entry_id,
-    )
-
-    device_registry.async_get_or_create(
-        identifiers={("test", "stale_device_2")},
-        connections={("mac", "30:31:32:33:34:02")},
-        config_entry_id=config_entry.entry_id,
-    )
-
-    devices_config_entry = device_registry.devices.get_devices_for_config_entry_id(
-        config_entry.entry_id
-    )
-
-    # 3 devices linked to the config entry are expected (1 current device + 2 stales)
-    assert len(devices_config_entry) == 3
-
-    # Manual cleanup should unlink stales devices from the config entry
-    async_remove_stale_devices_links_keep_current_device(
-        hass,
-        entry_id=config_entry.entry_id,
-        current_device_id=current_device.id,
-    )
-
-    devices_config_entry = device_registry.devices.get_devices_for_config_entry_id(
-        config_entry.entry_id
-    )
-
-    # After cleanup, only one device is expected to be linked to the config entry
-    assert len(devices_config_entry) == 1
-
-    assert current_device in devices_config_entry
+    # Both helpers reported the deprecated usage and changed nothing
+    assert report_usage.call_count == 2
+    assert device_registry.async_get(current_device.id) is not None
+    assert device_registry.async_get(stale_device.id) is not None
+    helper_entity_entry = entity_registry.async_get(helper_entity.entity_id)
+    assert helper_entity_entry.device_id == stale_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate helpers `async_remove_stale_devices_links_keep_entity_device` and `async_remove_stale_devices_links_keep_current_device`

These helpers are no longer meaningful with the device registry redesign with single config entry per device, and have been changed to do nothing except logging a deprecation message.

Helpers should call the function `async_remove_helper_devices` to clean up unwanted devices

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
