### PR TITLE
Prefer a local read for Teslemetry Powerwall authorized-clients checks

### DIFF
--- a/homeassistant/components/tesla_fleet/manifest.json
+++ b/homeassistant/components/tesla_fleet/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==1.7.2"]
+  "requirements": ["tesla-fleet-api==1.7.6"]
 }

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -623,6 +623,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     id=site_id,
                     device=device,
                     subentry_id=subentry_id,
+                    gateway_id=product.get("gateway_id"),
                 )
             )
 

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -292,11 +292,19 @@ def _ensure_subentry(
 def _remove_stale_subentries(
     hass: HomeAssistant,
     entry: TeslemetryConfigEntry,
+    subentry_type: str,
     current_subentry_ids: set[str],
 ) -> None:
-    """Remove subentries that no longer have a matching energy site."""
+    """Remove subentries of the given type with no matching product.
+
+    Filtered by subentry_type so this only prunes its own kind and never
+    touches subentries owned by another feature (e.g. vehicle subentries).
+    """
     for subentry in list(entry.subentries.values()):
-        if subentry.subentry_id not in current_subentry_ids:
+        if (
+            subentry.subentry_type == subentry_type
+            and subentry.subentry_id not in current_subentry_ids
+        ):
             LOGGER.debug("Removing stale subentry %s", subentry.subentry_id)
             hass.config_entries.async_remove_subentry(entry, subentry.subentry_id)
 
@@ -559,8 +567,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                 {CONF_SITE_ID: site_id},
             )
 
-            # Route commands through a local Powerwall first when the subentry
-            # has been paired; otherwise this returns the plain cloud EnergySite.
             energy_site_api = await _async_resolve_energy_site_api(
                 hass, entry, subentry_id, energy_site
             )
@@ -629,7 +635,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             device_registry.async_remove_device(device_entry.id)
 
     _remove_stale_subentries(
-        hass, entry, {energysite.subentry_id for energysite in energysites}
+        hass,
+        entry,
+        SUBENTRY_TYPE_ENERGY_SITE,
+        {energysite.subentry_id for energysite in energysites},
     )
 
     entry.runtime_data = TeslemetryData(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -3,9 +3,12 @@
 import asyncio
 from collections.abc import Callable
 from functools import partial
+from pathlib import Path
+from types import MappingProxyType
 from typing import Any, Final, cast
 
 from aiohttp import ClientError
+from aiopowerwall import PowerwallClient, PowerwallEnergySite
 from tesla_fleet_api.const import Scope
 from tesla_fleet_api.exceptions import (
     Forbidden,
@@ -14,15 +17,16 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
-from tesla_fleet_api.teslemetry import Teslemetry
+from tesla_fleet_api.tesla import EnergySiteRouter
+from tesla_fleet_api.teslemetry import EnergySite, Teslemetry
 from teslemetry_stream import TeslemetryStream
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
     async_import_client_credential,
 )
-from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-from homeassistant.const import CONF_ACCESS_TOKEN, Platform
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState, ConfigSubentry
+from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, CONF_PASSWORD, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
@@ -44,7 +48,16 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CLIENT_ID, DOMAIN, LOGGER, VEHICLE_ISSUE_LEARN_MORE
+from .const import (
+    CLIENT_ID,
+    CONF_SITE_ID,
+    DOMAIN,
+    LOGGER,
+    POWERWALL_KEY_FILE,
+    RSA_PARENT_KEY,
+    SUBENTRY_TYPE_ENERGY_SITE,
+    VEHICLE_ISSUE_LEARN_MORE,
+)
 from .coordinator import (
     TeslemetryEnergyHistoryCoordinator,
     TeslemetryEnergySiteInfoCoordinator,
@@ -244,6 +257,95 @@ def _setup_vehicle_repairs(
     entry.async_on_unload(
         metadata_coordinator.async_add_listener(_handle_metadata_update)
     )
+
+
+def _ensure_subentry(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    subentry_type: str,
+    unique_id: str,
+    title: str,
+    data: dict[str, Any],
+) -> str:
+    """Return the subentry id for unique_id, creating or updating it as needed."""
+    for subentry in entry.subentries.values():
+        if subentry.subentry_type == subentry_type and subentry.unique_id == unique_id:
+            # Merge over the existing data so keys added by a pairing flow (the
+            # energy gateway host/password) are preserved across reloads.
+            merged = {**subentry.data, **data}
+            if subentry.title != title or dict(subentry.data) != merged:
+                hass.config_entries.async_update_subentry(
+                    entry, subentry, title=title, data=merged
+                )
+            return subentry.subentry_id
+
+    subentry = ConfigSubentry(
+        data=MappingProxyType(data),
+        subentry_type=subentry_type,
+        title=title,
+        unique_id=unique_id,
+    )
+    hass.config_entries.async_add_subentry(entry, subentry)
+    return subentry.subentry_id
+
+
+def _remove_stale_subentries(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    current_subentry_ids: set[str],
+) -> None:
+    """Remove subentries that no longer have a matching energy site."""
+    for subentry in list(entry.subentries.values()):
+        if subentry.subentry_id not in current_subentry_ids:
+            LOGGER.debug("Removing stale subentry %s", subentry.subentry_id)
+            hass.config_entries.async_remove_subentry(entry, subentry.subentry_id)
+
+
+async def _async_get_rsa_key_pem(hass: HomeAssistant) -> bytes:
+    """Return the integration's RSA private key PEM, generating it if needed.
+
+    Cached on ``hass.data`` so the key file is only touched once even when
+    several energy sites are paired for local TEDAPI v1r access.
+    """
+    pem: bytes | None = hass.data.get(RSA_PARENT_KEY)
+    if pem is None:
+        path = hass.config.path(POWERWALL_KEY_FILE)
+        await Teslemetry(
+            session=async_get_clientsession(hass), access_token=""
+        ).get_rsa_private_key(path)
+        pem = await hass.async_add_executor_job(Path(path).read_bytes)
+        hass.data[RSA_PARENT_KEY] = pem
+    return pem
+
+
+async def _async_resolve_energy_site_api(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    subentry_id: str,
+    cloud_energy_site: EnergySite,
+) -> EnergySite | EnergySiteRouter:
+    """Return the API an energy site's platforms should call.
+
+    When the subentry has been paired (its data carries a local gateway
+    ``host``/``password``), wrap the cloud EnergySite in an EnergySiteRouter that
+    tries the local Powerwall (via aiopowerwall) first and fails over to cloud
+    per command. Otherwise returns the plain cloud EnergySite unchanged.
+    """
+    data = entry.subentries[subentry_id].data
+    host = data.get(CONF_HOST)
+    password = data.get(CONF_PASSWORD)
+    if not host or not password:
+        return cloud_energy_site
+
+    key_pem = await _async_get_rsa_key_pem(hass)
+    powerwall_client = PowerwallClient(
+        host=host,
+        gateway_password=password,
+        rsa_private_key_pem=key_pem,
+        session=async_get_clientsession(hass),
+    )
+    local_energy_site = PowerwallEnergySite(powerwall_client)
+    return EnergySiteRouter(local_energy_site, cloud_energy_site)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
@@ -448,9 +550,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     translation_key="not_ready_api_error",
                 ) from e
 
+            subentry_id = _ensure_subentry(
+                hass,
+                entry,
+                SUBENTRY_TYPE_ENERGY_SITE,
+                str(site_id),
+                product.get("site_name", "Energy Site"),
+                {CONF_SITE_ID: site_id},
+            )
+
+            # Route commands through a local Powerwall first when the subentry
+            # has been paired; otherwise this returns the plain cloud EnergySite.
+            energy_site_api = await _async_resolve_energy_site_api(
+                hass, entry, subentry_id, energy_site
+            )
+
             energysites.append(
                 TeslemetryEnergyData(
-                    api=energy_site,
+                    api=energy_site_api,
                     live_coordinator=(
                         TeslemetryEnergySiteLiveCoordinator(
                             hass, entry, energy_site, live_status
@@ -468,6 +585,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     ),
                     id=site_id,
                     device=device,
+                    subentry_id=subentry_id,
                 )
             )
 
@@ -509,6 +627,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         ):
             LOGGER.debug("Removing stale device %s", device_entry.id)
             device_registry.async_remove_device(device_entry.id)
+
+    _remove_stale_subentries(
+        hass, entry, {energysite.subentry_id for energysite in energysites}
+    )
 
     entry.runtime_data = TeslemetryData(
         vehicles=vehicles,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -558,18 +558,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     translation_key="not_ready_api_error",
                 ) from e
 
-            subentry_id = _ensure_subentry(
-                hass,
-                entry,
-                SUBENTRY_TYPE_ENERGY_SITE,
-                str(site_id),
-                product.get("site_name", "Energy Site"),
-                {CONF_SITE_ID: site_id},
-            )
-
-            energy_site_api = await _async_resolve_energy_site_api(
-                hass, entry, subentry_id, energy_site
-            )
+            # Only a Powerwall gateway can pair for local (TEDAPI) control, so
+            # wall-connector-only sites get no local-control subentry or routing.
+            subentry_id: str | None = None
+            energy_site_api: EnergySite | EnergySiteRouter = energy_site
+            if powerwall:
+                subentry_id = _ensure_subentry(
+                    hass,
+                    entry,
+                    SUBENTRY_TYPE_ENERGY_SITE,
+                    str(site_id),
+                    product.get("site_name", "Energy Site"),
+                    {CONF_SITE_ID: site_id},
+                )
+                energy_site_api = await _async_resolve_energy_site_api(
+                    hass, entry, subentry_id, energy_site
+                )
 
             energysites.append(
                 TeslemetryEnergyData(
@@ -638,7 +642,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         hass,
         entry,
         SUBENTRY_TYPE_ENERGY_SITE,
-        {energysite.subentry_id for energysite in energysites},
+        {
+            energysite.subentry_id
+            for energysite in energysites
+            if energysite.subentry_id is not None
+        },
     )
 
     entry.runtime_data = TeslemetryData(

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -503,9 +503,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
         ):
             site_id = product["energy_site_id"]
 
-            powerwall = (
-                product["components"]["battery"] or product["components"]["solar"]
-            )
+            battery = product["components"]["battery"]
+            powerwall = battery or product["components"]["solar"]
             wall_connector = "wall_connectors" in product["components"]
             if not powerwall and not wall_connector:
                 LOGGER.debug(
@@ -558,11 +557,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
                     translation_key="not_ready_api_error",
                 ) from e
 
-            # Only a Powerwall gateway can pair for local (TEDAPI) control, so
-            # wall-connector-only sites get no local-control subentry or routing.
+            # Only a battery/Powerwall gateway can pair for local (TEDAPI)
+            # command control; solar-only and wall-connector-only sites get no
+            # local-control subentry or routing.
             subentry_id: str | None = None
             energy_site_api: EnergySite | EnergySiteRouter = energy_site
-            if powerwall:
+            if battery:
                 subentry_id = _ensure_subentry(
                     hass,
                     entry,

--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -309,6 +309,33 @@ def _remove_stale_subentries(
             hass.config_entries.async_remove_subentry(entry, subentry.subentry_id)
 
 
+def _prune_energy_subentries(
+    hass: HomeAssistant,
+    entry: TeslemetryConfigEntry,
+    scopes: list[Scope],
+    energysites: list[TeslemetryEnergyData],
+) -> None:
+    """Remove energy-site subentries whose site is no longer present.
+
+    Skipped without the energy scope: setup then skips every energy product, so
+    an empty site list means the inventory was never resolved rather than that
+    the sites are gone. Pruning against it would delete the local gateway
+    credentials a user paired.
+    """
+    if Scope.ENERGY_DEVICE_DATA not in scopes:
+        return
+    _remove_stale_subentries(
+        hass,
+        entry,
+        SUBENTRY_TYPE_ENERGY_SITE,
+        {
+            energysite.subentry_id
+            for energysite in energysites
+            if energysite.subentry_id is not None
+        },
+    )
+
+
 async def _async_get_rsa_key_pem(hass: HomeAssistant) -> bytes:
     """Return the integration's RSA private key PEM, generating it if needed.
 
@@ -638,16 +665,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
             LOGGER.debug("Removing stale device %s", device_entry.id)
             device_registry.async_remove_device(device_entry.id)
 
-    _remove_stale_subentries(
-        hass,
-        entry,
-        SUBENTRY_TYPE_ENERGY_SITE,
-        {
-            energysite.subentry_id
-            for energysite in energysites
-            if energysite.subentry_id is not None
-        },
-    )
+    _prune_energy_subentries(hass, entry, scopes, energysites)
 
     entry.runtime_data = TeslemetryData(
         vehicles=vehicles,

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -76,6 +76,12 @@ class PowerwallLookupError(Exception):
     """
 
 
+_PENDING_STATES = (
+    AuthorizedClientState.PENDING,
+    AuthorizedClientState.PENDING_VERIFICATION,
+)
+
+
 def _is_gateway_unreachable(err: TeslaFleetError | ClientResponseError) -> bool:
     """Return whether err is a 502 Bad Gateway from an energy gateway command.
 
@@ -271,7 +277,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
 
         try:
             self._discovered_host = await self._energy_site.find_gateway_address() or ""
-        except TeslaFleetError as err:
+        except (ClientResponseError, TeslaFleetError) as err:
             LOGGER.debug("Gateway address discovery failed: %s", err)
             self._discovered_host = ""
 
@@ -296,7 +302,13 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             # without re-registering it (re-adding would reset a pending key).
             if client.state == AuthorizedClientState.VERIFIED:
                 return await self.async_step_credentials()
-            return await self.async_step_pair()
+            if client.state in _PENDING_STATES:
+                return await self.async_step_pair()
+            # The typed accessor preserves an unrecognized state verbatim. Such
+            # a read is not usable, so treat it as a lookup failure rather than
+            # resuming pairing on a state we cannot reason about.
+            LOGGER.debug("Unrecognized authorized-client state: %s", client.state)
+            return self.async_abort(reason="cannot_connect")
 
         try:
             # Not revoked on removal by design; see the class docstring.
@@ -351,9 +363,15 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             return await self.async_step_credentials()
         if client.state == AuthorizedClientState.PENDING:
             return self.async_show_form(step_id="pair", errors={"base": "key_pending"})
-        return self.async_show_form(
-            step_id="pair", errors={"base": "key_pending_verification"}
-        )
+        if client.state == AuthorizedClientState.PENDING_VERIFICATION:
+            return self.async_show_form(
+                step_id="pair", errors={"base": "key_pending_verification"}
+            )
+        # Only an explicit PENDING_VERIFICATION may claim the approval is still
+        # being verified; an unrecognized state is a failed read, and reporting
+        # it as pending would trap the user in the form retrying forever.
+        LOGGER.debug("Unrecognized authorized-client state: %s", client.state)
+        return self.async_show_form(step_id="pair", errors={"base": "cannot_connect"})
 
     async def _find_authorized_client(self) -> AuthorizedClient | None:
         """Return our RSA key's authorized-client entry on the gateway, or None.

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.config_entries import (
     SOURCE_REAUTH,
     SOURCE_RECONFIGURE,
     ConfigEntry,
+    ConfigEntryState,
     ConfigFlowResult,
     ConfigSubentryFlow,
     SubentryFlowResult,
@@ -253,6 +254,10 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         """Look up the site's cloud API and start (or resume) key pairing."""
         subentry = self._get_reconfigure_subentry()
         entry = cast(TeslemetryConfigEntry, self._get_entry())
+        # runtime_data (the resolved energy sites) only exists while the entry is
+        # loaded; core clears it on unload, so bail out cleanly if it is not.
+        if entry.state is not ConfigEntryState.LOADED:
+            return self.async_abort(reason="entry_not_loaded")
         energy_data = next(
             (
                 energysite

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -11,6 +11,7 @@ from aiopowerwall import (
     DEFAULT_GATEWAY_HOST,
     PowerwallAuthenticationError,
     PowerwallClient,
+    PowerwallEnergySite,
     PowerwallError,
 )
 from tesla_fleet_api.const import (
@@ -125,6 +126,25 @@ def _din_matches(expected: str, actual: str) -> bool:
     case or whitespace skew would be worse than not comparing at all.
     """
     return expected.strip().casefold() == actual.strip().casefold()
+
+
+def _authorized_client_from_local(entry: dict[str, Any]) -> AuthorizedClient:
+    """Build an ``AuthorizedClient`` from a local ``list_authorized_clients`` entry.
+
+    aiopowerwall normalizes ``public_key``/``state`` to the same keys the
+    cloud envelope uses, with ``state`` already the enum member's name (for
+    example ``"VERIFIED"``) rather than an int. An unrecognized name is kept
+    verbatim rather than dropped, matching the cloud accessor's handling of
+    an unrecognized state.
+    """
+    state = entry["state"]
+    try:
+        typed_state: AuthorizedClientState | str = AuthorizedClientState[state]
+    except KeyError:
+        typed_state = state
+    return AuthorizedClient(
+        public_key=entry["public_key"], state=typed_state, raw=entry
+    )
 
 
 class OAuth2FlowHandler(
@@ -271,6 +291,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
     def __init__(self) -> None:
         """Initialize the energy site subentry flow."""
         self._energy_site: TeslemetryEnergySite | None = None
+        self._local_energy_site: PowerwallEnergySite | None = None
         self._key_pem: bytes | None = None
         self._public_key_der: bytes = b""
         self._public_key_b64: str = ""
@@ -303,12 +324,12 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         )
         if energy_data is None:
             return self.async_abort(reason="cannot_connect")
-        self._energy_site = cast(
-            TeslemetryEnergySite,
-            energy_data.api.secondary
-            if isinstance(energy_data.api, EnergySiteRouter)
-            else energy_data.api,
-        )
+        if isinstance(energy_data.api, EnergySiteRouter):
+            self._energy_site = cast(TeslemetryEnergySite, energy_data.api.secondary)
+            self._local_energy_site = cast(PowerwallEnergySite, energy_data.api.primary)
+        else:
+            self._energy_site = cast(TeslemetryEnergySite, energy_data.api)
+            self._local_energy_site = None
         self._gateway_id = energy_data.gateway_id
 
         try:
@@ -408,31 +429,42 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
     async def _find_authorized_client(self) -> AuthorizedClient | None:
         """Return our RSA key's authorized-client entry on the gateway, or None.
 
-        Parsing lives in the library's typed ``find_authorized_clients`` accessor
-        (envelope unwrap, null-body handling, ``state`` typing). ``None`` is
-        returned only when the gateway answers successfully but our key is not
-        among the authorized clients (an explicitly empty list authoritatively
-        means "not registered").
+        Reads the gateway directly over the LAN when the site is already
+        paired for local control - the authoritative source for whether a key
+        can make signed local requests, and the one that works whether or not
+        Teslemetry's cloud proxy is behaving. Only queries the cloud when
+        there is no local key to read from yet (the site is not paired).
+        ``None`` is returned only when the gateway answers successfully but
+        our key is not among the authorized clients (an explicitly empty list
+        authoritatively means "not registered").
 
-        A 502 (gateway unreachable) raises ``PowerwallUnreachableError``; any
-        other lookup failure raises ``PowerwallLookupError``. Neither is
-        collapsed into ``None`` so the caller never mistakes a failed lookup for
-        an absent key and re-registers it.
+        A 502 from the cloud path raises ``PowerwallUnreachableError``; any
+        other lookup failure (cloud or local) raises ``PowerwallLookupError``.
+        Neither is collapsed into ``None`` so the caller never mistakes a
+        failed lookup for an absent key and re-registers it.
         """
         assert self._energy_site is not None
-        try:
-            result = await self._energy_site.find_authorized_clients()
-        except (ClientError, TeslaFleetError) as err:
-            if _is_gateway_unreachable(err):
-                raise PowerwallUnreachableError from err
-            LOGGER.debug("find_authorized_clients failed: %s", err)
-            raise PowerwallLookupError from err
+        if self._local_energy_site is not None:
+            try:
+                payload = await self._local_energy_site.list_authorized_clients()
+            except PowerwallError as err:
+                LOGGER.debug("local list_authorized_clients failed: %s", err)
+                raise PowerwallLookupError from err
+            clients = [
+                _authorized_client_from_local(entry)
+                for entry in payload["response"]["clients"]
+            ]
+        else:
+            try:
+                result = await self._energy_site.find_authorized_clients()
+            except (ClientError, TeslaFleetError) as err:
+                if _is_gateway_unreachable(err):
+                    raise PowerwallUnreachableError from err
+                LOGGER.debug("find_authorized_clients failed: %s", err)
+                raise PowerwallLookupError from err
+            clients = result.clients
         return next(
-            (
-                client
-                for client in result.clients
-                if client.public_key == self._public_key_b64
-            ),
+            (client for client in clients if client.public_key == self._public_key_b64),
             None,
         )
 

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -1,6 +1,5 @@
 """Config Flow for Teslemetry integration."""
 
-import asyncio
 from collections.abc import Mapping
 from http import HTTPStatus
 import logging
@@ -51,8 +50,6 @@ from . import TeslemetryConfigEntry
 from .const import (
     CLIENT_ID,
     DOMAIN,
-    KEY_PAIRING_POLL_ATTEMPTS,
-    KEY_PAIRING_POLL_INTERVAL,
     LOGGER,
     POWERWALL_KEY_FILE,
     SUBENTRY_TYPE_ENERGY_SITE,
@@ -318,27 +315,38 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
     async def async_step_pair(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:
-        """Ask the user to approve the pending key, then poll for VERIFIED."""
+        """Check once whether the pending key has been approved on the gateway.
+
+        Advances to credentials if verified; otherwise re-shows this form with
+        an error describing what the user still needs to do, so they can
+        approve the key and submit again.
+        """
         assert self._energy_site is not None
         if user_input is None:
             return self.async_show_form(step_id="pair")
 
-        for _ in range(KEY_PAIRING_POLL_ATTEMPTS):
-            try:
-                verified = await self._key_is_verified()
-            except PowerwallUnreachableError:
-                return self.async_show_form(
-                    step_id="pair", errors={"base": "powerwall_unreachable"}
-                )
-            except PowerwallLookupError:
-                return self.async_show_form(
-                    step_id="pair", errors={"base": "cannot_connect"}
-                )
-            if verified:
-                return await self.async_step_credentials()
-            await asyncio.sleep(KEY_PAIRING_POLL_INTERVAL)
+        try:
+            client = await self._find_authorized_client()
+        except PowerwallUnreachableError:
+            return self.async_show_form(
+                step_id="pair", errors={"base": "powerwall_unreachable"}
+            )
+        except PowerwallLookupError:
+            return self.async_show_form(
+                step_id="pair", errors={"base": "cannot_connect"}
+            )
 
-        return self.async_show_form(step_id="pair", errors={"base": "timeout"})
+        if client is None:
+            return self.async_show_form(
+                step_id="pair", errors={"base": "key_not_registered"}
+            )
+        if client.state == AuthorizedClientState.VERIFIED:
+            return await self.async_step_credentials()
+        if client.state == AuthorizedClientState.PENDING:
+            return self.async_show_form(step_id="pair", errors={"base": "key_pending"})
+        return self.async_show_form(
+            step_id="pair", errors={"base": "key_pending_verification"}
+        )
 
     async def _find_authorized_client(self) -> AuthorizedClient | None:
         """Return our RSA key's authorized-client entry on the gateway, or None.
@@ -370,11 +378,6 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             ),
             None,
         )
-
-    async def _key_is_verified(self) -> bool:
-        """Report whether our public key is registered and VERIFIED on the gateway."""
-        client = await self._find_authorized_client()
-        return client is not None and client.state == AuthorizedClientState.VERIFIED
 
     async def async_step_credentials(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -12,7 +12,6 @@ from aiopowerwall import (
     PowerwallAuthenticationError,
     PowerwallClient,
     PowerwallError,
-    PowerwallFaultError,
 )
 from tesla_fleet_api.const import (
     AuthorizedClientKeyType,
@@ -83,6 +82,21 @@ class PowerwallKeyRejectedError(Exception):
     Distinct from a bad gateway password: the login succeeded, but the key has
     not been approved on the gateway, so only signed requests fail.
     """
+
+
+class PowerwallGatewayMismatchError(Exception):
+    """Signal that the local gateway's DIN doesn't match the site's cloud DIN.
+
+    The RSA key is shared by every site, so it authorizes each of the
+    account's gateways: without this check a host pointed at the wrong
+    gateway would command another site's house.
+    """
+
+    def __init__(self, expected: str, actual: str) -> None:
+        """Store the mismatched DINs for the caller's abort placeholders."""
+        super().__init__(f"expected {expected}, got {actual}")
+        self.expected = expected
+        self.actual = actual
 
 
 _PENDING_STATES = (
@@ -427,11 +441,15 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
 
         ``connect()`` only performs the gateway password login and fetches the
         DIN over an unsigned endpoint, so it succeeds even when the gateway has
-        not approved our key. The signed read that follows is what an
-        unapproved key actually fails, and it raises
-        ``PowerwallKeyRejectedError`` when it does.
+        not approved our key. The DIN is checked against the site's cloud
+        gateway ID before the signed read that follows, so a host pointed at
+        the wrong gateway is rejected without issuing a signed request against
+        it. The signed read is what an unapproved key actually fails, and it
+        raises ``PowerwallAuthenticationError`` when it does; any other
+        protocol fault is a ``PowerwallFaultError`` and is not a rejected key.
         """
         assert self._key_pem is not None
+        assert self._energy_site is not None
         async with PowerwallClient(
             host=host,
             gateway_password=password,
@@ -439,9 +457,21 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             session=async_get_clientsession(self.hass),
         ) as client:
             din = await client.connect()
+            if self._gateway_id is None:
+                # Pairing proceeds: refusing over a missing comparand would
+                # block a valid gateway. Warn so a skipped identity check is
+                # never silent.
+                LOGGER.warning(
+                    "Energy site %s reports no gateway ID, so %s cannot be "
+                    "confirmed as this site's own gateway; pairing anyway",
+                    self._energy_site.energy_site_id,
+                    din,
+                )
+            elif not _din_matches(self._gateway_id, din):
+                raise PowerwallGatewayMismatchError(self._gateway_id, din)
             try:
                 await client.get_status()
-            except (PowerwallAuthenticationError, PowerwallFaultError) as err:
+            except PowerwallAuthenticationError as err:
                 raise PowerwallKeyRejectedError from err
             return din
 
@@ -458,7 +488,15 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             # the full string, so trim it to what the gateway will accept.
             password = user_input[CONF_PASSWORD].strip()[-5:]
             try:
-                din = await self._verify_local_gateway(host, password)
+                await self._verify_local_gateway(host, password)
+            except PowerwallGatewayMismatchError as err:
+                return self.async_abort(
+                    reason="gateway_mismatch",
+                    description_placeholders={
+                        "expected": err.expected,
+                        "actual": err.actual,
+                    },
+                )
             except PowerwallKeyRejectedError as err:
                 LOGGER.debug("Powerwall rejected the signed read: %s", err.__cause__)
                 errors["base"] = "key_not_approved"
@@ -468,27 +506,6 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
                 LOGGER.debug("Local Powerwall verify failed: %s", err)
                 errors["base"] = "cannot_connect"
             else:
-                # The RSA key is shared by every site, so it authorizes each of
-                # the account's gateways: without this check a host pointed at
-                # the wrong gateway would command another site's house.
-                if self._gateway_id is None:
-                    # Pairing proceeds: refusing over a missing comparand would
-                    # block a valid gateway. Warn so a skipped identity check is
-                    # never silent.
-                    LOGGER.warning(
-                        "Energy site %s reports no gateway ID, so %s cannot be "
-                        "confirmed as this site's own gateway; pairing anyway",
-                        self._energy_site.energy_site_id,
-                        din,
-                    )
-                elif not _din_matches(self._gateway_id, din):
-                    return self.async_abort(
-                        reason="gateway_mismatch",
-                        description_placeholders={
-                            "expected": self._gateway_id,
-                            "actual": din,
-                        },
-                    )
                 return self.async_update_reload_and_abort(
                     self._get_entry(),
                     self._get_reconfigure_subentry(),

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -6,12 +6,13 @@ import logging
 from pathlib import Path
 from typing import Any, cast, override
 
-from aiohttp import ClientConnectionError, ClientResponseError
+from aiohttp import ClientError
 from aiopowerwall import (
     DEFAULT_GATEWAY_HOST,
     PowerwallAuthenticationError,
     PowerwallClient,
     PowerwallError,
+    PowerwallFaultError,
 )
 from tesla_fleet_api.const import (
     AuthorizedClientKeyType,
@@ -76,21 +77,40 @@ class PowerwallLookupError(Exception):
     """
 
 
+class PowerwallKeyRejectedError(Exception):
+    """Signal that the gateway refused a v1r-signed read with our RSA key.
+
+    Distinct from a bad gateway password: the login succeeded, but the key has
+    not been approved on the gateway, so only signed requests fail.
+    """
+
+
 _PENDING_STATES = (
     AuthorizedClientState.PENDING,
     AuthorizedClientState.PENDING_VERIFICATION,
 )
 
 
-def _is_gateway_unreachable(err: TeslaFleetError | ClientResponseError) -> bool:
+def _is_gateway_unreachable(err: TeslaFleetError | ClientError) -> bool:
     """Return whether err is a 502 Bad Gateway from an energy gateway command.
 
     A bodyless 502 surfaces from tesla-fleet-api as ``ResponseError`` (a
     ``TeslaFleetError`` carrying ``status``); a 502 with a JSON body instead
     surfaces as ``aiohttp.ClientResponseError``. ``status`` is looked up with
-    ``getattr`` since a bare ``TeslaFleetError`` is not guaranteed to carry one.
+    ``getattr`` since neither a bare ``TeslaFleetError`` nor a transport-level
+    ``ClientError`` is guaranteed to carry one.
     """
     return getattr(err, "status", None) == HTTPStatus.BAD_GATEWAY
+
+
+def _din_matches(expected: str, actual: str) -> bool:
+    """Return whether two gateway DINs identify the same gateway.
+
+    Compared normalized: the local gateway's DIN has not been confirmed
+    byte-identical to the cloud's, and rejecting a valid pairing over a
+    case or whitespace skew would be worse than not comparing at all.
+    """
+    return expected.strip().casefold() == actual.strip().casefold()
 
 
 class OAuth2FlowHandler(
@@ -180,7 +200,7 @@ class OAuth2FlowHandler(
             return {"base": "invalid_access_token"}
         except SubscriptionRequired:
             return {"base": "subscription_required"}
-        except ClientConnectionError:
+        except ClientError:
             return {"base": "cannot_connect"}
         except TeslaFleetError as e:
             LOGGER.error("Teslemetry API error: %s", e)
@@ -241,6 +261,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         self._public_key_der: bytes = b""
         self._public_key_b64: str = ""
         self._discovered_host: str = ""
+        self._gateway_id: str | None = None
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -274,10 +295,11 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             if isinstance(energy_data.api, EnergySiteRouter)
             else energy_data.api,
         )
+        self._gateway_id = energy_data.gateway_id
 
         try:
             self._discovered_host = await self._energy_site.find_gateway_address() or ""
-        except (ClientResponseError, TeslaFleetError) as err:
+        except (ClientError, TeslaFleetError) as err:
             LOGGER.debug("Gateway address discovery failed: %s", err)
             self._discovered_host = ""
 
@@ -319,12 +341,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
                 key_type=AuthorizedClientKeyType.RSA,
                 authorized_client_type=AuthorizedClientType.CUSTOMER_MOBILE_APP,
             )
-        except ClientResponseError as err:
-            if _is_gateway_unreachable(err):
-                return self.async_abort(reason="powerwall_unreachable")
-            LOGGER.error("Add authorized client failed: %s", err)
-            return self.async_abort(reason="cannot_connect")
-        except TeslaFleetError as err:
+        except (ClientError, TeslaFleetError) as err:
             if _is_gateway_unreachable(err):
                 return self.async_abort(reason="powerwall_unreachable")
             LOGGER.error("Add authorized client failed: %s", err)
@@ -391,7 +408,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         assert self._energy_site is not None
         try:
             result = await self._energy_site.find_authorized_clients()
-        except (ClientResponseError, TeslaFleetError) as err:
+        except (ClientError, TeslaFleetError) as err:
             if _is_gateway_unreachable(err):
                 raise PowerwallUnreachableError from err
             LOGGER.debug("find_authorized_clients failed: %s", err)
@@ -405,11 +422,28 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             None,
         )
 
-    async def _key_is_verified(self) -> bool:
-        """Report whether our public key is registered and VERIFIED on the gateway."""
-        client = await self._find_authorized_client()
-        LOGGER.debug("Powerwall keys: %s", client)
-        return client is not None and client.state == AuthorizedClientState.VERIFIED
+    async def _verify_local_gateway(self, host: str, password: str) -> str:
+        """Prove the LAN connection and the RSA key, returning the gateway DIN.
+
+        ``connect()`` only performs the gateway password login and fetches the
+        DIN over an unsigned endpoint, so it succeeds even when the gateway has
+        not approved our key. The signed read that follows is what an
+        unapproved key actually fails, and it raises
+        ``PowerwallKeyRejectedError`` when it does.
+        """
+        assert self._key_pem is not None
+        async with PowerwallClient(
+            host=host,
+            gateway_password=password,
+            rsa_private_key_pem=self._key_pem,
+            session=async_get_clientsession(self.hass),
+        ) as client:
+            din = await client.connect()
+            try:
+                await client.get_status()
+            except (PowerwallAuthenticationError, PowerwallFaultError) as err:
+                raise PowerwallKeyRejectedError from err
+            return din
 
     async def async_step_credentials(
         self, user_input: dict[str, Any] | None = None
@@ -422,25 +456,34 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             # the Wi-Fi password printed on the gateway; users routinely enter
             # the full string, so trim it to what the gateway will accept.
             password = user_input[CONF_PASSWORD].strip()[-5:]
-            assert self._key_pem is not None
             try:
-                async with PowerwallClient(
-                    host=host,
-                    gateway_password=password,
-                    rsa_private_key_pem=self._key_pem,
-                    session=async_get_clientsession(self.hass),
-                ) as client:
-                    await client.connect()
+                din = await self._verify_local_gateway(host, password)
+            except PowerwallKeyRejectedError as err:
+                LOGGER.debug("Powerwall rejected the signed read: %s", err.__cause__)
+                errors["base"] = "key_not_approved"
             except PowerwallAuthenticationError:
                 errors["base"] = "invalid_password"
             except PowerwallError as err:
                 LOGGER.debug("Local Powerwall verify failed: %s", err)
                 errors["base"] = "cannot_connect"
             else:
-                entry = self._get_entry()
-                self.hass.config_entries.async_schedule_reload(entry.entry_id)
-                return self.async_update_and_abort(
-                    entry,
+                # The RSA key is shared by every site, so it authorizes each of
+                # the account's gateways: without this check a host pointed at
+                # the wrong gateway would command another site's house.
+                if self._gateway_id is None:
+                    LOGGER.debug(
+                        "No cloud gateway ID for this site; skipping DIN binding"
+                    )
+                elif not _din_matches(self._gateway_id, din):
+                    return self.async_abort(
+                        reason="gateway_mismatch",
+                        description_placeholders={
+                            "expected": self._gateway_id,
+                            "actual": din,
+                        },
+                    )
+                return self.async_update_reload_and_abort(
+                    self._get_entry(),
                     self._get_reconfigure_subentry(),
                     data_updates={CONF_HOST: host, CONF_PASSWORD: password},
                 )

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -312,6 +312,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
 
         try:
             # Not revoked on removal by design; see the class docstring.
+            LOGGER.info("Powerwall key setup: id=%s", self._energy_site.energy_site_id)
             await self._energy_site.add_authorized_client(
                 self._public_key_der,
                 description="Home Assistant",

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -1,16 +1,31 @@
 """Config Flow for Teslemetry integration."""
 
+import asyncio
 from collections.abc import Mapping
 import logging
-from typing import Any, override
+from pathlib import Path
+from typing import Any, cast, override
 
 from aiohttp import ClientConnectionError
+from aiopowerwall import (
+    DEFAULT_GATEWAY_HOST,
+    PowerwallAuthenticationError,
+    PowerwallClient,
+    PowerwallError,
+)
+from tesla_fleet_api.const import (
+    AuthorizedClientKeyType,
+    AuthorizedClientState,
+    AuthorizedClientType,
+)
 from tesla_fleet_api.exceptions import (
     InvalidToken,
     SubscriptionRequired,
     TeslaFleetError,
 )
-from tesla_fleet_api.teslemetry import Teslemetry
+from tesla_fleet_api.tesla import EnergySiteRouter
+from tesla_fleet_api.teslemetry import EnergySite, Teslemetry
+import voluptuous as vol
 
 from homeassistant.components.application_credentials import (
     ClientCredential,
@@ -19,12 +34,72 @@ from homeassistant.components.application_credentials import (
 from homeassistant.config_entries import (
     SOURCE_REAUTH,
     SOURCE_RECONFIGURE,
+    ConfigEntry,
     ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
 )
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import callback
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import CLIENT_ID, DOMAIN, LOGGER
+from . import TeslemetryConfigEntry
+from .const import (
+    CLIENT_ID,
+    DOMAIN,
+    KEY_PAIRING_POLL_ATTEMPTS,
+    KEY_PAIRING_POLL_INTERVAL,
+    LOGGER,
+    POWERWALL_KEY_FILE,
+    SUBENTRY_TYPE_ENERGY_SITE,
+)
+
+# Authorized-client states meaning "the gateway has confirmed this key".
+# Includes both the enum and its raw int value since the command endpoint's
+# response shape for this field is not documented.
+_VERIFIED_VALUES: tuple[Any, ...] = (
+    AuthorizedClientState.VERIFIED,
+    int(AuthorizedClientState.VERIFIED),
+)
+
+
+def _normalize_b64(value: Any) -> str:
+    """Strip whitespace from a base64 string; return "" for non-strings."""
+    return "".join(value.split()) if isinstance(value, str) else ""
+
+
+def _iter_clients(payload: Any) -> list[Any]:
+    """Find the list of authorized clients inside a command response.
+
+    The exact response shape isn't documented, so this walks common wrapper
+    keys before falling back to a depth-first search of nested values.
+    """
+    if isinstance(payload, list):
+        return payload
+    if not isinstance(payload, Mapping):
+        return []
+    for key in ("authorized_clients", "authorizedClients", "clients", "response"):
+        if key in payload and (found := _iter_clients(payload[key])):
+            return found
+    for value in payload.values():
+        if isinstance(value, (list, Mapping)) and (found := _iter_clients(value)):
+            return found
+    return []
+
+
+def _is_verified(list_response: Any, public_key_b64: str) -> bool:
+    """Return True if ``list_response`` contains our key in VERIFIED state."""
+    target = _normalize_b64(public_key_b64)
+    for client in _iter_clients(list_response):
+        if not isinstance(client, Mapping):
+            continue
+        key = client.get("public_key") or client.get("publicKey") or ""
+        if _normalize_b64(key) != target:
+            continue
+        state = client.get("state") or client.get("authorized_client_state")
+        return state in _VERIFIED_VALUES
+    return False
 
 
 class OAuth2FlowHandler(
@@ -46,6 +121,15 @@ class OAuth2FlowHandler(
     def logger(self) -> logging.Logger:
         """Return logger."""
         return LOGGER
+
+    @classmethod
+    @callback
+    @override
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        """Return the subentry types supported by this integration."""
+        return {SUBENTRY_TYPE_ENERGY_SITE: EnergySiteSubentryFlowHandler}
 
     @override
     async def async_step_user(
@@ -137,3 +221,145 @@ class OAuth2FlowHandler(
     ) -> ConfigFlowResult:
         """Handle reconfiguration."""
         return await self.async_step_user()
+
+
+class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
+    """Pair a local Powerwall gateway for TEDAPI v1r command routing.
+
+    Reconfiguring an energy site subentry registers the integration's RSA key
+    as an authorized client on the gateway (via the cloud API), walks the user
+    through approving it on the Powerwall, then collects the local gateway host
+    and password. Once paired, the host/password are stored on the subentry,
+    which enables Powerwall-first command routing for that site on the next
+    reload.
+    """
+
+    def __init__(self) -> None:
+        """Initialize the energy site subentry flow."""
+        self._energy_site: EnergySite | None = None
+        self._key_pem: bytes | None = None
+        self._public_key_der: bytes = b""
+        self._public_key_b64: str = ""
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Reject manual creation; energy sites come from the Teslemetry account."""
+        return self.async_abort(reason="not_supported")
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Look up the site's cloud API and start (or resume) key pairing."""
+        subentry = self._get_reconfigure_subentry()
+        entry = cast(TeslemetryConfigEntry, self._get_entry())
+        energy_data = next(
+            (
+                energysite
+                for energysite in entry.runtime_data.energysites
+                if energysite.subentry_id == subentry.subentry_id
+            ),
+            None,
+        )
+        if energy_data is None:
+            return self.async_abort(reason="cannot_connect")
+        self._energy_site = (
+            energy_data.api.secondary
+            if isinstance(energy_data.api, EnergySiteRouter)
+            else energy_data.api
+        )
+
+        path = self.hass.config.path(POWERWALL_KEY_FILE)
+        keyholder = Teslemetry(
+            session=async_get_clientsession(self.hass), access_token=""
+        )
+        await keyholder.get_rsa_private_key(path)
+        self._key_pem = await self.hass.async_add_executor_job(Path(path).read_bytes)
+        self._public_key_der = keyholder.rsa_public_der_pkcs1
+        self._public_key_b64 = keyholder.rsa_public_der_pkcs1_b64
+
+        try:
+            response = await self._energy_site.list_authorized_clients()
+        except TeslaFleetError as err:
+            LOGGER.debug("list_authorized_clients failed: %s", err)
+            response = None
+
+        if _is_verified(response, self._public_key_b64):
+            return await self.async_step_credentials()
+
+        try:
+            await self._energy_site.add_authorized_client(
+                self._public_key_der,
+                description="Home Assistant",
+                key_type=AuthorizedClientKeyType.RSA,
+                authorized_client_type=AuthorizedClientType.CUSTOMER_MOBILE_APP,
+            )
+        except TeslaFleetError as err:
+            LOGGER.error("Add authorized client failed: %s", err)
+            return self.async_abort(reason="cannot_connect")
+
+        return await self.async_step_pair()
+
+    async def async_step_pair(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Ask the user to approve the pending key, then poll for VERIFIED."""
+        assert self._energy_site is not None
+        if user_input is None:
+            return self.async_show_form(step_id="pair")
+
+        for _ in range(KEY_PAIRING_POLL_ATTEMPTS):
+            try:
+                response = await self._energy_site.list_authorized_clients()
+            except TeslaFleetError:
+                response = None
+            if _is_verified(response, self._public_key_b64):
+                return await self.async_step_credentials()
+            await asyncio.sleep(KEY_PAIRING_POLL_INTERVAL)
+
+        return self.async_show_form(step_id="pair", errors={"base": "timeout"})
+
+    async def async_step_credentials(
+        self, user_input: dict[str, Any] | None = None
+    ) -> SubentryFlowResult:
+        """Collect the local gateway host/password and verify the LAN connection."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            host = user_input[CONF_HOST].strip()
+            # The Powerwall gateway login accepts only the last 5 characters of
+            # the Wi-Fi password printed on the gateway; users routinely enter
+            # the full string, so trim it to what the gateway will accept.
+            password = user_input[CONF_PASSWORD].strip()[-5:]
+            assert self._key_pem is not None
+            try:
+                async with PowerwallClient(
+                    host=host,
+                    gateway_password=password,
+                    rsa_private_key_pem=self._key_pem,
+                    session=async_get_clientsession(self.hass),
+                ) as client:
+                    await client.connect()
+            except PowerwallAuthenticationError:
+                errors["base"] = "invalid_password"
+            except PowerwallError as err:
+                LOGGER.debug("Local Powerwall verify failed: %s", err)
+                errors["base"] = "cannot_connect"
+            else:
+                entry = self._get_entry()
+                self.hass.config_entries.async_schedule_reload(entry.entry_id)
+                return self.async_update_and_abort(
+                    entry,
+                    self._get_reconfigure_subentry(),
+                    data_updates={CONF_HOST: host, CONF_PASSWORD: password},
+                )
+
+        return self.async_show_form(
+            step_id="credentials",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=DEFAULT_GATEWAY_HOST): str,
+                    vol.Required(CONF_PASSWORD): str,
+                }
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -24,7 +24,8 @@ from tesla_fleet_api.exceptions import (
     TeslaFleetError,
 )
 from tesla_fleet_api.tesla import EnergySiteRouter
-from tesla_fleet_api.teslemetry import EnergySite, Teslemetry
+from tesla_fleet_api.teslemetry import Teslemetry
+from tesla_fleet_api.teslemetry.energysite import TeslemetryEnergySite
 import voluptuous as vol
 
 from homeassistant.components.application_credentials import (
@@ -55,52 +56,6 @@ from .const import (
     POWERWALL_KEY_FILE,
     SUBENTRY_TYPE_ENERGY_SITE,
 )
-
-# Authorized-client states meaning "the gateway has confirmed this key".
-# Includes both the enum and its raw int value since the command endpoint's
-# response shape for this field is not documented.
-_VERIFIED_VALUES: tuple[Any, ...] = (
-    AuthorizedClientState.VERIFIED,
-    int(AuthorizedClientState.VERIFIED),
-)
-
-
-def _normalize_b64(value: Any) -> str:
-    """Strip whitespace from a base64 string; return "" for non-strings."""
-    return "".join(value.split()) if isinstance(value, str) else ""
-
-
-def _iter_clients(payload: Any) -> list[Any]:
-    """Find the list of authorized clients inside a command response.
-
-    The exact response shape isn't documented, so this walks common wrapper
-    keys before falling back to a depth-first search of nested values.
-    """
-    if isinstance(payload, list):
-        return payload
-    if not isinstance(payload, Mapping):
-        return []
-    for key in ("authorized_clients", "authorizedClients", "clients", "response"):
-        if key in payload and (found := _iter_clients(payload[key])):
-            return found
-    for value in payload.values():
-        if isinstance(value, (list, Mapping)) and (found := _iter_clients(value)):
-            return found
-    return []
-
-
-def _is_verified(list_response: Any, public_key_b64: str) -> bool:
-    """Return True if ``list_response`` contains our key in VERIFIED state."""
-    target = _normalize_b64(public_key_b64)
-    for client in _iter_clients(list_response):
-        if not isinstance(client, Mapping):
-            continue
-        key = client.get("public_key") or client.get("publicKey") or ""
-        if _normalize_b64(key) != target:
-            continue
-        state = client.get("state") or client.get("authorized_client_state")
-        return state in _VERIFIED_VALUES
-    return False
 
 
 class OAuth2FlowHandler(
@@ -237,7 +192,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
 
     def __init__(self) -> None:
         """Initialize the energy site subentry flow."""
-        self._energy_site: EnergySite | None = None
+        self._energy_site: TeslemetryEnergySite | None = None
         self._key_pem: bytes | None = None
         self._public_key_der: bytes = b""
         self._public_key_b64: str = ""
@@ -268,10 +223,11 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         )
         if energy_data is None:
             return self.async_abort(reason="cannot_connect")
-        self._energy_site = (
+        self._energy_site = cast(
+            TeslemetryEnergySite,
             energy_data.api.secondary
             if isinstance(energy_data.api, EnergySiteRouter)
-            else energy_data.api
+            else energy_data.api,
         )
 
         path = self.hass.config.path(POWERWALL_KEY_FILE)
@@ -283,13 +239,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         self._public_key_der = keyholder.rsa_public_der_pkcs1
         self._public_key_b64 = keyholder.rsa_public_der_pkcs1_b64
 
-        try:
-            response = await self._energy_site.list_authorized_clients()
-        except TeslaFleetError as err:
-            LOGGER.debug("list_authorized_clients failed: %s", err)
-            response = None
-
-        if _is_verified(response, self._public_key_b64):
+        if await self._key_is_verified():
             return await self.async_step_credentials()
 
         try:
@@ -314,15 +264,30 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             return self.async_show_form(step_id="pair")
 
         for _ in range(KEY_PAIRING_POLL_ATTEMPTS):
-            try:
-                response = await self._energy_site.list_authorized_clients()
-            except TeslaFleetError:
-                response = None
-            if _is_verified(response, self._public_key_b64):
+            if await self._key_is_verified():
                 return await self.async_step_credentials()
             await asyncio.sleep(KEY_PAIRING_POLL_INTERVAL)
 
         return self.async_show_form(step_id="pair", errors={"base": "timeout"})
+
+    async def _key_is_verified(self) -> bool:
+        """Report whether our public key is registered and VERIFIED on the gateway.
+
+        Parsing lives in the library's typed ``find_authorized_clients`` accessor
+        (envelope unwrap, null-body handling, ``state`` typing); an explicitly
+        empty client list authoritatively means "not verified".
+        """
+        assert self._energy_site is not None
+        try:
+            result = await self._energy_site.find_authorized_clients()
+        except TeslaFleetError as err:
+            LOGGER.debug("find_authorized_clients failed: %s", err)
+            return False
+        return any(
+            client.public_key == self._public_key_b64
+            and client.state == AuthorizedClientState.VERIFIED
+            for client in result.clients
+        )
 
     async def async_step_credentials(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -404,6 +404,12 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             None,
         )
 
+    async def _key_is_verified(self) -> bool:
+        """Report whether our public key is registered and VERIFIED on the gateway."""
+        client = await self._find_authorized_client()
+        LOGGER.debug("Powerwall keys: %s", client)
+        return client is not None and client.state == AuthorizedClientState.VERIFIED
+
     async def async_step_credentials(
         self, user_input: dict[str, Any] | None = None
     ) -> SubentryFlowResult:

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -234,6 +234,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         self._key_pem: bytes | None = None
         self._public_key_der: bytes = b""
         self._public_key_b64: str = ""
+        self._discovered_host: str = ""
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -267,6 +268,12 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             if isinstance(energy_data.api, EnergySiteRouter)
             else energy_data.api,
         )
+
+        try:
+            self._discovered_host = await self._energy_site.find_gateway_address() or ""
+        except TeslaFleetError as err:
+            LOGGER.debug("Gateway address discovery failed: %s", err)
+            self._discovered_host = ""
 
         path = self.hass.config.path(POWERWALL_KEY_FILE)
         keyholder = Teslemetry(
@@ -417,7 +424,10 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             step_id="credentials",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default=DEFAULT_GATEWAY_HOST): str,
+                    vol.Required(
+                        CONF_HOST,
+                        default=self._discovered_host or DEFAULT_GATEWAY_HOST,
+                    ): str,
                     vol.Required(CONF_PASSWORD): str,
                 }
             ),

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -191,14 +191,12 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
 
     The authorized-client key this flow registers is intentionally left on
     the gateway when the Home Assistant config entry/subentry is later
-    removed: tesla-fleet-api exposes no revoke/delete endpoint, and the same
-    gateway-side authorization can be relied on by other clients (other
-    integrations, other Home Assistant instances, or the Tesla app itself),
-    so removing this integration's config must not silently deauthorize a
-    credential those other consumers may still be using. A user who wants
-    the "Home Assistant" client fully revoked has to remove it manually,
-    independent of Home Assistant, via the gateway's own local web UI
-    (Settings > Access on the gateway's local IP) or the Tesla app.
+    removed. The same gateway-side authorization may be relied on by other
+    consumers that share the credential (such as other integrations), so
+    removing this integration's config must not deauthorize a credential
+    those other consumers may still be using. tesla-fleet-api does expose
+    ``remove_authorized_client``, but it is deliberately not called on
+    removal for that reason.
     """
 
     def __init__(self) -> None:
@@ -254,8 +252,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             return await self.async_step_credentials()
 
         try:
-            # Not revoked on removal by design; see the class docstring for
-            # why, and how a user can manually revoke it on the gateway.
+            # Not revoked on removal by design; see the class docstring.
             await self._energy_site.add_authorized_client(
                 self._public_key_der,
                 description="Home Assistant",

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -69,6 +69,16 @@ class PowerwallUnreachableError(Exception):
     """
 
 
+class PowerwallLookupError(Exception):
+    """Signal that the authorized-client lookup failed for a non-retryable reason.
+
+    Distinct from the key simply being absent: the gateway did not return a
+    usable client list, so the caller must abort (or keep the user on a
+    retryable form) rather than mistake the failure for an unregistered key and
+    re-register it, which would reset an already pending or verified key.
+    """
+
+
 def _is_gateway_unreachable(err: TeslaFleetError | ClientResponseError) -> bool:
     """Return whether err is a 502 Bad Gateway from an energy gateway command.
 
@@ -273,6 +283,8 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             client = await self._find_authorized_client()
         except PowerwallUnreachableError:
             return self.async_abort(reason="powerwall_unreachable")
+        except PowerwallLookupError:
+            return self.async_abort(reason="cannot_connect")
         if client is not None:
             # The key is already registered on the gateway. If it is verified,
             # move on to credentials; if it is still pending, resume approval
@@ -317,6 +329,10 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
                 return self.async_show_form(
                     step_id="pair", errors={"base": "powerwall_unreachable"}
                 )
+            except PowerwallLookupError:
+                return self.async_show_form(
+                    step_id="pair", errors={"base": "cannot_connect"}
+                )
             if verified:
                 return await self.async_step_credentials()
             await asyncio.sleep(KEY_PAIRING_POLL_INTERVAL)
@@ -327,26 +343,24 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         """Return our RSA key's authorized-client entry on the gateway, or None.
 
         Parsing lives in the library's typed ``find_authorized_clients`` accessor
-        (envelope unwrap, null-body handling, ``state`` typing); an explicitly
-        empty client list authoritatively means "not registered".
+        (envelope unwrap, null-body handling, ``state`` typing). ``None`` is
+        returned only when the gateway answers successfully but our key is not
+        among the authorized clients (an explicitly empty list authoritatively
+        means "not registered").
 
-        A 502 (gateway unreachable) raises ``PowerwallUnreachableError`` so the
-        caller can retry; any other failure, or the key simply not being present,
-        resolves to ``None`` (treated as an unregistered, unverified key).
+        A 502 (gateway unreachable) raises ``PowerwallUnreachableError``; any
+        other lookup failure raises ``PowerwallLookupError``. Neither is
+        collapsed into ``None`` so the caller never mistakes a failed lookup for
+        an absent key and re-registers it.
         """
         assert self._energy_site is not None
         try:
             result = await self._energy_site.find_authorized_clients()
-        except ClientResponseError as err:
+        except (ClientResponseError, TeslaFleetError) as err:
             if _is_gateway_unreachable(err):
                 raise PowerwallUnreachableError from err
             LOGGER.debug("find_authorized_clients failed: %s", err)
-            return None
-        except TeslaFleetError as err:
-            if _is_gateway_unreachable(err):
-                raise PowerwallUnreachableError from err
-            LOGGER.debug("find_authorized_clients failed: %s", err)
-            return None
+            raise PowerwallLookupError from err
         return next(
             (
                 client

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -84,9 +84,10 @@ def _is_gateway_unreachable(err: TeslaFleetError | ClientResponseError) -> bool:
 
     A bodyless 502 surfaces from tesla-fleet-api as ``ResponseError`` (a
     ``TeslaFleetError`` carrying ``status``); a 502 with a JSON body instead
-    surfaces as ``aiohttp.ClientResponseError``. Both expose ``status``.
+    surfaces as ``aiohttp.ClientResponseError``. ``status`` is looked up with
+    ``getattr`` since a bare ``TeslaFleetError`` is not guaranteed to carry one.
     """
-    return err.status == HTTPStatus.BAD_GATEWAY
+    return getattr(err, "status", None) == HTTPStatus.BAD_GATEWAY
 
 
 class OAuth2FlowHandler(

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -2,11 +2,12 @@
 
 import asyncio
 from collections.abc import Mapping
+from http import HTTPStatus
 import logging
 from pathlib import Path
 from typing import Any, cast, override
 
-from aiohttp import ClientConnectionError
+from aiohttp import ClientConnectionError, ClientResponseError
 from aiopowerwall import (
     DEFAULT_GATEWAY_HOST,
     PowerwallAuthenticationError,
@@ -56,6 +57,26 @@ from .const import (
     POWERWALL_KEY_FILE,
     SUBENTRY_TYPE_ENERGY_SITE,
 )
+
+
+class PowerwallUnreachableError(Exception):
+    """Signal that an energy gateway-relay command returned HTTP 502.
+
+    The Teslemetry API returns 502 Bad Gateway on energy gateway-relay grpc
+    commands when the customer's Powerwall gateway is unreachable (for example
+    it has dropped off the network). This is a retryable upstream condition,
+    distinct from an ordinary API failure.
+    """
+
+
+def _is_gateway_unreachable(err: TeslaFleetError | ClientResponseError) -> bool:
+    """Return whether err is a 502 Bad Gateway from an energy gateway command.
+
+    A bodyless 502 surfaces from tesla-fleet-api as ``ResponseError`` (a
+    ``TeslaFleetError`` carrying ``status``); a 502 with a JSON body instead
+    surfaces as ``aiohttp.ClientResponseError``. Both expose ``status``.
+    """
+    return err.status == HTTPStatus.BAD_GATEWAY
 
 
 class OAuth2FlowHandler(
@@ -248,7 +269,11 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         self._public_key_der = keyholder.rsa_public_der_pkcs1
         self._public_key_b64 = keyholder.rsa_public_der_pkcs1_b64
 
-        if await self._key_is_verified():
+        try:
+            verified = await self._key_is_verified()
+        except PowerwallUnreachableError:
+            return self.async_abort(reason="powerwall_unreachable")
+        if verified:
             return await self.async_step_credentials()
 
         try:
@@ -259,7 +284,13 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
                 key_type=AuthorizedClientKeyType.RSA,
                 authorized_client_type=AuthorizedClientType.CUSTOMER_MOBILE_APP,
             )
+        except ClientResponseError as err:
+            if _is_gateway_unreachable(err):
+                return self.async_abort(reason="powerwall_unreachable")
+            raise
         except TeslaFleetError as err:
+            if _is_gateway_unreachable(err):
+                return self.async_abort(reason="powerwall_unreachable")
             LOGGER.error("Add authorized client failed: %s", err)
             return self.async_abort(reason="cannot_connect")
 
@@ -274,7 +305,13 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             return self.async_show_form(step_id="pair")
 
         for _ in range(KEY_PAIRING_POLL_ATTEMPTS):
-            if await self._key_is_verified():
+            try:
+                verified = await self._key_is_verified()
+            except PowerwallUnreachableError:
+                return self.async_show_form(
+                    step_id="pair", errors={"base": "powerwall_unreachable"}
+                )
+            if verified:
                 return await self.async_step_credentials()
             await asyncio.sleep(KEY_PAIRING_POLL_INTERVAL)
 
@@ -290,7 +327,13 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         assert self._energy_site is not None
         try:
             result = await self._energy_site.find_authorized_clients()
+        except ClientResponseError as err:
+            if _is_gateway_unreachable(err):
+                raise PowerwallUnreachableError from err
+            raise
         except TeslaFleetError as err:
+            if _is_gateway_unreachable(err):
+                raise PowerwallUnreachableError from err
             LOGGER.debug("find_authorized_clients failed: %s", err)
             return False
         return any(

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -188,6 +188,17 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
     and password. Once paired, the host/password are stored on the subentry,
     which enables Powerwall-first command routing for that site on the next
     reload.
+
+    The authorized-client key this flow registers is intentionally left on
+    the gateway when the Home Assistant config entry/subentry is later
+    removed: tesla-fleet-api exposes no revoke/delete endpoint, and the same
+    gateway-side authorization can be relied on by other clients (other
+    integrations, other Home Assistant instances, or the Tesla app itself),
+    so removing this integration's config must not silently deauthorize a
+    credential those other consumers may still be using. A user who wants
+    the "Home Assistant" client fully revoked has to remove it manually,
+    independent of Home Assistant, via the gateway's own local web UI
+    (Settings > Access on the gateway's local IP) or the Tesla app.
     """
 
     def __init__(self) -> None:
@@ -243,6 +254,8 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
             return await self.async_step_credentials()
 
         try:
+            # Not revoked on removal by design; see the class docstring for
+            # why, and how a user can manually revoke it on the gateway.
             await self._energy_site.add_authorized_client(
                 self._public_key_der,
                 description="Home Assistant",

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -472,9 +472,9 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
                 # the account's gateways: without this check a host pointed at
                 # the wrong gateway would command another site's house.
                 if self._gateway_id is None:
-                    # Pairing is allowed to proceed: refusing it over a missing
-                    # comparand would block a valid gateway. Warn rather than
-                    # debug so the check being skipped is never silent.
+                    # Pairing proceeds: refusing over a missing comparand would
+                    # block a valid gateway. Warn so a skipped identity check is
+                    # never silent.
                     LOGGER.warning(
                         "Energy site %s reports no gateway ID, so %s cannot be "
                         "confirmed as this site's own gateway; pairing anyway",

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -451,6 +451,7 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         """Collect the local gateway host/password and verify the LAN connection."""
         errors: dict[str, str] = {}
         if user_input is not None:
+            assert self._energy_site is not None
             host = user_input[CONF_HOST].strip()
             # The Powerwall gateway login accepts only the last 5 characters of
             # the Wi-Fi password printed on the gateway; users routinely enter
@@ -471,8 +472,14 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
                 # the account's gateways: without this check a host pointed at
                 # the wrong gateway would command another site's house.
                 if self._gateway_id is None:
-                    LOGGER.debug(
-                        "No cloud gateway ID for this site; skipping DIN binding"
+                    # Pairing is allowed to proceed: refusing it over a missing
+                    # comparand would block a valid gateway. Warn rather than
+                    # debug so the check being skipped is never silent.
+                    LOGGER.warning(
+                        "Energy site %s reports no gateway ID, so %s cannot be "
+                        "confirmed as this site's own gateway; pairing anyway",
+                        self._energy_site.energy_site_id,
+                        din,
                     )
                 elif not _din_matches(self._gateway_id, din):
                     return self.async_abort(

--- a/homeassistant/components/teslemetry/config_flow.py
+++ b/homeassistant/components/teslemetry/config_flow.py
@@ -26,7 +26,7 @@ from tesla_fleet_api.exceptions import (
 )
 from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import Teslemetry
-from tesla_fleet_api.teslemetry.energysite import TeslemetryEnergySite
+from tesla_fleet_api.teslemetry.energysite import AuthorizedClient, TeslemetryEnergySite
 import voluptuous as vol
 
 from homeassistant.components.application_credentials import (
@@ -270,11 +270,16 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         self._public_key_b64 = keyholder.rsa_public_der_pkcs1_b64
 
         try:
-            verified = await self._key_is_verified()
+            client = await self._find_authorized_client()
         except PowerwallUnreachableError:
             return self.async_abort(reason="powerwall_unreachable")
-        if verified:
-            return await self.async_step_credentials()
+        if client is not None:
+            # The key is already registered on the gateway. If it is verified,
+            # move on to credentials; if it is still pending, resume approval
+            # without re-registering it (re-adding would reset a pending key).
+            if client.state == AuthorizedClientState.VERIFIED:
+                return await self.async_step_credentials()
+            return await self.async_step_pair()
 
         try:
             # Not revoked on removal by design; see the class docstring.
@@ -287,7 +292,8 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         except ClientResponseError as err:
             if _is_gateway_unreachable(err):
                 return self.async_abort(reason="powerwall_unreachable")
-            raise
+            LOGGER.error("Add authorized client failed: %s", err)
+            return self.async_abort(reason="cannot_connect")
         except TeslaFleetError as err:
             if _is_gateway_unreachable(err):
                 return self.async_abort(reason="powerwall_unreachable")
@@ -317,12 +323,16 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
 
         return self.async_show_form(step_id="pair", errors={"base": "timeout"})
 
-    async def _key_is_verified(self) -> bool:
-        """Report whether our public key is registered and VERIFIED on the gateway.
+    async def _find_authorized_client(self) -> AuthorizedClient | None:
+        """Return our RSA key's authorized-client entry on the gateway, or None.
 
         Parsing lives in the library's typed ``find_authorized_clients`` accessor
         (envelope unwrap, null-body handling, ``state`` typing); an explicitly
-        empty client list authoritatively means "not verified".
+        empty client list authoritatively means "not registered".
+
+        A 502 (gateway unreachable) raises ``PowerwallUnreachableError`` so the
+        caller can retry; any other failure, or the key simply not being present,
+        resolves to ``None`` (treated as an unregistered, unverified key).
         """
         assert self._energy_site is not None
         try:
@@ -330,17 +340,26 @@ class EnergySiteSubentryFlowHandler(ConfigSubentryFlow):
         except ClientResponseError as err:
             if _is_gateway_unreachable(err):
                 raise PowerwallUnreachableError from err
-            raise
+            LOGGER.debug("find_authorized_clients failed: %s", err)
+            return None
         except TeslaFleetError as err:
             if _is_gateway_unreachable(err):
                 raise PowerwallUnreachableError from err
             LOGGER.debug("find_authorized_clients failed: %s", err)
-            return False
-        return any(
-            client.public_key == self._public_key_b64
-            and client.state == AuthorizedClientState.VERIFIED
-            for client in result.clients
+            return None
+        return next(
+            (
+                client
+                for client in result.clients
+                if client.public_key == self._public_key_b64
+            ),
+            None,
         )
+
+    async def _key_is_verified(self) -> bool:
+        """Report whether our public key is registered and VERIFIED on the gateway."""
+        client = await self._find_authorized_client()
+        return client is not None and client.state == AuthorizedClientState.VERIFIED
 
     async def async_step_credentials(
         self, user_input: dict[str, Any] | None = None

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -12,6 +12,27 @@ AUTHORIZE_URL = "https://teslemetry.com/connect"
 TOKEN_URL = "https://api.teslemetry.com/oauth/token"
 CLIENT_ID = "homeassistant"
 
+# Config subentry type holding an energy site's local Powerwall pairing config
+SUBENTRY_TYPE_ENERGY_SITE = "energy_site"
+
+# Energy site subentry data key. An energy site subentry also stores CONF_HOST
+# and CONF_PASSWORD (from homeassistant.const) once paired; their presence
+# enables Powerwall-first command routing over the local network.
+CONF_SITE_ID = "site_id"
+
+# File holding the integration's RSA private key used to sign local TEDAPI v1r
+# requests. The matching public key is what gets registered as an authorized
+# client on the energy gateway when pairing.
+POWERWALL_KEY_FILE = "tesla_powerwall.key"
+
+# hass.data key caching the RSA private key PEM shared across energy sites.
+RSA_PARENT_KEY = f"{DOMAIN}_rsa_parent"
+
+# Number of list_authorized_clients() polls, and the delay between them, while
+# waiting for the user to approve the pending key on the Powerwall.
+KEY_PAIRING_POLL_ATTEMPTS = 10
+KEY_PAIRING_POLL_INTERVAL = 2
+
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",
     "generator_energy_exported",

--- a/homeassistant/components/teslemetry/const.py
+++ b/homeassistant/components/teslemetry/const.py
@@ -28,11 +28,6 @@ POWERWALL_KEY_FILE = "tesla_powerwall.key"
 # hass.data key caching the RSA private key PEM shared across energy sites.
 RSA_PARENT_KEY = f"{DOMAIN}_rsa_parent"
 
-# Number of list_authorized_clients() polls, and the delay between them, while
-# waiting for the user to approve the pending key on the Powerwall.
-KEY_PAIRING_POLL_ATTEMPTS = 10
-KEY_PAIRING_POLL_INTERVAL = 2
-
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",
     "generator_energy_exported",

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import Any, override
 
 from tesla_fleet_api.const import Scope
+from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 
 from homeassistant.exceptions import ServiceValidationError
@@ -136,7 +137,7 @@ class TeslemetryVehiclePollingEntity(TeslemetryPollingEntity):
 class TeslemetryEnergyLiveEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Energy Site Live entities."""
 
-    api: EnergySite
+    api: EnergySite | EnergySiteRouter
 
     def __init__(
         self,
@@ -157,7 +158,7 @@ class TeslemetryEnergyLiveEntity(TeslemetryPollingEntity):
 class TeslemetryEnergyInfoEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Energy Site Info Entities."""
 
-    api: EnergySite
+    api: EnergySite | EnergySiteRouter
 
     def __init__(
         self,
@@ -196,7 +197,7 @@ class TeslemetryWallConnectorEntity(TeslemetryPollingEntity):
     """Parent class for Teslemetry Wall Connector Entities."""
 
     _attr_has_entity_name = True
-    api: EnergySite
+    api: EnergySite | EnergySiteRouter
 
     def __init__(
         self,

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -11,7 +11,7 @@
   "quality_scale": "platinum",
   "requirements": [
     "aiopowerwall==0.3.0",
-    "tesla-fleet-api==1.7.2",
+    "tesla-fleet-api==1.7.6",
     "teslemetry-stream==0.9.1"
   ]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -9,5 +9,9 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla_fleet_api", "teslemetry_stream"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==1.7.2", "teslemetry-stream==0.9.1"]
+  "requirements": [
+    "aiopowerwall==0.2.0",
+    "tesla-fleet-api==1.7.2",
+    "teslemetry-stream==0.9.1"
+  ]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -10,7 +10,7 @@
   "loggers": ["aiopowerwall", "tesla_fleet_api", "teslemetry_stream"],
   "quality_scale": "platinum",
   "requirements": [
-    "aiopowerwall==0.2.0",
+    "aiopowerwall==0.3.0",
     "tesla-fleet-api==1.7.2",
     "teslemetry-stream==0.9.1"
   ]

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -7,7 +7,7 @@
   "documentation": "https://www.home-assistant.io/integrations/teslemetry",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "loggers": ["tesla_fleet_api", "teslemetry_stream"],
+  "loggers": ["aiopowerwall", "tesla_fleet_api", "teslemetry_stream"],
   "quality_scale": "platinum",
   "requirements": [
     "aiopowerwall==0.2.0",

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -60,3 +60,7 @@ class TeslemetryEnergyData:
     # The local-control subentry id, or None for sites without a battery
     # (solar-only or wall-connector-only), which have no Powerwall to pair.
     subentry_id: str | None
+    # The site's gateway DIN as the cloud reports it, which pairing compares
+    # against the DIN the local gateway reports so a subentry can only ever be
+    # bound to its own hardware. None when the cloud omits it.
+    gateway_id: str | None

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -4,6 +4,7 @@ import asyncio
 from dataclasses import dataclass, field
 
 from tesla_fleet_api.const import Scope
+from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 from teslemetry_stream import TeslemetryStream, TeslemetryStreamVehicle
 
@@ -50,9 +51,13 @@ class TeslemetryVehicleData:
 class TeslemetryEnergyData:
     """Data for a vehicle in the Teslemetry integration."""
 
-    api: EnergySite
+    # Plain cloud EnergySite, or an EnergySiteRouter that tries a paired local
+    # Powerwall (aiopowerwall) first and falls back to the cloud EnergySite
+    # per command.
+    api: EnergySite | EnergySiteRouter
     live_coordinator: TeslemetryEnergySiteLiveCoordinator | None
     info_coordinator: TeslemetryEnergySiteInfoCoordinator
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None
     id: int
     device: DeviceInfo
+    subentry_id: str

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -60,4 +60,6 @@ class TeslemetryEnergyData:
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None
     id: int
     device: DeviceInfo
-    subentry_id: str
+    # The local-control subentry id, or None for wall-connector-only sites,
+    # which have no Powerwall gateway to pair.
+    subentry_id: str | None

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -51,15 +51,12 @@ class TeslemetryVehicleData:
 class TeslemetryEnergyData:
     """Data for an energy site in the Teslemetry integration."""
 
-    # Plain cloud EnergySite, or an EnergySiteRouter that tries a paired local
-    # Powerwall (aiopowerwall) first and falls back to the cloud EnergySite
-    # per command.
     api: EnergySite | EnergySiteRouter
     live_coordinator: TeslemetryEnergySiteLiveCoordinator | None
     info_coordinator: TeslemetryEnergySiteInfoCoordinator
     history_coordinator: TeslemetryEnergyHistoryCoordinator | None
     id: int
     device: DeviceInfo
-    # The local-control subentry id, or None for wall-connector-only sites,
-    # which have no Powerwall gateway to pair.
+    # The local-control subentry id, or None for sites without a battery
+    # (solar-only or wall-connector-only), which have no Powerwall to pair.
     subentry_id: str | None

--- a/homeassistant/components/teslemetry/models.py
+++ b/homeassistant/components/teslemetry/models.py
@@ -49,7 +49,7 @@ class TeslemetryVehicleData:
 
 @dataclass
 class TeslemetryEnergyData:
-    """Data for a vehicle in the Teslemetry integration."""
+    """Data for an energy site in the Teslemetry integration."""
 
     # Plain cloud EnergySite, or an EnergySiteRouter that tries a paired local
     # Powerwall (aiopowerwall) first and falls back to the cloud EnergySite

--- a/homeassistant/components/teslemetry/number.py
+++ b/homeassistant/components/teslemetry/number.py
@@ -7,6 +7,7 @@ from typing import Any, override
 
 from tesla_fleet_api import firmware_at_least
 from tesla_fleet_api.const import Scope
+from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 from teslemetry_stream import TeslemetryStreamVehicle
 
@@ -97,7 +98,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetryNumberVehicleEntityDescription, ...] = (
 class TeslemetryNumberBatteryEntityDescription(NumberEntityDescription):
     """Describes Teslemetry Number entity."""
 
-    func: Callable[[EnergySite, float], Awaitable[Any]]
+    func: Callable[[EnergySite | EnergySiteRouter, float], Awaitable[Any]]
     requires: str | None = None
     scopes: list[Scope]
 

--- a/homeassistant/components/teslemetry/services.py
+++ b/homeassistant/components/teslemetry/services.py
@@ -139,7 +139,7 @@ def async_setup_services(hass: HomeAssistant) -> None:
             vehicle.api.navigation_gps_request(
                 lat=call.data[ATTR_GPS][CONF_LATITUDE],
                 lon=call.data[ATTR_GPS][CONF_LONGITUDE],
-                order=call.data.get(ATTR_ORDER),
+                order=call.data.get(ATTR_ORDER, 0),
             )
         )
 

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -79,7 +79,7 @@
           "title": "Connect to the local gateway"
         },
         "pair": {
-          "description": "Flick the switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once.",
+          "description": "Flick the switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on the gateway; to revoke it yourself, remove the \"Home Assistant\" client from the gateway's local web UI or the Tesla app.",
           "title": "Approve the local access key"
         }
       }

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -64,9 +64,9 @@
       "error": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "invalid_password": "[%key:common::config_flow::error::invalid_auth%]",
-        "key_not_registered": "Home Assistant's key is no longer registered on the gateway. Restart setup to register it again.",
-        "key_pending": "Home Assistant's key has not been approved yet. Flick the switch on the side of your primary Powerwall off and back on to approve it, then submit again.",
-        "key_pending_verification": "Your approval is still being verified by the gateway. Wait a moment, then submit again.",
+        "key_not_registered": "Home Assistant's key is no longer registered on your Powerwall system. Restart setup to register it again.",
+        "key_pending": "Home Assistant's key has not been approved yet. Flick the On/Off switch on the side of your primary Powerwall off and back on to approve it, then submit again.",
+        "key_pending_verification": "Your approval is still being verified by your Powerwall system. Wait a moment, then submit again.",
         "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later."
       },
       "initiate_flow": {
@@ -79,11 +79,11 @@
             "host": "[%key:common::config_flow::data::host%]",
             "password": "[%key:common::config_flow::data::password%]"
           },
-          "description": "Enter the local network address of your energy gateway and its Wi-Fi password (the last 5 characters printed on the gateway are all that's needed).",
-          "title": "Connect to the local gateway"
+          "description": "Enter your Powerwall system's local network address and its Wi-Fi password. Only the last 5 characters of the password are needed - find them on the QR label behind the front cover of your Powerwall 3, or behind the Backup Gateway door on Powerwall 2.",
+          "title": "Connect to your Powerwall system"
         },
         "pair": {
-          "description": "Flick the switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on the gateway.",
+          "description": "Flick the On/Off switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on your Powerwall or Backup Gateway.",
           "title": "Approve the local access key"
         }
       }

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -51,6 +51,39 @@
       }
     }
   },
+  "config_subentries": {
+    "energy_site": {
+      "abort": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "not_supported": "Energy sites are added automatically from your Teslemetry account and cannot be added manually.",
+        "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+      },
+      "entry_type": "Energy site",
+      "error": {
+        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "invalid_password": "[%key:common::config_flow::error::invalid_auth%]",
+        "timeout": "Timed out waiting for the key to be approved. Try again after flicking the switch on the side of your primary Powerwall off and back on."
+      },
+      "initiate_flow": {
+        "reconfigure": "Set up local control",
+        "user": "Add energy site"
+      },
+      "step": {
+        "credentials": {
+          "data": {
+            "host": "[%key:common::config_flow::data::host%]",
+            "password": "[%key:common::config_flow::data::password%]"
+          },
+          "description": "Enter the local network address of your energy gateway and its Wi-Fi password (the last 5 characters printed on the gateway are all that's needed).",
+          "title": "Connect to the local gateway"
+        },
+        "pair": {
+          "description": "Flick the switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once.",
+          "title": "Approve the local access key"
+        }
+      }
+    }
+  },
   "entity": {
     "binary_sensor": {
       "automatic_blind_spot_camera": {

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -57,12 +57,14 @@
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "entry_not_loaded": "The Teslemetry account must be loaded before setting up local control. Try again once it has finished loading.",
         "not_supported": "Energy sites are added automatically from your Teslemetry account and cannot be added manually.",
+        "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later.",
         "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
       },
       "entry_type": "Energy site",
       "error": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "invalid_password": "[%key:common::config_flow::error::invalid_auth%]",
+        "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later.",
         "timeout": "Timed out waiting for the key to be approved. Try again after flicking the switch on the side of your primary Powerwall off and back on."
       },
       "initiate_flow": {

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -65,7 +65,7 @@
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "invalid_password": "[%key:common::config_flow::error::invalid_auth%]",
         "key_not_registered": "Home Assistant's key is no longer registered on your Powerwall system. Restart setup to register it again.",
-        "key_pending": "Home Assistant's key has not been approved yet. Flick the On/Off switch on the side of your primary Powerwall off and back on to approve it, then submit again.",
+        "key_pending": "Home Assistant's key has not been approved yet. Flick the On/Off switch on your primary Powerwall off and back on to approve it, then submit again.",
         "key_pending_verification": "Your approval is still being verified by your Powerwall system. Wait a moment, then submit again.",
         "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later."
       },
@@ -83,7 +83,7 @@
           "title": "Connect to your Powerwall system"
         },
         "pair": {
-          "description": "Flick the On/Off switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on your Powerwall or Backup Gateway.",
+          "description": "Flick the On/Off switch on your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on your Powerwall or Backup Gateway.",
           "title": "Approve the local access key"
         }
       }

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -56,6 +56,7 @@
       "abort": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "entry_not_loaded": "The Teslemetry account must be loaded before setting up local control. Try again once it has finished loading.",
+        "gateway_mismatch": "This Powerwall system belongs to a different energy site. Expected gateway {expected} but found {actual}. Check the local network address and try again.",
         "not_supported": "Energy sites are added automatically from your Teslemetry account and cannot be added manually.",
         "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later.",
         "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
@@ -64,6 +65,7 @@
       "error": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "invalid_password": "[%key:common::config_flow::error::invalid_auth%]",
+        "key_not_approved": "Your Powerwall system rejected Home Assistant's key because it has not been approved. Flick the On/Off switch on your primary Powerwall off and back on to approve it, then submit again.",
         "key_not_registered": "Home Assistant's key is no longer registered on your Powerwall system. Restart setup to register it again.",
         "key_pending": "Home Assistant's key has not been approved yet. Flick the On/Off switch on your primary Powerwall off and back on to approve it, then submit again.",
         "key_pending_verification": "Your approval is still being verified by your Powerwall system. Wait a moment, then submit again.",

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -64,8 +64,10 @@
       "error": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
         "invalid_password": "[%key:common::config_flow::error::invalid_auth%]",
-        "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later.",
-        "timeout": "Timed out waiting for the key to be approved. Try again after flicking the switch on the side of your primary Powerwall off and back on."
+        "key_not_registered": "Home Assistant's key is no longer registered on the gateway. Restart setup to register it again.",
+        "key_pending": "Home Assistant's key has not been approved yet. Flick the switch on the side of your primary Powerwall off and back on to approve it, then submit again.",
+        "key_pending_verification": "Your approval is still being verified by the gateway. Wait a moment, then submit again.",
+        "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later."
       },
       "initiate_flow": {
         "reconfigure": "Set up local control",

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -70,7 +70,7 @@
         "powerwall_unreachable": "There is a problem communicating with your Powerwall. Ensure it has a reliable network connection and try again later."
       },
       "initiate_flow": {
-        "reconfigure": "Set up local control",
+        "reconfigure": "Reconfigure energy site",
         "user": "Add energy site"
       },
       "step": {

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -55,6 +55,7 @@
     "energy_site": {
       "abort": {
         "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+        "entry_not_loaded": "The Teslemetry account must be loaded before setting up local control. Try again once it has finished loading.",
         "not_supported": "Energy sites are added automatically from your Teslemetry account and cannot be added manually.",
         "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
       },

--- a/homeassistant/components/teslemetry/strings.json
+++ b/homeassistant/components/teslemetry/strings.json
@@ -79,7 +79,7 @@
           "title": "Connect to the local gateway"
         },
         "pair": {
-          "description": "Flick the switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on the gateway; to revoke it yourself, remove the \"Home Assistant\" client from the gateway's local web UI or the Tesla app.",
+          "description": "Flick the switch on the side of your primary Powerwall off and back on to approve Home Assistant's access, then continue. This only needs to be done once. Removing this integration later does not revoke this access on the gateway.",
           "title": "Approve the local access key"
         }
       }

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
   "quality_scale": "silver",
-  "requirements": ["tessie-api==0.1.3", "tesla-fleet-api==1.7.2"]
+  "requirements": ["tessie-api==0.1.3", "tesla-fleet-api==1.7.6"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -378,7 +378,7 @@ aiopegelonline==0.1.1
 aiopnsense==1.0.10
 
 # homeassistant.components.teslemetry
-aiopowerwall==0.2.0
+aiopowerwall==0.3.0
 
 # homeassistant.components.ptdevices
 aioptdevices==2026.03.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -377,6 +377,9 @@ aiopegelonline==0.1.1
 # homeassistant.components.opnsense
 aiopnsense==1.0.10
 
+# homeassistant.components.teslemetry
+aiopowerwall==0.2.0
+
 # homeassistant.components.ptdevices
 aioptdevices==2026.03.2
 

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3178,7 +3178,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==1.7.2
+tesla-fleet-api==1.7.6
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.3

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1,22 +1,33 @@
 """Test the Teslemetry config flow."""
 
+from collections.abc import Generator
+from pathlib import Path
 import time
 from typing import Any
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
-from aiohttp import ClientConnectionError
+from aiohttp import ClientConnectionError, ClientResponseError
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 import pytest
 from tesla_fleet_api.exceptions import (
     InvalidToken,
+    ResponseError,
     SubscriptionRequired,
     TeslaFleetError,
+)
+from tesla_fleet_api.teslemetry import Teslemetry
+from tesla_fleet_api.teslemetry.energysite import (
+    AuthorizedClients,
+    TeslemetryEnergySite,
 )
 
 from homeassistant.components.teslemetry.const import (
     AUTHORIZE_URL,
     CLIENT_ID,
     DOMAIN,
+    SUBENTRY_TYPE_ENERGY_SITE,
     TOKEN_URL,
 )
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
@@ -32,6 +43,42 @@ from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
 
 REDIRECT = "https://example.com/auth/external/callback"
+
+# A small key generated once keeps the pairing-flow tests off the slow
+# RSA-4096 keygen path; the flow only reads its public bytes, never its size.
+_TEST_RSA_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_TEST_RSA_PEM = _TEST_RSA_KEY.private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.TraditionalOpenSSL,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+
+
+@pytest.fixture
+def mock_rsa_key() -> Generator[None]:
+    """Provide the pairing flow a ready RSA key instead of generating one."""
+
+    async def _fake_get_rsa_private_key(
+        self: Teslemetry, path: str, key_size: int = 4096
+    ) -> rsa.RSAPrivateKey:
+        self.rsa_private_key = _TEST_RSA_KEY
+        Path(path).write_bytes(_TEST_RSA_PEM)
+        return _TEST_RSA_KEY
+
+    with patch(
+        "homeassistant.components.teslemetry.config_flow.Teslemetry.get_rsa_private_key",
+        _fake_get_rsa_private_key,
+    ):
+        yield
+
+
+def _energy_subentry_id(entry: MockConfigEntry) -> str:
+    """Return the energy-site subentry id created during setup."""
+    return next(
+        subentry_id
+        for subentry_id, subentry in entry.subentries.items()
+        if subentry.subentry_type == SUBENTRY_TYPE_ENERGY_SITE
+    )
 
 
 @pytest.mark.usefixtures("current_request_with_host")
@@ -521,3 +568,148 @@ async def test_migrate_error_from_future(
 
     entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
     assert entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+POWERWALL_502_ERRORS = [
+    pytest.param(ResponseError(status=502), id="response_error"),
+    pytest.param(ClientResponseError(None, (), status=502), id="client_response_error"),
+]
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize("error", POWERWALL_502_ERRORS)
+async def test_energy_subentry_verify_powerwall_unreachable(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """A 502 while checking the key aborts with the retryable message."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    with patch.object(
+        TeslemetryEnergySite,
+        "find_authorized_clients",
+        AsyncMock(side_effect=error),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "powerwall_unreachable"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize("error", POWERWALL_502_ERRORS)
+async def test_energy_subentry_add_client_powerwall_unreachable(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """A 502 while registering the key aborts with the retryable message."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=AuthorizedClients(clients=[], raw=None)),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(side_effect=error),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "powerwall_unreachable"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_add_client_generic_error(
+    hass: HomeAssistant,
+) -> None:
+    """A non-502 error while registering the key keeps the generic abort."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=AuthorizedClients(clients=[], raw=None)),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(side_effect=TeslaFleetError),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize("error", POWERWALL_502_ERRORS)
+async def test_energy_subentry_pair_poll_powerwall_unreachable(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """A 502 while polling for approval re-shows the pair form as retryable."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+    empty = AuthorizedClients(clients=[], raw=None)
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(side_effect=[empty, error]),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert not result["errors"]
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": "powerwall_unreachable"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_empty_client_list_proceeds(
+    hass: HomeAssistant,
+) -> None:
+    """An empty (200) authorized-client list is valid and advances to pairing."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=AuthorizedClients(clients=[], raw=None)),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert not result["errors"]

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -27,6 +27,7 @@ from tesla_fleet_api.teslemetry.energysite import (
 )
 from yarl import URL
 
+from homeassistant.components.teslemetry.config_flow import _is_gateway_unreachable
 from homeassistant.components.teslemetry.const import (
     AUTHORIZE_URL,
     CLIENT_ID,
@@ -590,6 +591,23 @@ async def test_migrate_error_from_future(
 
     entry = hass.config_entries.async_get_entry(mock_entry.entry_id)
     assert entry.state is ConfigEntryState.MIGRATION_ERROR
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        pytest.param(TeslaFleetError(), False, id="tesla_fleet_error_no_status"),
+        pytest.param(ResponseError(status=502), True, id="response_error_502"),
+        pytest.param(
+            ClientResponseError(None, (), status=500),
+            False,
+            id="client_response_error_500",
+        ),
+    ],
+)
+def test_is_gateway_unreachable(error: Exception, expected: bool) -> None:
+    """A bare TeslaFleetError has no status set and must not raise AttributeError."""
+    assert _is_gateway_unreachable(error) is expected
 
 
 POWERWALL_502_ERRORS = [

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -963,6 +963,99 @@ async def test_energy_subentry_pair_submit_still_pending(
     add_client.assert_not_awaited()
 
 
+_UNKNOWN_CLIENT_STATES = [
+    pytest.param(None, id="none"),
+    pytest.param(99, id="unknown_int"),
+    pytest.param("bogus", id="unknown_str"),
+]
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize("state", _UNKNOWN_CLIENT_STATES)
+async def test_energy_subentry_unknown_state_aborts_as_lookup_failure(
+    hass: HomeAssistant,
+    state: object,
+) -> None:
+    """An unrecognized client state aborts rather than resuming pairing.
+
+    The typed accessor preserves a missing or unrecognized state verbatim, so a
+    key in such a state cannot be reasoned about; resuming approval on it would
+    leave the user working an unusable read.
+    """
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    unknown = AuthorizedClients(
+        clients=[
+            AuthorizedClient(public_key=_TEST_PUBLIC_KEY_B64, state=state, raw={})
+        ],
+        raw=None,
+    )
+    add_client = AsyncMock(return_value={})
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=unknown),
+        ),
+        patch.object(TeslemetryEnergySite, "add_authorized_client", add_client),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    add_client.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize("state", _UNKNOWN_CLIENT_STATES)
+async def test_energy_subentry_pair_submit_unknown_state(
+    hass: HomeAssistant,
+    state: object,
+) -> None:
+    """An unrecognized state on submit reports a lookup failure, not pending verification.
+
+    Reporting it as pending verification would tell the user to keep waiting for
+    an approval that no longer has a readable state.
+    """
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    pending = AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key=_TEST_PUBLIC_KEY_B64,
+                state=AuthorizedClientState.PENDING,
+                raw={},
+            )
+        ],
+        raw=None,
+    )
+    unknown = AuthorizedClients(
+        clients=[
+            AuthorizedClient(public_key=_TEST_PUBLIC_KEY_B64, state=state, raw={})
+        ],
+        raw=None,
+    )
+
+    with patch.object(
+        TeslemetryEnergySite,
+        "find_authorized_clients",
+        AsyncMock(side_effect=[pending, unknown]),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 @pytest.mark.usefixtures("mock_rsa_key")
 async def test_energy_subentry_pair_submit_verified_advances_to_credentials(
     hass: HomeAssistant,

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -701,11 +701,11 @@ async def test_energy_subentry_add_client_generic_error(
 
 @pytest.mark.usefixtures("mock_rsa_key")
 @pytest.mark.parametrize("error", POWERWALL_502_ERRORS)
-async def test_energy_subentry_pair_poll_powerwall_unreachable(
+async def test_energy_subentry_pair_check_powerwall_unreachable(
     hass: HomeAssistant,
     error: Exception,
 ) -> None:
-    """A 502 while polling for approval re-shows the pair form as retryable."""
+    """A 502 while checking approval on submit re-shows the pair form as retryable."""
     entry = await setup_platform(hass)
     subentry_id = _energy_subentry_id(entry)
     empty = AuthorizedClients(clients=[], raw=None)
@@ -744,11 +744,11 @@ async def test_energy_subentry_pair_poll_powerwall_unreachable(
         pytest.param(_NON_502_CLIENT_RESPONSE_ERROR, id="client_response_error"),
     ],
 )
-async def test_energy_subentry_pair_poll_generic_error(
+async def test_energy_subentry_pair_check_generic_error(
     hass: HomeAssistant,
     error: Exception,
 ) -> None:
-    """A non-502 error while polling for approval re-shows the pair form as retryable."""
+    """A non-502 error while checking approval on submit re-shows the pair form as retryable."""
     entry = await setup_platform(hass)
     subentry_id = _energy_subentry_id(entry)
     empty = AuthorizedClients(clients=[], raw=None)
@@ -910,3 +910,185 @@ async def test_energy_subentry_verified_key_advances_to_credentials(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "credentials"
     add_client.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize(
+    ("state", "expected_error"),
+    [
+        pytest.param(AuthorizedClientState.PENDING, "key_pending", id="pending"),
+        pytest.param(
+            AuthorizedClientState.PENDING_VERIFICATION,
+            "key_pending_verification",
+            id="pending_verification",
+        ),
+    ],
+)
+async def test_energy_subentry_pair_submit_still_pending(
+    hass: HomeAssistant,
+    state: AuthorizedClientState,
+    expected_error: str,
+) -> None:
+    """Submitting the pair form while the key is still pending re-shows it with an error."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    pending = AuthorizedClients(
+        clients=[
+            AuthorizedClient(public_key=_TEST_PUBLIC_KEY_B64, state=state, raw={})
+        ],
+        raw=None,
+    )
+    add_client = AsyncMock(return_value={})
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=pending),
+        ),
+        patch.object(TeslemetryEnergySite, "add_authorized_client", add_client),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert not result["errors"]
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": expected_error}
+    add_client.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_pair_submit_verified_advances_to_credentials(
+    hass: HomeAssistant,
+) -> None:
+    """Submitting the pair form once the key has become verified advances to credentials."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    pending = AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key=_TEST_PUBLIC_KEY_B64,
+                state=AuthorizedClientState.PENDING,
+                raw={},
+            )
+        ],
+        raw=None,
+    )
+    verified = AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key=_TEST_PUBLIC_KEY_B64,
+                state=AuthorizedClientState.VERIFIED,
+                raw={},
+            )
+        ],
+        raw=None,
+    )
+
+    with patch.object(
+        TeslemetryEnergySite,
+        "find_authorized_clients",
+        AsyncMock(side_effect=[pending, verified]),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_pair_submit_key_not_registered(
+    hass: HomeAssistant,
+) -> None:
+    """If the key is no longer registered on the gateway, submitting the pair form errors clearly."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+    empty = AuthorizedClients(clients=[], raw=None)
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=empty),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert not result["errors"]
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": "key_not_registered"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_pair_recovers_after_error(
+    hass: HomeAssistant,
+) -> None:
+    """After a lookup error on submit, a later submit can still succeed once verified."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+    empty = AuthorizedClients(clients=[], raw=None)
+    verified = AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key=_TEST_PUBLIC_KEY_B64,
+                state=AuthorizedClientState.VERIFIED,
+                raw={},
+            )
+        ],
+        raw=None,
+    )
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(side_effect=[empty, TeslaFleetError(), verified]),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert result["errors"] == {"base": "cannot_connect"}
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -1,5 +1,6 @@
 """Test the Teslemetry config flow."""
 
+import base64
 from collections.abc import Generator
 from pathlib import Path
 import time
@@ -7,10 +8,12 @@ from typing import Any
 from unittest.mock import AsyncMock, patch
 from urllib.parse import parse_qs, urlparse
 
-from aiohttp import ClientConnectionError, ClientResponseError
+from aiohttp import ClientConnectionError, ClientResponseError, RequestInfo
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from multidict import CIMultiDict
 import pytest
+from tesla_fleet_api.const import AuthorizedClientState
 from tesla_fleet_api.exceptions import (
     InvalidToken,
     ResponseError,
@@ -19,9 +22,11 @@ from tesla_fleet_api.exceptions import (
 )
 from tesla_fleet_api.teslemetry import Teslemetry
 from tesla_fleet_api.teslemetry.energysite import (
+    AuthorizedClient,
     AuthorizedClients,
     TeslemetryEnergySite,
 )
+from yarl import URL
 
 from homeassistant.components.teslemetry.const import (
     AUTHORIZE_URL,
@@ -51,6 +56,19 @@ _TEST_RSA_PEM = _TEST_RSA_KEY.private_bytes(
     encoding=serialization.Encoding.PEM,
     format=serialization.PrivateFormat.TraditionalOpenSSL,
     encryption_algorithm=serialization.NoEncryption(),
+)
+# The base64 DER PKCS1 public key the flow matches gateway clients against.
+_TEST_PUBLIC_KEY_B64 = base64.b64encode(
+    _TEST_RSA_KEY.public_key().public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.PKCS1,
+    )
+).decode("ascii")
+
+# A well-formed non-502 ClientResponseError; a real one carries request_info,
+# so it renders when logged, unlike the bodyless 502 fixtures below.
+_NON_502_CLIENT_RESPONSE_ERROR = ClientResponseError(
+    RequestInfo(URL("http://gateway"), "GET", CIMultiDict()), (), status=500
 )
 
 
@@ -626,10 +644,18 @@ async def test_energy_subentry_add_client_powerwall_unreachable(
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(TeslaFleetError(), id="tesla_fleet_error"),
+        pytest.param(_NON_502_CLIENT_RESPONSE_ERROR, id="client_response_error"),
+    ],
+)
 async def test_energy_subentry_add_client_generic_error(
     hass: HomeAssistant,
+    error: Exception,
 ) -> None:
-    """A non-502 error while registering the key keeps the generic abort."""
+    """A non-502 error while registering the key aborts cleanly, never crashes."""
     entry = await setup_platform(hass)
     subentry_id = _energy_subentry_id(entry)
 
@@ -642,7 +668,7 @@ async def test_energy_subentry_add_client_generic_error(
         patch.object(
             TeslemetryEnergySite,
             "add_authorized_client",
-            AsyncMock(side_effect=TeslaFleetError),
+            AsyncMock(side_effect=error),
         ),
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
@@ -713,3 +739,109 @@ async def test_energy_subentry_empty_client_list_proceeds(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "pair"
     assert not result["errors"]
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(TeslaFleetError(), id="tesla_fleet_error"),
+        pytest.param(_NON_502_CLIENT_RESPONSE_ERROR, id="client_response_error"),
+    ],
+)
+async def test_energy_subentry_verify_generic_error_registers(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """A non-502 error while listing clients is treated as unverified, not a crash.
+
+    The flow can no longer read the gateway's client list, so it falls through to
+    registering the key and advancing to pairing rather than re-raising.
+    """
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    add_client = AsyncMock(return_value={})
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(side_effect=error),
+        ),
+        patch.object(TeslemetryEnergySite, "add_authorized_client", add_client),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert not result["errors"]
+    add_client.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_resume_pending_key_not_reregistered(
+    hass: HomeAssistant,
+) -> None:
+    """Resuming with an already-pending key advances to pairing without re-adding it."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    pending = AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key=_TEST_PUBLIC_KEY_B64,
+                state=AuthorizedClientState.PENDING,
+                raw={},
+            )
+        ],
+        raw=None,
+    )
+    add_client = AsyncMock(return_value={})
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=pending),
+        ),
+        patch.object(TeslemetryEnergySite, "add_authorized_client", add_client),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert not result["errors"]
+    add_client.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_energy_subentry_verified_key_advances_to_credentials(
+    hass: HomeAssistant,
+) -> None:
+    """An already-verified key skips registration and asks for local credentials."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+
+    verified = AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key=_TEST_PUBLIC_KEY_B64,
+                state=AuthorizedClientState.VERIFIED,
+                raw={},
+            )
+        ],
+        raw=None,
+    )
+    add_client = AsyncMock(return_value={})
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(return_value=verified),
+        ),
+        patch.object(TeslemetryEnergySite, "add_authorized_client", add_client),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    add_client.assert_not_awaited()

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -27,7 +27,10 @@ from tesla_fleet_api.teslemetry.energysite import (
 )
 from yarl import URL
 
-from homeassistant.components.teslemetry.config_flow import _is_gateway_unreachable
+from homeassistant.components.teslemetry.config_flow import (
+    _authorized_client_from_local,
+    _is_gateway_unreachable,
+)
 from homeassistant.components.teslemetry.const import (
     AUTHORIZE_URL,
     CLIENT_ID,
@@ -608,6 +611,23 @@ async def test_migrate_error_from_future(
 def test_is_gateway_unreachable(error: Exception, expected: bool) -> None:
     """A bare TeslaFleetError has no status set and must not raise AttributeError."""
     assert _is_gateway_unreachable(error) is expected
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        pytest.param("VERIFIED", AuthorizedClientState.VERIFIED, id="verified"),
+        pytest.param("PENDING", AuthorizedClientState.PENDING, id="pending"),
+        pytest.param("SOME_FUTURE_STATE", "SOME_FUTURE_STATE", id="unrecognized"),
+    ],
+)
+def test_authorized_client_from_local(
+    state: str, expected: AuthorizedClientState | str
+) -> None:
+    """An unrecognized local state is kept verbatim rather than dropped."""
+    client = _authorized_client_from_local({"public_key": "abc", "state": state})
+    assert client.public_key == "abc"
+    assert client.state == expected
 
 
 POWERWALL_502_ERRORS = [

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -2,7 +2,6 @@
 
 import base64
 from collections.abc import Generator
-from pathlib import Path
 import time
 from typing import Any
 from unittest.mock import AsyncMock, patch
@@ -80,12 +79,17 @@ def mock_rsa_key() -> Generator[None]:
         self: Teslemetry, path: str, key_size: int = 4096
     ) -> rsa.RSAPrivateKey:
         self.rsa_private_key = _TEST_RSA_KEY
-        Path(path).write_bytes(_TEST_RSA_PEM)
         return _TEST_RSA_KEY
 
-    with patch(
-        "homeassistant.components.teslemetry.config_flow.Teslemetry.get_rsa_private_key",
-        _fake_get_rsa_private_key,
+    with (
+        patch(
+            "homeassistant.components.teslemetry.config_flow.Teslemetry.get_rsa_private_key",
+            _fake_get_rsa_private_key,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.Path.read_bytes",
+            return_value=_TEST_RSA_PEM,
+        ),
     ):
         yield
 

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -715,6 +715,49 @@ async def test_energy_subentry_pair_poll_powerwall_unreachable(
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(TeslaFleetError(), id="tesla_fleet_error"),
+        pytest.param(_NON_502_CLIENT_RESPONSE_ERROR, id="client_response_error"),
+    ],
+)
+async def test_energy_subentry_pair_poll_generic_error(
+    hass: HomeAssistant,
+    error: Exception,
+) -> None:
+    """A non-502 error while polling for approval re-shows the pair form as retryable."""
+    entry = await setup_platform(hass)
+    subentry_id = _energy_subentry_id(entry)
+    empty = AuthorizedClients(clients=[], raw=None)
+
+    with (
+        patch.object(
+            TeslemetryEnergySite,
+            "find_authorized_clients",
+            AsyncMock(side_effect=[empty, error]),
+        ),
+        patch.object(
+            TeslemetryEnergySite,
+            "add_authorized_client",
+            AsyncMock(return_value={}),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert not result["errors"]
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
 async def test_energy_subentry_empty_client_list_proceeds(
     hass: HomeAssistant,
 ) -> None:
@@ -749,14 +792,15 @@ async def test_energy_subentry_empty_client_list_proceeds(
         pytest.param(_NON_502_CLIENT_RESPONSE_ERROR, id="client_response_error"),
     ],
 )
-async def test_energy_subentry_verify_generic_error_registers(
+async def test_energy_subentry_verify_generic_error_aborts(
     hass: HomeAssistant,
     error: Exception,
 ) -> None:
-    """A non-502 error while listing clients is treated as unverified, not a crash.
+    """A non-502 error while listing clients aborts instead of re-registering.
 
-    The flow can no longer read the gateway's client list, so it falls through to
-    registering the key and advancing to pairing rather than re-raising.
+    The flow can no longer read the gateway's client list, so it must not mistake
+    the failure for an absent key and re-register (which would reset an already
+    pending or verified key); it aborts with cannot_connect instead.
     """
     entry = await setup_platform(hass)
     subentry_id = _energy_subentry_id(entry)
@@ -772,10 +816,9 @@ async def test_energy_subentry_verify_generic_error_registers(
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "pair"
-    assert not result["errors"]
-    add_client.assert_awaited_once()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    add_client.assert_not_awaited()
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -1,0 +1,479 @@
+"""Test the Teslemetry energy site local Powerwall routing and pairing flow."""
+
+from collections.abc import Generator
+from types import MappingProxyType
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
+
+from aiopowerwall import PowerwallAuthenticationError, PowerwallConnectionError
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+import pytest
+from tesla_fleet_api.exceptions import TeslaFleetError
+from tesla_fleet_api.tesla import EnergySiteRouter
+from tesla_fleet_api.teslemetry import EnergySite
+
+from homeassistant.components.teslemetry import _async_get_rsa_key_pem
+from homeassistant.components.teslemetry.const import (
+    CONF_SITE_ID,
+    SUBENTRY_TYPE_ENERGY_SITE,
+)
+from homeassistant.config_entries import ConfigSubentry, ConfigSubentryData
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from . import mock_config_entry
+
+from tests.common import MockConfigEntry
+
+SITE_ID = 123456
+HOST = "192.168.91.1"
+PASSWORD = "abcde"
+PUBLIC_KEY_DER = b"public-key-der"
+PUBLIC_KEY_B64 = "cHVibGljLWtleS1kZXI="
+
+# aiopowerwall's PowerwallClient parses the PEM at construction time, so tests
+# that build one need a real (if undersized, for speed) RSA key rather than
+# arbitrary bytes.
+_TEST_RSA_KEY_PEM = rsa.generate_private_key(
+    public_exponent=65537, key_size=1024
+).private_bytes(
+    encoding=serialization.Encoding.PEM,
+    format=serialization.PrivateFormat.TraditionalOpenSSL,
+    encryption_algorithm=serialization.NoEncryption(),
+)
+
+
+def _entry_with_powerwall() -> MockConfigEntry:
+    """Return a config entry whose energy site subentry is already paired."""
+    entry = mock_config_entry()
+    return MockConfigEntry(
+        domain=entry.domain,
+        version=entry.version,
+        minor_version=entry.minor_version,
+        unique_id=entry.unique_id,
+        data=dict(entry.data),
+        subentries_data=[
+            ConfigSubentryData(
+                subentry_type=SUBENTRY_TYPE_ENERGY_SITE,
+                unique_id=str(SITE_ID),
+                title="Energy Site",
+                data={
+                    CONF_SITE_ID: SITE_ID,
+                    CONF_HOST: HOST,
+                    CONF_PASSWORD: PASSWORD,
+                },
+            )
+        ],
+    )
+
+
+@pytest.fixture
+def mock_rsa_key() -> Generator[None]:
+    """Mock RSA key generation/loading, avoiding real crypto and disk I/O."""
+    with (
+        patch(
+            "homeassistant.components.teslemetry.config_flow.Teslemetry.get_rsa_private_key",
+            new=AsyncMock(),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.Teslemetry.rsa_public_der_pkcs1",
+            new_callable=PropertyMock,
+            return_value=PUBLIC_KEY_DER,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.Teslemetry.rsa_public_der_pkcs1_b64",
+            new_callable=PropertyMock,
+            return_value=PUBLIC_KEY_B64,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.Path.read_bytes",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+    ):
+        yield
+
+
+def _mock_powerwall_client(*, connect_error: Exception | None = None) -> MagicMock:
+    """Return a mock aiopowerwall PowerwallClient async context manager."""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    client.connect = AsyncMock(side_effect=connect_error)
+    return client
+
+
+def _verified_clients_response() -> dict:
+    """Return a list_authorized_clients response verifying our public key.
+
+    Includes a non-dict entry and a mismatched key to exercise the parsing
+    helpers' defensive branches.
+    """
+    return {
+        "response": {
+            "authorized_clients": [
+                "not-a-dict",
+                {"public_key": "some-other-key", "state": 3},
+                {"public_key": PUBLIC_KEY_B64, "state": 3},
+            ]
+        }
+    }
+
+
+def _unverified_clients_response() -> dict:
+    """Return a list_authorized_clients response with no matching client.
+
+    Nests the client list under an unrecognized wrapper key to exercise the
+    parsing helpers' generic (non-keyed) fallback search.
+    """
+    return {"result": [{"public_key": "some-other-key", "state": 1}]}
+
+
+def _empty_clients_response() -> dict:
+    """Return a response with no client list findable anywhere in it."""
+    return {"foo": "bar"}
+
+
+async def test_energy_site_router_with_powerwall(hass: HomeAssistant) -> None:
+    """A paired energy site wraps its cloud API in an EnergySiteRouter."""
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    energysite = entry.runtime_data.energysites[0]
+    assert isinstance(energysite.api, EnergySiteRouter)
+
+
+async def test_energy_site_cloud_without_powerwall(hass: HomeAssistant) -> None:
+    """An energy site without paired credentials keeps the plain cloud API."""
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.teslemetry.PLATFORMS", []):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    energysite = entry.runtime_data.energysites[0]
+    assert isinstance(energysite.api, EnergySite)
+    assert not isinstance(energysite.api, EnergySiteRouter)
+
+
+async def _setup_energy_site_subentry(hass: HomeAssistant) -> MockConfigEntry:
+    """Set up an entry and return it with an (unpaired) energy site subentry."""
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    with patch("homeassistant.components.teslemetry.PLATFORMS", []):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_pairing_already_verified(hass: HomeAssistant) -> None:
+    """Pairing skips straight to credentials when the key is already verified."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client()
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload") as mock_reload,
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.subentries[subentry_id].data[CONF_HOST] == HOST
+    assert entry.subentries[subentry_id].data[CONF_PASSWORD] == PASSWORD
+    mock_reload.assert_called_once_with(entry.entry_id)
+    client.connect.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> None:
+    """Pairing registers the key, waits for approval, then proceeds."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client()
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(
+                side_effect=[
+                    TeslaFleetError(),
+                    TeslaFleetError(),
+                    _verified_clients_response(),
+                ]
+            ),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=AsyncMock(),
+        ) as mock_add,
+        patch(
+            "homeassistant.components.teslemetry.config_flow.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
+        # reconfigure -> list_authorized_clients raises -> add_authorized_client -> pair
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        mock_add.assert_awaited_once()
+
+        # confirm pair -> poll (unverified, then verified) -> credentials
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.subentries[subentry_id].data[CONF_HOST] == HOST
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_pair_timeout(hass: HomeAssistant) -> None:
+    """The pair step shows a timeout error when the key is never approved."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_empty_clients_response()),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=AsyncMock(),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.asyncio.sleep",
+            new=AsyncMock(),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "pair"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": "timeout"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_add_authorized_client_fails(hass: HomeAssistant) -> None:
+    """Reconfigure aborts if registering the key with the gateway fails."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_unverified_clients_response()),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=AsyncMock(side_effect=TeslaFleetError()),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_invalid_password(hass: HomeAssistant) -> None:
+    """The credentials step shows an error when the gateway password is wrong."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client(connect_error=PowerwallAuthenticationError())
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert result["errors"] == {"base": "invalid_password"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_cannot_connect(hass: HomeAssistant) -> None:
+    """The credentials step shows an error when the gateway is unreachable."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client(connect_error=PowerwallConnectionError())
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_reconfigure_reuses_router_fallback(
+    hass: HomeAssistant,
+) -> None:
+    """Reconfiguring an already-paired site pairs against the cloud fallback."""
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+    assert isinstance(entry.runtime_data.energysites[0].api, EnergySiteRouter)
+
+    new_password = "fghij"
+    client = _mock_powerwall_client()
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: new_password}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert entry.subentries[subentry_id].data[CONF_PASSWORD] == new_password
+
+
+async def test_subentry_reconfigure_no_matching_energy_site(
+    hass: HomeAssistant,
+) -> None:
+    """Reconfiguring a stale subentry with no matching energy site aborts."""
+    entry = await _setup_energy_site_subentry(hass)
+
+    stale_subentry = ConfigSubentry(
+        data=MappingProxyType({CONF_SITE_ID: 999999}),
+        subentry_type=SUBENTRY_TYPE_ENERGY_SITE,
+        title="Stale Site",
+        unique_id="999999",
+    )
+    hass.config_entries.async_add_subentry(entry, stale_subentry)
+
+    result = await entry.start_subentry_reconfigure_flow(
+        hass, stale_subentry.subentry_id
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+async def test_subentry_user_step_rejected(hass: HomeAssistant) -> None:
+    """Manually adding an energy site subentry is rejected."""
+    entry = await _setup_energy_site_subentry(hass)
+
+    result = await hass.config_entries.subentries.async_init(
+        (entry.entry_id, SUBENTRY_TYPE_ENERGY_SITE),
+        context={"source": "user"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "not_supported"
+
+
+async def test_get_rsa_key_pem_generates_and_caches(hass: HomeAssistant) -> None:
+    """The RSA key is generated/read once, then served from the hass.data cache."""
+    with (
+        patch(
+            "homeassistant.components.teslemetry.Teslemetry.get_rsa_private_key",
+            new=AsyncMock(),
+        ) as mock_get_key,
+        patch(
+            "homeassistant.components.teslemetry.Path.read_bytes",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+    ):
+        first = await _async_get_rsa_key_pem(hass)
+        second = await _async_get_rsa_key_pem(hass)
+
+    assert first == _TEST_RSA_KEY_PEM
+    assert second == _TEST_RSA_KEY_PEM
+    mock_get_key.assert_awaited_once()

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -1,6 +1,7 @@
 """Test the Teslemetry energy site local Powerwall routing and pairing flow."""
 
 from collections.abc import Generator
+from copy import deepcopy
 from types import MappingProxyType
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
@@ -27,10 +28,12 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import mock_config_entry
+from .const import METADATA, PRODUCTS
 
 from tests.common import MockConfigEntry
 
 SITE_ID = 123456
+WALL_CONNECTOR_SITE_ID = 555555
 HOST = "192.168.91.1"
 PASSWORD = "abcde"
 PUBLIC_KEY_DER = b"public-key-der"
@@ -593,3 +596,44 @@ async def test_subentry_credentials_password_truncated(hass: HomeAssistant) -> N
     assert result["type"] is FlowResultType.ABORT
     assert entry.subentries[subentry_id].data[CONF_PASSWORD] == "sword"
     assert mock_client.call_args.kwargs["gateway_password"] == "sword"
+
+
+async def test_wall_connector_only_site_has_no_local_control(
+    hass: HomeAssistant,
+) -> None:
+    """A wall-connector-only site gets no local-control subentry, a Powerwall does."""
+    products = deepcopy(PRODUCTS)
+    products["response"].append(
+        {
+            "energy_site_id": WALL_CONNECTOR_SITE_ID,
+            "site_name": "Wall Connector Site",
+            "components": {
+                "battery": False,
+                "solar": False,
+                "grid": True,
+                "wall_connectors": [{"device_id": "wc-1", "din": "WC-DIN-1"}],
+            },
+        }
+    )
+    metadata = deepcopy(METADATA)
+    metadata["energy_sites"][str(WALL_CONNECTOR_SITE_ID)] = {
+        "access": True,
+        "name": "Wall Connector Site",
+    }
+
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    with (
+        patch("tesla_fleet_api.teslemetry.Teslemetry.products", return_value=products),
+        patch("tesla_fleet_api.teslemetry.Teslemetry.metadata", return_value=metadata),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    unique_ids = {
+        subentry.unique_id
+        for subentry in entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)
+    }
+    assert str(SITE_ID) in unique_ids
+    assert str(WALL_CONNECTOR_SITE_ID) not in unique_ids

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -11,6 +11,7 @@ from aiopowerwall import (
     PowerwallAuthenticationError,
     PowerwallConnectionError,
     PowerwallError,
+    PowerwallFaultError,
 )
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -46,6 +47,8 @@ SITE_ID = 123456
 WALL_CONNECTOR_SITE_ID = 555555
 HOST = "192.168.91.1"
 PASSWORD = "abcde"
+# Matches the paired site's `gateway_id` in the products fixture.
+GATEWAY_DIN = "ABC123"
 PUBLIC_KEY_DER = b"public-key-der"
 PUBLIC_KEY_B64 = "cHVibGljLWtleS1kZXI="
 
@@ -126,12 +129,18 @@ def mock_rsa_key() -> Generator[None]:
         yield
 
 
-def _mock_powerwall_client(*, connect_error: Exception | None = None) -> MagicMock:
+def _mock_powerwall_client(
+    *,
+    connect_error: Exception | None = None,
+    din: str = GATEWAY_DIN,
+    status_error: Exception | None = None,
+) -> MagicMock:
     """Return a mock aiopowerwall PowerwallClient async context manager."""
     client = MagicMock()
     client.__aenter__ = AsyncMock(return_value=client)
     client.__aexit__ = AsyncMock(return_value=False)
-    client.connect = AsyncMock(side_effect=connect_error)
+    client.connect = AsyncMock(return_value=din, side_effect=connect_error)
+    client.get_status = AsyncMock(side_effect=status_error)
     return client
 
 
@@ -253,6 +262,7 @@ async def test_subentry_pairing_already_verified(hass: HomeAssistant) -> None:
     assert entry.subentries[subentry_id].data[CONF_PASSWORD] == PASSWORD
     mock_reload.assert_called_once_with(entry.entry_id)
     client.connect.assert_awaited_once()
+    client.get_status.assert_awaited_once()
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
@@ -283,13 +293,11 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
         ),
         patch.object(hass.config_entries, "async_schedule_reload"),
     ):
-        # reconfigure -> key absent -> add_authorized_client -> pair
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "pair"
         mock_add.assert_awaited_once()
 
-        # confirm pair while still pending -> re-shows pair with an error
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], {}
         )
@@ -297,7 +305,6 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
         assert result["step_id"] == "pair"
         assert result["errors"] == {"base": "key_pending"}
 
-        # confirm pair again, now verified -> credentials
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], {}
         )
@@ -476,12 +483,50 @@ async def test_subentry_add_authorized_client_fails(hass: HomeAssistant) -> None
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_subentry_credentials_invalid_password(hass: HomeAssistant) -> None:
-    """The credentials step shows an error when the gateway password is wrong."""
+@pytest.mark.parametrize(
+    ("client_kwargs", "expected_error"),
+    [
+        pytest.param(
+            {"connect_error": PowerwallAuthenticationError()},
+            "invalid_password",
+            id="wrong_gateway_password",
+        ),
+        pytest.param(
+            {"connect_error": PowerwallConnectionError()},
+            "cannot_connect",
+            id="gateway_unreachable",
+        ),
+        pytest.param(
+            {"status_error": PowerwallAuthenticationError()},
+            "key_not_approved",
+            id="signed_read_rejects_unapproved_key",
+        ),
+        pytest.param(
+            {"status_error": PowerwallFaultError("MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID")},
+            "key_not_approved",
+            id="signed_read_faults_on_unknown_key",
+        ),
+        pytest.param(
+            {"status_error": PowerwallConnectionError()},
+            "cannot_connect",
+            id="signed_read_unreachable",
+        ),
+    ],
+)
+async def test_subentry_credentials_errors(
+    hass: HomeAssistant,
+    client_kwargs: dict[str, Exception],
+    expected_error: str,
+) -> None:
+    """The credentials step reports each local verification failure distinctly.
+
+    A key the gateway has not approved only fails the signed read, so it must
+    not be reported as a bad password.
+    """
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
 
-    client = _mock_powerwall_client(connect_error=PowerwallAuthenticationError())
+    client = _mock_powerwall_client(**client_kwargs)
     with (
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
@@ -503,16 +548,30 @@ async def test_subentry_credentials_invalid_password(hass: HomeAssistant) -> Non
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "credentials"
-    assert result["errors"] == {"base": "invalid_password"}
+    assert result["errors"] == {"base": expected_error}
+    assert CONF_HOST not in entry.subentries[subentry_id].data
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_subentry_credentials_cannot_connect(hass: HomeAssistant) -> None:
-    """The credentials step shows an error when the gateway is unreachable."""
+@pytest.mark.parametrize(
+    "din",
+    [
+        pytest.param("SOMEONE-ELSES-GATEWAY", id="different_gateway"),
+        pytest.param("", id="no_din_reported"),
+    ],
+)
+async def test_subentry_credentials_gateway_mismatch(
+    hass: HomeAssistant, din: str
+) -> None:
+    """Pairing aborts when the local gateway is not the site's own gateway.
+
+    The RSA key authorizes every gateway on the account, so without this the
+    subentry would command another site's house.
+    """
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
 
-    client = _mock_powerwall_client(connect_error=PowerwallConnectionError())
+    client = _mock_powerwall_client(din=din)
     with (
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
@@ -532,9 +591,48 @@ async def test_subentry_credentials_cannot_connect(hass: HomeAssistant) -> None:
             result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
         )
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "credentials"
-    assert result["errors"] == {"base": "cannot_connect"}
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "gateway_mismatch"
+    assert result["description_placeholders"] == {
+        "expected": GATEWAY_DIN,
+        "actual": din,
+    }
+    assert CONF_HOST not in entry.subentries[subentry_id].data
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_gateway_din_normalized(
+    hass: HomeAssistant,
+) -> None:
+    """A case or whitespace skew in the local DIN still pairs the same gateway."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client(din=f"  {GATEWAY_DIN.lower()} ")
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.subentries[subentry_id].data[CONF_HOST] == HOST
 
 
 def _credentials_host_default(result: SubentryFlowResult) -> str:
@@ -812,6 +910,59 @@ async def test_stale_cleanup_preserves_foreign_subentry(hass: HomeAssistant) -> 
 
     assert foreign.subentry_id in entry.subentries
     assert entry.subentries[foreign.subentry_id].subentry_type == "vehicle"
+
+
+async def test_stale_cleanup_removes_energy_subentry(hass: HomeAssistant) -> None:
+    """A paired site that is gone from the account has its subentry pruned.
+
+    The counterpart to the scope guard: with an authoritative inventory in hand,
+    pruning must still happen.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    products = deepcopy(PRODUCTS)
+    products["response"] = [
+        product
+        for product in products["response"]
+        if product.get("energy_site_id") != SITE_ID
+    ]
+
+    with (
+        patch("tesla_fleet_api.teslemetry.Teslemetry.products", return_value=products),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert subentry_id not in entry.subentries
+
+
+async def test_solar_only_site_has_no_local_control(hass: HomeAssistant) -> None:
+    """A solar-only site gets no local-control subentry: there is no Powerwall."""
+    products = deepcopy(PRODUCTS)
+    site = next(
+        product
+        for product in products["response"]
+        if product.get("energy_site_id") == SITE_ID
+    )
+    site["components"]["battery"] = False
+    site["components"].pop("wall_connectors")
+
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    with (
+        patch("tesla_fleet_api.teslemetry.Teslemetry.products", return_value=products),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert not entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)
+    energysite = entry.runtime_data.energysites[0]
+    assert energysite.subentry_id is None
+    assert not isinstance(energysite.api, EnergySiteRouter)
 
 
 async def test_stale_cleanup_preserves_pairing_without_energy_scope(

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -3,6 +3,7 @@
 from collections.abc import Generator
 from copy import deepcopy
 from types import MappingProxyType
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aiohttp import ClientResponseError, RequestInfo
@@ -217,11 +218,19 @@ async def test_energy_site_cloud_without_powerwall(hass: HomeAssistant) -> None:
     assert not isinstance(energysite.api, EnergySiteRouter)
 
 
-async def _setup_energy_site_subentry(hass: HomeAssistant) -> MockConfigEntry:
+async def _setup_energy_site_subentry(
+    hass: HomeAssistant, products: dict[str, Any] | None = None
+) -> MockConfigEntry:
     """Set up an entry and return it with an (unpaired) energy site subentry."""
     entry = mock_config_entry()
     entry.add_to_hass(hass)
-    with patch("homeassistant.components.teslemetry.PLATFORMS", []):
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Teslemetry.products",
+            return_value=products or PRODUCTS,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
     return entry
@@ -598,6 +607,55 @@ async def test_subentry_credentials_gateway_mismatch(
         "actual": din,
     }
     assert CONF_HOST not in entry.subentries[subentry_id].data
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_without_cloud_gateway_id(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A site with no cloud gateway ID pairs, but says so rather than skipping quietly.
+
+    There is nothing to compare the local DIN against, and refusing a valid
+    gateway would be worse than not binding it.
+    """
+    products = deepcopy(PRODUCTS)
+    site = next(
+        product
+        for product in products["response"]
+        if product.get("energy_site_id") == SITE_ID
+    )
+    site.pop("gateway_id")
+
+    entry = await _setup_energy_site_subentry(hass, products=products)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client(din="UNKNOWN-GATEWAY")
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: PASSWORD}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert entry.subentries[subentry_id].data[CONF_HOST] == HOST
+    assert f"Energy site {SITE_ID} reports no gateway ID" in caplog.text
+    assert caplog.records[-1].levelname == "WARNING"
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -5,6 +5,7 @@ from copy import deepcopy
 from types import MappingProxyType
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
+from aiohttp import ClientResponseError, RequestInfo
 from aiopowerwall import (
     DEFAULT_GATEWAY_HOST,
     PowerwallAuthenticationError,
@@ -13,11 +14,14 @@ from aiopowerwall import (
 )
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from multidict import CIMultiDict
 import pytest
 from tesla_fleet_api.const import AuthorizedClientState
-from tesla_fleet_api.exceptions import TeslaFleetError
+from tesla_fleet_api.exceptions import InvalidResponse, TeslaFleetError
 from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite
+from tesla_fleet_api.teslemetry.energysite import AuthorizedClient, AuthorizedClients
+from yarl import URL
 
 from homeassistant.components.teslemetry import _async_get_rsa_key_pem
 from homeassistant.components.teslemetry.const import (
@@ -34,7 +38,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
 from . import mock_config_entry
-from .const import METADATA, PRODUCTS
+from .const import METADATA, METADATA_NOSCOPE, PRODUCTS
 
 from tests.common import MockConfigEntry
 
@@ -131,75 +135,44 @@ def _mock_powerwall_client(*, connect_error: Exception | None = None) -> MagicMo
     return client
 
 
-def _verified_clients_response() -> dict:
-    """Return a list_authorized_clients response verifying our public key.
+def _own_key_clients(
+    state: AuthorizedClientState | int | str | None,
+) -> AuthorizedClients:
+    """Return a typed client list carrying our key in the given state.
 
-    Includes a non-dict entry and a mismatched key so the library's typed
-    ``find_authorized_clients`` accessor has noise to skip past.
+    Includes a decoy entry so the flow's own key-matching predicate has noise
+    to skip past. Unwrapping the gateway's raw envelope into these typed
+    entries is the library's job, so tests drive the accessor the integration
+    actually calls rather than the raw command underneath it.
     """
-    return {
-        "response": {
-            "authorized_clients": [
-                "not-a-dict",
-                {"public_key": "some-other-key", "state": 3},
-                {"public_key": PUBLIC_KEY_B64, "state": 3},
-            ]
-        }
-    }
+    return AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key="some-other-key",
+                state=AuthorizedClientState.VERIFIED,
+                raw={},
+            ),
+            AuthorizedClient(public_key=PUBLIC_KEY_B64, state=state, raw={}),
+        ],
+        raw=None,
+    )
 
 
-def _unverified_clients_response() -> dict:
-    """Return a list_authorized_clients response with no matching client."""
-    return {"response": {"authorized_clients": [{"public_key": "other", "state": 1}]}}
+def _unverified_clients() -> AuthorizedClients:
+    """Return a typed client list holding no entry for our key."""
+    return AuthorizedClients(
+        clients=[
+            AuthorizedClient(
+                public_key="other", state=AuthorizedClientState.PENDING, raw={}
+            )
+        ],
+        raw=None,
+    )
 
 
-def _pending_clients_response() -> dict:
-    """Return a list_authorized_clients response with our key still pending."""
-    return {
-        "response": {"authorized_clients": [{"public_key": PUBLIC_KEY_B64, "state": 1}]}
-    }
-
-
-def _empty_clients_response() -> dict:
-    """Return a response whose authorized-clients list is explicitly empty."""
-    return {"response": {"authorized_clients": []}}
-
-
-def _real_shape_clients_response(state: AuthorizedClientState) -> dict:
-    """Return a response matching the gateway's real envelope and field shape.
-
-    Modeled on a live ``authorized_clients`` capture: the list is nested under
-    ``clients`` (not ``authorized_clients``), and each entry carries the full
-    real field set including an object-shaped ``added_time``. Includes a
-    decoy entry so the flow's key-matching predicate has noise to skip past.
-    """
-    return {
-        "response": {
-            "request_id": "03153d0c37283795cf0d1a593eebd9a0",
-            "clients": [
-                {
-                    "type": 1,
-                    "description": "Some Other App",
-                    "key_type": 1,
-                    "public_key": "not-a-match",
-                    "roles": [1],
-                    "state": 3,
-                    "verification": 1,
-                    "added_time": {"seconds": 1700000000},
-                },
-                {
-                    "type": 1,
-                    "description": "Home Assistant",
-                    "key_type": 1,
-                    "public_key": PUBLIC_KEY_B64,
-                    "roles": [1],
-                    "state": int(state),
-                    "verification": 1,
-                    "added_time": {"seconds": 1783997627},
-                },
-            ],
-        }
-    }
+def _empty_clients() -> AuthorizedClients:
+    """Return a typed client list that is authoritatively empty."""
+    return AuthorizedClients(clients=[], raw=None)
 
 
 async def test_energy_site_router_with_powerwall(hass: HomeAssistant) -> None:
@@ -254,8 +227,10 @@ async def test_subentry_pairing_already_verified(hass: HomeAssistant) -> None:
     client = _mock_powerwall_client()
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",
@@ -289,12 +264,12 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
     client = _mock_powerwall_client()
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
             new=AsyncMock(
                 side_effect=[
-                    _empty_clients_response(),
-                    _pending_clients_response(),
-                    _verified_clients_response(),
+                    _empty_clients(),
+                    _own_key_clients(AuthorizedClientState.PENDING),
+                    _own_key_clients(AuthorizedClientState.VERIFIED),
                 ]
             ),
         ),
@@ -347,8 +322,8 @@ async def test_subentry_pair_key_not_registered(hass: HomeAssistant) -> None:
 
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_empty_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(return_value=_empty_clients()),
         ),
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
@@ -379,11 +354,9 @@ async def test_subentry_recognizes_own_verified_key_no_reregister(
     add_client = AsyncMock()
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
             new=AsyncMock(
-                return_value=_real_shape_clients_response(
-                    AuthorizedClientState.VERIFIED
-                )
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
             ),
         ),
         patch(
@@ -427,8 +400,8 @@ async def test_subentry_recognizes_own_pending_key_no_reregister(
     add_client = AsyncMock()
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_real_shape_clients_response(state)),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(return_value=_own_key_clients(state)),
         ),
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
@@ -452,12 +425,12 @@ async def test_subentry_recognizes_own_pending_key_no_reregister(
 
 @pytest.mark.usefixtures("mock_rsa_key")
 async def test_subentry_null_body_aborts_as_lookup_failure(hass: HomeAssistant) -> None:
-    """A bare null (200) authorized-clients body aborts rather than registering.
+    """A malformed authorized-clients read aborts rather than registering.
 
     Tesla's undocumented endpoint can answer with JSON ``null``; the library's
-    typed accessor now raises ``InvalidResponse`` for it rather than collapsing
-    it to an empty client list, since a malformed response could just as
-    easily be hiding an already-registered key. The flow must not mistake this
+    typed accessor raises ``InvalidResponse`` for it rather than collapsing it
+    to an empty client list, since a malformed response could just as easily be
+    hiding an already-registered key. The flow must not mistake that failure
     for an absent key and re-register it.
     """
     entry = await _setup_energy_site_subentry(hass)
@@ -465,8 +438,8 @@ async def test_subentry_null_body_aborts_as_lookup_failure(hass: HomeAssistant) 
 
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=None),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(side_effect=InvalidResponse),
         ),
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
@@ -488,8 +461,8 @@ async def test_subentry_add_authorized_client_fails(hass: HomeAssistant) -> None
 
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_unverified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(return_value=_unverified_clients()),
         ),
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
@@ -511,8 +484,10 @@ async def test_subentry_credentials_invalid_password(hass: HomeAssistant) -> Non
     client = _mock_powerwall_client(connect_error=PowerwallAuthenticationError())
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",
@@ -540,8 +515,10 @@ async def test_subentry_credentials_cannot_connect(hass: HomeAssistant) -> None:
     client = _mock_powerwall_client(connect_error=PowerwallConnectionError())
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",
@@ -583,8 +560,10 @@ async def test_subentry_credentials_prefills_discovered_host(
             new=AsyncMock(return_value=discovered_host),
         ),
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
@@ -595,21 +574,40 @@ async def test_subentry_credentials_prefills_discovered_host(
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_subentry_credentials_discovery_fleet_error_falls_back(
+@pytest.mark.parametrize(
+    "error",
+    [
+        pytest.param(TeslaFleetError(), id="tesla_fleet_error"),
+        pytest.param(
+            ClientResponseError(
+                RequestInfo(URL("http://gateway"), "GET", CIMultiDict()), (), status=500
+            ),
+            id="client_response_error",
+        ),
+    ],
+)
+async def test_subentry_credentials_discovery_error_falls_back(
     hass: HomeAssistant,
+    error: Exception,
 ) -> None:
-    """A TeslaFleetError during discovery falls back to the default host, no abort."""
+    """Discovery is best-effort: any lookup error falls back to the default host.
+
+    Both exception types escape the same cloud-command path, and neither may
+    abort the flow - the user must still reach the credentials step.
+    """
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
 
     with (
         patch(
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_gateway_address",
-            new=AsyncMock(side_effect=TeslaFleetError()),
+            new=AsyncMock(side_effect=error),
         ),
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
@@ -633,8 +631,10 @@ async def test_subentry_credentials_discovery_none_falls_back(
             new=AsyncMock(return_value=None),
         ),
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
@@ -669,8 +669,10 @@ async def test_subentry_reconfigure_reuses_router_fallback(
     client = _mock_powerwall_client()
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",
@@ -812,6 +814,36 @@ async def test_stale_cleanup_preserves_foreign_subentry(hass: HomeAssistant) -> 
     assert entry.subentries[foreign.subentry_id].subentry_type == "vehicle"
 
 
+async def test_stale_cleanup_preserves_pairing_without_energy_scope(
+    hass: HomeAssistant,
+) -> None:
+    """Losing the energy scope must not delete a paired site's stored credentials.
+
+    Without ``energy_device_data`` the product loop skips every energy site, so
+    the resolved site list is empty for want of an inventory rather than because
+    the sites are gone. Pruning against it would silently drop the user's local
+    gateway host/password.
+    """
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.Teslemetry.metadata",
+            return_value=METADATA_NOSCOPE,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert not entry.runtime_data.energysites
+    assert subentry_id in entry.subentries
+    assert entry.subentries[subentry_id].data[CONF_HOST] == HOST
+    assert entry.subentries[subentry_id].data[CONF_PASSWORD] == PASSWORD
+
+
 async def test_subentry_reconfigure_entry_not_loaded(hass: HomeAssistant) -> None:
     """Reconfigure aborts cleanly when the parent entry is not loaded."""
     entry = _entry_with_powerwall()
@@ -834,8 +866,10 @@ async def test_subentry_credentials_password_truncated(hass: HomeAssistant) -> N
     client = _mock_powerwall_client()
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
-            new=AsyncMock(return_value=_verified_clients_response()),
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=AsyncMock(
+                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+            ),
         ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -4,7 +4,11 @@ from collections.abc import Generator
 from types import MappingProxyType
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
-from aiopowerwall import PowerwallAuthenticationError, PowerwallConnectionError
+from aiopowerwall import (
+    PowerwallAuthenticationError,
+    PowerwallConnectionError,
+    PowerwallError,
+)
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 import pytest
@@ -477,3 +481,115 @@ async def test_get_rsa_key_pem_generates_and_caches(hass: HomeAssistant) -> None
     assert first == _TEST_RSA_KEY_PEM
     assert second == _TEST_RSA_KEY_PEM
     mock_get_key.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    ("local_error", "expected", "cloud_awaits"),
+    [
+        pytest.param(None, {"routed": "local"}, 0, id="local_success"),
+        pytest.param(
+            PowerwallError("boom"), {"routed": "cloud"}, 1, id="cloud_fallback"
+        ),
+    ],
+)
+async def test_energy_site_router_command_routing(
+    hass: HomeAssistant,
+    local_error: Exception | None,
+    expected: dict[str, str],
+    cloud_awaits: int,
+) -> None:
+    """A command routes to the local Powerwall first and falls back to cloud."""
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    router = entry.runtime_data.energysites[0].api
+    assert isinstance(router, EnergySiteRouter)
+
+    local = AsyncMock(side_effect=local_error, return_value={"routed": "local"})
+    cloud = AsyncMock(return_value={"routed": "cloud"})
+    with (
+        patch("aiopowerwall.energysite.PowerwallEnergySite.backup", new=local),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.backup",
+            new=cloud,
+        ),
+    ):
+        result = await router.backup(50)
+
+    assert result == expected
+    local.assert_awaited_once_with(50)
+    assert cloud.await_count == cloud_awaits
+
+
+async def test_stale_cleanup_preserves_foreign_subentry(hass: HomeAssistant) -> None:
+    """Energy stale-subentry cleanup does not remove other subentry types."""
+    entry = mock_config_entry()
+    entry.add_to_hass(hass)
+    foreign = ConfigSubentry(
+        data=MappingProxyType({"vin": "VIN123"}),
+        subentry_type="vehicle",
+        title="A Vehicle",
+        unique_id="VIN123",
+    )
+    hass.config_entries.async_add_subentry(entry, foreign)
+
+    with patch("homeassistant.components.teslemetry.PLATFORMS", []):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert foreign.subentry_id in entry.subentries
+    assert entry.subentries[foreign.subentry_id].subentry_type == "vehicle"
+
+
+async def test_subentry_reconfigure_entry_not_loaded(hass: HomeAssistant) -> None:
+    """Reconfigure aborts cleanly when the parent entry is not loaded."""
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+    # Added but never set up, so runtime_data is absent.
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "entry_not_loaded"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_password_truncated(hass: HomeAssistant) -> None:
+    """A full Wi-Fi password is trimmed to its final five characters."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client()
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ) as mock_client,
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["step_id"] == "credentials"
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: "long-wifi-password"}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert entry.subentries[subentry_id].data[CONF_PASSWORD] == "sword"
+    assert mock_client.call_args.kwargs["gateway_password"] == "sword"

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -185,6 +185,24 @@ def _empty_clients() -> AuthorizedClients:
     return AuthorizedClients(clients=[], raw=None)
 
 
+def _own_key_local_payload(state: str) -> dict[str, Any]:
+    """Return a raw local ``list_authorized_clients`` response carrying our key.
+
+    Mirrors the envelope aiopowerwall's ``PowerwallEnergySite`` returns - a
+    decoy entry included so the flow's key-matching predicate has noise to
+    skip past, same as :func:`_own_key_clients`.
+    """
+    return {
+        "response": {
+            "clients": [
+                {"public_key": "some-other-key", "state": "VERIFIED"},
+                {"public_key": PUBLIC_KEY_B64, "state": state},
+            ],
+            "enable_line_switch_off": False,
+        }
+    }
+
+
 async def test_energy_site_router_with_powerwall(hass: HomeAssistant) -> None:
     """A paired energy site wraps its cloud API in an EnergySiteRouter."""
     entry = _entry_with_powerwall()
@@ -805,10 +823,10 @@ async def test_subentry_credentials_discovery_none_falls_back(
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_subentry_reconfigure_reuses_router_fallback(
+async def test_subentry_reconfigure_checks_local_client_when_paired(
     hass: HomeAssistant,
 ) -> None:
-    """Reconfiguring an already-paired site pairs against the cloud fallback."""
+    """Reconfiguring an already-paired site checks the gateway directly, not the cloud."""
     entry = _entry_with_powerwall()
     entry.add_to_hass(hass)
 
@@ -827,12 +845,17 @@ async def test_subentry_reconfigure_reuses_router_fallback(
 
     new_password = "fghij"
     client = _mock_powerwall_client()
+    cloud_find = AsyncMock(return_value=_empty_clients())
     with (
         patch(
-            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            "aiopowerwall.energysite.PowerwallEnergySite.list_authorized_clients",
             new=AsyncMock(
-                return_value=_own_key_clients(AuthorizedClientState.VERIFIED)
+                return_value=_own_key_local_payload(AuthorizedClientState.VERIFIED.name)
             ),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=cloud_find,
         ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",
@@ -847,8 +870,85 @@ async def test_subentry_reconfigure_reuses_router_fallback(
             result["flow_id"], {CONF_HOST: HOST, CONF_PASSWORD: new_password}
         )
 
+    cloud_find.assert_not_awaited()
     assert result["type"] is FlowResultType.ABORT
     assert entry.subentries[subentry_id].data[CONF_PASSWORD] == new_password
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_reconfigure_local_lookup_error_aborts(
+    hass: HomeAssistant,
+) -> None:
+    """A local read failure aborts cleanly instead of falling back to the cloud."""
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    cloud_find = AsyncMock(return_value=_empty_clients())
+    with (
+        patch(
+            "aiopowerwall.energysite.PowerwallEnergySite.list_authorized_clients",
+            new=AsyncMock(side_effect=PowerwallConnectionError("unreachable")),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_authorized_clients",
+            new=cloud_find,
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    cloud_find.assert_not_awaited()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_reconfigure_local_no_match_registers_via_cloud(
+    hass: HomeAssistant,
+) -> None:
+    """A local read with no entry for our key still registers it via the cloud."""
+    entry = _entry_with_powerwall()
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.teslemetry._async_get_rsa_key_pem",
+            return_value=_TEST_RSA_KEY_PEM,
+        ),
+        patch("homeassistant.components.teslemetry.PLATFORMS", []),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    add_client = AsyncMock(return_value={})
+    with (
+        patch(
+            "aiopowerwall.energysite.PowerwallEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value={"response": {"clients": []}}),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=add_client,
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    add_client.assert_awaited_once()
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
 
 
 async def test_subentry_reconfigure_no_matching_energy_site(

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -511,9 +511,9 @@ async def test_subentry_add_authorized_client_fails(hass: HomeAssistant) -> None
             id="signed_read_rejects_unapproved_key",
         ),
         pytest.param(
-            {"status_error": PowerwallFaultError("MESSAGEFAULT_ERROR_UNKNOWN_KEY_ID")},
-            "key_not_approved",
-            id="signed_read_faults_on_unknown_key",
+            {"status_error": PowerwallFaultError("MESSAGEFAULT_ERROR_BUSY")},
+            "cannot_connect",
+            id="signed_read_generic_gateway_fault",
         ),
         pytest.param(
             {"status_error": PowerwallConnectionError()},
@@ -530,7 +530,9 @@ async def test_subentry_credentials_errors(
     """The credentials step reports each local verification failure distinctly.
 
     A key the gateway has not approved only fails the signed read, so it must
-    not be reported as a bad password.
+    not be reported as a bad password. A generic gateway fault (busy, timeout,
+    internal) is a different failure than a rejected key and must not be
+    reported as one.
     """
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
@@ -575,7 +577,8 @@ async def test_subentry_credentials_gateway_mismatch(
     """Pairing aborts when the local gateway is not the site's own gateway.
 
     The RSA key authorizes every gateway on the account, so without this the
-    subentry would command another site's house.
+    subentry would command another site's house. The mismatch is caught
+    before the signed read, so a gateway that isn't ours is never sent one.
     """
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
@@ -607,6 +610,7 @@ async def test_subentry_credentials_gateway_mismatch(
         "actual": din,
     }
     assert CONF_HOST not in entry.subentries[subentry_id].data
+    client.get_status.assert_not_awaited()
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -227,8 +227,8 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
             new=AsyncMock(
                 side_effect=[
-                    TeslaFleetError(),
-                    TeslaFleetError(),
+                    _empty_clients_response(),
+                    _unverified_clients_response(),
                     _verified_clients_response(),
                 ]
             ),
@@ -247,7 +247,7 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
         ),
         patch.object(hass.config_entries, "async_schedule_reload"),
     ):
-        # reconfigure -> list_authorized_clients raises -> add_authorized_client -> pair
+        # reconfigure -> key absent -> add_authorized_client -> pair
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
         assert result["type"] is FlowResultType.FORM
         assert result["step_id"] == "pair"

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -6,6 +6,7 @@ from types import MappingProxyType
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 from aiopowerwall import (
+    DEFAULT_GATEWAY_HOST,
     PowerwallAuthenticationError,
     PowerwallConnectionError,
     PowerwallError,
@@ -23,7 +24,11 @@ from homeassistant.components.teslemetry.const import (
     CONF_SITE_ID,
     SUBENTRY_TYPE_ENERGY_SITE,
 )
-from homeassistant.config_entries import ConfigSubentry, ConfigSubentryData
+from homeassistant.config_entries import (
+    ConfigSubentry,
+    ConfigSubentryData,
+    SubentryFlowResult,
+)
 from homeassistant.const import CONF_HOST, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -74,6 +79,21 @@ def _entry_with_powerwall() -> MockConfigEntry:
             )
         ],
     )
+
+
+@pytest.fixture(autouse=True)
+def mock_gateway_discovery() -> Generator[AsyncMock]:
+    """Default gateway-address discovery to no result.
+
+    Keeps every existing subentry test path deterministic now that
+    ``async_step_reconfigure`` calls ``find_gateway_address``. Tests exercising
+    discovery itself override this per-test.
+    """
+    with patch(
+        "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_gateway_address",
+        new=AsyncMock(return_value=None),
+    ) as mock_find:
+        yield mock_find
 
 
 @pytest.fixture
@@ -538,6 +558,90 @@ async def test_subentry_credentials_cannot_connect(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "credentials"
     assert result["errors"] == {"base": "cannot_connect"}
+
+
+def _credentials_host_default(result: SubentryFlowResult) -> str:
+    """Return the CONF_HOST field's schema default from a credentials form result."""
+    for key in result["data_schema"].schema:
+        if key == CONF_HOST:
+            return key.default()
+    raise AssertionError("CONF_HOST field not found in credentials schema")
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_prefills_discovered_host(
+    hass: HomeAssistant,
+) -> None:
+    """A discovered gateway address pre-fills the credentials CONF_HOST default."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+    discovered_host = "192.168.1.138"
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_gateway_address",
+            new=AsyncMock(return_value=discovered_host),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert _credentials_host_default(result) == discovered_host
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_discovery_fleet_error_falls_back(
+    hass: HomeAssistant,
+) -> None:
+    """A TeslaFleetError during discovery falls back to the default host, no abort."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_gateway_address",
+            new=AsyncMock(side_effect=TeslaFleetError()),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert _credentials_host_default(result) == DEFAULT_GATEWAY_HOST
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_credentials_discovery_none_falls_back(
+    hass: HomeAssistant,
+) -> None:
+    """A None discovery result falls back to the default host, no abort."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.find_gateway_address",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_verified_clients_response()),
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    assert _credentials_host_default(result) == DEFAULT_GATEWAY_HOST
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -13,6 +13,7 @@ from aiopowerwall import (
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 import pytest
+from tesla_fleet_api.const import AuthorizedClientState
 from tesla_fleet_api.exceptions import TeslaFleetError
 from tesla_fleet_api.tesla import EnergySiteRouter
 from tesla_fleet_api.teslemetry import EnergySite
@@ -142,6 +143,43 @@ def _pending_clients_response() -> dict:
 def _empty_clients_response() -> dict:
     """Return a response whose authorized-clients list is explicitly empty."""
     return {"response": {"authorized_clients": []}}
+
+
+def _real_shape_clients_response(state: AuthorizedClientState) -> dict:
+    """Return a response matching the gateway's real envelope and field shape.
+
+    Modeled on a live ``authorized_clients`` capture: the list is nested under
+    ``clients`` (not ``authorized_clients``), and each entry carries the full
+    real field set including an object-shaped ``added_time``. Includes a
+    decoy entry so the flow's key-matching predicate has noise to skip past.
+    """
+    return {
+        "response": {
+            "request_id": "03153d0c37283795cf0d1a593eebd9a0",
+            "clients": [
+                {
+                    "type": 1,
+                    "description": "Some Other App",
+                    "key_type": 1,
+                    "public_key": "not-a-match",
+                    "roles": [1],
+                    "state": 3,
+                    "verification": 1,
+                    "added_time": {"seconds": 1700000000},
+                },
+                {
+                    "type": 1,
+                    "description": "Home Assistant",
+                    "key_type": 1,
+                    "public_key": PUBLIC_KEY_B64,
+                    "roles": [1],
+                    "state": int(state),
+                    "verification": 1,
+                    "added_time": {"seconds": 1783997627},
+                },
+            ],
+        }
+    }
 
 
 async def test_energy_site_router_with_powerwall(hass: HomeAssistant) -> None:
@@ -310,12 +348,97 @@ async def test_subentry_pair_key_not_registered(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_subentry_null_body_treated_as_unverified(hass: HomeAssistant) -> None:
-    """A bare null (200) authorized-clients body is authoritatively unverified.
+async def test_subentry_recognizes_own_verified_key_no_reregister(
+    hass: HomeAssistant,
+) -> None:
+    """A real gateway response recognizes our own VERIFIED key and skips re-adding it."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    client = _mock_powerwall_client()
+    add_client = AsyncMock()
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(
+                return_value=_real_shape_clients_response(
+                    AuthorizedClientState.VERIFIED
+                )
+            ),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=add_client,
+        ),
+        patch(
+            "homeassistant.components.teslemetry.config_flow.PowerwallClient",
+            return_value=client,
+        ),
+        patch.object(hass.config_entries, "async_schedule_reload"),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "credentials"
+    add_client.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+@pytest.mark.parametrize(
+    ("state", "expected_error"),
+    [
+        pytest.param(AuthorizedClientState.PENDING, "key_pending", id="pending"),
+        pytest.param(
+            AuthorizedClientState.PENDING_VERIFICATION,
+            "key_pending_verification",
+            id="pending_verification",
+        ),
+    ],
+)
+async def test_subentry_recognizes_own_pending_key_no_reregister(
+    hass: HomeAssistant,
+    state: AuthorizedClientState,
+    expected_error: str,
+) -> None:
+    """A real gateway response recognizes our own pending key and skips re-adding it."""
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    add_client = AsyncMock()
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=_real_shape_clients_response(state)),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=add_client,
+        ),
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert not result["errors"]
+
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    assert result["errors"] == {"base": expected_error}
+    add_client.assert_not_awaited()
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_null_body_aborts_as_lookup_failure(hass: HomeAssistant) -> None:
+    """A bare null (200) authorized-clients body aborts rather than registering.
 
     Tesla's undocumented endpoint can answer with JSON ``null``; the library's
-    typed accessor collapses that to an empty client list, so pairing treats it
-    as "not yet verified" and registers the key rather than erroring.
+    typed accessor now raises ``InvalidResponse`` for it rather than collapsing
+    it to an empty client list, since a malformed response could just as
+    easily be hiding an already-registered key. The flow must not mistake this
+    for an absent key and re-register it.
     """
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
@@ -332,9 +455,9 @@ async def test_subentry_null_body_treated_as_unverified(hass: HomeAssistant) -> 
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "pair"
-    mock_add.assert_awaited_once()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
+    mock_add.assert_not_awaited()
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -132,6 +132,13 @@ def _unverified_clients_response() -> dict:
     return {"response": {"authorized_clients": [{"public_key": "other", "state": 1}]}}
 
 
+def _pending_clients_response() -> dict:
+    """Return a list_authorized_clients response with our key still pending."""
+    return {
+        "response": {"authorized_clients": [{"public_key": PUBLIC_KEY_B64, "state": 1}]}
+    }
+
+
 def _empty_clients_response() -> dict:
     """Return a response whose authorized-clients list is explicitly empty."""
     return {"response": {"authorized_clients": []}}
@@ -217,7 +224,7 @@ async def test_subentry_pairing_already_verified(hass: HomeAssistant) -> None:
 
 @pytest.mark.usefixtures("mock_rsa_key")
 async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> None:
-    """Pairing registers the key, waits for approval, then proceeds."""
+    """Pairing registers the key, then advances to credentials once approved."""
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
 
@@ -228,7 +235,7 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
             new=AsyncMock(
                 side_effect=[
                     _empty_clients_response(),
-                    _unverified_clients_response(),
+                    _pending_clients_response(),
                     _verified_clients_response(),
                 ]
             ),
@@ -237,10 +244,6 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
             new=AsyncMock(),
         ) as mock_add,
-        patch(
-            "homeassistant.components.teslemetry.config_flow.asyncio.sleep",
-            new=AsyncMock(),
-        ),
         patch(
             "homeassistant.components.teslemetry.config_flow.PowerwallClient",
             return_value=client,
@@ -253,7 +256,15 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
         assert result["step_id"] == "pair"
         mock_add.assert_awaited_once()
 
-        # confirm pair -> poll (unverified, then verified) -> credentials
+        # confirm pair while still pending -> re-shows pair with an error
+        result = await hass.config_entries.subentries.async_configure(
+            result["flow_id"], {}
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "pair"
+        assert result["errors"] == {"base": "key_pending"}
+
+        # confirm pair again, now verified -> credentials
         result = await hass.config_entries.subentries.async_configure(
             result["flow_id"], {}
         )
@@ -271,8 +282,8 @@ async def test_subentry_pairing_requires_key_approval(hass: HomeAssistant) -> No
 
 
 @pytest.mark.usefixtures("mock_rsa_key")
-async def test_subentry_pair_timeout(hass: HomeAssistant) -> None:
-    """The pair step shows a timeout error when the key is never approved."""
+async def test_subentry_pair_key_not_registered(hass: HomeAssistant) -> None:
+    """The pair step errors clearly if the key is not found on the gateway."""
     entry = await _setup_energy_site_subentry(hass)
     subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
 
@@ -285,10 +296,6 @@ async def test_subentry_pair_timeout(hass: HomeAssistant) -> None:
             "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
             new=AsyncMock(),
         ),
-        patch(
-            "homeassistant.components.teslemetry.config_flow.asyncio.sleep",
-            new=AsyncMock(),
-        ),
     ):
         result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
         assert result["step_id"] == "pair"
@@ -299,7 +306,7 @@ async def test_subentry_pair_timeout(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "pair"
-    assert result["errors"] == {"base": "timeout"}
+    assert result["errors"] == {"base": "key_not_registered"}
 
 
 @pytest.mark.usefixtures("mock_rsa_key")

--- a/tests/components/teslemetry/test_energy_router.py
+++ b/tests/components/teslemetry/test_energy_router.py
@@ -113,8 +113,8 @@ def _mock_powerwall_client(*, connect_error: Exception | None = None) -> MagicMo
 def _verified_clients_response() -> dict:
     """Return a list_authorized_clients response verifying our public key.
 
-    Includes a non-dict entry and a mismatched key to exercise the parsing
-    helpers' defensive branches.
+    Includes a non-dict entry and a mismatched key so the library's typed
+    ``find_authorized_clients`` accessor has noise to skip past.
     """
     return {
         "response": {
@@ -128,17 +128,13 @@ def _verified_clients_response() -> dict:
 
 
 def _unverified_clients_response() -> dict:
-    """Return a list_authorized_clients response with no matching client.
-
-    Nests the client list under an unrecognized wrapper key to exercise the
-    parsing helpers' generic (non-keyed) fallback search.
-    """
-    return {"result": [{"public_key": "some-other-key", "state": 1}]}
+    """Return a list_authorized_clients response with no matching client."""
+    return {"response": {"authorized_clients": [{"public_key": "other", "state": 1}]}}
 
 
 def _empty_clients_response() -> dict:
-    """Return a response with no client list findable anywhere in it."""
-    return {"foo": "bar"}
+    """Return a response whose authorized-clients list is explicitly empty."""
+    return {"response": {"authorized_clients": []}}
 
 
 async def test_energy_site_router_with_powerwall(hass: HomeAssistant) -> None:
@@ -304,6 +300,34 @@ async def test_subentry_pair_timeout(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "pair"
     assert result["errors"] == {"base": "timeout"}
+
+
+@pytest.mark.usefixtures("mock_rsa_key")
+async def test_subentry_null_body_treated_as_unverified(hass: HomeAssistant) -> None:
+    """A bare null (200) authorized-clients body is authoritatively unverified.
+
+    Tesla's undocumented endpoint can answer with JSON ``null``; the library's
+    typed accessor collapses that to an empty client list, so pairing treats it
+    as "not yet verified" and registers the key rather than erroring.
+    """
+    entry = await _setup_energy_site_subentry(hass)
+    subentry_id = entry.get_subentries_of_type(SUBENTRY_TYPE_ENERGY_SITE)[0].subentry_id
+
+    with (
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.list_authorized_clients",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "tesla_fleet_api.teslemetry.energysite.TeslemetryEnergySite.add_authorized_client",
+            new=AsyncMock(),
+        ) as mock_add,
+    ):
+        result = await entry.start_subentry_reconfigure_flow(hass, subentry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pair"
+    mock_add.assert_awaited_once()
 
 
 @pytest.mark.usefixtures("mock_rsa_key")


### PR DESCRIPTION
## Proposed change

When a Teslemetry energy site is already paired for local Powerwall control, check its authorized-clients list directly on the gateway over the LAN instead of through Teslemetry's cloud proxy, falling back to the cloud only when the site has no local key yet. Also bumps `aiopowerwall` to 0.3.0, which adds the local implementation of `list_authorized_clients` this relies on.

This PR is a draft stacked on the still-unmerged #176969 (local Powerwall control) and includes a cherry-picked #176966 (tesla-fleet-api bump), both required for this to build; the diff below is large only because it carries their commits along until they merge.

## Type of change

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

  - aiopowerwall: https://github.com/Teslemetry/aiopowerwall/compare/v0.2.0...v0.3.0
  - tesla-fleet-api: https://github.com/Teslemetry/python-tesla-fleet-api/compare/v1.7.2...v1.7.6

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
