### PR TITLE
Fix swallowed exceptions in action handlers for Sky Remote

### DIFF
--- a/homeassistant/components/sky_remote/remote.py
+++ b/homeassistant/components/sky_remote/remote.py
@@ -8,7 +8,7 @@ from skyboxremote import VALID_KEYS, RemoteControl
 
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -67,8 +67,10 @@ class SkyRemote(RemoteEntity):
                 )
         try:
             self._remote.send_keys(command)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except ValueError as err:
-            _LOGGER.error("Invalid command: %s. Error: %s", command, err)
-            return
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_command",
+                translation_placeholders={"command": ", ".join(command)},
+            ) from err
         _LOGGER.debug("Successfully sent command %s", command)

--- a/homeassistant/components/sky_remote/strings.json
+++ b/homeassistant/components/sky_remote/strings.json
@@ -17,5 +17,10 @@
         "title": "Add Sky Remote"
       }
     }
+  },
+  "exceptions": {
+    "invalid_command": {
+      "message": "Invalid command: {command}"
+    }
   }
 }

--- a/tests/components/sky_remote/test_remote.py
+++ b/tests/components/sky_remote/test_remote.py
@@ -1,5 +1,7 @@
 """Test sky_remote remote."""
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from homeassistant.components.remote import (
@@ -7,11 +9,14 @@ from homeassistant.components.remote import (
     DOMAIN as REMOTE_DOMAIN,
     SERVICE_SEND_COMMAND,
 )
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.components.sky_remote.const import DOMAIN
+from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_OFF, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from . import setup_mock_entry
+
+from tests.common import MockConfigEntry
 
 ENTITY_ID = "remote.example_com"
 
@@ -44,3 +49,50 @@ async def test_send_invalid_command(
             blocking=True,
         )
     mock_remote_control._instance_mock.send_keys.assert_not_called()
+
+
+async def test_send_command_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_remote_control: MagicMock,
+) -> None:
+    """Test "send_command" method when the library rejects a command."""
+    await setup_mock_entry(hass, mock_config_entry)
+    mock_remote_control._instance_mock.send_keys.side_effect = ValueError("Bad key")
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            SERVICE_SEND_COMMAND,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_COMMAND: ["sky"]},
+            blocking=True,
+        )
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "invalid_command"
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_command"),
+    [
+        pytest.param(SERVICE_TURN_ON, "sky", id="turn_on"),
+        pytest.param(SERVICE_TURN_OFF, "power", id="turn_off"),
+    ],
+)
+async def test_turn_on_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_remote_control: MagicMock,
+    service: str,
+    expected_command: str,
+) -> None:
+    """Test "turn_on" and "turn_off" methods."""
+    await setup_mock_entry(hass, mock_config_entry)
+    await hass.services.async_call(
+        REMOTE_DOMAIN,
+        service,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+    mock_remote_control._instance_mock.send_keys.assert_called_once_with(
+        [expected_command]
+    )


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raise a translated `HomeAssistantError` instead of swallowing the `ValueError` in the Sky Remote `send_command` action handler, as tracked in #170677 (part of home-assistant/epics#64). The log-and-return branch and its pylint suppression comment are removed, an `exceptions` section is added to `strings.json`, and a test covering the failure path is added. The change mirrors the merged SamsungTV fix #170805.

To be clear about the impact: this branch is defensive. `send_command` already validates every command against `VALID_KEYS` before calling the library, and `skyboxremote` (pinned at 0.0.6) raises `ValueError` only for keys missing from the same key map that backs `VALID_KEYS`, so the branch is not reachable today. If the integration and the library ever diverge, the failure now surfaces to the caller instead of only being logged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170677
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
