### PR TITLE
Migrate integrations to async_get_device_by_identifier (part 1)

### DIFF
--- a/homeassistant/components/airgradient/coordinator.py
+++ b/homeassistant/components/airgradient/coordinator.py
@@ -75,8 +75,8 @@ class AirGradientCoordinator(DataUpdateCoordinator[AirGradientData]):
             ) from error
         if measures.firmware_version != self._current_version:
             device_registry = dr.async_get(self.hass)
-            device_entry = device_registry.async_get_device(
-                identifiers={(DOMAIN, self.serial_number)}
+            device_entry = device_registry.async_get_device_by_identifier(
+                (DOMAIN, self.serial_number), self.config_entry.entry_id
             )
             assert device_entry
             device_registry.async_update_device(

--- a/homeassistant/components/airos/__init__.py
+++ b/homeassistant/components/airos/__init__.py
@@ -184,8 +184,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: AirOSConfigEntry) -> b
         mac_adress = dr.format_mac(entry.unique_id)
 
         device_registry = dr.async_get(hass)
-        if device_entry := device_registry.async_get_device(
-            connections={(dr.CONNECTION_NETWORK_MAC, mac_adress)}
+        if device_entry := device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, mac_adress), entry.entry_id
         ):
             old_device_id = next(
                 (

--- a/homeassistant/components/airthings_ble/sensor.py
+++ b/homeassistant/components/airthings_ble/sensor.py
@@ -169,7 +169,9 @@ PARALLEL_UPDATES = 0
 
 
 @callback
-def async_migrate(hass: HomeAssistant, address: str, sensor_name: str) -> None:
+def async_migrate(
+    hass: HomeAssistant, entry_id: str, address: str, sensor_name: str
+) -> None:
     """Migrate entities to new unique ids (with BLE Address)."""
     ent_reg = er.async_get(hass)
     unique_id_trailer = f"_{sensor_name}"
@@ -179,8 +181,8 @@ def async_migrate(hass: HomeAssistant, address: str, sensor_name: str) -> None:
         return
     dev_reg = dr.async_get(hass)
     if not (
-        device := dev_reg.async_get_device(
-            connections={(CONNECTION_BLUETOOTH, address)}
+        device := dev_reg.async_get_device_by_connection(
+            (CONNECTION_BLUETOOTH, address), entry_id
         )
     ):
         return
@@ -221,7 +223,7 @@ async def async_setup_entry(
                 sensor_value,
             )
             continue
-        async_migrate(hass, coordinator.data.address, sensor_type)
+        async_migrate(hass, entry.entry_id, coordinator.data.address, sensor_type)
         entities.append(
             AirthingsSensor(
                 coordinator, coordinator.data, SENSORS_MAPPING_TEMPLATE[sensor_type]

--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -236,8 +236,8 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
                 "Detected change in devices: serial %s removed",
                 serial_num,
             )
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, serial_num)}
+            device = device_registry.async_get_device_by_identifier(
+                (DOMAIN, serial_num), self.config_entry.entry_id
             )
             if device:
                 device_registry.async_update_device(

--- a/homeassistant/components/androidtv/diagnostics.py
+++ b/homeassistant/components/androidtv/diagnostics.py
@@ -35,8 +35,8 @@ async def async_get_config_entry_diagnostics(
     # Gather information how this AndroidTV device is represented in Home Assistant
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
-    hass_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, str(entry.unique_id))}
+    hass_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, str(entry.unique_id)), entry.entry_id
     )
     if not hass_device:
         return data

--- a/homeassistant/components/anthropic/__init__.py
+++ b/homeassistant/components/anthropic/__init__.py
@@ -106,8 +106,8 @@ async def async_migrate_integration(hass: HomeAssistant) -> None:
             DOMAIN,
             entry.entry_id,
         )
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.entry_id)}
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.entry_id), entry.entry_id
         )
 
         if conversation_entity_id is not None:

--- a/homeassistant/components/aqvify/coordinator.py
+++ b/homeassistant/components/aqvify/coordinator.py
@@ -126,8 +126,9 @@ class AqvifyCoordinator(DataUpdateCoordinator[AqvifyCoordinatorData]):
             account_id = self.config_entry.unique_id
             device_registry = dr.async_get(self.hass)
             for device_id in stale_devices:
-                device = device_registry.async_get_device(
-                    identifiers={(DOMAIN, f"{account_id}_{device_id}")}
+                device = device_registry.async_get_device_by_identifier(
+                    (DOMAIN, f"{account_id}_{device_id}"),
+                    self.config_entry.entry_id,
                 )
                 if device:
                     device_registry.async_update_device(

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -17,7 +17,9 @@ async def async_remove_devices(
 ) -> None:
     """Get item that is removed from session."""
     dev_registry = dr.async_get(hass)
-    device = dev_registry.async_get_device(identifiers={(DOMAIN, entity.device_id)})
+    device = dev_registry.async_get_device_by_identifier(
+        (DOMAIN, entity.device_id), entry_id
+    )
     if device is not None:
         dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
 

--- a/homeassistant/components/broadlink/device.py
+++ b/homeassistant/components/broadlink/device.py
@@ -81,8 +81,8 @@ class BroadlinkDevice[_ApiT: blk.Device = blk.Device]:
         """
         device_registry = dr.async_get(hass)
         assert entry.unique_id
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.unique_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.unique_id), entry.entry_id
         )
         assert device_entry
         device_registry.async_update_device(device_entry.id, name=entry.title)

--- a/homeassistant/components/comelit/coordinator.py
+++ b/homeassistant/components/comelit/coordinator.py
@@ -145,8 +145,8 @@ class ComelitBaseCoordinator(DataUpdateCoordinator[T]):
                     i,
                 )
                 identifier = f"{self.config_entry.entry_id}-{dev_type}-{i}"
-                device = device_registry.async_get_device(
-                    identifiers={(DOMAIN, identifier)}
+                device = device_registry.async_get_device_by_identifier(
+                    (DOMAIN, identifier), self.config_entry.entry_id
                 )
                 if device:
                     device_registry.async_update_device(

--- a/homeassistant/components/comelit/utils.py
+++ b/homeassistant/components/comelit/utils.py
@@ -78,7 +78,9 @@ def _async_remove_state_config_entry_from_devices(
 
     device_registry = dr.async_get(hass)
     for identifier in identifiers:
-        device = device_registry.async_get_device(identifiers={(DOMAIN, identifier)})
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, identifier), config_entry.entry_id
+        )
         if device:
             _LOGGER.info(
                 "Removing config entry %s from device %s",

--- a/homeassistant/components/deconz/services.py
+++ b/homeassistant/components/deconz/services.py
@@ -187,8 +187,8 @@ async def async_remove_orphaned_entries_service(hub: DeconzHub) -> None:
     ]
 
     # Don't remove the Gateway service entry
-    hub_service = device_registry.async_get_device(
-        identifiers={(DOMAIN, hub.api.config.bridge_id)}
+    hub_service = device_registry.async_get_device_by_identifier(
+        (DOMAIN, hub.api.config.bridge_id), hub.config_entry.entry_id
     )
     if hub_service and hub_service.id in devices_to_be_removed:
         devices_to_be_removed.remove(hub_service.id)

--- a/homeassistant/components/devolo_home_control/entity.py
+++ b/homeassistant/components/devolo_home_control/entity.py
@@ -105,8 +105,9 @@ class DevoloDeviceEntity(Entity):
             self._attr_available = state
         elif message[1] == "del" and self.platform.config_entry:
             device_registry = dr.async_get(self.hass)
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, self._device_instance.uid)}
+            device = device_registry.async_get_device_by_identifier(
+                (DOMAIN, self._device_instance.uid),
+                self.platform.config_entry.entry_id,
             )
             if device:
                 device_registry.async_update_device(

--- a/homeassistant/components/devolo_home_control/entity.py
+++ b/homeassistant/components/devolo_home_control/entity.py
@@ -105,9 +105,8 @@ class DevoloDeviceEntity(Entity):
             self._attr_available = state
         elif message[1] == "del" and self.platform.config_entry:
             device_registry = dr.async_get(self.hass)
-            device = device_registry.async_get_device_by_identifier(
-                (DOMAIN, self._device_instance.uid),
-                self.platform.config_entry.entry_id,
+            device = device_registry.async_get_device(
+                identifiers={(DOMAIN, self._device_instance.uid)}
             )
             if device:
                 device_registry.async_update_device(

--- a/homeassistant/components/devolo_home_network/coordinator.py
+++ b/homeassistant/components/devolo_home_network/coordinator.py
@@ -44,6 +44,8 @@ type DevoloHomeNetworkConfigEntry = ConfigEntry[DevoloHomeNetworkData]
 class DevoloDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
     """Class to manage fetching data from devolo Home Network devices."""
 
+    config_entry: DevoloHomeNetworkConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -86,8 +88,8 @@ class DevoloDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
         """Update device registry with new firmware version."""
         device_registry = dr.async_get(self.hass)
         if (
-            device_entry := device_registry.async_get_device(
-                identifiers={(DOMAIN, self.device.serial_number)}
+            device_entry := device_registry.async_get_device_by_identifier(
+                (DOMAIN, self.device.serial_number), self.config_entry.entry_id
             )
         ) and device_entry.sw_version != self.device.firmware_version:
             device_registry.async_update_device(

--- a/homeassistant/components/dsmr/sensor.py
+++ b/homeassistant/components/dsmr/sensor.py
@@ -608,7 +608,9 @@ def rename_old_gas_to_mbus(
     """Rename old gas sensor to mbus variant."""
     dev_reg = dr.async_get(hass)
     for dev_id in (mbus_device_id, entry.entry_id):
-        device_entry_v1 = dev_reg.async_get_device(identifiers={(DOMAIN, dev_id)})
+        device_entry_v1 = dev_reg.async_get_device_by_identifier(
+            (DOMAIN, dev_id), entry.entry_id
+        )
         if device_entry_v1 is not None:
             device_id = device_entry_v1.id
 

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -258,8 +258,8 @@ async def async_setup_entry(
             device_reg = dr.async_get(hass)
             mac = entry.unique_id
             for node_id in stale_node_ids:
-                device = device_reg.async_get_device(
-                    identifiers={(DOMAIN, f"{mac}_{node_id}")}
+                device = device_reg.async_get_device_by_identifier(
+                    (DOMAIN, f"{mac}_{node_id}"), entry.entry_id
                 )
                 if device:
                     device_reg.async_update_device(

--- a/homeassistant/components/dwd_weather_warnings/__init__.py
+++ b/homeassistant/components/dwd_weather_warnings/__init__.py
@@ -12,7 +12,9 @@ async def async_setup_entry(
 ) -> bool:
     """Set up a config entry."""
     device_registry = dr.async_get(hass)
-    if device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)}):
+    if device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    ):
         device_registry.async_clear_config_entry(entry.entry_id, entry.domain)
     coordinator = DwdWeatherWarningsCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()

--- a/homeassistant/components/earn_e_p1/coordinator.py
+++ b/homeassistant/components/earn_e_p1/coordinator.py
@@ -20,6 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 class EarnEP1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Coordinator for the EARN-E P1 Meter."""
 
+    config_entry: EarnEP1ConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,
@@ -49,8 +51,8 @@ class EarnEP1Coordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.sw_version = device.sw_version
             device_registry = dr.async_get(self.hass)
             if (
-                device_entry := device_registry.async_get_device(
-                    identifiers={(DOMAIN, self.identifier)}
+                device_entry := device_registry.async_get_device_by_identifier(
+                    (DOMAIN, self.identifier), self.config_entry.entry_id
                 )
             ) is not None:
                 device_registry.async_update_device(

--- a/homeassistant/components/enphase_envoy/coordinator.py
+++ b/homeassistant/components/enphase_envoy/coordinator.py
@@ -216,13 +216,8 @@ class EnphaseUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Add to or update device registry connections as needed
         device_registry = dr.async_get(self.hass)
-        envoy_device = device_registry.async_get_device(
-            identifiers={
-                (
-                    DOMAIN,
-                    self.envoy_serial_number,
-                )
-            }
+        envoy_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, self.envoy_serial_number), self.config_entry.entry_id
         )
         if envoy_device is None:
             _LOGGER.error(

--- a/homeassistant/components/epson/media_player.py
+++ b/homeassistant/components/epson/media_player.py
@@ -106,7 +106,9 @@ class EpsonProjectorMediaPlayer(MediaPlayerEntity):
             if old_entity_id is not None:
                 ent_reg.async_update_entity(old_entity_id, new_unique_id=uid)
             dev_reg = dr.async_get(self.hass)
-            device = dev_reg.async_get_device({(DOMAIN, self._entry.entry_id)})
+            device = dev_reg.async_get_device_by_identifier(
+                (DOMAIN, self._entry.entry_id), self._entry.entry_id
+            )
             if device is not None:
                 dev_reg.async_update_device(device.id, new_identifiers={(DOMAIN, uid)})
             self.hass.async_create_task(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate integrations from the deprecated `async_get_device` to `async_get_device_by_identifier` (part 1)

This migrates trivial cases where all oof the following is true:
- The integration expects a single matching device
- The integration passes a single identifier
- The config entry is in scope

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
