### PR TITLE
Don't raise when attempting to link an entity to a composite device

### DIFF
--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1423,6 +1423,7 @@ class EntityRegistry(BaseRegistry):
             )
 
         self.hass.verify_event_loop_thread("entity_registry.async_get_or_create")
+        device_id = self._ignore_composite_device_id(platform, device_id)
         _validate_item(
             self.hass,
             domain,
@@ -1746,6 +1747,40 @@ class EntityRegistry(BaseRegistry):
             )
 
     @callback
+    def _ignore_composite_device_id(
+        self, platform: str, device_id: str | None | UndefinedType
+    ) -> str | None | UndefinedType:
+        """Ignore a request to link an entity to a composite device id.
+
+        A pre-migration composite device was split into one device per config
+        entry, and the composite id no longer refers to a real device. Return
+        UNDEFINED to keep the entity's current device link, and ask the user to
+        report an issue.
+        """
+        if not device_id or device_id is UNDEFINED:
+            return device_id
+        device_registry = dr.async_get(self.hass)
+        if device_id in device_registry.devices:
+            return device_id
+        if not device_registry.async_get_devices_for_composite_device_id(device_id):
+            # Not a composite id, let _validate_item reject it
+            return device_id
+        report_issue = async_suggest_report_issue(
+            self.hass, integration_domain=platform
+        )
+        _LOGGER.warning(
+            (
+                "Ignoring request to link entity from integration %s to device %s:"
+                " the device id refers to a composite device which was split into"
+                " one device per config entry, please %s"
+            ),
+            platform,
+            device_id,
+            report_issue,
+        )
+        return UNDEFINED
+
+    @callback
     def _async_update_entity(
         self,
         entity_id: str,
@@ -1781,6 +1816,8 @@ class EntityRegistry(BaseRegistry):
     ) -> RegistryEntry:
         """Private facing update properties method."""
         old = self.entities[entity_id]
+
+        device_id = self._ignore_composite_device_id(old.platform, device_id)
 
         new_values: dict[str, Any] = {}  # Dict with new key/value pairs
         old_values: dict[str, Any] = {}  # Dict with old key/value pairs

--- a/tests/helpers/test_entity_registry.py
+++ b/tests/helpers/test_entity_registry.py
@@ -3705,15 +3705,17 @@ async def test_device_does_not_exist(entity_registry: er.EntityRegistry) -> None
         entity_registry.async_update_entity(entity_id, device_id="blah")
 
 
-async def test_composite_device_id_not_allowed(
+async def test_composite_device_id_ignored(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test an entity cannot be linked to a pre-migration composite device id.
+    """Test a request to link an entity to a composite device id is ignored.
 
     async_get resolves a composite id to a synthesized read-only device, but it is not a
-    real device, so linking an entity to it must be rejected.
+    real device, so the request is ignored: the entity keeps its current device link and
+    a warning asks the user to report an issue.
     """
     entry_1 = MockConfigEntry(domain="itg1")
     entry_1.add_to_hass(hass)
@@ -3737,13 +3739,32 @@ async def test_composite_device_id_not_allowed(
     assert device_registry.async_get(old_id) is not None
     assert old_id not in device_registry.devices
 
-    match = f"Device {old_id} does not exist"
-    with pytest.raises(ValueError, match=match):
-        entity_registry.async_get_or_create("light", "hue", "1234", device_id=old_id)
+    warning = f"Ignoring request to link entity from integration hue to device {old_id}"
 
-    entity_id = entity_registry.async_get_or_create("light", "hue", "1234").entity_id
-    with pytest.raises(ValueError, match=match):
-        entity_registry.async_update_entity(entity_id, device_id=old_id)
+    # A new entity is created without a device link
+    entry = entity_registry.async_get_or_create(
+        "light", "hue", "1234", device_id=old_id
+    )
+    assert entry.device_id is None
+    assert warning in caplog.text
+
+    caplog.clear()
+    entry = entity_registry.async_update_entity(entry.entity_id, device_id=device_1.id)
+    assert entry.device_id == device_1.id
+    assert warning not in caplog.text
+
+    # An existing entity keeps its current device link on update
+    entry = entity_registry.async_update_entity(entry.entity_id, device_id=old_id)
+    assert entry.device_id == device_1.id
+    assert warning in caplog.text
+
+    caplog.clear()
+    # An existing entity keeps its current device link on re-registration
+    entry = entity_registry.async_get_or_create(
+        "light", "hue", "1234", device_id=old_id
+    )
+    assert entry.device_id == device_1.id
+    assert warning in caplog.text
 
 
 async def test_disabled_by_str_not_allowed(entity_registry: er.EntityRegistry) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Don't raise when attempting to link an entity to a composite device, instead log a warning asking users to file a bug report

Known violators of this pattern:
- template (core)
- powercalc (custom)
- battery_notes (custom)

This is a follow-up to https://github.com/home-assistant/core/pull/175785

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
