### PR TITLE
alexa_devices: update notification sensors from push events

### DIFF
--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -170,6 +170,9 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
         self.api.on_media_state_event.append(self.media_state_event_handler)
         self.api.on_media_state_event.freeze()
 
+        self.api.on_notification_event.append(self.notification_event_handler)
+        self.api.on_notification_event.freeze()
+
     @override
     async def _async_update_data(self) -> dict[str, AmazonDevice]:
         """Update device data."""
@@ -355,6 +358,12 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
     def media_states(self) -> dict[str, AmazonMediaState]:
         """Media state of devices."""
         return self._media_states
+
+    async def notification_event_handler(
+        self, devices: dict[str, AmazonDevice]
+    ) -> None:
+        """Handle pushed notification/timer/alarm/reminder events."""
+        self.async_set_updated_data(devices)
 
     async def volume_state_event_handler(
         self, volume_states: dict[str, AmazonVolumeState]

--- a/tests/components/alexa_devices/conftest.py
+++ b/tests/components/alexa_devices/conftest.py
@@ -66,6 +66,7 @@ def mock_amazon_devices_client() -> Generator[AsyncMock]:
         client.on_volume_state_event = MagicMock()
         client.on_media_state_event = MagicMock()
         client.on_todo_event = MagicMock()
+        client.on_notification_event = MagicMock()
 
         async def _start_http2_processing(*_args, **_kwargs) -> asyncio.Task[None]:
             async def _completed_task() -> None:

--- a/tests/components/alexa_devices/test_coordinator.py
+++ b/tests/components/alexa_devices/test_coordinator.py
@@ -1,12 +1,16 @@
 """Tests for the Alexa Devices coordinator."""
 
+from copy import deepcopy
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock
 
+from aioamazondevices.const.schedules import NOTIFICATION_TIMER
 from aioamazondevices.exceptions import (
     CannotAuthenticate,
     CannotConnect,
     CannotRetrieveData,
 )
+from aioamazondevices.structures import AmazonSchedule
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
@@ -213,3 +217,40 @@ async def test_sync_media_state_auth_failed(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is expected_state
+
+
+async def test_notification_event_handler_updates_sensors(
+    hass: HomeAssistant,
+    mock_amazon_devices_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that on_notification_event updates timer/alarm/reminder sensor entities."""
+    await setup_integration(hass, mock_config_entry)
+
+    # Timer sensor starts with no next_occurrence (state is unknown/None)
+    timer_entity_id = "sensor.echo_test_timer"
+    assert hass.states.get(timer_entity_id) is not None
+
+    # Retrieve the notification event handler registered by the coordinator
+    on_notification_event = mock_amazon_devices_client.on_notification_event
+    on_notification_event.append.assert_called_once()
+    notification_handler = on_notification_event.append.call_args.args[0]
+
+    # Build updated device with a timer that now has a next_occurrence
+    timer_occurrence = datetime(2026, 7, 21, 19, 11, 0, tzinfo=UTC)
+    updated_device = deepcopy(TEST_DEVICE_1)
+    updated_device.notifications[NOTIFICATION_TIMER] = AmazonSchedule(
+        type=NOTIFICATION_TIMER,
+        status="ON",
+        label="1 minute timer",
+        next_occurrence=timer_occurrence,
+    )
+
+    # Fire the push event as the library would
+    await notification_handler({TEST_DEVICE_1_SN: updated_device})
+    await hass.async_block_till_done()
+
+    # Timer sensor should now reflect the updated next_occurrence
+    state = hass.states.get(timer_entity_id)
+    assert state is not None
+    assert state.state == timer_occurrence.isoformat()


### PR DESCRIPTION
## Breaking change

No breaking change.

## Proposed change

Wire up the new `on_notification_event` signal introduced in `aioamazondevices` ([chemelli74/aioamazondevices#984](https://github.com/chemelli74/aioamazondevices/pull/984)) so that **timer, alarm, and reminder sensor entities update immediately** when Amazon delivers a `PUSH_NOTIFICATION_CHANGE` push event over the persistent HTTP/2 connection, rather than waiting for the next scheduled `DataUpdateCoordinator` poll (default: 5 minutes).

### Root cause

Amazon sends `PUSH_NOTIFICATION_CHANGE` whenever a timer, alarm, or reminder is created, updated, or deleted on a device. Before this fix, the `aioamazondevices` library recognised the event type (it is defined as `AmazonPushMessage.NotificationChange`) and correctly filtered duplicate versions, but had no handler for it — the event fell through to an `"Unhandled push event type"` debug log. On the HA side, `AmazonDevicesCoordinator` had no listener registered either.

After [chemelli74/aioamazondevices#984](https://github.com/chemelli74/aioamazondevices/pull/984) the library exposes an `on_notification_event` signal (same pattern as `on_volume_state_event`, `on_history_event`, etc.). This PR adds the corresponding listener in `AmazonDevicesCoordinator`.

### Changes

`coordinator.py`:
- Register `notification_event_handler` on `api.on_notification_event` and freeze the signal (same pattern as all other push-event handlers already present).
- `notification_event_handler` receives the updated `dict[str, AmazonDevice]` and calls `self.async_set_updated_data(devices)`.

`tests/components/alexa_devices/conftest.py`:
- Add `client.on_notification_event = MagicMock()` to the shared fixture so the coordinator can register its handler during test setup.

`tests/components/alexa_devices/test_coordinator.py`:
- Add `test_notification_event_handler_updates_sensors`: fires the registered notification handler with an updated device (1-minute timer with a `next_occurrence`) and asserts that the `sensor.echo_test_timer` entity state changes immediately.

### Log evidence (Home Assistant 2026.7.2 / aioamazondevices 14.1.9)

Captured at the moment a 1-minute timer was set by voice on an Echo device (2026-07-21 ~19:10 Europe/Rome):

```
2026-07-21 19:10:56.675 DEBUG [aioamazondevices] Detected push event type <PUSH_NOTIFICATION_CHANGE> on device <G090XG09002303Q0>
2026-07-21 19:10:56.675 DEBUG [aioamazondevices] Event - PUSH_NOTIFICATION_CHANGE : Payload - {
  'dopplerId': {'deviceSerialNumber': 'G090XG09002303Q0', 'deviceType': 'A1RABVCI4QCIKC'},
  'notificationId': '9bac1c2e-07e0-396f-8af6-d1c5f13dcd55',
  'notificationVersion': 3,
  'eventType': 'UPDATE',
  'destinationUserId': 'A25O4ECFICAYDB'
}
2026-07-21 19:10:56.675 DEBUG [aioamazondevices] Unhandled push event type: PUSH_NOTIFICATION_CHANGE
```

Before the fix, the timer entity remained stale until the next 5-minute poll. After applying both this PR and [chemelli74/aioamazondevices#984](https://github.com/chemelli74/aioamazondevices/pull/984) to a live instance (HA 2026.7.2, aioamazondevices 14.1.9, Python 3.14, Echo device type `A1RABVCI4QCIKC`), the timer sensor updated immediately upon receiving the push event.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Build related changes
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Documentation

## Additional information

- This PR depends on [chemelli74/aioamazondevices#984](https://github.com/chemelli74/aioamazondevices/pull/984) being merged and released. The `manifest.json` version pin will be updated to the release that includes that PR once it is published to PyPI.
- Tested on a live Home Assistant 2026.7.2 instance (Proxmox / HAOS) with an Echo Dot (device type `A1RABVCI4QCIKC`).

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] There is no commented out code in this PR
- [x] I have followed the [development checklist](https://developers.home-assistant.io/docs/development_checklist/)
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works
- [x] If the code communicates with devices, a communication log is provided (not applicable — this is a coordinator change only)