### PR TITLE
Remove redundant device lookups

### DIFF
--- a/homeassistant/components/acmeda/entity.py
+++ b/homeassistant/components/acmeda/entity.py
@@ -29,15 +29,13 @@ class AcmedaEntity(entity.Entity):
         if self.entity_id in ent_registry.entities:
             ent_registry.async_remove(self.entity_id)
 
-        dev_registry = dr.async_get(self.hass)
-        device = dev_registry.async_get_device(identifiers={(DOMAIN, self.unique_id)})
         if (
-            device is not None
-            and self.registry_entry is not None
-            and self.registry_entry.config_entry_id is not None
+            self.registry_entry is not None
+            and (config_entry_id := self.registry_entry.config_entry_id) is not None
+            and self.device_entry is not None
         ):
-            dev_registry.async_update_device(
-                device.id, remove_config_entry_id=self.registry_entry.config_entry_id
+            dr.async_get(self.hass).async_update_device(
+                self.device_entry.id, remove_config_entry_id=config_entry_id
             )
 
         await self.async_remove(force_remove=True)

--- a/homeassistant/components/acmeda/entity.py
+++ b/homeassistant/components/acmeda/entity.py
@@ -29,14 +29,8 @@ class AcmedaEntity(entity.Entity):
         if self.entity_id in ent_registry.entities:
             ent_registry.async_remove(self.entity_id)
 
-        if (
-            self.registry_entry is not None
-            and (config_entry_id := self.registry_entry.config_entry_id) is not None
-            and self.device_entry is not None
-        ):
-            dr.async_get(self.hass).async_update_device(
-                self.device_entry.id, remove_config_entry_id=config_entry_id
-            )
+        if self.device_entry:
+            dr.async_get(self.hass).async_remove_device(self.device_entry.id)
 
         await self.async_remove(force_remove=True)
 

--- a/homeassistant/components/devolo_home_control/entity.py
+++ b/homeassistant/components/devolo_home_control/entity.py
@@ -103,16 +103,11 @@ class DevoloDeviceEntity(Entity):
                     ].name,
                 )
             self._attr_available = state
-        elif message[1] == "del" and self.platform.config_entry:
-            device_registry = dr.async_get(self.hass)
-            device = device_registry.async_get_device(
-                identifiers={(DOMAIN, self._device_instance.uid)}
+        elif message[1] == "del" and self.platform.config_entry and self.device_entry:
+            dr.async_get(self.hass).async_update_device(
+                self.device_entry.id,
+                remove_config_entry_id=self.platform.config_entry.entry_id,
             )
-            if device:
-                device_registry.async_update_device(
-                    device.id,
-                    remove_config_entry_id=self.platform.config_entry.entry_id,
-                )
         else:
             _LOGGER.debug("No valid message received: %s", message)
 

--- a/homeassistant/components/devolo_home_control/entity.py
+++ b/homeassistant/components/devolo_home_control/entity.py
@@ -103,11 +103,8 @@ class DevoloDeviceEntity(Entity):
                     ].name,
                 )
             self._attr_available = state
-        elif message[1] == "del" and self.platform.config_entry and self.device_entry:
-            dr.async_get(self.hass).async_update_device(
-                self.device_entry.id,
-                remove_config_entry_id=self.platform.config_entry.entry_id,
-            )
+        elif message[1] == "del" and self.device_entry:
+            dr.async_get(self.hass).async_remove_device(self.device_entry.id)
         else:
             _LOGGER.debug("No valid message received: %s", message)
 

--- a/homeassistant/components/eq3btsmart/climate.py
+++ b/homeassistant/components/eq3btsmart/climate.py
@@ -25,7 +25,6 @@ from homeassistant.const import ATTR_TEMPERATURE, PRECISION_HALVES, UnitOfTemper
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 import homeassistant.util.dt as dt_util
 
@@ -96,12 +95,9 @@ class Eq3Climate(Eq3Entity, ClimateEntity):
     def _async_on_device_updated(self, data: Any) -> None:
         """Handle updated device data from the thermostat."""
 
-        device_registry = dr.async_get(self.hass)
-        if device := device_registry.async_get_device(
-            connections={(CONNECTION_BLUETOOTH, self._eq3_config.mac_address)},
-        ):
-            device_registry.async_update_device(
-                device.id,
+        if self.device_entry:
+            dr.async_get(self.hass).async_update_device(
+                self.device_entry.id,
                 sw_version=str(self._thermostat.device_data.firmware_version),
                 serial_number=self._thermostat.device_data.device_serial,
             )

--- a/homeassistant/components/freebox/entity.py
+++ b/homeassistant/components/freebox/entity.py
@@ -62,11 +62,10 @@ class FreeboxHomeEntity(Entity):
         self._node = self._router.home_devices[self._id]
         # Propagate Freebox device label changes to the device registry so
         # the entity stays in sync when users rename it on the Freebox app.
-        device_registry = dr.async_get(self.hass)
-        if device := device_registry.async_get_device(identifiers={(DOMAIN, self._id)}):
+        if device := self.device_entry:
             new_name = self._node["label"].strip()
             if device.name != new_name:
-                device_registry.async_update_device(device.id, name=new_name)
+                dr.async_get(self.hass).async_update_device(device.id, name=new_name)
         self.async_write_ha_state()
 
     async def set_home_endpoint_value(

--- a/homeassistant/components/husqvarna_automower/calendar.py
+++ b/homeassistant/components/husqvarna_automower/calendar.py
@@ -8,12 +8,10 @@ from aioautomower.model import make_name_string
 
 from homeassistant.components.calendar import CalendarEntity, CalendarEvent
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
 from . import AutomowerConfigEntry
-from .const import DOMAIN
 from .coordinator import AutomowerDataUpdateCoordinator
 from .entity import AutomowerBaseEntity
 
@@ -57,10 +55,7 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
     @property
     def device_name(self) -> str:
         """Return the prefix for the event summary."""
-        device_registry = dr.async_get(self.hass)
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, self.mower_id)}
-        )
+        device_entry = self.device_entry
         if TYPE_CHECKING:
             assert device_entry is not None
             assert device_entry.name is not None

--- a/homeassistant/components/kodi/media_player.py
+++ b/homeassistant/components/kodi/media_player.py
@@ -281,10 +281,11 @@ class KodiEntity(MediaPlayerEntity):
 
         version = (await self._kodi.get_application_properties(["version"]))["version"]
         sw_version = f"{version['major']}.{version['minor']}"
-        dev_reg = dr.async_get(self.hass)
-        device = dev_reg.async_get_device(identifiers={(DOMAIN, self.unique_id)})
-        dev_reg.async_update_device(device.id, sw_version=sw_version)
-        self._device_id = device.id
+        if self.device_entry:
+            dr.async_get(self.hass).async_update_device(
+                self.device_entry.id, sw_version=sw_version
+            )
+            self._device_id = self.device_entry.id
 
         self.async_schedule_update_ha_state(True)
 

--- a/homeassistant/components/netatmo/entity.py
+++ b/homeassistant/components/netatmo/entity.py
@@ -9,7 +9,6 @@ from pyatmo.modules.device_types import DEVICE_DESCRIPTION_MAP
 
 from homeassistant.const import EntityStateAttribute
 from homeassistant.core import callback
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -145,10 +144,7 @@ class NetatmoRoomEntity(NetatmoDeviceEntity):
     async def async_added_to_hass(self) -> None:
         """Entity created."""
         await super().async_added_to_hass()
-        registry = dr.async_get(self.hass)
-        if device := registry.async_get_device(
-            identifiers={(DOMAIN, self.device.entity_id)}
-        ):
+        if device := self.device_entry:
             self.data_handler.device_ids[self.device.entity_id] = device.id
 
     @property

--- a/homeassistant/components/notion/entity.py
+++ b/homeassistant/components/notion/entity.py
@@ -100,19 +100,16 @@ class NotionEntity(CoordinatorEntity[NotionDataUpdateCoordinator]):
         self._bridge_id = sensor.bridge.id
 
         device_registry = dr.async_get(self.hass)
-        this_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, sensor.hardware_id)}
-        )
         bridge = self.coordinator.data.bridges[self._bridge_id]
-        bridge_device = device_registry.async_get_device(
-            identifiers={(DOMAIN, bridge.hardware_id)}
+        bridge_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, bridge.hardware_id), self.coordinator.config_entry.entry_id
         )
 
-        if not bridge_device or not this_device:
+        if not bridge_device or not self.device_entry:
             return
 
         device_registry.async_update_device(
-            this_device.id, via_device_id=bridge_device.id
+            self.device_entry.id, via_device_id=bridge_device.id
         )
 
     @callback


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove redundant device lookups in `acmeda`, `devolo_home_control`, `eq3btmsart`, `freebox`, `husqvarna_automower`, `kodi`, `netatmo`, `notion`

Entities already have a reference to their device, there's no need to look it up

Needs https://github.com/home-assistant/core/pull/176941

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
