### PR TITLE
Add cost statistics to Anglian Water

### DIFF
--- a/homeassistant/components/anglian_water/coordinator.py
+++ b/homeassistant/components/anglian_water/coordinator.py
@@ -10,6 +10,7 @@ from pyanglianwater.exceptions import (
     ExpiredAccessTokenError,
     UnknownEndpointError,
 )
+from pyanglianwater.meter import SmartMeter
 
 from homeassistant.components.recorder import get_instance
 from homeassistant.components.recorder.models import (
@@ -194,3 +195,65 @@ class AnglianWaterUpdateCoordinator(DataUpdateCoordinator[None]):
                 "Adding %s statistics for %s", len(usage_statistics), usage_statistic_id
             )
             async_add_external_statistics(self.hass, usage_metadata, usage_statistics)
+            await self._insert_cost_statistics(meter, id_prefix, name_prefix)
+
+    async def _insert_cost_statistics(
+        self, meter: SmartMeter, id_prefix: str, name_prefix: str
+    ) -> None:
+        """Insert cost statistics for a water meter into Home Assistant.
+
+        Costs are provided by the library per reading (each day's total cost
+        distributed across that day's readings by consumption), so they can
+        be tracked against the usage statistic in the water dashboard.
+        """
+        hourly_costs = meter.get_hourly_costs()
+        if not hourly_costs:
+            _LOGGER.debug(
+                "No cost data available for meter %s, skipping cost statistics",
+                meter.serial_number,
+            )
+            return
+        cost_statistic_id = f"{DOMAIN}:{id_prefix}_cost".lower()
+        cost_metadata = StatisticMetaData(
+            mean_type=StatisticMeanType.NONE,
+            has_sum=True,
+            name=f"{name_prefix} Cost",
+            source=DOMAIN,
+            statistic_id=cost_statistic_id,
+            unit_class=None,
+            unit_of_measurement="GBP",
+        )
+        last_stat = await get_instance(self.hass).async_add_executor_job(
+            get_last_statistics, self.hass, 1, cost_statistic_id, True, {"sum"}
+        )
+        if last_stat:
+            last_records = last_stat[cost_statistic_id]
+            cost_sum = float(last_records[0].get("sum") or 0.0)
+            last_stats_time = last_records[0]["start"]
+        else:
+            cost_sum = 0.0
+            last_stats_time = None
+        cost_statistics = []
+        for entry in hourly_costs:
+            parsed_read_at = dt_util.parse_datetime(entry["read_at"])
+            if not parsed_read_at:
+                _LOGGER.debug(
+                    "Could not parse read_at time %s, skipping cost entry",
+                    entry["read_at"],
+                )
+                continue
+            # Align with usage statistics: attribute the reading to the hour
+            # it covers rather than the hour it was taken.
+            start = dt_util.as_local(parsed_read_at) - timedelta(hours=1)
+            if last_stats_time is not None and start.timestamp() <= last_stats_time:
+                continue
+            cost_sum += entry["cost"]
+            cost_statistics.append(
+                StatisticData(start=start, state=entry["cost"], sum=cost_sum)
+            )
+        if not cost_statistics:
+            return
+        _LOGGER.debug(
+            "Adding %s statistics for %s", len(cost_statistics), cost_statistic_id
+        )
+        async_add_external_statistics(self.hass, cost_metadata, cost_statistics)

--- a/tests/components/anglian_water/conftest.py
+++ b/tests/components/anglian_water/conftest.py
@@ -44,8 +44,9 @@ def mock_smart_meter(freezer: FrozenDateTimeFactory) -> SmartMeter:
         {"read_at": "2024-06-01T13:00:00", "consumption": 15, "read": 25},
         {"read_at": "2024-06-01T14:00:00", "consumption": 25, "read": 50},
     ]
-    meter.yesterday_water_cost = 0.5
-    meter.yesterday_sewerage_cost = 0.5
+    meter.daily_costs = {
+        "2024-06-01": {"total_cost": 1.0, "water_cost": 0.5, "sewerage_cost": 0.5}
+    }
     return meter
 
 

--- a/tests/components/anglian_water/test_coordinator.py
+++ b/tests/components/anglian_water/test_coordinator.py
@@ -227,6 +227,97 @@ async def test_coordinator_subsequent_run_missing_period_statistics(
     assert corrected_stats[statistic_id][0]["sum"] == 70
 
 
+async def test_coordinator_cost_statistics_first_run(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test cost statistics distribute the day's cost by consumption share."""
+    coordinator = AnglianWaterUpdateCoordinator(
+        hass, mock_anglian_water_client, mock_config_entry
+    )
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_cost"
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.utc_from_timestamp(0),
+        None,
+        {statistic_id},
+        "hour",
+        None,
+        {"state", "sum"},
+    )
+    rows = stats[statistic_id]
+    # £1.00 for the day, split across 10L/15L/25L readings
+    assert [round(row["state"], 2) for row in rows] == [0.2, 0.3, 0.5]
+    assert round(rows[-1]["sum"], 2) == 1.0
+
+
+async def test_coordinator_cost_statistics_subsequent_run(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smart_meter: SmartMeter,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test cost statistics only append hours newer than the last stored one."""
+    coordinator = AnglianWaterUpdateCoordinator(
+        hass, mock_anglian_water_client, mock_config_entry
+    )
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    # A new reading arrives for the same day.
+    mock_smart_meter.readings.append(
+        {"read_at": "2024-06-01T15:00:00", "consumption": 50, "read": 100}
+    )
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_cost"
+    stats = await hass.async_add_executor_job(
+        statistics_during_period,
+        hass,
+        dt_util.utc_from_timestamp(0),
+        None,
+        {statistic_id},
+        "hour",
+        None,
+        {"state", "sum"},
+    )
+    rows = stats[statistic_id]
+    assert len(rows) == 4
+    # The new hour is 50L of the day's (now) 100L -> £0.50, appended to the sum
+    assert round(rows[-1]["state"], 2) == 0.5
+    assert round(rows[-1]["sum"], 2) == 1.5
+
+
+async def test_coordinator_no_cost_data(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_smart_meter: SmartMeter,
+    mock_anglian_water_client: AsyncMock,
+) -> None:
+    """Test that no cost statistics are inserted when no cost data exists."""
+    mock_smart_meter.daily_costs = {}
+    coordinator = AnglianWaterUpdateCoordinator(
+        hass, mock_anglian_water_client, mock_config_entry
+    )
+    await coordinator._async_update_data()
+    await async_wait_recording_done(hass)
+
+    statistic_id = f"anglian_water:{ACCOUNT_NUMBER}_testsn_cost"
+    stats = await hass.async_add_executor_job(
+        get_last_statistics, hass, 1, statistic_id, True, {"sum"}
+    )
+    assert not stats
+
+
 async def test_coordinator_period_statistics_without_sum(
     recorder_mock: Recorder,
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

Insert a cost external statistic (`anglian_water:<account>_<serial>_cost`, GBP) alongside the existing usage statistic, so the water dashboard's cost column can be populated for this integration.

Because the integration's water source is an external statistic (Anglian Water publish readings ~3 days behind, so statistics are backdated), the energy dashboard cannot apply a static price or a price entity to it — the only supported path is an integration-provided statistic tracking total cost. This PR adds that, mirroring the existing usage-statistic insertion: same timestamps, cost per reading supplied by the library (each day's total cost distributed across that day's readings proportional to consumption; Anglian Water tariffs are volumetric).

**Depends on an unreleased pyanglianwater change** (pantherale0/pyanglianwater#74, which builds on #73 fixing a crash that currently breaks every update cycle): `SmartMeter.get_hourly_costs()` / `SmartMeter.daily_costs`. Draft until a release containing those lands and the requirement can be bumped — leaving the version pin untouched here for @pantherale0 to decide release/bump sequencing. The test fixture update in this PR (`daily_costs` instead of assigning `yesterday_water_cost`) also requires that release.

Tests run locally against the library PR branch: 18 passed, 12 snapshots passed (existing usage/sensor snapshots unchanged).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: N/A
- This PR is related to: pantherale0/pyanglianwater#74, pantherale0/pyanglianwater#73
- Link to documentation pull request: N/A (no user-facing config changes; the cost statistic appears in the water dashboard's cost tracker picker)

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr