### PR TITLE
Restore lost trusted proxy network masks during HTTP YAML migration

### DIFF
--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -380,9 +380,32 @@ class HTTPConfigStore:
         """Migrate YAML config to storage as pending if not the same as the config used for recovery."""
         await self.async_load()
         validated_config = cast(ConfData, HTTP_STORAGE_SCHEMA(config))
+        if self._stable_differs_only_by_lost_proxy_masks(validated_config):
+            # Releases up to 2026.7.1 dropped the network mask when storing
+            # trusted proxies, and the v1->v2 store migration turned those
+            # into host networks (e.g. 10.0.0.0/24 -> 10.0.0.0 -> 10.0.0.0/32).
+            # If the YAML config matches stable apart from those lost masks,
+            # the user changed nothing: restore the masks in stable instead of
+            # staging the YAML as pending.
+            self._stable = validated_config
         self._pending = None if validated_config == self._stable else validated_config
         self._yaml_migration_done = True
         await self._async_persist()
+
+    def _stable_differs_only_by_lost_proxy_masks(self, config: ConfData) -> bool:
+        """Return True if stable equals ``config`` with the trusted proxy masks lost.
+
+        "Lost" means each proxy was reduced to the host network of its network
+        address, the shape the old storage bug produced.
+        """
+        if (proxies := config.get(CONF_TRUSTED_PROXIES)) is None:
+            return False
+        return self._stable == {
+            **config,
+            CONF_TRUSTED_PROXIES: [
+                _ip_network_str(ip_network(proxy).network_address) for proxy in proxies
+            ],
+        }
 
     async def _async_persist(self) -> None:
         """Write the current state to disk (or remove the file if empty)."""

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1033,6 +1033,75 @@ async def test_yaml_migration_matches_stable_no_pending(
     assert issue is not None
 
 
+@pytest.mark.parametrize(
+    ("yaml_extra", "expected_stable_proxies", "expected_pending"),
+    [
+        pytest.param(
+            {},
+            ["127.0.0.0/8", "10.11.12.0/24"],
+            None,
+            id="only-lost-masks-repairs-stable",
+        ),
+        pytest.param(
+            {"server_port": 8765},
+            ["127.0.0.0/32", "10.11.12.0/32"],
+            {
+                "server_port": 8765,
+                "cors_allowed_origins": ["https://example.com"],
+                "use_x_forwarded_for": True,
+                "trusted_proxies": ["127.0.0.0/8", "10.11.12.0/24"],
+                "ip_ban_enabled": False,
+                "login_attempts_threshold": -1,
+                "ssl_profile": "modern",
+                "use_x_frame_options": True,
+            },
+            id="other-change-creates-pending",
+        ),
+    ],
+)
+async def test_yaml_migration_stable_lost_trusted_proxy_masks(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    yaml_extra: dict[str, Any],
+    expected_stable_proxies: list[str],
+    expected_pending: dict[str, Any] | None,
+) -> None:
+    """Test YAML migration against a stable config with lost trusted proxy masks.
+
+    Releases up to 2026.7.1 stored trusted proxies without the network mask,
+    which the v1->v2 store migration turned into host networks. If the YAML
+    config only differs from stable by those lost masks, the masks must be
+    restored in stable instead of staging the unchanged YAML as pending.
+    """
+    hass_storage[DOMAIN] = _stable_http_storage(
+        {
+            "server_port": 9123,
+            "cors_allowed_origins": ["https://example.com"],
+            "use_x_forwarded_for": True,
+            "trusted_proxies": ["127.0.0.0/32", "10.11.12.0/32"],
+            "ip_ban_enabled": False,
+        },
+        yaml_migration_done=False,
+    )
+
+    yaml_conf = {
+        "server_port": 9123,
+        "cors_allowed_origins": ["https://example.com"],
+        "use_x_forwarded_for": True,
+        "trusted_proxies": ["127.0.0.0/8", "10.11.12.0/24"],
+        "ip_ban_enabled": False,
+        **yaml_extra,
+    }
+    assert await async_setup_component(hass, DOMAIN, {"http": yaml_conf})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    stored = hass_storage[DOMAIN]["data"]
+    assert stored["yaml_migration_done"] is True
+    assert stored["pending"] == expected_pending
+    assert stored["stable"]["trusted_proxies"] == expected_stable_proxies
+
+
 async def test_yaml_migration_differs_from_stable_creates_pending(
     hass: HomeAssistant,
     issue_registry: ir.IssueRegistry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Restore lost trusted proxy network masks during HTTP YAML migration

Releases up to 2026.7.1 stored trusted proxies without the network
mask, which the v1->v2 store migration turned into host networks
(e.g. 10.0.0.0/24 -> 10.0.0.0 -> 10.0.0.0/32). When the YAML config
differs from the stored stable config only by those lost masks, the
user changed nothing: restore the masks in stable instead of staging
the unchanged YAML as pending and starting a config trial.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
