### PR TITLE
Fix Monzo pot entities after a pot is removed

### DIFF
--- a/homeassistant/components/monzo/coordinator.py
+++ b/homeassistant/components/monzo/coordinator.py
@@ -25,8 +25,8 @@ type MonzoConfigEntry = ConfigEntry[MonzoCoordinator]
 class MonzoData:
     """A dataclass for holding sensor data returned by the DataUpdateCoordinator."""
 
-    accounts: list[dict[str, Any]]
-    pots: list[dict[str, Any]]
+    accounts: dict[str, dict[str, Any]]
+    pots: dict[str, dict[str, Any]]
 
 
 class MonzoCoordinator(DataUpdateCoordinator[MonzoData]):
@@ -70,4 +70,7 @@ class MonzoCoordinator(DataUpdateCoordinator[MonzoData]):
                 message += " Enabling debug logging for details."
             raise UpdateFailed(message) from err
 
-        return MonzoData(accounts, pots)
+        return MonzoData(
+            accounts={account["id"]: account for account in accounts},
+            pots={pot["id"]: pot for pot in pots},
+        )

--- a/homeassistant/components/monzo/entity.py
+++ b/homeassistant/components/monzo/entity.py
@@ -1,7 +1,7 @@
 """Base entity for Monzo."""
 
 from collections.abc import Callable
-from typing import Any
+from typing import Any, override
 
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -19,13 +19,13 @@ class MonzoBaseEntity(CoordinatorEntity[MonzoCoordinator]):
     def __init__(
         self,
         coordinator: MonzoCoordinator,
-        index: int,
+        resource_id: str,
         device_model: str,
-        data_accessor: Callable[[MonzoData], list[dict[str, Any]]],
+        data_accessor: Callable[[MonzoData], dict[str, dict[str, Any]]],
     ) -> None:
         """Initialize sensor."""
         super().__init__(coordinator)
-        self.index = index
+        self._resource_id = resource_id
         self._data_accessor = data_accessor
 
         self._attr_device_info = DeviceInfo(
@@ -39,4 +39,12 @@ class MonzoBaseEntity(CoordinatorEntity[MonzoCoordinator]):
     @property
     def data(self) -> dict[str, Any]:
         """Shortcut to access coordinator data for the entity."""
-        return self._data_accessor(self.coordinator.data)[self.index]
+        return self._data_accessor(self.coordinator.data)[self._resource_id]
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return whether the entity is available."""
+        return super().available and self._resource_id in self._data_accessor(
+            self.coordinator.data
+        )

--- a/homeassistant/components/monzo/sensor.py
+++ b/homeassistant/components/monzo/sensor.py
@@ -69,18 +69,20 @@ async def async_setup_entry(
         MonzoSensor(
             coordinator,
             entity_description,
-            index,
+            account_id,
             account["name"],
             lambda x: x.accounts,
         )
         for entity_description in ACCOUNT_SENSORS
-        for index, account in enumerate(coordinator.data.accounts)
+        for account_id, account in coordinator.data.accounts.items()
     ]
 
     pots = [
-        MonzoSensor(coordinator, entity_description, index, MODEL_POT, lambda x: x.pots)
+        MonzoSensor(
+            coordinator, entity_description, pot_id, MODEL_POT, lambda x: x.pots
+        )
         for entity_description in POT_SENSORS
-        for index, _pot in enumerate(coordinator.data.pots)
+        for pot_id in coordinator.data.pots
     ]
 
     async_add_entities(accounts + pots)
@@ -95,14 +97,14 @@ class MonzoSensor(MonzoBaseEntity, SensorEntity):
         self,
         coordinator: MonzoCoordinator,
         entity_description: MonzoSensorEntityDescription,
-        index: int,
+        resource_id: str,
         device_model: str,
-        data_accessor: Callable[[MonzoData], list[dict[str, Any]]],
+        data_accessor: Callable[[MonzoData], dict[str, dict[str, Any]]],
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator, index, device_model, data_accessor)
+        super().__init__(coordinator, resource_id, device_model, data_accessor)
         self.entity_description = entity_description
-        self._attr_unique_id = f"{self.data['id']}_{entity_description.key}"
+        self._attr_unique_id = f"{resource_id}_{entity_description.key}"
 
     @property
     @override

--- a/tests/components/monzo/test_sensor.py
+++ b/tests/components/monzo/test_sensor.py
@@ -103,6 +103,40 @@ async def test_unavailable_entity(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_deleted_pot_does_not_change_another_pot(
+    hass: HomeAssistant,
+    basic_monzo: AsyncMock,
+    polling_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test deleting a pot does not shift another pot's data."""
+    holiday_pot = {
+        "id": "pot_holiday",
+        "name": "Holiday",
+        "balance": 12345,
+    }
+    basic_monzo.user_account.pots.return_value = [TEST_POTS[0], holiday_pot]
+    await setup_integration(hass, polling_config_entry)
+
+    deleted_entity_id = await async_get_entity_id(
+        hass, TEST_POTS[0]["id"], POT_SENSORS[0]
+    )
+    holiday_entity_id = await async_get_entity_id(
+        hass, holiday_pot["id"], POT_SENSORS[0]
+    )
+    assert deleted_entity_id
+    assert holiday_entity_id
+
+    basic_monzo.user_account.pots.return_value = [{**holiday_pot, "balance": 54321}]
+    freezer.tick(timedelta(minutes=1))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(deleted_entity_id).state == STATE_UNAVAILABLE
+    assert hass.states.get(holiday_entity_id).state == "543.21"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_all_entities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Monzo entities currently retain the list index at which their account or pot was discovered. If a pot is deleted or the API changes the list order, an existing entity can read another pot's data or fail with an out-of-range index.

Store coordinator accounts and pots by their stable Monzo resource IDs instead. Entities now look up their own resource ID on every update and become unavailable when that resource is no longer returned. Existing entity unique IDs and device identifiers are unchanged, so no registry migration is required.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
