### PR TITLE
Fix Nest WebRTC camera snapshot served as a PNG mislabeled image/jpeg

### DIFF
--- a/homeassistant/components/nest/camera.py
+++ b/homeassistant/components/nest/camera.py
@@ -256,8 +256,9 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         super().__init__(device)
         self._webrtc_sessions: dict[str, WebRtcStream] = {}
         self._refresh_unsub: dict[str, Callable[[], None]] = {}
-        # The placeholder returned by async_camera_image is a PNG, not the
-        # camera platform's default image/jpeg.
+        # The bundled placeholder is a PNG; the camera platform would otherwise
+        # serve it as its default image/jpeg, corrupting the frame for any
+        # client that trusts the Content-Type header.
         self.content_type = "image/png"
 
     async def _async_refresh_stream(self, session_id: str) -> datetime.datetime | None:

--- a/homeassistant/components/nest/camera.py
+++ b/homeassistant/components/nest/camera.py
@@ -256,6 +256,9 @@ class NestWebRTCEntity(NestCameraBaseEntity):
         super().__init__(device)
         self._webrtc_sessions: dict[str, WebRtcStream] = {}
         self._refresh_unsub: dict[str, Callable[[], None]] = {}
+        # The placeholder returned by async_camera_image is a PNG, not the
+        # camera platform's default image/jpeg.
+        self.content_type = "image/png"
 
     async def _async_refresh_stream(self, session_id: str) -> datetime.datetime | None:
         """Refresh stream to extend expiration time."""

--- a/tests/components/nest/test_camera.py
+++ b/tests/components/nest/test_camera.py
@@ -167,13 +167,16 @@ async def mock_create_stream(hass: HomeAssistant) -> Generator[AsyncMock]:
 
 
 async def async_get_image(
-    hass: HomeAssistant, width: int | None = None, height: int | None = None
+    hass: HomeAssistant,
+    width: int | None = None,
+    height: int | None = None,
+    expected_content_type: str = "image/jpeg",
 ) -> bytes:
     """Get the camera image."""
     image = await camera.async_get_image(
         hass, "camera.my_camera", width=width, height=height
     )
-    assert image.content_type == "image/jpeg"
+    assert image.content_type == expected_content_type
     return image.content
 
 
@@ -693,9 +696,12 @@ async def test_camera_web_rtc(
         "answer": "v=0\r\ns=-\r\n",
     }
 
-    # Nest WebRTC cameras return a placeholder
-    await async_get_image(hass)
-    await async_get_image(hass, width=1024, height=768)
+    # The WebRTC placeholder is a PNG, served as image/png not the default jpeg.
+    png_bytes = await async_get_image(hass, expected_content_type="image/png")
+    assert png_bytes.startswith(b"\x89PNG")
+    await async_get_image(
+        hass, width=1024, height=768, expected_content_type="image/png"
+    )
 
 
 @pytest.mark.usefixtures("auth", "camera_device")


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

WebRTC-only Nest cameras (cameras migrated to the Google Home app, which advertise `supportedProtocols: ["WEB_RTC"]` and no RTSP) cannot produce a still image — the SDM on-demand snapshot API no longer exists for them. For these cameras `NestWebRTCEntity.async_camera_image()` returns the bundled `placeholder.png`.

The problem: the camera platform serves that image with the entity's `content_type`, which defaults to `image/jpeg` (`DEFAULT_CONTENT_TYPE`). `placeholder.png` is a PNG. So `camera.snapshot` and `/api/camera_proxy/<entity>` return **PNG bytes labeled `Content-Type: image/jpeg`**, HTTP 200. Anything that trusts the header (image libraries, snapshots saved with a `.jpg` name, notification pipelines, re-encoders) gets a corrupt "JPEG".

This changes `NestWebRTCEntity` to advertise `content_type = "image/png"`, so the placeholder is served honestly as what it is. `NestRTSPEntity` (which generates real JPEG stills from its RTSP stream) is unchanged. This is a minimal correctness fix and does **not** change the intentional placeholder-on-tile behavior for WebRTC cameras. It does not attempt to produce real still frames for WebRTC-only cameras (the broader request in #176807) — only to stop mislabeling the placeholder that is served today.

Two alternatives were weighed and rejected: (1) returning `None`/raising makes `/api/camera_proxy` 500 and breaks the dashboard tile — the placeholder-on-tile is deliberate; (2) shipping a valid `placeholder.jpg` churns a binary asset and still hands automations a fake frame with no content-type signal. The PNG-as-PNG fix is smaller and equally honest.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: 
- This PR is related to issue: #176807
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

