### PR TITLE
Migrate integrations to async_get_device_by_identifier (part 4)

### DIFF
--- a/homeassistant/components/simplisafe/__init__.py
+++ b/homeassistant/components/simplisafe/__init__.py
@@ -117,8 +117,9 @@ def _async_register_base_station(
     )
 
     # Check for an old system ID format and remove it:
-    if old_base_station := device_registry.async_get_device(
-        identifiers={(DOMAIN, system.system_id)}  # type: ignore[arg-type]
+    if old_base_station := device_registry.async_get_device_by_identifier(
+        (DOMAIN, system.system_id),  # type: ignore[arg-type]
+        entry.entry_id,
     ):
         # Update the new base station with any properties the user might have configured
         # on the old base station:

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -244,8 +244,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: SmartThingsConfigEntry) 
 
     def handle_deleted_device(device_id: str) -> None:
         """Handle a deleted device."""
-        dev_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)},
+        dev_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), entry.entry_id
         )
         if dev_entry is not None:
             device_registry.async_update_device(
@@ -587,7 +587,9 @@ def create_devices(
                 if mac_connections:
                     kwargs.setdefault(ATTR_CONNECTIONS, set()).update(mac_connections)
         if (
-            device_registry.async_get_device({(DOMAIN, device.device.device_id)})
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, device.device.device_id), entry.entry_id
+            )
             is None
         ):
             kwargs.update(

--- a/homeassistant/components/smhi/config_flow.py
+++ b/homeassistant/components/smhi/config_flow.py
@@ -102,8 +102,8 @@ class SmhiFlowHandler(ConfigFlow, domain=DOMAIN):
                     )
 
                 device_reg = dr.async_get(self.hass)
-                if device := device_reg.async_get_device(
-                    identifiers={(DOMAIN, f"{old_lat}, {old_lon}")}
+                if device := device_reg.async_get_device_by_identifier(
+                    (DOMAIN, f"{old_lat}, {old_lon}"), reconfigure_entry.entry_id
                 ):
                     device_reg.async_update_device(
                         device.id, new_identifiers={(DOMAIN, f"{lat}, {lon}")}

--- a/homeassistant/components/solarlog/coordinator.py
+++ b/homeassistant/components/solarlog/coordinator.py
@@ -194,13 +194,12 @@ class SolarLogDeviceDataCoordinator(DataUpdateCoordinator[dict[int, InverterData
                     if did == removed_device[0]:
                         device_name = dn
                         break
-                if device := device_registry.async_get_device(
-                    identifiers={
-                        (
-                            DOMAIN,
-                            f"{self.config_entry.entry_id}_{slugify(device_name)}",
-                        )
-                    }
+                if device := device_registry.async_get_device_by_identifier(
+                    (
+                        DOMAIN,
+                        f"{self.config_entry.entry_id}_{slugify(device_name)}",
+                    ),
+                    self.config_entry.entry_id,
                 ):
                     device_registry.async_update_device(
                         device_id=device.id,

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -125,8 +125,8 @@ async def async_setup_entry(
         player = coordinator.player
         _LOGGER.debug("Setting up media_player device and entity for player %s", player)
         device_registry = dr.async_get(hass)
-        server_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, coordinator.server_uuid)},
+        server_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, coordinator.server_uuid), entry.entry_id
         )
 
         name = player.name

--- a/homeassistant/components/steam_online/__init__.py
+++ b/homeassistant/components/steam_online/__init__.py
@@ -64,7 +64,9 @@ async def async_migrate_entry(hass: HomeAssistant, entry: SteamConfigEntry) -> b
             hass.config_entries.async_add_subentry(entry, subentry)
 
         dev_reg = dr.async_get(hass)
-        if device := dev_reg.async_get_device({(DOMAIN, entry.entry_id)}):
+        if device := dev_reg.async_get_device_by_identifier(
+            (DOMAIN, entry.entry_id), entry.entry_id
+        ):
             if TYPE_CHECKING:
                 assert entry.unique_id
             dev_reg.async_update_device(

--- a/homeassistant/components/tailscale/coordinator.py
+++ b/homeassistant/components/tailscale/coordinator.py
@@ -67,7 +67,9 @@ class TailscaleDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         device_registry = dr.async_get(self.hass)
 
         for device_id in stale_device_ids:
-            device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+            device = device_registry.async_get_device_by_identifier(
+                (DOMAIN, device_id), self.config_entry.entry_id
+            )
             if device:
                 LOGGER.debug("Removing stale device: %s", device_id)
                 device_registry.async_remove_device(device.id)

--- a/homeassistant/components/tedee/coordinator.py
+++ b/homeassistant/components/tedee/coordinator.py
@@ -148,8 +148,8 @@ class TedeeApiCoordinator(DataUpdateCoordinator[dict[int, TedeeLock]]):
             _LOGGER.debug("Removed locks: %s", ", ".join(map(str, removed_locks)))
             device_registry = dr.async_get(self.hass)
             for lock_id in removed_locks:
-                if device := device_registry.async_get_device(
-                    identifiers={(DOMAIN, str(lock_id))}
+                if device := device_registry.async_get_device_by_identifier(
+                    (DOMAIN, str(lock_id)), self.config_entry.entry_id
                 ):
                     device_registry.async_update_device(
                         device_id=device.id,

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -106,8 +106,8 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
         ):
             device_registry = dr.async_get(self.hass)
             for device_id in stale_device_ids:
-                device = device_registry.async_get_device(
-                    identifiers={(DOMAIN, device_id)}
+                device = device_registry.async_get_device_by_identifier(
+                    (DOMAIN, device_id), self.config_entry.entry_id
                 )
                 if device:
                     device_registry.async_update_device(

--- a/homeassistant/components/tradfri/diagnostics.py
+++ b/homeassistant/components/tradfri/diagnostics.py
@@ -18,8 +18,8 @@ async def async_get_config_entry_diagnostics(
     device_registry = dr.async_get(hass)
     device = cast(
         dr.DeviceEntry,
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.data[CONF_GATEWAY_ID])}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.data[CONF_GATEWAY_ID]), entry.entry_id
         ),
     )
 

--- a/homeassistant/components/trmnl/coordinator.py
+++ b/homeassistant/components/trmnl/coordinator.py
@@ -59,8 +59,8 @@ class TRMNLCoordinator(DataUpdateCoordinator[dict[int, Device]]):
         if self.data is not None:
             device_registry = dr.async_get(self.hass)
             for device_id in set(self.data) - set(new_data):
-                if entry := device_registry.async_get_device(
-                    identifiers={(DOMAIN, str(device_id))}
+                if entry := device_registry.async_get_device_by_identifier(
+                    (DOMAIN, str(device_id)), self.config_entry.entry_id
                 ):
                     device_registry.async_update_device(
                         device_id=entry.id,

--- a/homeassistant/components/tuya/coordinator.py
+++ b/homeassistant/components/tuya/coordinator.py
@@ -163,8 +163,8 @@ class DeviceListener(SharingDeviceListener):
     def async_remove_device(self, device_id: str) -> None:
         """Remove device from Home Assistant."""
         device_registry = dr.async_get(self.hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, device_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, device_id), self._entry.entry_id
         )
         if device_entry is not None:
             device_registry.async_remove_device(device_entry.id)

--- a/homeassistant/components/twinkly/__init__.py
+++ b/homeassistant/components/twinkly/__init__.py
@@ -64,8 +64,8 @@ async def async_migrate_entry(hass: HomeAssistant, entry: TwinklyConfigEntry) ->
                 entity_entry.entity_id, new_unique_id=device_info["mac"]
             )
         device_registry = dr.async_get(hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, identifier)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, identifier), entry.entry_id
         )
         if device_entry:
             device_registry.async_update_device(

--- a/homeassistant/components/twinkly/coordinator.py
+++ b/homeassistant/components/twinkly/coordinator.py
@@ -105,8 +105,8 @@ class TwinklyCoordinator(DataUpdateCoordinator[TwinklyData]):
     def _async_update_device_info(self, name: str) -> None:
         """Update the device info."""
         device_registry = dr.async_get(self.hass)
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, self.data.device_info["mac"])},
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, self.data.device_info["mac"]), self.config_entry.entry_id
         )
         if device:
             device_registry.async_update_device(

--- a/homeassistant/components/uptime_kuma/coordinator.py
+++ b/homeassistant/components/uptime_kuma/coordinator.py
@@ -128,8 +128,9 @@ def async_migrate_entities_unique_ids(
     # migrate device identifiers and update version
     device_reg = dr.async_get(hass)
     for monitor in metrics.values():
-        if device := device_reg.async_get_device(
-            {(DOMAIN, f"{coordinator.config_entry.entry_id}_{monitor.monitor_name!s}")}
+        if device := device_reg.async_get_device_by_identifier(
+            (DOMAIN, f"{coordinator.config_entry.entry_id}_{monitor.monitor_name!s}"),
+            coordinator.config_entry.entry_id,
         ):
             new_identifier = {
                 (DOMAIN, f"{coordinator.config_entry.entry_id}_{monitor.monitor_id!s}")
@@ -139,8 +140,9 @@ def async_migrate_entities_unique_ids(
                 new_identifiers=new_identifier,
                 sw_version=coordinator.api.version.version,
             )
-    if device := device_reg.async_get_device(
-        {(DOMAIN, f"{coordinator.config_entry.entry_id}_update")}
+    if device := device_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{coordinator.config_entry.entry_id}_update"),
+        coordinator.config_entry.entry_id,
     ):
         device_reg.async_update_device(
             device.id,

--- a/homeassistant/components/uptimerobot/coordinator.py
+++ b/homeassistant/components/uptimerobot/coordinator.py
@@ -69,8 +69,8 @@ class UptimeRobotDataUpdateCoordinator(
             device_registry = dr.async_get(self.hass)
 
             for monitor_id in stale_ids:
-                if device := device_registry.async_get_device(
-                    identifiers={(DOMAIN, str(monitor_id))}
+                if device := device_registry.async_get_device_by_identifier(
+                    (DOMAIN, str(monitor_id)), self.config_entry.entry_id
                 ):
                     device_registry.async_update_device(
                         device_id=device.id,

--- a/homeassistant/components/waqi/__init__.py
+++ b/homeassistant/components/waqi/__init__.py
@@ -100,8 +100,8 @@ async def async_migrate_integration(hass: HomeAssistant) -> None:
         entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
         if TYPE_CHECKING:
             assert entry.unique_id is not None
-        device = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.unique_id)}
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.unique_id), entry.entry_id
         )
 
         for entity_entry in entities:

--- a/homeassistant/components/watts/coordinator.py
+++ b/homeassistant/components/watts/coordinator.py
@@ -148,7 +148,9 @@ class WattsVisionHubCoordinator(DataUpdateCoordinator[dict[str, Device]]):
         for device_id in stale_device_ids:
             _LOGGER.info("Removing stale device: %s", device_id)
 
-            device = device_registry.async_get_device(identifiers={(DOMAIN, device_id)})
+            device = device_registry.async_get_device_by_identifier(
+                (DOMAIN, device_id), self.config_entry.entry_id
+            )
             if device:
                 device_registry.async_update_device(
                     device_id=device.id,

--- a/homeassistant/components/wolflink/__init__.py
+++ b/homeassistant/components/wolflink/__init__.py
@@ -168,7 +168,9 @@ def _reattach_device_to_hub(
     device_registry = dr.async_get(hass)
     entity_registry = er.async_get(hass)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, str(device_id))})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, str(device_id)), source_entry.entry_id
+    )
     if device is None:
         return
 

--- a/homeassistant/components/xbox/__init__.py
+++ b/homeassistant/components/xbox/__init__.py
@@ -160,14 +160,18 @@ async def async_migrate_entry(hass: HomeAssistant, entry: XboxConfigEntry) -> bo
                 )
                 hass.config_entries.async_add_subentry(entry, subentry)
 
-                if device := dev_reg.async_get_device({(DOMAIN, friend.xuid)}):
+                if device := dev_reg.async_get_device_by_identifier(
+                    (DOMAIN, friend.xuid), entry.entry_id
+                ):
                     dev_reg.async_update_device(
                         device.id,
                         remove_config_entry_id=entry.entry_id,
                         add_config_subentry_id=subentry.subentry_id,
                         add_config_entry_id=entry.entry_id,
                     )
-            if device := dev_reg.async_get_device({(DOMAIN, "xbox_live")}):
+            if device := dev_reg.async_get_device_by_identifier(
+                (DOMAIN, "xbox_live"), entry.entry_id
+            ):
                 dev_reg.async_update_device(
                     device.id, new_identifiers={(DOMAIN, client.xuid)}
                 )

--- a/homeassistant/components/yolink/__init__.py
+++ b/homeassistant/components/yolink/__init__.py
@@ -80,8 +80,8 @@ class YoLinkHomeMessageListener(MessageListener):
             and msg_data.get("event") is not None
         ):
             device_registry = dr.async_get(self._hass)
-            device_entry = device_registry.async_get_device(
-                identifiers={(DOMAIN, device_coordinator.device.device_id)}
+            device_entry = device_registry.async_get_device_by_identifier(
+                (DOMAIN, device_coordinator.device.device_id), self._entry.entry_id
             )
             if device_entry is None:
                 return


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate integrations from the deprecated `async_get_device` to `async_get_device_by_identifier` (part 4)

This migrates trivial cases where all oof the following is true:
- The integration expects a single matching device
- The integration passes a single identifier
- The config entry is in scope

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
