### PR TITLE
Bump pypaperless to 5.2.3

### DIFF
--- a/homeassistant/components/paperless_ngx/__init__.py
+++ b/homeassistant/components/paperless_ngx/__init__.py
@@ -67,7 +67,7 @@ async def _get_paperless_api(
 ) -> Paperless:
     """Create and initialize paperless-ngx API."""
 
-    api = Paperless(
+    api = Paperless(  # type: ignore[abstract]
         entry.data[CONF_URL],
         entry.data[CONF_API_KEY],
         session=async_get_clientsession(hass, entry.data.get(CONF_VERIFY_SSL, True)),

--- a/homeassistant/components/paperless_ngx/config_flow.py
+++ b/homeassistant/components/paperless_ngx/config_flow.py
@@ -129,7 +129,7 @@ class PaperlessConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _validate_input(self, user_input: dict[str, Any]) -> dict[str, str]:
         errors: dict[str, str] = {}
 
-        client = Paperless(
+        client = Paperless(  # type: ignore[abstract]
             user_input[CONF_URL],
             user_input[CONF_API_KEY],
             session=async_get_clientsession(

--- a/homeassistant/components/paperless_ngx/manifest.json
+++ b/homeassistant/components/paperless_ngx/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_polling",
   "loggers": ["pypaperless"],
   "quality_scale": "platinum",
-  "requirements": ["pypaperless==4.1.1"]
+  "requirements": ["pypaperless==5.2.3"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2464,7 +2464,7 @@ pyoverkiz[nexity]==2.1.0
 pypalazzetti==0.1.20
 
 # homeassistant.components.paperless_ngx
-pypaperless==4.1.1
+pypaperless==5.2.3
 
 # homeassistant.components.elv
 pypca==0.0.7


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The minimum supported Paperless-ngx version is raised from 2.15 to 2.19.
Users on Paperless-ngx 2.15–2.18 must upgrade their instance before updating
Home Assistant, as pypaperless 5.2.3 no longer supports those versions.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps the pypaperless library from 4.1.1 to 5.2.3 to fix compatibility with Paperless-ngx 3.0.0.

pypaperless 4.1.1 advertises API version 7 in its `Accept` header. Paperless 3.0.0 requires the newer API version 9, causing connection failures. pypaperless 5.2.3 raises the API version to 9, restoring compatibility.

The API surface used by the Home Assistant integration (`initialize()`, `statistics()`, `status()`, `remote_version()`, `host_version`, `base_url`) remains unchanged — all existing tests (41) pass without modification.

### Changes in pypaperless 4.1.1 → 5.2.3

- API version bumped from 7 to 9
- Minimum Paperless-ngx version raised from 2.15 to 2.19
- Removed legacy DRF index fallback (`/api/`) during initialization; only `/api/schema/` is used
- Token parameter made optional (still passed by the integration)
- Added `WARNING` to `StatusType` enum
- `Paperless` now inherits from `PaperlessProtocol` (a `typing.Protocol`) — attributes are set dynamically in `initialize()`, requiring `# type: ignore[abstract]` at the two instantiation sites
- Various model enhancements (new endpoints, type improvements)


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you will most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174258
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46953
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you are unsure about any of them, do not hesitate to ask.
  We are here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

  - Upstream release: https://github.com/tb1337/paperless-api/releases/tag/v5.2.3
  - Upstream diff: https://github.com/tb1337/paperless-api/compare/v4.1.1...v5.2.3
  - Compatibility matrix: https://github.com/tb1337/paperless-api?tab=readme-ov-file#compatibility

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that has not yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
