### PR TITLE
Bump async-upnp-client to 0.47.1

### DIFF
--- a/homeassistant/components/dlna_dmr/manifest.json
+++ b/homeassistant/components/dlna_dmr/manifest.json
@@ -9,7 +9,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],
-  "requirements": ["async-upnp-client==0.47.0", "getmac==0.9.5"],
+  "requirements": ["async-upnp-client==0.47.1", "getmac==0.9.5"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:1",

--- a/homeassistant/components/dlna_dms/manifest.json
+++ b/homeassistant/components/dlna_dms/manifest.json
@@ -8,7 +8,7 @@
   "documentation": "https://www.home-assistant.io/integrations/dlna_dms",
   "integration_type": "service",
   "iot_class": "local_polling",
-  "requirements": ["async-upnp-client==0.47.0"],
+  "requirements": ["async-upnp-client==0.47.1"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaServer:1",

--- a/homeassistant/components/samsungtv/manifest.json
+++ b/homeassistant/components/samsungtv/manifest.json
@@ -40,7 +40,7 @@
     "samsungctl[websocket]==0.7.1",
     "samsungtvws[async,encrypted]==3.0.5",
     "wakeonlan==3.3.0",
-    "async-upnp-client==0.47.0"
+    "async-upnp-client==0.47.1"
   ],
   "ssdp": [
     {

--- a/homeassistant/components/ssdp/manifest.json
+++ b/homeassistant/components/ssdp/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "local_push",
   "loggers": ["async_upnp_client"],
   "quality_scale": "internal",
-  "requirements": ["async-upnp-client==0.47.0"]
+  "requirements": ["async-upnp-client==0.47.1"]
 }

--- a/homeassistant/components/upnp/manifest.json
+++ b/homeassistant/components/upnp/manifest.json
@@ -8,7 +8,7 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "loggers": ["async_upnp_client"],
-  "requirements": ["async-upnp-client==0.47.0", "getmac==0.9.5"],
+  "requirements": ["async-upnp-client==0.47.1", "getmac==0.9.5"],
   "ssdp": [
     {
       "st": "urn:schemas-upnp-org:device:InternetGatewayDevice:1"

--- a/homeassistant/components/yeelight/manifest.json
+++ b/homeassistant/components/yeelight/manifest.json
@@ -17,7 +17,7 @@
   "integration_type": "device",
   "iot_class": "local_push",
   "loggers": ["async_upnp_client", "yeelight"],
-  "requirements": ["yeelight==0.7.16", "async-upnp-client==0.47.0"],
+  "requirements": ["yeelight==0.7.16", "async-upnp-client==0.47.1"],
   "zeroconf": [
     {
       "name": "yeelink-*",

--- a/homeassistant/package_constraints.txt
+++ b/homeassistant/package_constraints.txt
@@ -13,7 +13,7 @@ aiozoneinfo==0.2.3
 annotatedyaml==1.0.2
 astral==2.2
 async-interrupt==1.2.2
-async-upnp-client==0.47.0
+async-upnp-client==0.47.1
 atomicwrites-homeassistant==1.4.1
 attrs==26.1.0
 audioop-lts==0.2.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -572,7 +572,7 @@ asusrouter==1.21.3
 # homeassistant.components.ssdp
 # homeassistant.components.upnp
 # homeassistant.components.yeelight
-async-upnp-client==0.47.0
+async-upnp-client==0.47.1
 
 # homeassistant.components.arve
 asyncarve==0.1.1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Bump async-upnp-client to 0.47.1. This fixes a security flaw in the library where a rouge device (already on the network) can cause a blind SSRF, see [CWE-918](https://cwe.mitre.org/data/definitions/918.html).

With this, #172202 is most likely also fixed.

Additionally, this fixes a problem where stale subscriptions were not properly dropped and could cause a busy-loop and starve the asyncio event loop.

Link to advisory: https://github.com/StevenLooman/async_upnp_client/security/advisories/GHSA-94v4-2fvf-ff8p
Link to version on PyPI: https://pypi.org/project/async-upnp-client/0.47.1/
Link to change log: https://github.com/StevenLooman/async_upnp_client/blob/development/CHANGES.rst#async_upnp_client-0471-2026-07-20

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes GHSA-94v4-2fvf-ff8p, #172202
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Link to advisory: https://github.com/StevenLooman/async_upnp_client/security/advisories/GHSA-94v4-2fvf-ff8p
- Link to version on PyPI: https://pypi.org/project/async-upnp-client/0.47.1/
- Link to change log: https://github.com/StevenLooman/async_upnp_client/blob/development/CHANGES.rst#async_upnp_client-0471-2026-07-20

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
