### PR TITLE
Fix HomeKit accessory reload when attributes change while unavailable

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -591,9 +591,16 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
                 attr: baseline_state.attributes.get(attr)
                 for attr in self._reload_on_change_attrs
             }
-        if state is not None and state is not baseline_state:
-            # Catch up on changes between construction and run.
-            self._async_reload_if_attrs_changed(state)
+        if (
+            state is not None
+            and state is not baseline_state
+            and self._async_reload_attrs_diverged(state)
+        ):
+            # Catch up on changes between construction and run. The reload
+            # is deferred: dispatcher targets start eagerly, so an inline
+            # reload would stop and replace this accessory before it
+            # finished starting.
+            self.hass.loop.call_soon(self.async_reload)
         self._subscriptions.append(
             async_track_state_change_event(
                 self.hass,
@@ -642,13 +649,15 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
             self.async_update_battery(battery_state, battery_charging_state)
 
     @ha_callback
-    def _async_reload_if_attrs_changed(self, new_state: State) -> bool:
-        """Request a reload if any reload attr diverged from the baseline.
+    def _async_reload_attrs_diverged(self, new_state: State) -> bool:
+        """Check if any reload attr diverged from the baseline.
 
         The baseline is the state the accessory was built from, so
         changes that arrive while the entity is unavailable (which
-        strips most attributes) still trigger a reload once the entity
-        is back. Returns True if a reload was requested.
+        strips most attributes) are still detected once the entity is
+        back. On divergence the baseline advances so a reload is only
+        requested once; the recreated accessory captures a fresh
+        baseline.
         """
         if (
             new_state.state == STATE_UNAVAILABLE
@@ -666,14 +675,10 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
                     baseline_value,
                     new_attributes.get(attr),
                 )
-                # Advance the baseline so the reload is only requested
-                # once per divergence; the recreated accessory will
-                # capture a fresh baseline.
                 self._reload_attr_baseline = {
                     reload_attr: new_attributes.get(reload_attr)
                     for reload_attr in baseline
                 }
-                self.async_reload()
                 return True
         return False
 
@@ -684,7 +689,8 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
         """Handle state change event listener callback."""
         new_state = event.data["new_state"]
         self._update_available_from_state(new_state)
-        if new_state and self._async_reload_if_attrs_changed(new_state):
+        if new_state and self._async_reload_attrs_diverged(new_state):
+            self.async_reload()
             return
         self.async_update_state_callback(new_state)
 

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -449,6 +449,8 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
             **kwargs,
         )
         self._reload_on_change_attrs = list(RELOAD_ON_CHANGE_ATTRS)
+        self._reload_attr_baseline: dict[str, Any] | None = None
+        self._creation_state: State | None = None
         self.config = config or {}
         if device_id:
             self.device_id: str | None = device_id
@@ -522,6 +524,7 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
         state = self.hass.states.get(self.entity_id)
         self._update_available_from_state(state)
         assert state is not None
+        self._creation_state = state
         entity_attributes = state.attributes
         battery_found = entity_attributes.get(ATTR_BATTERY_LEVEL)
 
@@ -579,6 +582,18 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
         if state := self.hass.states.get(self.entity_id):
             self.async_update_state_callback(state)
         self._update_available_from_state(state)
+        baseline_state = self._creation_state or state
+        self._creation_state = None
+        if self._reload_attr_baseline is None and baseline_state is not None:
+            # Materialized here, not in __init__: subclasses extend
+            # _reload_on_change_attrs after HomeAccessory.__init__.
+            self._reload_attr_baseline = {
+                attr: baseline_state.attributes.get(attr)
+                for attr in self._reload_on_change_attrs
+            }
+        if state is not None and state is not baseline_state:
+            # Catch up on changes between construction and run.
+            self._async_reload_if_attrs_changed(state)
         self._subscriptions.append(
             async_track_state_change_event(
                 self.hass,
@@ -627,32 +642,50 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
             self.async_update_battery(battery_state, battery_charging_state)
 
     @ha_callback
+    def _async_reload_if_attrs_changed(self, new_state: State) -> bool:
+        """Request a reload if any reload attr diverged from the baseline.
+
+        The baseline is the state the accessory was built from, so
+        changes that arrive while the entity is unavailable (which
+        strips most attributes) still trigger a reload once the entity
+        is back. Returns True if a reload was requested.
+        """
+        if (
+            new_state.state == STATE_UNAVAILABLE
+            or (baseline := self._reload_attr_baseline) is None
+        ):
+            return False
+        new_attributes = new_state.attributes
+        for attr, baseline_value in baseline.items():
+            if baseline_value != new_attributes.get(attr):
+                _LOGGER.debug(
+                    "%s: Reloading HomeKit accessory since"
+                    " %s has changed from %s -> %s",
+                    self.entity_id,
+                    attr,
+                    baseline_value,
+                    new_attributes.get(attr),
+                )
+                # Advance the baseline so the reload is only requested
+                # once per divergence; the recreated accessory will
+                # capture a fresh baseline.
+                self._reload_attr_baseline = {
+                    reload_attr: new_attributes.get(reload_attr)
+                    for reload_attr in baseline
+                }
+                self.async_reload()
+                return True
+        return False
+
+    @ha_callback
     def async_update_event_state_callback(
         self, event: Event[EventStateChangedData]
     ) -> None:
         """Handle state change event listener callback."""
         new_state = event.data["new_state"]
-        old_state = event.data["old_state"]
         self._update_available_from_state(new_state)
-        if (
-            new_state
-            and old_state
-            and STATE_UNAVAILABLE not in (old_state.state, new_state.state)
-        ):
-            old_attributes = old_state.attributes
-            new_attributes = new_state.attributes
-            for attr in self._reload_on_change_attrs:
-                if old_attributes.get(attr) != new_attributes.get(attr):
-                    _LOGGER.debug(
-                        "%s: Reloading HomeKit accessory since"
-                        " %s has changed from %s -> %s",
-                        self.entity_id,
-                        attr,
-                        old_attributes.get(attr),
-                        new_attributes.get(attr),
-                    )
-                    self.async_reload()
-                    return
+        if new_state and self._async_reload_if_attrs_changed(new_state):
+            return
         self.async_update_state_callback(new_state)
 
     @ha_callback

--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -1,5 +1,6 @@
 """Extend the basic Accessory and Bridge functions."""
 
+import asyncio
 import logging
 from typing import Any, cast
 from uuid import UUID
@@ -451,6 +452,7 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
         self._reload_on_change_attrs = list(RELOAD_ON_CHANGE_ATTRS)
         self._reload_attr_baseline: dict[str, Any] | None = None
         self._creation_state: State | None = None
+        self._pending_reload: asyncio.Handle | None = None
         self.config = config or {}
         if device_id:
             self.device_id: str | None = device_id
@@ -600,7 +602,7 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
             # is deferred: dispatcher targets start eagerly, so an inline
             # reload would stop and replace this accessory before it
             # finished starting.
-            self.hass.loop.call_soon(self.async_reload)
+            self._pending_reload = self.hass.loop.call_soon(self.async_reload)
         self._subscriptions.append(
             async_track_state_change_event(
                 self.hass,
@@ -652,12 +654,14 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
     def _async_reload_attrs_diverged(self, new_state: State) -> bool:
         """Check if any reload attr diverged from the baseline.
 
-        The baseline is the state the accessory was built from, so
-        changes that arrive while the entity is unavailable (which
-        strips most attributes) are still detected once the entity is
-        back. On divergence the baseline advances so a reload is only
-        requested once; the recreated accessory captures a fresh
-        baseline.
+        The baseline holds the attribute values the accessory structure
+        was built from. Comparing against it instead of the previous
+        event's state also detects changes that land where pairwise
+        comparison cannot see them: transitions involving unavailable
+        states, entity remove/re-add (no old state), and the window
+        between accessory construction and driver start. On divergence
+        the baseline advances so a reload is only requested once; the
+        recreated accessory captures a fresh baseline.
         """
         if (
             new_state.state == STATE_UNAVAILABLE
@@ -868,6 +872,9 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
     @ha_callback
     def async_stop(self) -> None:
         """Cancel any subscriptions when the bridge is stopped."""
+        if self._pending_reload is not None:
+            self._pending_reload.cancel()
+            self._pending_reload = None
         while self._subscriptions:
             self._subscriptions.pop(0)()
 

--- a/tests/components/homekit/test_accessories.py
+++ b/tests/components/homekit/test_accessories.py
@@ -41,6 +41,7 @@ from homeassistant.const import (
     ATTR_MANUFACTURER,
     ATTR_MODEL,
     ATTR_SERVICE,
+    ATTR_SUPPORTED_FEATURES,
     ATTR_SW_VERSION,
     STATE_OFF,
     STATE_ON,
@@ -66,6 +67,85 @@ async def test_accessory_cancels_track_state_change_on_stop(
         "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
     ):
         acc.run()
+    await acc.stop()
+
+
+async def test_reload_on_attr_change_after_unavailable_at_creation(
+    hass: HomeAssistant, hk_driver: HomeDriver
+) -> None:
+    """Test reload when a reload attr changes across an unavailable transition.
+
+    The accessory is created while the entity is unavailable and the
+    attribute change arrives in the same state change that makes the
+    entity available again.
+    """
+    entity_id = "sensor.accessory"
+    hass.states.async_set(entity_id, STATE_UNAVAILABLE, {ATTR_SUPPORTED_FEATURES: 1})
+    await hass.async_block_till_done()
+    acc = HomeAccessory(
+        hass, hk_driver, "Home Accessory", entity_id, 2, {"platform": "isy994"}
+    )
+    with (
+        patch(
+            "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+        ),
+        patch.object(acc, "async_reload") as mock_reload,
+    ):
+        acc.run()
+        await hass.async_block_till_done()
+        hass.states.async_set(entity_id, STATE_ON, {ATTR_SUPPORTED_FEATURES: 3})
+        await hass.async_block_till_done()
+        mock_reload.assert_called_once()
+    await acc.stop()
+
+
+async def test_reload_on_attr_change_between_creation_and_run(
+    hass: HomeAssistant, hk_driver: HomeDriver
+) -> None:
+    """Test catch-up reload when attrs change before the accessory runs."""
+    entity_id = "sensor.accessory"
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_SUPPORTED_FEATURES: 1})
+    await hass.async_block_till_done()
+    acc = HomeAccessory(
+        hass, hk_driver, "Home Accessory", entity_id, 2, {"platform": "isy994"}
+    )
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_SUPPORTED_FEATURES: 3})
+    await hass.async_block_till_done()
+    with (
+        patch(
+            "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+        ),
+        patch.object(acc, "async_reload") as mock_reload,
+    ):
+        acc.run()
+        await hass.async_block_till_done()
+        mock_reload.assert_called_once()
+    await acc.stop()
+
+
+async def test_no_reload_on_unavailable_flap_with_unchanged_attrs(
+    hass: HomeAssistant, hk_driver: HomeDriver
+) -> None:
+    """Test no reload when the entity flaps unavailable and recovers unchanged."""
+    entity_id = "sensor.accessory"
+    hass.states.async_set(entity_id, STATE_ON, {ATTR_SUPPORTED_FEATURES: 1})
+    await hass.async_block_till_done()
+    acc = HomeAccessory(
+        hass, hk_driver, "Home Accessory", entity_id, 2, {"platform": "isy994"}
+    )
+    with (
+        patch(
+            "homeassistant.components.homekit.accessories.HomeAccessory.async_update_state"
+        ),
+        patch.object(acc, "async_reload") as mock_reload,
+    ):
+        acc.run()
+        await hass.async_block_till_done()
+        hass.states.async_set(entity_id, STATE_UNAVAILABLE)
+        await hass.async_block_till_done()
+        hass.states.async_set(entity_id, STATE_ON, {ATTR_SUPPORTED_FEATURES: 1})
+        await hass.async_block_till_done()
+        mock_reload.assert_not_called()
     await acc.stop()
 
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1111,9 +1111,10 @@ TV_ATTRS_ON = {
             {
                 ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.TV,
                 ATTR_SUPPORTED_FEATURES: TV_FEATURES_ON,
+                ATTR_INPUT_SOURCE_LIST: ["Live TV"],
             },
-            [],
-            False,
+            ["Live TV"],
+            True,
             [(STATE_ON, TV_ATTRS_ON)],
             ["Live TV", "HDMI 1", "HDMI 2", "Netflix"],
             id="created_while_unavailable",
@@ -1159,10 +1160,10 @@ async def test_homekit_reload_tv_accessory_on_attr_change(
 ) -> None:
     """Test a TV accessory in accessory mode is recreated when reload attrs change.
 
-    An unavailable entity has most attributes stripped, so an accessory
-    created while unavailable has no input sources. An available
-    webOS-style TV starts with only the "Live TV" fallback and TURN_ON
-    support that is dropped once the TV is on.
+    A webOS-style TV that is off/unreachable at startup reports only the
+    "Live TV" fallback in its source list; turning the TV on delivers
+    the full source list (and drops TURN_ON support) in a transition the
+    old code either skipped (unavailable) or must not miss (off -> on).
     """
     entry = MockConfigEntry(
         domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -42,6 +42,11 @@ from homeassistant.components.light import (
     ATTR_SUPPORTED_COLOR_MODES,
     ColorMode,
 )
+from homeassistant.components.media_player import (
+    ATTR_INPUT_SOURCE_LIST,
+    MediaPlayerDeviceClass,
+    MediaPlayerEntityFeature,
+)
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_ZEROCONF
@@ -49,12 +54,15 @@ from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_DEVICE_ID,
     ATTR_ENTITY_ID,
+    ATTR_SUPPORTED_FEATURES,
     ATTR_UNIT_OF_MEASUREMENT,
     CONF_NAME,
     CONF_PORT,
     EVENT_HOMEASSISTANT_STARTED,
     SERVICE_RELOAD,
+    STATE_OFF,
     STATE_ON,
+    STATE_UNAVAILABLE,
     EntityCategory,
     UnitOfDensity,
     UnitOfRatio,
@@ -1061,6 +1069,160 @@ async def test_homekit_reload_accessory_same_class(
         await hass.async_block_till_done()
         light_accessory_color_and_temp = next(iter(bridge.accessories.values()))
         assert hasattr(light_accessory_color_and_temp, "char_color_temp")
+
+        await homekit.async_stop()
+
+
+TV_FEATURES_OFF = (
+    MediaPlayerEntityFeature.PAUSE
+    | MediaPlayerEntityFeature.VOLUME_SET
+    | MediaPlayerEntityFeature.VOLUME_MUTE
+    | MediaPlayerEntityFeature.TURN_ON
+    | MediaPlayerEntityFeature.TURN_OFF
+    | MediaPlayerEntityFeature.VOLUME_STEP
+    | MediaPlayerEntityFeature.SELECT_SOURCE
+)
+TV_FEATURES_ON = TV_FEATURES_OFF & ~MediaPlayerEntityFeature.TURN_ON
+TV_ATTRS_OFF = {
+    ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.TV,
+    ATTR_SUPPORTED_FEATURES: TV_FEATURES_OFF,
+    ATTR_INPUT_SOURCE_LIST: ["Live TV"],
+}
+TV_ATTRS_ON = {
+    ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.TV,
+    ATTR_SUPPORTED_FEATURES: TV_FEATURES_ON,
+    ATTR_INPUT_SOURCE_LIST: ["Live TV", "HDMI 1", "HDMI 2", "Netflix"],
+}
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf", "mock_hap")
+@pytest.mark.parametrize(
+    (
+        "initial_state",
+        "initial_attrs",
+        "initial_sources",
+        "initial_support_select_source",
+        "events",
+        "expected_sources",
+    ),
+    [
+        pytest.param(
+            STATE_UNAVAILABLE,
+            {
+                ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.TV,
+                ATTR_SUPPORTED_FEATURES: TV_FEATURES_ON,
+            },
+            [],
+            False,
+            [(STATE_ON, TV_ATTRS_ON)],
+            ["Live TV", "HDMI 1", "HDMI 2", "Netflix"],
+            id="created_while_unavailable",
+        ),
+        pytest.param(
+            STATE_OFF,
+            TV_ATTRS_OFF,
+            ["Live TV"],
+            True,
+            [(STATE_ON, TV_ATTRS_ON)],
+            ["Live TV", "HDMI 1", "HDMI 2", "Netflix"],
+            id="source_list_grows_while_available",
+        ),
+        pytest.param(
+            STATE_OFF,
+            TV_ATTRS_OFF,
+            ["Live TV"],
+            True,
+            [
+                (
+                    STATE_ON,
+                    {
+                        ATTR_DEVICE_CLASS: MediaPlayerDeviceClass.TV,
+                        ATTR_SUPPORTED_FEATURES: TV_FEATURES_ON,
+                        ATTR_INPUT_SOURCE_LIST: ["Live TV"],
+                    },
+                ),
+                (STATE_ON, TV_ATTRS_ON),
+            ],
+            ["Live TV", "HDMI 1", "HDMI 2", "Netflix"],
+            id="rapid_state_changes",
+        ),
+    ],
+)
+async def test_homekit_reload_tv_accessory_on_attr_change(
+    hass: HomeAssistant,
+    initial_state: str,
+    initial_attrs: dict[str, Any],
+    initial_sources: list[str],
+    initial_support_select_source: bool,
+    events: list[tuple[str, dict[str, Any]]],
+    expected_sources: list[str],
+) -> None:
+    """Test a TV accessory in accessory mode is recreated when reload attrs change.
+
+    An unavailable entity has most attributes stripped, so an accessory
+    created while unavailable has no input sources. An available
+    webOS-style TV starts with only the "Live TV" fallback and TURN_ON
+    support that is dropped once the TV is on.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "media_player.television"
+    hass.states.async_set(entity_id, initial_state, initial_attrs)
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_ACCESSORY)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit):
+        await async_init_entry(hass, entry)
+        acc = homekit.driver.accessory
+        acc.run()
+        assert type(acc).__name__ == "TelevisionMediaPlayer"
+        assert acc.sources == initial_sources
+        assert acc.support_select_source is initial_support_select_source
+        await hass.async_block_till_done()
+        assert homekit.status == STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
+        config_version = homekit.driver.state.config_version
+        for event_state, event_attrs in events:
+            hass.states.async_set(entity_id, event_state, event_attrs)
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        new_acc = homekit.driver.accessory
+        assert new_acc is not acc
+        assert new_acc.support_select_source is True
+        assert new_acc.sources == expected_sources
+        assert homekit.driver.state.config_version > config_version
+
+        await homekit.async_stop()
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf", "mock_hap")
+async def test_homekit_reload_bridged_tv_when_source_list_grows(
+    hass: HomeAssistant,
+) -> None:
+    """Test reloading a bridged TV accessory when the source list grows."""
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "media_player.television"
+    hass.states.async_set(entity_id, STATE_OFF, TV_ATTRS_OFF)
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit):
+        await async_init_entry(hass, entry)
+        bridge: HomeBridge = homekit.driver.accessory
+        await bridge.run()
+        acc = next(iter(bridge.accessories.values()))
+        assert type(acc).__name__ == "TelevisionMediaPlayer"
+        assert acc.sources == ["Live TV"]
+        await hass.async_block_till_done()
+        assert homekit.status == STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
+        hass.states.async_set(entity_id, STATE_ON, TV_ATTRS_ON)
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        new_acc = next(iter(bridge.accessories.values()))
+        assert new_acc is not acc
+        assert new_acc.sources == ["Live TV", "HDMI 1", "HDMI 2", "Netflix"]
 
         await homekit.async_stop()
 

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -1196,6 +1196,39 @@ async def test_homekit_reload_tv_accessory_on_attr_change(
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf", "mock_hap")
+async def test_homekit_reload_tv_accessory_attrs_changed_before_run(
+    hass: HomeAssistant,
+) -> None:
+    """Test catch-up reload for changes between accessory creation and run.
+
+    The replaced accessory must not keep any state subscriptions behind.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_NAME: "mock_name", CONF_PORT: 12345}
+    )
+    entity_id = "media_player.television"
+    hass.states.async_set(entity_id, STATE_OFF, TV_ATTRS_OFF)
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_ACCESSORY)
+
+    with patch(f"{PATH_HOMEKIT}.HomeKit", return_value=homekit):
+        await async_init_entry(hass, entry)
+        acc = homekit.driver.accessory
+        assert acc.sources == ["Live TV"]
+        hass.states.async_set(entity_id, STATE_ON, TV_ATTRS_ON)
+        acc.run()
+        await hass.async_block_till_done()
+        await hass.async_block_till_done()
+        assert homekit.status == STATUS_RUNNING
+        homekit.driver.aio_stop_event = MagicMock()
+        new_acc = homekit.driver.accessory
+        assert new_acc is not acc
+        assert new_acc.sources == ["Live TV", "HDMI 1", "HDMI 2", "Netflix"]
+        assert not acc._subscriptions
+
+        await homekit.async_stop()
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf", "mock_hap")
 async def test_homekit_reload_bridged_tv_when_source_list_grows(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The HomeKit integration rebuilds an accessory when attributes that define its HomeKit structure change (`supported_features`, `device_class`, `unit_of_measurement`, and per-type extras such as a TV's `source_list`). That check compared the old vs new state of each `state_changed` event and was skipped entirely whenever either state was `unavailable`, so any structural change that arrives together with an `unavailable → available` transition never triggered a rebuild.

Real-world impact (#156842): an LG webOS TV that is off when Home Assistant starts exposes only the hardcoded "Live TV" fallback source. Once the TV comes online the `media_player` entity gets the full source list, but the HomeKit accessory keeps the single stale input forever — the Apple Home app shows only "Live TV" until Home Assistant is restarted with the TV on. The same failure mode applies to any integration whose entities are unavailable while the device is off or unreachable.

This PR replaces the old-vs-new comparison with a comparison against a baseline captured from the state the accessory was built from:

- `HomeAccessory` snapshots its creation `State` in `__init__` and materializes the `_reload_attr_baseline` dict in `run()` (subclasses extend `_reload_on_change_attrs` after `HomeAccessory.__init__`, so it cannot be built earlier).
- Compared to only removing the unavailable guard from the pairwise comparison, the baseline also detects changes that land where event pairs cannot see them: transitions involving skipped states, entity remove/re-add (`old_state is None`), and the window between accessory construction and driver start.
- A new available state whose reload attributes diverge from the baseline requests a reload; the baseline advances so a reload is only requested once per divergence, and the recreated accessory captures a fresh baseline.
- `run()` performs a catch-up check for changes that land between accessory construction and driver start — a window the old code also missed.
- Entities that flap unavailable and recover with unchanged attributes do not reload, so flaky devices cannot cause reload storms. The event-path hot code got marginally cheaper (no old-state lookup or per-event tuple allocation).

Validated on real hardware (LG webOS TV + iPhone) in both accessory mode scenarios: created-while-unavailable and the available `off → on` transition with a growing source list. After this change, turning the TV on rebuilds the accessory and the Apple Home app shows the full input list.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156842
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
