### PR TITLE
Add test-before-configure pylint quality scale checker

### DIFF
--- a/homeassistant/components/edifier_infrared/quality_scale.yaml
+++ b/homeassistant/components/edifier_infrared/quality_scale.yaml
@@ -33,7 +33,11 @@ rules:
     status: exempt
     comment: |
       This integration does not store runtime data.
-  test-before-configure: done
+  test-before-configure:
+    status: exempt
+    comment: |
+      This integration only proxies commands through an existing infrared
+      entity, so there is no connection to test in the config flow.
   test-before-setup:
     status: exempt
     comment: |

--- a/homeassistant/components/marantz_infrared/quality_scale.yaml
+++ b/homeassistant/components/marantz_infrared/quality_scale.yaml
@@ -30,7 +30,11 @@ rules:
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done
-  test-before-configure: done
+  test-before-configure:
+    status: exempt
+    comment: |
+      This integration only proxies commands through an existing infrared
+      entity, so there is no connection to test in the config flow.
   test-before-setup:
     status: exempt
     comment: |

--- a/homeassistant/components/probe_plus/quality_scale.yaml
+++ b/homeassistant/components/probe_plus/quality_scale.yaml
@@ -30,7 +30,12 @@ rules:
   entity-unique-id: done
   has-entity-name: done
   runtime-data: done
-  test-before-configure: done
+  test-before-configure:
+    status: exempt
+    comment: |
+      The integration relies on Bluetooth auto-discovery; the config flow
+      only offers discovered devices, so there is no user-provided
+      connection to test.
   test-before-setup:
     status: exempt
     comment: |

--- a/homeassistant/components/samsung_infrared/quality_scale.yaml
+++ b/homeassistant/components/samsung_infrared/quality_scale.yaml
@@ -33,7 +33,11 @@ rules:
     status: exempt
     comment: |
       This integration does not store runtime data.
-  test-before-configure: done
+  test-before-configure:
+    status: exempt
+    comment: |
+      This integration only proxies commands through an existing infrared
+      entity, so there is no connection to test in the config flow.
   test-before-setup:
     status: exempt
     comment: |

--- a/pylint/plugins/README.md
+++ b/pylint/plugins/README.md
@@ -131,6 +131,7 @@ Every check has a code following the
 | `W7413` | [`home-assistant-missing-config-entry-unloading`](#w7413-home-assistant-missing-config-entry-unloading) | Integration should implement `async_unload_entry` |
 | `W7415` | [`home-assistant-sequential-executor-jobs`](#w7415-home-assistant-sequential-executor-jobs) | Sequential `async_add_executor_job` calls should be grouped |
 | `W7416` | [`home-assistant-missing-has-entity-name`](#w7416-home-assistant-missing-has-entity-name) | Entity class should set `_attr_has_entity_name = True` |
+| `W7433` | [`home-assistant-missing-test-before-configure`](#w7433-home-assistant-missing-test-before-configure) | Config flow should test the connection before creating an entry |
 | `W7429` | [`home-assistant-unnecessary-format-mac`](#w7429-home-assistant-unnecessary-format-mac) | `format_mac()` is unnecessary with `CONNECTION_NETWORK_MAC` |
 | `W7430` | [`home-assistant-serial-port-selector-usb-dependency`](#w7430-home-assistant-serial-port-selector-usb-dependency) | Config flow using `SerialPortSelector` must declare `usb` in `dependencies` |
 
@@ -829,6 +830,27 @@ Entity class should statically guarantee `_attr_has_entity_name = True`:
 either set at class level, set unconditionally at the top of a method, or
 supplied by an `entity_description` whose class sets `has_entity_name = True`.
 Conditional patterns are rejected.
+
+
+## `home_assistant_test_before_configure` checker
+
+Quality-scale-gated checker for the
+[`test-before-configure`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-configure)
+Bronze rule. Fires only when the integration claims the rule as `done`.
+
+### `W7433`: `home-assistant-missing-test-before-configure`
+
+The config flow creates entries but shows no evidence of surfacing
+connection failures to the user: no `errors=` keyword passed to a call
+(with a non-empty literal or dynamic value) and no abort inside an
+`except` handler. A failure can only be surfaced if it was detected
+first, so this single footprint covers the whole test-before-configure
+chain. Evidence is searched in `config_flow.py` and in the defining
+modules of inherited flow classes from other integrations. OAuth flows
+(`AbstractOAuth2FlowHandler`) are skipped; the token exchange is the
+connection test. Integrations that rely on auto-discovery without
+user-provided connection data should mark the rule `exempt`, per the
+rule's exceptions.
 
 
 ## `home_assistant_unnecessary_format_mac` checker

--- a/pylint/plugins/pylint_home_assistant/checkers/quality_scale/test_before_configure.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/quality_scale/test_before_configure.py
@@ -1,0 +1,182 @@
+"""Checker for the ``test-before-configure`` Bronze quality-scale rule.
+
+**Quality-scale-gated**: only fires for integrations whose
+``quality_scale.yaml`` marks ``test-before-configure`` as ``done``.
+
+The config flow must test the connection with the user-provided data and
+surface failures to the user before creating the entry. Testing cannot
+be proven statically, so the checker looks for the footprint that
+surfacing a failure always leaves behind, and fires when none is found:
+
+- an ``errors=`` keyword passed to a call (e.g. ``async_show_form``)
+  with a non-empty literal or any dynamic value, or
+- an ``async_abort`` call or ``AbortFlow`` raise inside an ``except``
+  handler (the catch-and-abort pattern of confirm-only flows).
+
+A failure can only be surfaced if it was detected first, so this single
+footprint covers the whole test-before-configure chain; flows that
+detect failures but never show them to the user fail the check.
+
+The footprint is searched in ``config_flow.py`` itself and in the
+defining modules of inherited flow classes from other integrations
+(e.g. the shared ``homeassistant_hardware`` firmware flow, which probes
+the device before an entry can be created). Framework modules outside
+``homeassistant.components`` are never treated as evidence.
+
+Config flow classes inheriting ``AbstractOAuth2FlowHandler`` are
+skipped: the OAuth token exchange is the connection test. Integrations
+that rely on auto-discovery without user-provided connection data should
+mark the rule ``exempt`` instead, per the rule's exceptions.
+
+https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-configure/
+"""
+
+from astroid import nodes
+from pylint.checkers import BaseChecker
+from pylint.lint import PyLinter
+
+from pylint_home_assistant.const import Module, QualityScaleRule
+from pylint_home_assistant.helpers.ast_utils import extended_ancestors
+from pylint_home_assistant.helpers.module_info import (
+    get_module_platform,
+    is_integration_module,
+)
+from pylint_home_assistant.helpers.quality_scale import quality_scale_rule_is_done
+
+_CONFIG_FLOW_QNAME = "homeassistant.config_entries.ConfigFlow"
+_OAUTH_FLOW_QNAME = (
+    "homeassistant.helpers.config_entry_oauth2_flow.AbstractOAuth2FlowHandler"
+)
+
+
+def _is_surfacing_errors_value(value: nodes.NodeNG) -> bool:
+    """Return True if the ``errors=`` value can show something to the user.
+
+    A non-empty dict literal or any dynamic expression counts; an empty
+    literal or ``None`` cannot surface anything.
+    """
+    match value:
+        case nodes.Dict(items=items):
+            return bool(items)
+        case nodes.Const():
+            return False
+        case _:
+            return True
+
+
+def _handler_aborts(handler: nodes.ExceptHandler) -> bool:
+    """Return True if the except handler aborts the flow."""
+    for node in handler.nodes_of_class((nodes.Call, nodes.Raise)):
+        match node:
+            case nodes.Call(func=nodes.Attribute(attrname="async_abort")):
+                return True
+            case nodes.Raise(
+                exc=nodes.Call(
+                    func=nodes.Name(name="AbortFlow")
+                    | nodes.Attribute(attrname="AbortFlow")
+                )
+            ):
+                return True
+    return False
+
+
+def _module_surfaces_failures(module: nodes.Module) -> bool:
+    """Return True if the module shows evidence of surfacing failures."""
+    for node in module.nodes_of_class((nodes.Call, nodes.ExceptHandler)):
+        match node:
+            case nodes.ExceptHandler():
+                if _handler_aborts(node):
+                    return True
+            case nodes.Call(keywords=keywords):
+                if any(
+                    keyword.arg == "errors"
+                    and _is_surfacing_errors_value(keyword.value)
+                    for keyword in keywords
+                ):
+                    return True
+    return False
+
+
+def _creates_entry(class_node: nodes.ClassDef) -> bool:
+    """Return True if the class calls ``async_create_entry``."""
+    return any(
+        isinstance(call.func, nodes.Attribute)
+        and call.func.attrname == "async_create_entry"
+        for call in class_node.nodes_of_class(nodes.Call)
+    )
+
+
+class TestBeforeConfigureChecker(BaseChecker):
+    """Checker for connection testing in config flow modules."""
+
+    name = "home_assistant_test_before_configure"
+    priority = -1
+    msgs = {
+        "W7433": (
+            (
+                "Config flow should test the connection with the user-provided "
+                "data and show failures to the user before creating an entry "
+                "(https://developers.home-assistant.io/docs/core/"
+                "integration-quality-scale/rules/test-before-configure)"
+            ),
+            "home-assistant-missing-test-before-configure",
+            (
+                "Used when an integration marks test-before-configure as done "
+                "but its config flow shows no evidence of surfacing connection "
+                "failures to the user: no errors passed to async_show_form and "
+                "no abort on a caught failure."
+            ),
+        ),
+    }
+    options = ()
+
+    _check_module: bool
+    _module_surfaces: bool
+
+    def __init__(self, linter: PyLinter) -> None:
+        """Initialize the checker and its ancestor module evidence cache."""
+        super().__init__(linter)
+        self._ancestor_surfaces: dict[str, bool] = {}
+
+    def _ancestor_module_surfaces(self, module: nodes.Module) -> bool:
+        """Check an inherited flow class's module for evidence, cached."""
+        if module.name not in self._ancestor_surfaces:
+            self._ancestor_surfaces[module.name] = _module_surfaces_failures(module)
+        return self._ancestor_surfaces[module.name]
+
+    def visit_module(self, node: nodes.Module) -> None:
+        """Cache per-module gating and evidence scan results."""
+        self._check_module = get_module_platform(
+            node.name
+        ) == Module.CONFIG_FLOW and quality_scale_rule_is_done(
+            node, QualityScaleRule.TEST_BEFORE_CONFIGURE
+        )
+        self._module_surfaces = self._check_module and _module_surfaces_failures(node)
+
+    def visit_classdef(self, node: nodes.ClassDef) -> None:
+        """Flag config flow classes that create entries without testing."""
+        if not self._check_module or self._module_surfaces:
+            return
+        if not _creates_entry(node):
+            return
+        ancestors = list(extended_ancestors(node))
+        ancestor_qnames = {a.qname() for a in ancestors}
+        if (
+            _CONFIG_FLOW_QNAME not in ancestor_qnames
+            or _OAUTH_FLOW_QNAME in ancestor_qnames
+        ):
+            return
+        for ancestor in ancestors:
+            ancestor_module = ancestor.root()
+            if (
+                ancestor_module.name != node.root().name
+                and is_integration_module(ancestor_module.name)
+                and self._ancestor_module_surfaces(ancestor_module)
+            ):
+                return
+        self.add_message("home-assistant-missing-test-before-configure", node=node)
+
+
+def register(linter: PyLinter) -> None:
+    """Register the checker."""
+    linter.register_checker(TestBeforeConfigureChecker(linter))

--- a/pylint/plugins/pylint_home_assistant/checkers/quality_scale/test_before_configure.py
+++ b/pylint/plugins/pylint_home_assistant/checkers/quality_scale/test_before_configure.py
@@ -157,21 +157,27 @@ class TestBeforeConfigureChecker(BaseChecker):
         """Flag config flow classes that create entries without testing."""
         if not self._check_module or self._module_surfaces:
             return
-        if not _creates_entry(node):
-            return
-        ancestors = list(extended_ancestors(node))
-        ancestor_qnames = {a.qname() for a in ancestors}
+        ancestor_qnames: set[str] = set()
+        integration_ancestors: list[nodes.ClassDef] = []
+        for ancestor in extended_ancestors(node):
+            ancestor_qnames.add(ancestor.qname())
+            if is_integration_module(ancestor.root().name):
+                integration_ancestors.append(ancestor)
         if (
             _CONFIG_FLOW_QNAME not in ancestor_qnames
             or _OAUTH_FLOW_QNAME in ancestor_qnames
         ):
             return
-        for ancestor in ancestors:
+        # Entry creation may be inherited from a shared base flow, so
+        # integration-module ancestors count as well.
+        if not _creates_entry(node) and not any(
+            _creates_entry(ancestor) for ancestor in integration_ancestors
+        ):
+            return
+        for ancestor in integration_ancestors:
             ancestor_module = ancestor.root()
-            if (
-                ancestor_module.name != node.root().name
-                and is_integration_module(ancestor_module.name)
-                and self._ancestor_module_surfaces(ancestor_module)
+            if ancestor_module.name != node.root().name and (
+                self._ancestor_module_surfaces(ancestor_module)
             ):
                 return
         self.add_message("home-assistant-missing-test-before-configure", node=node)

--- a/tests/pylint/quality_scale/test_test_before_configure.py
+++ b/tests/pylint/quality_scale/test_test_before_configure.py
@@ -285,6 +285,48 @@ class MyConfigFlow(BaseHardwareFlow, domain="test_integration"):
         walk_checker(linter, configure_checker, root_node)
 
 
+def test_before_configure_inherited_entry_creation_fires(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+) -> None:
+    """Warning when entry creation is inherited and nothing surfaces failures."""
+    astroid.parse(
+        """
+from homeassistant.config_entries import ConfigFlow
+
+class BaseSharedFlow(ConfigFlow):
+    async def async_step_user(self, user_input=None):
+        return self.async_create_entry(title="Test", data={})
+""",
+        "homeassistant.components.shared_base.config_flow",
+    )
+    integration_dir = _make_integration(tmp_path, {"test-before-configure": "done"})
+    root_node = _parse_config_flow(
+        integration_dir,
+        """
+from homeassistant.components.shared_base.config_flow import BaseSharedFlow
+
+class MyConfigFlow(BaseSharedFlow, domain="test_integration"):
+    VERSION = 1
+""",
+    )
+    class_node = root_node.body[-1]
+
+    with assert_adds_messages(
+        linter,
+        MessageTest(
+            msg_id="home-assistant-missing-test-before-configure",
+            node=class_node,
+            line=4,
+            col_offset=0,
+            end_line=4,
+            end_col_offset=18,
+        ),
+    ):
+        walk_checker(linter, configure_checker, root_node)
+
+
 def test_before_configure_non_config_flow_class(
     linter: UnittestLinter,
     configure_checker: TestBeforeConfigureChecker,

--- a/tests/pylint/quality_scale/test_test_before_configure.py
+++ b/tests/pylint/quality_scale/test_test_before_configure.py
@@ -1,0 +1,350 @@
+"""Tests for the test-before-configure quality scale checker."""
+
+import json
+from pathlib import Path
+
+import astroid
+from pylint.testutils import MessageTest, UnittestLinter
+from pylint_home_assistant.checkers.quality_scale.test_before_configure import (
+    TestBeforeConfigureChecker,
+)
+from pylint_home_assistant.helpers.integration import clear_caches
+from pylint_home_assistant.helpers.quality_scale import clear_quality_scale_cache
+import pytest
+import yaml
+
+from tests.pylint import assert_adds_messages, assert_no_messages, walk_checker
+
+_MODULE_NAME = "homeassistant.components.test_integration.config_flow"
+
+_FLOW_WITHOUT_TEST = """
+from homeassistant.config_entries import ConfigFlow
+
+class MyConfigFlow(ConfigFlow, domain="test_integration"):
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user")
+"""
+
+
+@pytest.fixture(name="configure_checker")
+def configure_checker_fixture(linter: UnittestLinter) -> TestBeforeConfigureChecker:
+    """Fixture to provide a test before configure checker."""
+    clear_quality_scale_cache()
+    clear_caches()
+    return TestBeforeConfigureChecker(linter)
+
+
+def _make_integration(
+    tmp_path: Path, rules: dict | None = None, manifest: dict | None = None
+) -> Path:
+    """Create a fake integration directory."""
+    integration_dir = tmp_path / "homeassistant" / "components" / "test_integration"
+    integration_dir.mkdir(parents=True)
+    if rules is not None:
+        (integration_dir / "quality_scale.yaml").write_text(yaml.dump({"rules": rules}))
+    (integration_dir / "manifest.json").write_text(
+        json.dumps({"domain": "test_integration"} | (manifest or {}))
+    )
+    return integration_dir
+
+
+def _parse_config_flow(
+    integration_dir: Path, source: str, module_name: str = _MODULE_NAME
+) -> astroid.Module:
+    """Parse the integration's config_flow module."""
+    root_node = astroid.parse(source, module_name)
+    root_node.file = str(integration_dir / "config_flow.py")
+    return root_node
+
+
+@pytest.mark.parametrize(
+    "flow_body",
+    [
+        pytest.param(
+            """
+    async def async_step_user(self, user_input=None):
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            try:
+                await MyClient(user_input["host"]).get_data()
+            except MyException:
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user", errors=errors)
+""",
+            id="try_except_with_errors",
+        ),
+        pytest.param(
+            """
+    async def async_step_user(self, user_input=None):
+        errors = None
+        if user_input is not None:
+            errors = await validate_input(self.hass, user_input)
+            if not errors:
+                return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user", errors=errors)
+""",
+            id="errors_from_helper_call",
+        ),
+        pytest.param(
+            """
+    async def async_step_user(self, user_input=None):
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if not await MyClient(user_input["host"]).connect():
+                errors["base"] = "cannot_connect"
+            else:
+                return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user", errors=errors)
+""",
+            id="errors_subscript_without_try",
+        ),
+        pytest.param(
+            """
+    async def async_step_user(self, user_input=None):
+        errors = {}
+        if user_input is not None:
+            serial, errors = await self._validate_host(user_input["host"])
+            if not errors:
+                return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user", errors=errors)
+""",
+            id="errors_from_tuple_unpacking",
+        ),
+        pytest.param(
+            """
+    async def async_step_confirm(self, user_input=None):
+        try:
+            await self._probe_device()
+        except TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+        return self.async_create_entry(title="Test", data={})
+""",
+            id="catch_and_abort",
+        ),
+        pytest.param(
+            """
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            feed = await async_fetch_feed(self.hass, user_input["url"])
+            if feed.bozo:
+                return self.async_show_form(
+                    step_id="user", errors={"base": "url_error"}
+                )
+            return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user")
+""",
+            id="errors_literal_kwarg",
+        ),
+    ],
+)
+def test_before_configure_evidence_present(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+    flow_body: str,
+) -> None:
+    """No warning when the config flow surfaces failures to the user."""
+    integration_dir = _make_integration(tmp_path, {"test-before-configure": "done"})
+    root_node = _parse_config_flow(
+        integration_dir,
+        "from homeassistant.config_entries import ConfigFlow\n"
+        f'class MyConfigFlow(ConfigFlow, domain="test_integration"):\n{flow_body}',
+    )
+
+    with assert_no_messages(linter):
+        walk_checker(linter, configure_checker, root_node)
+
+
+_FLOW_DETECTED_NOT_SURFACED = """
+from homeassistant.config_entries import ConfigFlow
+
+class MyConfigFlow(ConfigFlow, domain="test_integration"):
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            serial, errors = await self._validate_host(user_input["host"])
+            if not errors:
+                return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user")
+"""
+
+_FLOW_SWALLOWED_EXCEPTION = """
+from homeassistant.config_entries import ConfigFlow
+
+class MyConfigFlow(ConfigFlow, domain="test_integration"):
+    async def async_step_user(self, user_input=None):
+        if user_input is not None:
+            try:
+                await MyClient(user_input["host"]).get_data()
+            except MyException:
+                pass
+            return self.async_create_entry(title="Test", data=user_input)
+        return self.async_show_form(step_id="user")
+"""
+
+
+@pytest.mark.parametrize(
+    ("flow_source", "manifest"),
+    [
+        pytest.param(_FLOW_WITHOUT_TEST, None, id="no_evidence"),
+        pytest.param(
+            _FLOW_WITHOUT_TEST,
+            {"bluetooth": [{"connectable": True}]},
+            id="discovery_manifest_does_not_skip",
+        ),
+        pytest.param(_FLOW_DETECTED_NOT_SURFACED, None, id="detected_but_not_surfaced"),
+        pytest.param(_FLOW_SWALLOWED_EXCEPTION, None, id="swallowed_exception"),
+    ],
+)
+def test_before_configure_missing_fires(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+    flow_source: str,
+    manifest: dict | None,
+) -> None:
+    """Warning when the config flow never surfaces connection failures to the user."""
+    integration_dir = _make_integration(
+        tmp_path, {"test-before-configure": "done"}, manifest
+    )
+    root_node = _parse_config_flow(integration_dir, flow_source)
+    class_node = root_node.body[-1]
+
+    with assert_adds_messages(
+        linter,
+        MessageTest(
+            msg_id="home-assistant-missing-test-before-configure",
+            node=class_node,
+            line=4,
+            col_offset=0,
+            end_line=4,
+            end_col_offset=18,
+        ),
+    ):
+        walk_checker(linter, configure_checker, root_node)
+
+
+def test_before_configure_oauth_flow_skipped(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+) -> None:
+    """No warning for OAuth flows; the token exchange is the connection test."""
+    integration_dir = _make_integration(tmp_path, {"test-before-configure": "done"})
+    root_node = _parse_config_flow(
+        integration_dir,
+        """
+from homeassistant.helpers.config_entry_oauth2_flow import AbstractOAuth2FlowHandler
+
+class MyConfigFlow(AbstractOAuth2FlowHandler, domain="test_integration"):
+    async def async_oauth_create_entry(self, data):
+        return self.async_create_entry(title="Test", data=data)
+""",
+    )
+
+    with assert_no_messages(linter):
+        walk_checker(linter, configure_checker, root_node)
+
+
+def test_before_configure_inherited_evidence(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+) -> None:
+    """No warning when surfacing evidence lives in an inherited flow class's module."""
+    astroid.parse(
+        """
+from homeassistant.config_entries import ConfigFlow
+
+class BaseHardwareFlow(ConfigFlow):
+    async def async_step_confirm(self, user_input=None):
+        try:
+            await self._probe_device()
+        except TimeoutError:
+            return self.async_abort(reason="cannot_connect")
+        return self._async_flow_finished()
+""",
+        "homeassistant.components.hw_base.firmware_flow",
+    )
+    integration_dir = _make_integration(tmp_path, {"test-before-configure": "done"})
+    root_node = _parse_config_flow(
+        integration_dir,
+        """
+from homeassistant.components.hw_base.firmware_flow import BaseHardwareFlow
+
+class MyConfigFlow(BaseHardwareFlow, domain="test_integration"):
+    def _async_flow_finished(self):
+        return self.async_create_entry(title="Test", data={})
+""",
+    )
+
+    with assert_no_messages(linter):
+        walk_checker(linter, configure_checker, root_node)
+
+
+def test_before_configure_non_config_flow_class(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+) -> None:
+    """No warning for classes that are not config flows."""
+    integration_dir = _make_integration(tmp_path, {"test-before-configure": "done"})
+    root_node = _parse_config_flow(
+        integration_dir,
+        """
+class MyHelper:
+    def make(self):
+        return self.async_create_entry(title="Test", data={})
+""",
+    )
+
+    with assert_no_messages(linter):
+        walk_checker(linter, configure_checker, root_node)
+
+
+@pytest.mark.parametrize(
+    ("module_name", "rules"),
+    [
+        pytest.param(
+            _MODULE_NAME,
+            None,
+            id="no_quality_scale_file",
+        ),
+        pytest.param(
+            _MODULE_NAME,
+            {"test-before-configure": "todo"},
+            id="rule_todo",
+        ),
+        pytest.param(
+            _MODULE_NAME,
+            {"test-before-configure": {"status": "exempt", "comment": "reason"}},
+            id="rule_exempt",
+        ),
+        pytest.param(
+            "homeassistant.components.test_integration.sensor",
+            {"test-before-configure": "done"},
+            id="not_config_flow_module",
+        ),
+        pytest.param(
+            "not_homeassistant.something",
+            {"test-before-configure": "done"},
+            id="not_an_integration",
+        ),
+    ],
+)
+def test_before_configure_not_fired(
+    linter: UnittestLinter,
+    configure_checker: TestBeforeConfigureChecker,
+    tmp_path: Path,
+    module_name: str,
+    rules: dict | None,
+) -> None:
+    """No warning when the rule is not done or the module is not config_flow."""
+    integration_dir = _make_integration(tmp_path, rules)
+    root_node = _parse_config_flow(integration_dir, _FLOW_WITHOUT_TEST, module_name)
+
+    with assert_no_messages(linter):
+        walk_checker(linter, configure_checker, root_node)

--- a/tests/pylint/quality_scale/test_test_before_configure.py
+++ b/tests/pylint/quality_scale/test_test_before_configure.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 import astroid
+from astroid import nodes
 from pylint.testutils import MessageTest, UnittestLinter
 from pylint_home_assistant.checkers.quality_scale.test_before_configure import (
     TestBeforeConfigureChecker,
@@ -57,6 +58,19 @@ def _parse_config_flow(
     root_node = astroid.parse(source, module_name)
     root_node.file = str(integration_dir / "config_flow.py")
     return root_node
+
+
+def _expect_missing(class_node: nodes.ClassDef) -> MessageTest:
+    """Build the expected MessageTest for a flagged config flow class."""
+    pos = class_node.position
+    return MessageTest(
+        msg_id="home-assistant-missing-test-before-configure",
+        node=class_node,
+        line=pos.lineno,
+        col_offset=pos.col_offset,
+        end_line=pos.end_lineno,
+        end_col_offset=pos.end_col_offset,
+    )
 
 
 @pytest.mark.parametrize(
@@ -213,17 +227,7 @@ def test_before_configure_missing_fires(
     root_node = _parse_config_flow(integration_dir, flow_source)
     class_node = root_node.body[-1]
 
-    with assert_adds_messages(
-        linter,
-        MessageTest(
-            msg_id="home-assistant-missing-test-before-configure",
-            node=class_node,
-            line=4,
-            col_offset=0,
-            end_line=4,
-            end_col_offset=18,
-        ),
-    ):
+    with assert_adds_messages(linter, _expect_missing(class_node)):
         walk_checker(linter, configure_checker, root_node)
 
 
@@ -313,17 +317,7 @@ class MyConfigFlow(BaseSharedFlow, domain="test_integration"):
     )
     class_node = root_node.body[-1]
 
-    with assert_adds_messages(
-        linter,
-        MessageTest(
-            msg_id="home-assistant-missing-test-before-configure",
-            node=class_node,
-            line=4,
-            col_offset=0,
-            end_line=4,
-            end_col_offset=18,
-        ),
-    ):
+    with assert_adds_messages(linter, _expect_missing(class_node)):
         walk_checker(linter, configure_checker, root_node)
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a quality-scale-gated pylint checker (`W7433`, `home-assistant-missing-test-before-configure`) for the Bronze [test-before-configure](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/test-before-configure/) rule, following the pattern of the existing gated checkers. The rule previously had no automation in hassfest or pylint.

Since actually testing a connection cannot be proven statically, the checker looks for the footprint that surfacing a failure to the user always leaves behind: an `errors=` keyword passed to a call (non-empty literal or dynamic value), or an `async_abort`/`AbortFlow` inside an except handler (the catch-and-abort pattern of confirm-only flows). Flows that detect failures but never show them to the user fail the check, as do flows with no failure handling at all. The footprint is searched in `config_flow.py` and in the defining modules of inherited flow classes from other integrations (needed for `homeassistant_connect_zbt2`, whose device probing lives in the shared `homeassistant_hardware` firmware flow). Config flows inheriting `AbstractOAuth2FlowHandler` are skipped since the OAuth token exchange is the connection test.

The checker was validated against all 300+ integrations claiming the rule as `done`. Four claims did not hold up and are flipped to `exempt` with rationale comments in this PR: `edifier_infrared`, `marantz_infrared` and `samsung_infrared` only proxy commands through an existing infrared entity (the connection to the IR blaster is owned and tested by the integration providing that entity), and `probe_plus` only offers devices already seen via Bluetooth discovery, matching the rule's auto-discovery exception. All other `done` integrations pass.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
