### PR TITLE
fix(frontend): prevent stale index after upgrades

### DIFF
--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Iterator
 from functools import lru_cache, partial
+import hashlib
 import logging
 import os
 import pathlib
@@ -9,6 +10,7 @@ import shutil
 from typing import Any, TypedDict, override
 
 from aiohttp import hdrs, web, web_urldispatcher
+from aiohttp.helpers import ETag
 import jinja2
 from propcache.api import cached_property
 import voluptuous as vol
@@ -873,16 +875,24 @@ class IndexView(web_urldispatcher.AbstractResource):
             extra_modules = hass.data[DATA_EXTRA_MODULE_URL].urls
             extra_js_es5 = hass.data[DATA_EXTRA_JS_URL_ES5].urls
 
-        response = web.Response(
-            text=_async_render_index_cached(
-                template,
-                theme_color=MANIFEST_JSON["theme_color"],
-                extra_modules=extra_modules,
-                extra_js_es5=extra_js_es5,
-            ),
-            content_type="text/html",
+        content = _async_render_index_cached(
+            template,
+            theme_color=MANIFEST_JSON["theme_color"],
+            extra_modules=extra_modules,
+            extra_js_es5=extra_js_es5,
         )
-        response.enable_compression()
+        etag = ETag(hashlib.sha256(content.encode()).hexdigest(), is_weak=True)
+
+        if request.if_none_match and any(
+            tag.value in (etag.value, "*") for tag in request.if_none_match
+        ):
+            response = web.Response(status=304)
+        else:
+            response = web.Response(text=content, content_type="text/html")
+            response.enable_compression()
+
+        response.headers[hdrs.CACHE_CONTROL] = "no-cache"
+        response.etag = etag
         return response
 
     @override

--- a/homeassistant/components/frontend/__init__.py
+++ b/homeassistant/components/frontend/__init__.py
@@ -528,20 +528,20 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
 
     static_paths_configs: list[StaticPathConfig] = []
 
-    for path, should_cache in (
-        ("service_worker.js", False),
-        ("sw-modern.js", False),
-        ("sw-modern.js.map", False),
-        ("sw-legacy.js", False),
-        ("sw-legacy.js.map", False),
-        ("robots.txt", False),
-        ("onboarding.html", not is_dev),
-        ("static", not is_dev),
-        ("frontend_latest", not is_dev),
-        ("frontend_es5", not is_dev),
+    for path, should_cache, immutable in (
+        ("service_worker.js", False, False),
+        ("sw-modern.js", False, False),
+        ("sw-modern.js.map", False, False),
+        ("sw-legacy.js", False, False),
+        ("sw-legacy.js.map", False, False),
+        ("robots.txt", False, False),
+        ("onboarding.html", not is_dev, False),
+        ("static", not is_dev, False),
+        ("frontend_latest", not is_dev, True),
+        ("frontend_es5", not is_dev, True),
     ):
         static_paths_configs.append(
-            StaticPathConfig(f"/{path}", str(root_path / path), should_cache)
+            StaticPathConfig(f"/{path}", str(root_path / path), should_cache, immutable)
         )
 
     static_paths_configs.append(
@@ -772,8 +772,11 @@ async def _async_setup_themes(
 
 @callback
 @lru_cache(maxsize=1)
-def _async_render_index_cached(template: jinja2.Template, **kwargs: Any) -> str:
-    return template.render(**kwargs)
+def _async_render_index_cached(
+    template: jinja2.Template, **kwargs: Any
+) -> tuple[str, ETag]:
+    content = template.render(**kwargs)
+    return content, ETag(hashlib.sha256(content.encode()).hexdigest(), is_weak=True)
 
 
 class IndexView(web_urldispatcher.AbstractResource):
@@ -875,13 +878,12 @@ class IndexView(web_urldispatcher.AbstractResource):
             extra_modules = hass.data[DATA_EXTRA_MODULE_URL].urls
             extra_js_es5 = hass.data[DATA_EXTRA_JS_URL_ES5].urls
 
-        content = _async_render_index_cached(
+        content, etag = _async_render_index_cached(
             template,
             theme_color=MANIFEST_JSON["theme_color"],
             extra_modules=extra_modules,
             extra_js_es5=extra_js_es5,
         )
-        etag = ETag(hashlib.sha256(content.encode()).hexdigest(), is_weak=True)
 
         if request.if_none_match and any(
             tag.value in (etag.value, "*") for tag in request.if_none_match

--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -95,7 +95,7 @@ from .forwarded import async_setup_forwarded
 from .headers import setup_headers
 from .request_context import setup_request_context
 from .security_filter import setup_security_filter
-from .static import CACHE_HEADERS, CachingStaticResource
+from .static import CACHE_HEADERS, CachingStaticResource, ImmutableCachingStaticResource
 from .web_runner import HomeAssistantUnixSite
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -149,6 +149,7 @@ class StaticPathConfig:
     url_path: str
     path: str
     cache_headers: bool = True
+    immutable: bool = False
 
 
 _STATIC_CLASSES = {
@@ -606,9 +607,11 @@ class HomeAssistantHTTP:
     ) -> dict[str, CachingStaticResource | web.StaticResource | None]:
         """Create a list of static resources."""
         return {
-            config.url_path: _STATIC_CLASSES[config.cache_headers](
-                config.url_path, config.path
-            )
+            config.url_path: (
+                ImmutableCachingStaticResource
+                if config.cache_headers and config.immutable
+                else _STATIC_CLASSES[config.cache_headers]
+            )(config.url_path, config.path)
             if os.path.isdir(config.path)
             else None
             for config in configs

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -11,7 +11,7 @@ from aiohttp.web_urldispatcher import StaticResource
 from lru import LRU
 
 CACHE_TIME: Final = 31 * 86400  # = 1 month
-CACHE_HEADER = f"public, max-age={CACHE_TIME}"
+CACHE_HEADER = f"public, max-age={CACHE_TIME}, immutable"
 CACHE_HEADERS: Mapping[str, str] = {CACHE_CONTROL: CACHE_HEADER}
 RESPONSE_CACHE: LRU[tuple[str, Path], tuple[Path, str]] = LRU(512)
 

--- a/homeassistant/components/http/static.py
+++ b/homeassistant/components/http/static.py
@@ -11,7 +11,8 @@ from aiohttp.web_urldispatcher import StaticResource
 from lru import LRU
 
 CACHE_TIME: Final = 31 * 86400  # = 1 month
-CACHE_HEADER = f"public, max-age={CACHE_TIME}, immutable"
+CACHE_HEADER = f"public, max-age={CACHE_TIME}"
+IMMUTABLE_CACHE_HEADER = f"{CACHE_HEADER}, immutable"
 CACHE_HEADERS: Mapping[str, str] = {CACHE_CONTROL: CACHE_HEADER}
 RESPONSE_CACHE: LRU[tuple[str, Path], tuple[Path, str]] = LRU(512)
 
@@ -20,6 +21,8 @@ _GUESSER = CONTENT_TYPES.guess_file_type
 
 class CachingStaticResource(StaticResource):
     """Static Resource handler that will add cache headers."""
+
+    cache_header = CACHE_HEADER
 
     @override
     async def _handle(self, request: Request) -> StreamResponse:
@@ -43,5 +46,11 @@ class CachingStaticResource(StaticResource):
             content_type = response.headers[CONTENT_TYPE]
             RESPONSE_CACHE[key] = (file_path, content_type)
 
-        response.headers[CACHE_CONTROL] = CACHE_HEADER
+        response.headers[CACHE_CONTROL] = self.cache_header
         return response
+
+
+class ImmutableCachingStaticResource(CachingStaticResource):
+    """Static resource handler for content-addressed assets."""
+
+    cache_header = IMMUTABLE_CACHE_HEADER

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -167,9 +167,16 @@ async def test_frontend_and_static(mock_http_client: TestClient) -> None:
     """Test if we can get the frontend."""
     resp = await mock_http_client.get("")
     assert resp.status == 200
-    assert "cache-control" not in resp.headers
+    assert resp.headers["cache-control"] == "no-cache"
+    etag = resp.headers["etag"]
+    assert etag.startswith('W/"')
 
     text = await resp.text()
+
+    resp = await mock_http_client.get("", headers={"If-None-Match": etag})
+    assert resp.status == HTTPStatus.NOT_MODIFIED
+    assert resp.headers["cache-control"] == "no-cache"
+    assert resp.headers["etag"] == etag
 
     # Test we can retrieve frontend.js
     frontendjs = re.search(r"(?P<app>\/frontend_es5\/app.[A-Za-z0-9_-]{16}.js)", text)
@@ -178,6 +185,7 @@ async def test_frontend_and_static(mock_http_client: TestClient) -> None:
     resp = await mock_http_client.get(frontendjs.groups(0)[0])
     assert resp.status == 200
     assert "public" in resp.headers.get("cache-control")
+    assert "immutable" in resp.headers.get("cache-control")
 
 
 @pytest.mark.parametrize("sw_url", ["/sw-modern.js", "/sw-legacy.js"])

--- a/tests/components/frontend/test_init.py
+++ b/tests/components/frontend/test_init.py
@@ -626,7 +626,7 @@ async def test_extra_js(
     async def get_response():
         resp = await mock_http_client_with_extra_js.get("")
         assert resp.status == 200
-        assert "cache-control" not in resp.headers
+        assert resp.headers["cache-control"] == "no-cache"
 
         return await resp.text()
 

--- a/tests/components/http/test_static.py
+++ b/tests/components/http/test_static.py
@@ -61,5 +61,6 @@ async def test_async_register_static_paths(
     client = await hass_client()
     resp = await client.get("/something/__init__.py")
     assert resp.status == HTTPStatus.OK
+    assert "immutable" not in resp.headers["cache-control"]
     resp = await client.get("/something_else/__init__.py")
     assert resp.status == HTTPStatus.OK


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

This is not a breaking change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Prevent browsers and reverse proxies from serving a stale frontend index after a Home Assistant upgrade.

The frontend index is now served with `Cache-Control: no-cache` and a weak ETag derived from the rendered HTML. Matching `If-None-Match` requests receive `304 Not Modified`. Content-hashed frontend assets use `immutable` caching.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176912
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

AI tools were used to assist with repository exploration and drafting. I reviewed the implementation and test changes and understand them.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than the
  number of reviewers who can review and merge them, so there is a long backlog
  of pull requests waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull requests will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr