### PR TITLE
Use registry for Alexa name override

### DIFF
--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -45,7 +45,7 @@ from homeassistant.const import (
     __version__,
 )
 from homeassistant.core import HomeAssistant, State, callback
-from homeassistant.helpers import network
+from homeassistant.helpers import entity_registry as er, intent, network
 from homeassistant.helpers.entity import entity_sources
 from homeassistant.util.decorator import Registry
 
@@ -283,10 +283,14 @@ class AlexaEntity:
 
     def friendly_name(self) -> str:
         """Return the Alexa API friendly name."""
-        friendly_name: str = self.entity_conf.get(
-            CONF_NAME, self.entity.name
-        ).translate(TRANSLATION_TABLE)
-        return friendly_name
+        name: str | None = self.entity_conf.get(CONF_NAME)
+        if name is None:
+            entity_entry = er.async_get(self.hass).async_get(self.entity_id)
+            aliases = intent.async_get_entity_aliases(
+                self.hass, entity_entry, state=self.entity, allow_empty=False
+            )
+            name = aliases[0]
+        return name.translate(TRANSLATION_TABLE)
 
     def description(self) -> str:
         """Return the Alexa API description."""

--- a/tests/components/alexa/test_entities.py
+++ b/tests/components/alexa/test_entities.py
@@ -77,10 +77,18 @@ async def test_categorized_hidden_entities(
     assert not msg["payload"]["endpoints"]
 
 
-async def test_serialize_discovery(hass: HomeAssistant) -> None:
+async def test_serialize_discovery(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
     """Test we can serialize a discovery."""
     request = get_new_request("Alexa.Discovery", "Discover")
 
+    entity_entry = entity_registry.async_get_or_create(
+        "switch", "test", "bla", suggested_object_id="bla"
+    )
+    entity_registry.async_update_entity(
+        entity_entry.entity_id, aliases=["Alexa Switch"]
+    )
     hass.states.async_set("switch.bla", "on", {"friendly_name": "Boop Woz"})
 
     msg = await smart_home.async_handle_message(hass, get_default_config(hass), request)
@@ -89,6 +97,7 @@ async def test_serialize_discovery(hass: HomeAssistant) -> None:
     msg = msg["event"]
     endpoint = msg["payload"]["endpoints"][0]
 
+    assert endpoint["friendlyName"] == "Alexa Switch"
     assert endpoint["additionalAttributes"] == {
         "manufacturer": "Home Assistant",
         "model": "switch",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Use registry for Alexa name override.

Uses the same mechanism that is already used for Google and Assist aliases. Unlike those two however Alexa does not support more than one name for an exposed entity.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/168900
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53216

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
