### PR TITLE
Clear entity device_entry on device removal

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1659,6 +1659,12 @@ class Entity(
         """Handle device registry update."""
         data = event.data
 
+        if data["action"] == "remove":
+            # Prevent accesses to a removed device registry entry before the
+            # entity has been removed
+            self.device_entry = None
+            return
+
         if data["action"] != "update":
             return
 

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1749,6 +1749,52 @@ async def test_device_entry_cleared_on_registry_detach(
     assert ent.device_entry is None
 
 
+async def test_device_entry_cleared_on_device_removal(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the cached device entry is cleared when the device is removed."""
+
+    ent = MockEntity(
+        unique_id="qwer",
+        device_info={
+            "identifiers": {("hue", "1234")},
+            "name": "Device Bla",
+        },
+    )
+
+    async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        """Mock setup entry method."""
+        async_add_entities([ent])
+
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
+    entity_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    assert await entity_platform.async_setup_entry(config_entry)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_device_by_identifier(
+        ("hue", "1234"), config_entry.entry_id
+    )
+    assert device is not None
+    assert ent.device_entry is not None
+    assert ent.device_entry.id == device.id
+
+    device_registry.async_remove_device(device.id)
+    # Cleared synchronously while the removal event is dispatched, so removal
+    # callbacks of sibling entities sharing the device cannot see a stale entry
+    assert ent.device_entry is None
+    await hass.async_block_till_done()
+
+
 async def test_translation_key(hass: HomeAssistant) -> None:
     """Test translation key property."""
     mock_entity1 = entity.Entity()

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1795,6 +1795,51 @@ async def test_device_entry_cleared_on_device_removal(
     await hass.async_block_till_done()
 
 
+async def test_shared_device_removal_from_entity_callbacks(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test sibling entities removing their shared device from callbacks.
+
+    Integrations remove their own device from entity callbacks (e.g. a remove
+    signal fanned out to every entity of the device); callbacks running after
+    the first removal must observe device_entry as None, not a stale entry.
+    """
+    ent1 = MockEntity(unique_id="qwer", device_info={"identifiers": {("hue", "1234")}})
+    ent2 = MockEntity(unique_id="asdf", device_info={"identifiers": {("hue", "1234")}})
+
+    async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        """Mock setup entry method."""
+        async_add_entities([ent1, ent2])
+
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
+    entity_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    assert await entity_platform.async_setup_entry(config_entry)
+    await hass.async_block_till_done()
+
+    assert ent1.device_entry is not None
+    assert ent2.device_entry is not None
+
+    # Both entities react to the same removal signal; without the synchronous
+    # clearing, the second iteration raises KeyError on the stale device id
+    for ent in (ent1, ent2):
+        if ent.device_entry:
+            device_registry.async_remove_device(ent.device_entry.id)
+
+    assert ent1.device_entry is None
+    assert ent2.device_entry is None
+    await hass.async_block_till_done()
+
+
 async def test_translation_key(hass: HomeAssistant) -> None:
     """Test translation key property."""
     mock_entity1 = entity.Entity()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clear entity device_entry on device removal to prevent it being accessed by entities

Spotted in https://github.com/home-assistant/core/pull/176909

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
