### PR TITLE
Fix swallowed exceptions in action handlers for DirecTV

### DIFF
--- a/homeassistant/components/directv/remote.py
+++ b/homeassistant/components/directv/remote.py
@@ -2,19 +2,18 @@
 
 from collections.abc import Iterable
 from datetime import timedelta
-import logging
 from typing import Any, override
 
 from directv import DIRECTV, DIRECTVError
 
 from homeassistant.components.remote import ATTR_NUM_REPEATS, RemoteEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import DirecTVConfigEntry
+from .const import DOMAIN
 from .entity import DIRECTVEntity
-
-_LOGGER = logging.getLogger(__name__)
 
 SCAN_INTERVAL = timedelta(minutes=2)
 
@@ -93,10 +92,12 @@ class DIRECTVRemote(DIRECTVEntity, RemoteEntity):
             for single_command in command:
                 try:
                     await self.dtv.remote(single_command, self._address)
-                # pylint: disable-next=home-assistant-action-swallowed-exception
-                except DIRECTVError:
-                    _LOGGER.exception(
-                        "Sending command %s to device %s failed",
-                        single_command,
-                        self._device_id,
-                    )
+                except DIRECTVError as err:
+                    raise HomeAssistantError(
+                        translation_domain=DOMAIN,
+                        translation_key="send_command_failed",
+                        translation_placeholders={
+                            "command": single_command,
+                            "device": self._device_id,
+                        },
+                    ) from err

--- a/homeassistant/components/directv/strings.json
+++ b/homeassistant/components/directv/strings.json
@@ -21,5 +21,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "send_command_failed": {
+      "message": "Sending command {command} to device {device} failed."
+    }
   }
 }

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -106,3 +106,4 @@ async def test_send_command_failed(
     remote_mock.assert_called_once_with("dash", "0")
     assert err.value.translation_domain == DOMAIN
     assert err.value.translation_key == "send_command_failed"
+    assert err.value.translation_placeholders == {"command": "dash", "device": "0"}

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -2,6 +2,10 @@
 
 from unittest.mock import patch
 
+from directv import DIRECTVError
+import pytest
+
+from homeassistant.components.directv.const import DOMAIN
 from homeassistant.components.remote import (
     ATTR_COMMAND,
     DOMAIN as REMOTE_DOMAIN,
@@ -9,6 +13,7 @@ from homeassistant.components.remote import (
 )
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
@@ -79,3 +84,25 @@ async def test_main_services(
             blocking=True,
         )
         remote_mock.assert_called_once_with("dash", "0")
+
+
+async def test_send_command_failed(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """Test that a failed command raises an error."""
+    await setup_integration(hass, aioclient_mock)
+
+    with (
+        patch("directv.DIRECTV.remote", side_effect=DIRECTVError) as remote_mock,
+        pytest.raises(HomeAssistantError) as err,
+    ):
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: MAIN_ENTITY_ID, ATTR_COMMAND: ["dash"]},
+            blocking=True,
+        )
+
+    remote_mock.assert_called_once_with("dash", "0")
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "send_command_failed"

--- a/tests/components/directv/test_remote.py
+++ b/tests/components/directv/test_remote.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
-from . import setup_integration
+from . import RECEIVER_ID, setup_integration
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -106,4 +106,7 @@ async def test_send_command_failed(
     remote_mock.assert_called_once_with("dash", "0")
     assert err.value.translation_domain == DOMAIN
     assert err.value.translation_key == "send_command_failed"
-    assert err.value.translation_placeholders == {"command": "dash", "device": "0"}
+    assert err.value.translation_placeholders == {
+        "command": "dash",
+        "device": RECEIVER_ID,
+    }


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raise `HomeAssistantError` when sending a remote command to a DirecTV receiver fails, instead of only logging the error, as tracked in #170608 (part of home-assistant/epics#64). Previously a failed `remote.send_command` action looked successful to the caller even though the receiver never executed the command.

The `DIRECTVError` from the client library is now re-raised as a `HomeAssistantError` with a translatable message that includes the command and the device, so the action fails on the first command that cannot be sent. The pylint suppression comment and the now unused logger were removed, and an `exceptions` section was added to `strings.json`. A new test verifies that the action raises when the client reports an error; the existing success path tests are unchanged.

This follows the same approach as the merged SamsungTV fix #170805.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170608
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
