### PR TITLE
Add ScorpionTrack speed sensor

### DIFF
--- a/homeassistant/components/scorpiontrack/const.py
+++ b/homeassistant/components/scorpiontrack/const.py
@@ -12,4 +12,4 @@ CONF_SHARE_TOKEN = "share_token"
 
 DEFAULT_SCAN_INTERVAL = timedelta(minutes=2)
 
-PLATFORMS: tuple[Platform, ...] = (Platform.DEVICE_TRACKER,)
+PLATFORMS: tuple[Platform, ...] = (Platform.DEVICE_TRACKER, Platform.SENSOR)

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -1,0 +1,68 @@
+"""Sensor platform for ScorpionTrack."""
+
+from typing import override
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.const import UnitOfSpeed
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import ScorpionTrackConfigEntry, ScorpionTrackCoordinator
+from .entity import ScorpionTrackEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ScorpionTrackConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up ScorpionTrack speed sensors."""
+    coordinator = entry.runtime_data
+    async_add_entities(
+        ScorpionTrackSpeedSensor(coordinator, vehicle.id)
+        for vehicle in coordinator.data.vehicles
+    )
+
+
+class ScorpionTrackSpeedSensor(ScorpionTrackEntity, SensorEntity):
+    """Represent the latest shared vehicle speed."""
+
+    _attr_device_class = SensorDeviceClass.SPEED
+    _attr_native_unit_of_measurement = UnitOfSpeed.KILOMETERS_PER_HOUR
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 1
+    _attr_translation_key = "speed"
+
+    def __init__(self, coordinator: ScorpionTrackCoordinator, vehicle_id: int) -> None:
+        """Initialize the speed sensor."""
+        super().__init__(coordinator, vehicle_id)
+        self._attr_unique_id = f"{coordinator.data.id}_{vehicle_id}_speed"
+        self._attr_suggested_unit_of_measurement = (
+            UnitOfSpeed.MILES_PER_HOUR
+            if coordinator.data.uses_miles
+            else UnitOfSpeed.KILOMETERS_PER_HOUR
+        )
+
+    def _available_speed(self) -> float | None:
+        """Return the speed if the sensor is available."""
+        if not super().available:
+            return None
+        return self.get_vehicle().position.speed_kmh
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return if the speed sensor is available."""
+        return self._available_speed() is not None
+
+    @property
+    @override
+    def native_value(self) -> float | None:
+        """Return the speed in kilometres per hour."""
+        return self._available_speed()

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -50,15 +50,13 @@ class ScorpionTrackSpeedSensor(ScorpionTrackEntity, SensorEntity):
 
     def _available_speed(self) -> float | None:
         """Return the speed if the sensor is available."""
-        if not super().available:
-            return None
         return self.get_vehicle().position.speed_kmh
 
     @property
     @override
     def available(self) -> bool:
         """Return if the speed sensor is available."""
-        return self._available_speed() is not None
+        return super().available and self._available_speed() is not None
 
     @property
     @override

--- a/homeassistant/components/scorpiontrack/sensor.py
+++ b/homeassistant/components/scorpiontrack/sensor.py
@@ -37,7 +37,6 @@ class ScorpionTrackSpeedSensor(ScorpionTrackEntity, SensorEntity):
     _attr_native_unit_of_measurement = UnitOfSpeed.KILOMETERS_PER_HOUR
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 1
-    _attr_translation_key = "speed"
 
     def __init__(self, coordinator: ScorpionTrackCoordinator, vehicle_id: int) -> None:
         """Initialize the speed sensor."""

--- a/homeassistant/components/scorpiontrack/strings.json
+++ b/homeassistant/components/scorpiontrack/strings.json
@@ -22,6 +22,13 @@
       }
     }
   },
+  "entity": {
+    "sensor": {
+      "speed": {
+        "name": "Speed"
+      }
+    }
+  },
   "exceptions": {
     "cannot_connect": {
       "message": "The ScorpionTrack share could not be reached right now."

--- a/homeassistant/components/scorpiontrack/strings.json
+++ b/homeassistant/components/scorpiontrack/strings.json
@@ -22,13 +22,6 @@
       }
     }
   },
-  "entity": {
-    "sensor": {
-      "speed": {
-        "name": "Speed"
-      }
-    }
-  },
   "exceptions": {
     "cannot_connect": {
       "message": "The ScorpionTrack share could not be reached right now."

--- a/tests/components/scorpiontrack/snapshots/test_sensor.ambr
+++ b/tests/components/scorpiontrack/snapshots/test_sensor.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_speed_sensor_snapshot[sensor.ab12_cde_speed-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.ab12_cde_speed',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Speed',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.SPEED: 'speed'>,
+    'original_icon': None,
+    'original_name': 'Speed',
+    'platform': 'scorpiontrack',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'speed',
+    'unique_id': '101_1_speed',
+    'unit_of_measurement': <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
+  })
+# ---
+# name: test_speed_sensor_snapshot[sensor.ab12_cde_speed-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'speed',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'AB12 CDE Speed',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.ab12_cde_speed',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '30.0122285850632',
+  })
+# ---

--- a/tests/components/scorpiontrack/snapshots/test_sensor.ambr
+++ b/tests/components/scorpiontrack/snapshots/test_sensor.ambr
@@ -39,7 +39,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'speed',
+    'translation_key': None,
     'unique_id': '101_1_speed',
     'unit_of_measurement': <UnitOfSpeed.MILES_PER_HOUR: 'mph'>,
   })

--- a/tests/components/scorpiontrack/test_device_tracker.py
+++ b/tests/components/scorpiontrack/test_device_tracker.py
@@ -1,14 +1,14 @@
 """Test the ScorpionTrack device tracker platform."""
 
 from dataclasses import replace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 from pyscorpiontrack import ScorpionTrackConnectionError, ScorpionTrackShare
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL
-from homeassistant.const import STATE_UNAVAILABLE
+from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -24,7 +24,10 @@ async def test_device_tracker_state(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the ScorpionTrack device tracker state and attributes."""
-    await setup_integration(hass, mock_config_entry)
+    with patch(
+        "homeassistant.components.scorpiontrack.PLATFORMS", (Platform.DEVICE_TRACKER,)
+    ):
+        await setup_integration(hass, mock_config_entry)
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 

--- a/tests/components/scorpiontrack/test_sensor.py
+++ b/tests/components/scorpiontrack/test_sensor.py
@@ -1,0 +1,153 @@
+"""Test the ScorpionTrack sensor platform."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock, patch
+
+from freezegun.api import FrozenDateTimeFactory
+from pyscorpiontrack import ScorpionTrackShare
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.scorpiontrack.const import DEFAULT_SCAN_INTERVAL
+from homeassistant.const import (
+    ATTR_LATITUDE,
+    ATTR_LONGITUDE,
+    ATTR_UNIT_OF_MEASUREMENT,
+    STATE_UNAVAILABLE,
+    Platform,
+    UnitOfSpeed,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
+
+ENTITY_ID = "sensor.ab12_cde_speed"
+
+
+async def test_speed_sensor_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test the speed sensor uses the coordinator snapshot."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert float(state.state) == pytest.approx(48.3 * 0.621371192237334)
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfSpeed.MILES_PER_HOUR
+    assert ATTR_LATITUDE not in state.attributes
+    assert ATTR_LONGITUDE not in state.attributes
+    mock_scorpiontrack_client.async_get_share.assert_awaited_once_with()
+
+
+async def test_speed_sensor_snapshot(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test the speed sensor entity and state attributes."""
+    with patch("homeassistant.components.scorpiontrack.PLATFORMS", (Platform.SENSOR,)):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_speed_sensor_metric_display(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test a metric share suggests kilometres per hour."""
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, distance_units="kilometres"
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == "48.3"
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfSpeed.KILOMETERS_PER_HOUR
+
+
+@pytest.mark.parametrize(
+    ("speed_kmh", "expected_state"),
+    [
+        pytest.param(0.0, "0.0", id="zero"),
+        pytest.param(None, STATE_UNAVAILABLE, id="missing"),
+    ],
+)
+async def test_speed_sensor_availability(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+    speed_kmh: float | None,
+    expected_state: str,
+) -> None:
+    """Test zero is valid and missing speed is unavailable."""
+    vehicle = mock_share.vehicles[0]
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share,
+        vehicles=(
+            replace(
+                vehicle,
+                position=replace(vehicle.position, speed_kmh=speed_kmh),
+            ),
+        ),
+    )
+
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == expected_state
+
+
+async def test_removed_vehicle_makes_speed_sensor_unavailable(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_config_entry: MockConfigEntry,
+    mock_share: ScorpionTrackShare,
+    mock_scorpiontrack_client: AsyncMock,
+) -> None:
+    """Test a speed sensor becomes unavailable if its vehicle leaves the share."""
+    await setup_integration(hass, mock_config_entry)
+
+    mock_scorpiontrack_client.async_get_share.return_value = replace(
+        mock_share, vehicles=()
+    )
+    freezer.tick(DEFAULT_SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_speed_sensor_uses_existing_vehicle_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the speed sensor shares the vehicle device with the tracker."""
+    await setup_integration(hass, mock_config_entry)
+
+    speed_entry = entity_registry.async_get(ENTITY_ID)
+    tracker_entry = entity_registry.async_get("device_tracker.ab12_cde")
+    assert speed_entry is not None
+    assert tracker_entry is not None
+    assert speed_entry.device_id == tracker_entry.device_id
+    assert speed_entry.device_id is not None
+
+    device = device_registry.async_get(speed_entry.device_id)
+    assert device is not None
+    assert device.identifiers == {("scorpiontrack", "101_1")}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This adds one Speed sensor for each vehicle in a ScorpionTrack share. The value
comes from the integration's existing coordinator update, so the sensor does
not make another request.

pyscorpiontrack provides the native value in km/h. The share's miles or metric
preference is used as Home Assistant's suggested display unit, so Home
Assistant can display mph or km/h and the user can still change the unit in the
entity settings.

The existing device tracker and map coordinates are unchanged, and the
integration continues to update every two minutes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46976
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
