### PR TITLE
Retry NMBS setup when the iRail station list is unavailable

### DIFF
--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -24,9 +24,9 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NMBS from a config entry."""
 
-    # Fetch the shared station list on the first entry to be set up. A transient
-    # API failure here raises ConfigEntryNotReady so Home Assistant retries with
-    # backoff instead of hard-failing the integration until the next restart.
+    # The station list is shared by all entries, so fetch and cache it only
+    # once. Raise ConfigEntryNotReady if the API is unavailable so setup is
+    # retried instead of failing permanently.
     if not hass.data.get(DOMAIN):
         api_client = iRail(session=async_get_clientsession(hass))
         station_response = await api_client.get_stations()

--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -11,7 +11,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN
 
@@ -20,13 +19,6 @@ PLATFORMS = [Platform.SENSOR]
 
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
-
-
-async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
-    """Set up the NMBS component."""
-
-    hass.data.setdefault(DOMAIN, {})
-    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -8,6 +8,7 @@ from pyrail import iRail
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -24,21 +25,24 @@ CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the NMBS component."""
 
-    api_client = iRail(session=async_get_clientsession(hass))
-
     hass.data.setdefault(DOMAIN, {})
-    station_response = await api_client.get_stations()
-    if station_response is None:
-        return False
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=home-assistant-use-runtime-data
-    hass.data[DOMAIN] = station_response.stations
-
     return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NMBS from a config entry."""
+
+    # Fetch the shared station list on the first entry to be set up. A transient
+    # API failure here raises ConfigEntryNotReady so Home Assistant retries with
+    # backoff instead of hard-failing the integration until the next restart.
+    if not hass.data.get(DOMAIN):
+        api_client = iRail(session=async_get_clientsession(hass))
+        station_response = await api_client.get_stations()
+        if station_response is None:
+            raise ConfigEntryNotReady(
+                "Unable to fetch the NMBS station list; the iRail API is unavailable"
+            )
+        hass.data[DOMAIN] = station_response.stations
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -27,12 +27,7 @@ async def test_setup_entry_api_unavailable(
     mock_nmbs_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test the entry is retried when the station list cannot be fetched.
-
-    A transient API failure while fetching the shared station list should raise
-    ConfigEntryNotReady (state SETUP_RETRY) so Home Assistant retries with
-    backoff, instead of hard-failing the integration until the next restart.
-    """
+    """Test the entry is retried when the station list cannot be fetched."""
     mock_nmbs_client.get_stations.return_value = None
     mock_config_entry.add_to_hass(hass)
 

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -1,0 +1,42 @@
+"""Test the NMBS integration setup."""
+
+from unittest.mock import AsyncMock
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant,
+    mock_nmbs_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a config entry is set up successfully."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+
+async def test_setup_entry_api_unavailable(
+    hass: HomeAssistant,
+    mock_nmbs_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the entry is retried when the station list cannot be fetched.
+
+    A transient API failure while fetching the shared station list should raise
+    ConfigEntryNotReady (state SETUP_RETRY) so Home Assistant retries with
+    backoff, instead of hard-failing the integration until the next restart.
+    """
+    mock_nmbs_client.get_stations.return_value = None
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The NMBS integration fetches the shared iRail station list during setup. When that request fails (for example the iRail API returns a transient `504` during Home Assistant startup), setup returned `False`, a hard failure: the integration and all of its config entries failed to initialize and were **not** retried. The only way to recover was a full Home Assistant restart, even though the API is typically reachable again seconds later.

This is easy to hit in practice: iRail's upstream occasionally returns `no_healthy_upstream` for a few seconds, and if that window overlaps HA's startup, NMBS stays down until the user restarts.

This change moves the station-list fetch into `async_setup_entry` and raises `ConfigEntryNotReady` when the fetch fails, so Home Assistant retries setup with its normal exponential backoff. The list is still fetched only once (by the first config entry to be set up) and cached in `hass.data[DOMAIN]`; subsequent entries reuse it. Runtime updates already degrade gracefully (the sensors log a warning and keep their last value on a failed poll), so this aligns startup behaviour with runtime behaviour. The now-redundant `async_setup` has been removed. The config flow fetches its own station list independently and is unaffected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
