### PR TITLE
Add explicit methods for composite devices

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1277,9 +1277,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         )
 
     @callback
-    def async_get(
-        self, device_id: str, *, restore_composite: bool = True
-    ) -> DeviceEntry | None:
+    def async_get(self, device_id: str) -> DeviceEntry | None:
         """Get device.
 
         We retrieve the DeviceEntry from the underlying dict to avoid
@@ -1289,14 +1287,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         merged from the split devices is returned, so integration code that resolves a
         device by id (e.g. in a service handler) keeps working. The composite is
         synthesized on demand and never stored, so it stays invisible to enumeration,
-        identifier search and the frontend device list. Pass restore_composite=False
-        to instead return None for a composite device id.
+        identifier search and the frontend device list.
         """
         if (device := self._device_data.get(device_id)) is not None:
             return device
-        if restore_composite and (
-            split_devices := self.devices.get_devices_for_composite_device_id(device_id)
-        ):
+        if split_devices := self.devices.get_devices_for_composite_device_id(device_id):
             return self._restore_composite_device(device_id, split_devices)
         return None
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1277,7 +1277,9 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         )
 
     @callback
-    def async_get(self, device_id: str) -> DeviceEntry | None:
+    def async_get(
+        self, device_id: str, *, restore_composite: bool = True
+    ) -> DeviceEntry | None:
         """Get device.
 
         We retrieve the DeviceEntry from the underlying dict to avoid
@@ -1287,11 +1289,14 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         merged from the split devices is returned, so integration code that resolves a
         device by id (e.g. in a service handler) keeps working. The composite is
         synthesized on demand and never stored, so it stays invisible to enumeration,
-        identifier search and the frontend device list.
+        identifier search and the frontend device list. Pass restore_composite=False
+        to instead return None for a composite device id.
         """
         if (device := self._device_data.get(device_id)) is not None:
             return device
-        if split_devices := self.devices.get_devices_for_composite_device_id(device_id):
+        if restore_composite and (
+            split_devices := self.devices.get_devices_for_composite_device_id(device_id)
+        ):
             return self._restore_composite_device(device_id, split_devices)
         return None
 
@@ -1456,6 +1461,17 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         empty list for a device id which is not a composite device id.
         """
         return self.devices.get_devices_for_composite_device_id(composite_device_id)
+
+    @callback
+    def async_is_composite_device_id(self, device_id: str) -> bool:
+        """Return True if device_id is a pre-migration composite device id.
+
+        A composite device was split into one device per config entry; the
+        composite device id no longer refers to a registered device.
+        """
+        return device_id not in self.devices and bool(
+            self.devices.get_devices_for_composite_device_id(device_id)
+        )
 
     def _substitute_name_placeholders(
         self,

--- a/homeassistant/helpers/entity_registry.py
+++ b/homeassistant/helpers/entity_registry.py
@@ -1760,10 +1760,8 @@ class EntityRegistry(BaseRegistry):
         if not device_id or device_id is UNDEFINED:
             return device_id
         device_registry = dr.async_get(self.hass)
-        if device_id in device_registry.devices:
-            return device_id
-        if not device_registry.async_get_devices_for_composite_device_id(device_id):
-            # Not a composite id, let _validate_item reject it
+        if not device_registry.async_is_composite_device_id(device_id):
+            # A real device or an unknown id; let _validate_item handle it
             return device_id
         report_issue = async_suggest_report_issue(
             self.hass, integration_domain=platform

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2946,6 +2946,69 @@ async def test_clear_config_subentry_clears_pending_move_targeting_it(
     assert device.id not in device_registry.devices
 
 
+async def test_async_is_composite_device_id(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test asking the registry if a device id is a pre-migration composite id."""
+    entry_1 = MockConfigEntry(domain="test")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="test")
+    entry_2.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "1")}
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "2")}
+    )
+    old_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry.devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=old_id
+    )
+    device_registry.devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=old_id
+    )
+
+    assert device_registry.async_is_composite_device_id(old_id) is True
+    assert device_registry.async_is_composite_device_id(device_1.id) is False
+    assert device_registry.async_is_composite_device_id(device_2.id) is False
+    assert device_registry.async_is_composite_device_id("unknown_id") is False
+
+
+async def test_async_get_restore_composite(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test async_get can be asked to not restore a composite device."""
+    entry_1 = MockConfigEntry(domain="test")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="test")
+    entry_2.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "1")}
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "2")}
+    )
+    old_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry.devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=old_id
+    )
+    device_registry.devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=old_id
+    )
+
+    # A composite device is restored by default, but not when opted out
+    assert device_registry.async_get(old_id) is not None
+    assert device_registry.async_get(old_id, restore_composite=False) is None
+
+    # A real device is returned in both cases
+    assert device_registry.async_get(
+        device_1.id, restore_composite=False
+    ) is device_registry.async_get(device_1.id)
+    assert device_registry.async_get("unknown_id", restore_composite=False) is None
+
+
 @pytest.mark.parametrize("load_registries", [False])
 async def test_async_get_device_composite_reuses_pre_migration_id(
     hass: HomeAssistant, hass_storage: dict[str, Any]

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2975,40 +2975,6 @@ async def test_async_is_composite_device_id(
     assert device_registry.async_is_composite_device_id("unknown_id") is False
 
 
-async def test_async_get_restore_composite(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
-    """Test async_get can be asked to not restore a composite device."""
-    entry_1 = MockConfigEntry(domain="test")
-    entry_1.add_to_hass(hass)
-    entry_2 = MockConfigEntry(domain="test")
-    entry_2.add_to_hass(hass)
-    device_1 = device_registry.async_get_or_create(
-        config_entry_id=entry_1.entry_id, identifiers={("test", "1")}
-    )
-    device_2 = device_registry.async_get_or_create(
-        config_entry_id=entry_2.entry_id, identifiers={("test", "2")}
-    )
-    old_id = "composite00000000000000000000ab"
-    # Simulate a migration split: both devices carry the pre-migration composite id
-    device_registry.devices[device_1.id] = attr.evolve(
-        device_1, composite_device_id=old_id
-    )
-    device_registry.devices[device_2.id] = attr.evolve(
-        device_2, composite_device_id=old_id
-    )
-
-    # A composite device is restored by default, but not when opted out
-    assert device_registry.async_get(old_id) is not None
-    assert device_registry.async_get(old_id, restore_composite=False) is None
-
-    # A real device is returned in both cases
-    assert device_registry.async_get(
-        device_1.id, restore_composite=False
-    ) is device_registry.async_get(device_1.id)
-    assert device_registry.async_get("unknown_id", restore_composite=False) is None
-
-
 @pytest.mark.parametrize("load_registries", [False])
 async def test_async_get_device_composite_reuses_pre_migration_id(
     hass: HomeAssistant, hass_storage: dict[str, Any]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add explicit methods for composite device handling:
- ~~Add an opt-out option to async_get to not have it return composites~~ removed
- Add method `async_is_composite_device_id` to check if a device id is a composite device

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
