### PR TITLE
Do not wait for HTTP clients to disconnect when stopping the server

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -815,7 +815,11 @@ class HomeAssistantHTTP:
                         err,
                     )
         if self._server is not None:
+            # Only close (stop listening); do not await wait_closed() here.
+            # Since Python 3.12.1 it waits for all client connections to
+            # terminate, but those are only torn down by runner.cleanup()
+            # below, so waiting first hangs shutdown until clients (e.g.
+            # open websockets) disconnect on their own.
             self._server.close()
-            await self._server.wait_closed()
         if self.runner is not None:
             await self.runner.cleanup()

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -816,10 +816,7 @@ class HomeAssistantHTTP:
                     )
         if self._server is not None:
             # Only close (stop listening); do not await wait_closed() here.
-            # Since Python 3.12.1 it waits for all client connections to
-            # terminate, but those are only torn down by runner.cleanup()
-            # below, so waiting first hangs shutdown until clients (e.g.
-            # open websockets) disconnect on their own.
+            # Let runner.cleanup() terminate active connections.
             self._server.close()
         if self.runner is not None:
             await self.runner.cleanup()

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1673,6 +1673,31 @@ async def test_bound_server_closed_on_stop_before_start(
     assert not server.sockets
 
 
+async def test_stop_completes_with_open_connections(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Stopping the server must not wait for connected clients to disconnect.
+
+    Server.wait_closed() waits for all client connections to terminate since
+    Python 3.12.1, but connections are only torn down by the runner cleanup,
+    so waiting for them first hangs shutdown while a client (e.g. an open
+    websocket) stays connected.
+    """
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    assert hass.http._server is not None
+    port = hass.http._server.sockets[0].getsockname()[1]
+    _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+
+    try:
+        await asyncio.wait_for(hass.http.stop(), timeout=15)
+    finally:
+        writer.close()
+
+
 async def test_stable_config_bind_failure_fails_setup(
     hass: HomeAssistant,
     hass_storage: dict[str, Any],

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1690,9 +1690,16 @@ async def test_stop_completes_with_open_connections(
 
     assert hass.http._server is not None
     port = hass.http._server.sockets[0].getsockname()[1]
-    _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+    reader, writer = await asyncio.open_connection("127.0.0.1", port)
 
     try:
+        # Complete a request/response round trip so the connection is
+        # accepted and tracked by the server (a mere TCP connect may still
+        # sit in the listen backlog), then keep the connection open.
+        writer.write(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        await writer.drain()
+        assert await reader.readline()
+
         await asyncio.wait_for(hass.http.stop(), timeout=15)
     finally:
         writer.close()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Since #176384, stopping the HTTP server awaits `Server.wait_closed()` before the aiohttp runner cleanup. Since Python 3.12.1, `wait_closed()` waits for *all client connections* to terminate — but the client connections are only torn down by `runner.cleanup()`, which runs afterwards. As a result, any connected client (in practice: an open frontend websocket, i.e. almost always) hung shutdown until the "stop integrations" shutdown stage timeout expired, delaying every stop/restart by up to 100 seconds:

```
WARNING (MainThread) [homeassistant.core] Timed out waiting for integrations to stop, the shutdown will continue
WARNING (MainThread) [homeassistant.core] Shutdown stage 'stop integrations': still running: <Task pending name='Task-436' coro=<async_setup.<locals>.stop_server() running at .../components/http/__init__.py:307 ...>
```

Only close the server (stop listening) — like aiohttp's own `BaseSite.stop()` does — and leave terminating the connections to the runner cleanup, which handles them with its shutdown timeout and handler cancellation.

The regression test opens a client connection and stops the server: without the fix, `stop()` hangs until the test timeout; with the fix it completes immediately.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
