### PR TITLE
Remove confusing set intersection from device registry restore

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -682,10 +682,10 @@ class DeletedDeviceEntry:
             config_entry_id=config_entry.entry_id,
             config_subentry_id=config_subentry_id,
             # type ignores: likely https://github.com/python/mypy/issues/8625
-            connections=self.connections & connections,  # type: ignore[arg-type]
+            connections=connections,  # type: ignore[arg-type]
             created_at=self.created_at,
             disabled_by=disabled_by,
-            identifiers=self.identifiers & identifiers,  # type: ignore[arg-type]
+            identifiers=identifiers,  # type: ignore[arg-type]
             id=self.id,
             labels=self.labels,  # type: ignore[arg-type]
             name_by_user=self.name_by_user,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -5622,6 +5622,110 @@ async def test_restore_device(
 
 
 @pytest.mark.parametrize(
+    ("stored_connections", "stored_identifiers", "new_connections", "new_identifiers"),
+    [
+        pytest.param(
+            {(dr.CONNECTION_NETWORK_MAC, "aa:aa:aa:aa:aa:aa")},
+            {("bridgeid", "0123")},
+            {
+                (dr.CONNECTION_NETWORK_MAC, "aa:aa:aa:aa:aa:aa"),
+                (dr.CONNECTION_NETWORK_MAC, "bb:bb:bb:bb:bb:bb"),
+            },
+            {("bridgeid", "0123"), ("bridgeid", "4567")},
+            id="broader_reregistration",
+        ),
+        pytest.param(
+            {(dr.CONNECTION_NETWORK_MAC, "aa:aa:aa:aa:aa:aa")},
+            {("bridgeid", "0123")},
+            {(dr.CONNECTION_NETWORK_MAC, "bb:bb:bb:bb:bb:bb")},
+            {("bridgeid", "0123")},
+            id="disjoint_connection_matched_on_identifier",
+        ),
+    ],
+)
+async def test_restore_device_reflects_reregistered_identity(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    stored_connections: set[tuple[str, str]],
+    stored_identifiers: set[tuple[str, str]],
+    new_connections: set[tuple[str, str]],
+    new_identifiers: set[tuple[str, str]],
+) -> None:
+    """A restored device keeps the connections and identifiers it is re-registered with.
+
+    The restored device must reflect the identity the integration reports on
+    re-registration, not its intersection with the stored (deleted) identity, so a
+    device that now reports a broader (or shifted) set is restored with all of it.
+    """
+    entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        connections=stored_connections,
+        identifiers=stored_identifiers,
+    )
+    device_registry.async_remove_device(entry.id)
+    assert len(device_registry.deleted_devices) == 1
+
+    restored = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        connections=new_connections,
+        identifiers=new_identifiers,
+    )
+
+    assert restored.id == entry.id
+    assert restored.connections == new_connections
+    assert restored.identifiers == new_identifiers
+
+
+@pytest.mark.parametrize(
+    ("new_connections", "new_identifiers"),
+    [
+        pytest.param(
+            {
+                (dr.CONNECTION_NETWORK_MAC, "aa:aa:aa:aa:aa:aa"),
+                (dr.CONNECTION_NETWORK_MAC, "bb:bb:bb:bb:bb:bb"),
+            },
+            {("bridgeid", "0123"), ("bridgeid", "4567")},
+            id="broader_reregistration",
+        ),
+        pytest.param(
+            {(dr.CONNECTION_NETWORK_MAC, "cc:cc:cc:cc:cc:cc")},
+            {("bridgeid", "9999")},
+            id="disjoint_reregistration",
+        ),
+    ],
+)
+async def test_deleted_device_to_device_entry_uses_reregistered_identity(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    new_connections: set[tuple[str, str]],
+    new_identifiers: set[tuple[str, str]],
+) -> None:
+    """DeletedDeviceEntry.to_device_entry keeps the passed connections and identifiers.
+
+    Regression guard: it must not intersect them with the stored ones, which would drop
+    (or, for a disjoint re-registration, entirely empty) the device's identity.
+    """
+    entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "aa:aa:aa:aa:aa:aa")},
+        identifiers={("bridgeid", "0123")},
+    )
+    device_registry.async_remove_device(entry.id)
+    deleted_device = device_registry.deleted_devices[entry.id]
+
+    restored = deleted_device.to_device_entry(
+        mock_config_entry,
+        None,
+        new_connections,
+        new_identifiers,
+        None,
+    )
+
+    assert restored.connections == new_connections
+    assert restored.identifiers == new_identifiers
+
+
+@pytest.mark.parametrize(
     ("device_disabled_by", "expected_disabled_by"),
     [
         (None, None),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove confusing set intersection from device registry restore

The intersection was harmless because we merged in new identifiers and connections later, but very confusing

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
