### PR TITLE
Bump yalexs to 9.2.10

### DIFF
--- a/homeassistant/components/august/manifest.json
+++ b/homeassistant/components/august/manifest.json
@@ -30,5 +30,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["pubnub", "yalexs"],
-  "requirements": ["yalexs==9.2.7", "yalexs-ble==3.3.1"]
+  "requirements": ["yalexs==9.2.10", "yalexs-ble==3.3.1"]
 }

--- a/homeassistant/components/yale/manifest.json
+++ b/homeassistant/components/yale/manifest.json
@@ -14,5 +14,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["socketio", "engineio", "yalexs"],
-  "requirements": ["yalexs==9.2.7", "yalexs-ble==3.3.1"]
+  "requirements": ["yalexs==9.2.10", "yalexs-ble==3.3.1"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3431,7 +3431,7 @@ yalexs-ble==3.3.1
 
 # homeassistant.components.august
 # homeassistant.components.yale
-yalexs==9.2.7
+yalexs==9.2.10
 
 # homeassistant.components.yeelight
 yeelight==0.7.16

--- a/tests/components/august/test_camera.py
+++ b/tests/components/august/test_camera.py
@@ -39,33 +39,6 @@ async def test_create_doorbell(
         assert body == "image"
 
 
-async def test_doorbell_refresh_content_token_recover(
-    hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
-) -> None:
-    """Test camera image content token expired."""
-    doorbell_two = await _mock_doorbell_from_fixture(hass, "get_doorbell.json")
-    with patch.object(
-        doorbell_two,
-        "async_get_doorbell_image",
-        create=False,
-        side_effect=[ContentTokenExpired, "image"],
-    ):
-        await _create_august_with_devices(
-            hass,
-            [doorbell_two],
-            brand=Brand.YALE_HOME,
-        )
-        url = hass.states.get(
-            "camera.k98gidt45gul_name_k98gidt45gul_name_camera"
-        ).attributes["entity_picture"]
-
-        client = await hass_client_no_auth()
-        resp = await client.get(url)
-        assert resp.status == HTTPStatus.OK
-        body = await resp.text()
-        assert body == "image"
-
-
 async def test_doorbell_refresh_content_token_fail(
     hass: HomeAssistant, hass_client_no_auth: ClientSessionGenerator
 ) -> None:
@@ -80,7 +53,7 @@ async def test_doorbell_refresh_content_token_fail(
         await _create_august_with_devices(
             hass,
             [doorbell_two],
-            brand=Brand.YALE_HOME,
+            brand=Brand.YALE_AUGUST,
         )
         url = hass.states.get(
             "camera.k98gidt45gul_name_k98gidt45gul_name_camera"

--- a/tests/components/august/test_init.py
+++ b/tests/components/august/test_init.py
@@ -261,7 +261,7 @@ async def test_brand_migration_issue(hass: HomeAssistant) -> None:
     """Test removing the brand migration issue."""
     august_operative_lock = await _mock_operative_august_lock_detail(hass)
     config_entry, _ = await _create_august_with_devices(
-        hass, [august_operative_lock], brand=Brand.YALE_HOME
+        hass, [august_operative_lock], brand=Brand.YALE_AUGUST
     )
 
     assert config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bumps `yalexs` from 9.2.7 to 9.2.10. Both the `august` and `yale` integrations depend on `yalexs` and share a single pinned version, so both manifests are bumped together.


The motivating fix is delayed-activity handling. The activity stream advanced its per-device "latest activity" marker *while iterating* a batch. Because the activities API returns newest-first, a delayed older event arriving in the same batch as a newer one was discarded as stale even though it had never been processed — so lock/unlock events went missing in Home Assistant while still visible in the August/Yale app, and locks could sit on a stale state. 9.2.10 snapshots the marker before the poll, selects everything newer than it, and processes it chronologically. It also isolates subscriber callback failures so one failing callback no longer drops the rest of a batch.

I submitted the `yalexs` PR to process the delayed activities and it was merged over a month ago.



Version diff 9.2.7 → 9.2.10:

- Yale-Libs/yalexs#413 — process delayed activities chronologically (9.2.10)
- Yale-Libs/yalexs#416 — isolate subscriber callback failures (9.2.10)
- Yale-Libs/yalexs#411 — correct lock-operation return-type annotations (9.2.10)
- Yale-Libs/yalexs#407 — type `DeviceDetail` name/serial/pubsub fields as optional (9.2.9)
- Yale-Libs/yalexs#410 — **drop `Brand.YALE_HOME`** (its API key no longer works; those accounts now authenticate via `Brand.YALE_GLOBAL`) (9.2.8)

#176630 was opened a couple of days ago but ran into difficulty due to dependences in HA on `Brand.YALE_HOME` in the yalexs library, which was recently removed. While there were HA-core tests which relied on `YALE_HOME`, the HA integration itself did not expose `YALE_HOME`; updating `yalexs` dependency is not a breaking change to HA users.

Because 9.2.8 removed the `Brand.YALE_HOME` enum member, three `august` tests that referenced it are updated:

- `test_init.py::test_brand_migration_issue` — used `YALE_HOME` incidentally; the repair issue is cleared on entry removal regardless of brand, so it moves to `YALE_AUGUST`.
- `test_camera.py::test_doorbell_refresh_content_token_fail` — moves to `YALE_AUGUST`, the brand the `august` integration actually forces at setup (`DEFAULT_AUGUST_BRAND`). Behavior is unchanged (expired content token → HTTP 500).
- `test_camera.py::test_doorbell_refresh_content_token_recover` — removed. Content-token retry is now gated on `YALE_GLOBAL` only (yalexs#410), which the `august` integration never uses, so the recover path is unreachable from `august`. The identical recover test already exists in the `yale` suite under `YALE_GLOBAL` (`tests/components/yale/test_camera.py`).

Release notes: https://github.com/Yale-Libs/yalexs/releases/tag/v9.2.10
Diff: https://github.com/Yale-Libs/yalexs/compare/v9.2.7...v9.2.10

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174214, #175779, #153236

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
