### PR TITLE
Bump aiohasupervisor to 0.6.0

### DIFF
--- a/homeassistant/components/hassio/manifest.json
+++ b/homeassistant/components/hassio/manifest.json
@@ -6,6 +6,6 @@
   "documentation": "https://www.home-assistant.io/integrations/hassio",
   "iot_class": "local_polling",
   "quality_scale": "internal",
-  "requirements": ["aiohasupervisor==0.5.0"],
+  "requirements": ["aiohasupervisor==0.6.0"],
   "single_config_entry": true
 }

--- a/homeassistant/components/hassio/strings.json
+++ b/homeassistant/components/hassio/strings.json
@@ -224,6 +224,10 @@
       "description": "System is currently unhealthy due to {reason}. For troubleshooting information, select Learn more.",
       "title": "Unhealthy system - {reason}"
     },
+    "unhealthy_data_filesystem_check_error": {
+      "description": "System is currently unhealthy because a filesystem integrity check failed on the data partition. This can be caused by unexpected power loss or failing storage and may affect configuration, apps, or backups. For troubleshooting information, select Learn more.",
+      "title": "Unhealthy system - Data partition filesystem check failed"
+    },
     "unhealthy_docker": {
       "description": "System is currently unhealthy because Docker is configured incorrectly. For troubleshooting information, select Learn more.",
       "title": "Unhealthy system - Docker misconfigured"
@@ -235,6 +239,10 @@
     "unhealthy_duplicate_os_installation": {
       "description": "System is currently unhealthy because it has detected multiple Home Assistant OS installations. For troubleshooting information, select Learn more.",
       "title": "Unhealthy system - Duplicate Home Assistant OS installation"
+    },
+    "unhealthy_os_filesystem_check_error": {
+      "description": "System is currently unhealthy because a filesystem integrity check failed on an operating system partition. This can be caused by unexpected power loss or failing storage. For troubleshooting information, select Learn more.",
+      "title": "Unhealthy system - OS partition filesystem check failed"
     },
     "unhealthy_oserror_bad_message": {
       "description": "System is currently unhealthy because the operating system has reported an OS error: Bad message. For troubleshooting information, select Learn more.",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -288,7 +288,7 @@ aioharmanluxury==0.2.3
 aioharmony==1.0.8
 
 # homeassistant.components.hassio
-aiohasupervisor==0.5.0
+aiohasupervisor==0.6.0
 
 # homeassistant.components.home_connect
 aiohomeconnect==0.38.0

--- a/tests/components/conftest.py
+++ b/tests/components/conftest.py
@@ -796,6 +796,7 @@ def os_info_fixture(supervisor_client: AsyncMock) -> AsyncMock:
     supervisor_client.os.info.return_value = OSInfo(
         version="1.0.0",
         version_latest="1.0.0",
+        version_pending=None,
         update_available=False,
         board=None,
         boot=None,

--- a/tests/components/hassio/test_binary_sensor.py
+++ b/tests/components/hassio/test_binary_sensor.py
@@ -268,18 +268,21 @@ async def test_mount_refresh_after_issue(
                     "type": "mount_failed",
                     "context": "mount",
                     "reference": "nas",
+                    "reference_extra": None,
                     "suggestions": [
                         {
                             "uuid": uuid4().hex,
                             "type": "execute_reload",
                             "context": "mount",
                             "reference": "nas",
+                            "reference_extra": None,
                         },
                         {
                             "uuid": uuid4().hex,
                             "type": "execute_remove",
                             "context": "mount",
                             "reference": "nas",
+                            "reference_extra": None,
                         },
                     ],
                 },
@@ -306,6 +309,7 @@ async def test_mount_refresh_after_issue(
                     "type": "mount_failed",
                     "context": "mount",
                     "reference": "nas",
+                    "reference_extra": None,
                 },
             },
         }

--- a/tests/components/hassio/test_issues.py
+++ b/tests/components/hassio/test_issues.py
@@ -378,6 +378,7 @@ async def test_reset_issues_supervisor_restart(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(uuid := uuid4()),
+                reference_extra=None,
             )
         ],
         suggestions_by_issue={
@@ -388,6 +389,7 @@ async def test_reset_issues_supervisor_restart(
                     reference=None,
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 )
             ]
         },
@@ -626,18 +628,21 @@ async def test_supervisor_issues(
                 context=ContextType.ADDON,
                 reference="test",
                 uuid=(uuid_issue1 := uuid4()),
+                reference_extra=None,
             ),
             Issue(
                 type=IssueType.MULTIPLE_DATA_DISKS,
                 context=ContextType.SYSTEM,
                 reference="/dev/sda1",
                 uuid=(uuid_issue2 := uuid4()),
+                reference_extra=None,
             ),
             Issue(
                 type="should_not_be_repair",
                 context=ContextType.OS,
                 reference=None,
                 uuid=uuid4(),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -648,6 +653,7 @@ async def test_supervisor_issues(
                     reference="/dev/sda1",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 )
             ]
         },
@@ -699,6 +705,7 @@ async def test_supervisor_issues_initial_failure(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(uuid := uuid4()),
+                reference_extra=None,
             )
         ],
         suggestions_by_issue={
@@ -709,6 +716,7 @@ async def test_supervisor_issues_initial_failure(
                     reference=None,
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 )
             ]
         },
@@ -823,6 +831,7 @@ async def test_supervisor_issues_suggestions_fail(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=uuid4(),
+                reference_extra=None,
             )
         ],
     )
@@ -1258,6 +1267,7 @@ async def test_supervisor_issues_periodic_refresh_backstop(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=uuid4(),
+                reference_extra=None,
             )
         ],
     )
@@ -1300,6 +1310,7 @@ async def test_supervisor_issues_suggestions_change_updates_fixable_state(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=issue_uuid,
+                reference_extra=None,
             )
         ],
         suggestions=[
@@ -1309,6 +1320,7 @@ async def test_supervisor_issues_suggestions_change_updates_fixable_state(
                 reference=None,
                 uuid=uuid4(),
                 auto=False,
+                reference_extra=None,
             )
         ],
         checks=[
@@ -1323,6 +1335,7 @@ async def test_supervisor_issues_suggestions_change_updates_fixable_state(
             reference=None,
             uuid=uuid4(),
             auto=False,
+            reference_extra=None,
         )
     ]
 
@@ -1385,6 +1398,7 @@ async def test_supervisor_issues_periodic_refresh_recovers_after_initial_failure
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=issue_uuid,
+                reference_extra=None,
             )
         ],
         suggestions_by_issue={
@@ -1395,6 +1409,7 @@ async def test_supervisor_issues_periodic_refresh_recovers_after_initial_failure
                     reference=None,
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 )
             ]
         },

--- a/tests/components/hassio/test_repairs.py
+++ b/tests/components/hassio/test_repairs.py
@@ -50,6 +50,7 @@ async def test_supervisor_issue_repair_flow(
                 context=ContextType.SYSTEM,
                 reference="/dev/sda1",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -60,6 +61,7 @@ async def test_supervisor_issue_repair_flow(
                     reference="/dev/sda1",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 )
             ]
         },
@@ -129,6 +131,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions(
                 context=ContextType.SYSTEM,
                 reference="test",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -139,6 +142,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions(
                     reference="test",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
                 Suggestion(
                     type="test_type",
@@ -146,6 +150,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions(
                     reference="test",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -228,6 +233,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confir
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -238,6 +244,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confir
                     reference=None,
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
                 Suggestion(
                     type="test_type",
@@ -245,6 +252,7 @@ async def test_supervisor_issue_repair_flow_with_multiple_suggestions_and_confir
                     reference=None,
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -343,6 +351,7 @@ async def test_supervisor_issue_repair_flow_skip_confirmation(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -353,6 +362,7 @@ async def test_supervisor_issue_repair_flow_skip_confirmation(
                     reference=None,
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -422,6 +432,7 @@ async def test_supervisor_issue_ntp_sync_failed_repair_flow(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -432,6 +443,7 @@ async def test_supervisor_issue_ntp_sync_failed_repair_flow(
                     reference=None,
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -501,6 +513,7 @@ async def test_supervisor_issue_ntp_sync_failed_repair_flow_error(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -511,6 +524,7 @@ async def test_supervisor_issue_ntp_sync_failed_repair_flow_error(
                     reference=None,
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -568,6 +582,7 @@ async def test_mount_failed_repair_flow_error(
                 context=ContextType.MOUNT,
                 reference="backup_share",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -578,6 +593,7 @@ async def test_mount_failed_repair_flow_error(
                     reference="backup_share",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
                 Suggestion(
                     type=SuggestionType.EXECUTE_REMOVE,
@@ -585,6 +601,7 @@ async def test_mount_failed_repair_flow_error(
                     reference="backup_share",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -645,6 +662,7 @@ async def test_mount_failed_repair_flow(
                 context=ContextType.MOUNT,
                 reference="backup_share",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -655,6 +673,7 @@ async def test_mount_failed_repair_flow(
                     reference="backup_share",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
                 Suggestion(
                     type=SuggestionType.EXECUTE_REMOVE,
@@ -662,6 +681,7 @@ async def test_mount_failed_repair_flow(
                     reference="backup_share",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -748,18 +768,21 @@ async def test_supervisor_issue_docker_config_repair_flow(
                 context=ContextType.SYSTEM,
                 reference=None,
                 uuid=(issue1_uuid := uuid4()),
+                reference_extra=None,
             ),
             Issue(
                 type=IssueType.DOCKER_CONFIG,
                 context=ContextType.CORE,
                 reference=None,
                 uuid=(issue2_uuid := uuid4()),
+                reference_extra=None,
             ),
             Issue(
                 type=IssueType.DOCKER_CONFIG,
                 context=ContextType.ADDON,
                 reference="test",
                 uuid=(issue3_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -770,6 +793,7 @@ async def test_supervisor_issue_docker_config_repair_flow(
                     reference=None,
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ],
             issue2_uuid: [
@@ -779,6 +803,7 @@ async def test_supervisor_issue_docker_config_repair_flow(
                     reference=None,
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ],
             issue3_uuid: [
@@ -788,6 +813,7 @@ async def test_supervisor_issue_docker_config_repair_flow(
                     reference="test",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ],
         },
@@ -857,6 +883,7 @@ async def test_supervisor_issue_repair_flow_multiple_data_disks(
                 context=ContextType.SYSTEM,
                 reference="/dev/sda1",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -867,6 +894,7 @@ async def test_supervisor_issue_repair_flow_multiple_data_disks(
                     reference="/dev/sda1",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
                 Suggestion(
                     type=SuggestionType.ADOPT_DATA_DISK,
@@ -874,6 +902,7 @@ async def test_supervisor_issue_repair_flow_multiple_data_disks(
                     reference="/dev/sda1",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -975,6 +1004,7 @@ async def test_supervisor_issue_detached_addon_removed(
                 context=ContextType.ADDON,
                 reference="test",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -985,6 +1015,7 @@ async def test_supervisor_issue_detached_addon_removed(
                     reference="test",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -1062,6 +1093,7 @@ async def test_supervisor_issue_addon_boot_fail(
                 context=ContextType.ADDON,
                 reference="test",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -1072,6 +1104,7 @@ async def test_supervisor_issue_addon_boot_fail(
                     reference="test",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
                 Suggestion(
                     type="disable_boot",
@@ -1079,6 +1112,7 @@ async def test_supervisor_issue_addon_boot_fail(
                     reference="test",
                     uuid=uuid4(),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -1169,6 +1203,7 @@ async def test_supervisor_issue_deprecated_addon(
                 context=ContextType.ADDON,
                 reference="test",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -1179,6 +1214,7 @@ async def test_supervisor_issue_deprecated_addon(
                     reference="test",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },
@@ -1258,6 +1294,7 @@ async def test_supervisor_issue_deprecated_arch_addon(
                 context=ContextType.ADDON,
                 reference="test",
                 uuid=(issue_uuid := uuid4()),
+                reference_extra=None,
             ),
         ],
         suggestions_by_issue={
@@ -1268,6 +1305,7 @@ async def test_supervisor_issue_deprecated_arch_addon(
                     reference="test",
                     uuid=(sugg_uuid := uuid4()),
                     auto=False,
+                    reference_extra=None,
                 ),
             ]
         },

--- a/tests/components/hassio/test_system_health.py
+++ b/tests/components/hassio/test_system_health.py
@@ -102,6 +102,7 @@ async def test_hassio_system_health(
     )
     hass.data[DATA_OS_INFO] = OSInfo(
         version="5.9",
+        version_pending=None,
         version_latest="5.9",
         update_available=False,
         board="odroid-n2",
@@ -293,6 +294,7 @@ async def test_hassio_system_health_with_issues(
     )
     hass.data[DATA_OS_INFO] = OSInfo(
         version=None,
+        version_pending=None,
         version_latest=None,
         update_available=False,
         board=None,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump `aiohasupervisor` from `0.5.0` to `0.6.0` for the `hassio` integration and regenerate `requirements_all.txt`.

This library release adds new `UnhealthyReason` values:
- `os_filesystem_check_error`
- `data_filesystem_check_error`

`tests/components/hassio/test_issues.py` intentionally parametrizes all unhealthy/unsupported reasons from `aiohasupervisor` and validates that corresponding repair translations exist. After the bump, those tests fail until matching translation keys are added in `homeassistant/components/hassio/strings.json`.

This PR therefore includes:
- dependency bump + generated requirements update
- repair translation strings for both new unhealthy reasons
- a small fixture compatibility update in `tests/components/conftest.py` for the new `OSInfo.version_pending` argument introduced in `aiohasupervisor==0.6.0`

Dependency links:
- PyPI release: https://pypi.org/project/aiohasupervisor/0.6.0/
- Release notes: https://github.com/home-assistant-libs/python-supervisor-client/releases/tag/0.6.0
- Compare diff: https://github.com/home-assistant-libs/python-supervisor-client/compare/0.5.0...0.6.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
