### PR TITLE
fix: close httpx clients created during config entry setup on entry unload

### DIFF
--- a/homeassistant/helpers/httpx_client.py
+++ b/homeassistant/helpers/httpx_client.py
@@ -10,6 +10,7 @@ from typing import Any, Self, override
 import httpcore  # noqa: F401
 import httpx
 
+from homeassistant import config_entries
 from homeassistant.const import APPLICATION_NAME, EVENT_HOMEASSISTANT_CLOSE, __version__
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.util.hass_dict import HassKey
@@ -58,8 +59,11 @@ def get_async_client(
     clients = hass.data.setdefault(DATA_ASYNC_CLIENT, {})
 
     if (client := clients.get(client_key)) is None:
-        client = clients[client_key] = create_async_httpx_client(
-            hass, verify_ssl, alpn_protocols=alpn_protocols
+        client = clients[client_key] = _create_async_httpx_client(
+            hass,
+            verify_ssl,
+            auto_cleanup_method=_async_register_default_async_client_shutdown,
+            alpn_protocols=alpn_protocols,
         )
 
     return client
@@ -94,14 +98,43 @@ def create_async_httpx_client(
 ) -> httpx.AsyncClient:
     """Create a new httpx.AsyncClient with kwargs, i.e. for cookies.
 
-    If auto_cleanup is False, the client will be
-    automatically closed on homeassistant_stop.
+    If auto_cleanup is False, the client will not be closed automatically.
+    Default is True: the client will be automatically closed on
+    homeassistant_close or, when created during config entry setup, when the
+    config entry is unloaded.
 
     Pass alpn_protocols=SSL_ALPN_HTTP11_HTTP2 for HTTP/2 support (automatically
     enables httpx http2 mode).
 
     This method must be run in the event loop.
     """
+    auto_cleanup_method = None
+    if auto_cleanup:
+        auto_cleanup_method = _async_register_async_client_shutdown
+
+    return _create_async_httpx_client(
+        hass,
+        verify_ssl,
+        auto_cleanup_method=auto_cleanup_method,
+        ssl_cipher_list=ssl_cipher_list,
+        alpn_protocols=alpn_protocols,
+        **kwargs,
+    )
+
+
+@callback
+def _create_async_httpx_client(
+    hass: HomeAssistant,
+    verify_ssl: bool = True,
+    auto_cleanup_method: Callable[
+        [HomeAssistant, Callable[[], Coroutine[Any, Any, None]]], None
+    ]
+    | None = None,
+    ssl_cipher_list: SSLCipherList = SSLCipherList.PYTHON_DEFAULT,
+    alpn_protocols: SSLALPNProtocols = SSL_ALPN_HTTP11,
+    **kwargs: Any,
+) -> httpx.AsyncClient:
+    """Create a new httpx.AsyncClient with kwargs, i.e. for cookies."""
     # Use the requested ALPN protocols directly to ensure proper SSL context
     # bucketing. httpx/httpcore mutates SSL contexts by calling set_alpn_protocols(),
     # so we pre-set the correct protocols to prevent shared context corruption.
@@ -129,8 +162,8 @@ def create_async_httpx_client(
         client.aclose, "closes the Home Assistant httpx client"
     )
 
-    if auto_cleanup:
-        _async_register_async_client_shutdown(hass, client, original_aclose)
+    if auto_cleanup_method:
+        auto_cleanup_method(hass, original_aclose)
 
     return client
 
@@ -138,10 +171,32 @@ def create_async_httpx_client(
 @callback
 def _async_register_async_client_shutdown(
     hass: HomeAssistant,
-    client: httpx.AsyncClient,
     original_aclose: Callable[[], Coroutine[Any, Any, None]],
 ) -> None:
-    """Register httpx AsyncClient aclose on Home Assistant shutdown.
+    """Register httpx AsyncClient aclose on Home Assistant shutdown or config entry unload.
+
+    This method must be run in the event loop.
+    """
+
+    async def _async_close_client(*_: Any) -> None:
+        """Close httpx client."""
+        await original_aclose()
+
+    unsub = hass.bus.async_listen_once(EVENT_HOMEASSISTANT_CLOSE, _async_close_client)
+
+    if not (config_entry := config_entries.current_entry.get()):
+        return
+
+    config_entry.async_on_unload(unsub)
+    config_entry.async_on_unload(_async_close_client)
+
+
+@callback
+def _async_register_default_async_client_shutdown(
+    hass: HomeAssistant,
+    original_aclose: Callable[[], Coroutine[Any, Any, None]],
+) -> None:
+    """Register default httpx AsyncClient aclose on Home Assistant shutdown.
 
     This method must be run in the event loop.
     """

--- a/tests/helpers/test_httpx_client.py
+++ b/tests/helpers/test_httpx_client.py
@@ -1,16 +1,40 @@
 """Test the httpx client helper."""
 
-from unittest.mock import Mock, patch
+from collections.abc import Callable, Generator
+from functools import partial
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
 
+from homeassistant.config_entries import ConfigEntry, ConfigEntryState
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import httpx_client as client
 from homeassistant.util.ssl import SSL_ALPN_HTTP11, SSL_ALPN_HTTP11_HTTP2
 
-from tests.common import MockModule, extract_stack_to_frame, mock_integration
+from tests.common import (
+    MockConfigEntry,
+    MockModule,
+    extract_stack_to_frame,
+    mock_config_flow,
+    mock_integration,
+    mock_platform,
+)
+
+
+@pytest.fixture
+def mock_comp_flow() -> Generator[None]:
+    """Mock a config flow for the comp integration."""
+
+    class MockConfigFlow:
+        """Mock the comp config flow."""
+
+        VERSION = 1
+        MINOR_VERSION = 1
+
+    with mock_config_flow("comp", MockConfigFlow):
+        yield
 
 
 async def test_get_async_client_with_ssl(hass: HomeAssistant) -> None:
@@ -296,3 +320,125 @@ async def test_warning_close_session_custom(
         "at custom_components/hue/light.py, line 23: await session.aclose(). "
         "Please report it to the author of the 'hue' custom integration"
     ) in caplog.text
+
+
+@pytest.mark.parametrize(
+    (
+        "client_factory",
+        "listener_delta_after_setup",
+        "closed_after_unload",
+        "listener_delta_after_unload",
+        "closed_after_close_event",
+    ),
+    [
+        pytest.param(
+            client.create_async_httpx_client, 1, True, 0, True, id="created_client"
+        ),
+        pytest.param(client.get_async_client, 1, False, 1, True, id="shared_client"),
+        pytest.param(
+            partial(client.create_async_httpx_client, auto_cleanup=False),
+            0,
+            False,
+            0,
+            False,
+            id="no_auto_cleanup",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_comp_flow")
+async def test_httpx_client_cleanup_on_entry_unload(
+    hass: HomeAssistant,
+    client_factory: Callable[[HomeAssistant], httpx.AsyncClient],
+    listener_delta_after_setup: int,
+    closed_after_unload: bool,
+    listener_delta_after_unload: int,
+    closed_after_close_event: bool,
+) -> None:
+    """Test cleanup of a client created during config entry setup."""
+    baseline = hass.bus.async_listeners().get(EVENT_HOMEASSISTANT_CLOSE, 0)
+    created: list[httpx.AsyncClient] = []
+
+    async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        created.append(client_factory(hass))
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+    entry = MockConfigEntry(domain="comp")
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+    assert (
+        hass.bus.async_listeners().get(EVENT_HOMEASSISTANT_CLOSE, 0)
+        == baseline + listener_delta_after_setup
+    )
+    assert not created[0].is_closed
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert created[0].is_closed is closed_after_unload
+    assert (
+        hass.bus.async_listeners().get(EVENT_HOMEASSISTANT_CLOSE, 0)
+        == baseline + listener_delta_after_unload
+    )
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+    assert created[0].is_closed is closed_after_close_event
+
+
+@pytest.mark.usefixtures("mock_comp_flow")
+async def test_get_async_client_survives_entry_unload(hass: HomeAssistant) -> None:
+    """Test the shared client is not entry-bound even when first created in setup."""
+    shared: list[httpx.AsyncClient] = []
+
+    async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+        shared.append(client.get_async_client(hass))
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp",
+            async_setup_entry=async_setup_entry,
+            async_unload_entry=AsyncMock(return_value=True),
+        ),
+    )
+    mock_platform(hass, "comp.config_flow", None)
+    entry = MockConfigEntry(domain="comp")
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.LOADED
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert shared[0] is hass.data[client.DATA_ASYNC_CLIENT][(True, SSL_ALPN_HTTP11)]
+    assert not shared[0].is_closed
+    assert client.get_async_client(hass) is shared[0]
+
+
+async def test_create_async_httpx_client_outside_entry_cleanup(
+    hass: HomeAssistant,
+) -> None:
+    """Test a client created outside entry setup is closed on homeassistant_close."""
+    baseline = hass.bus.async_listeners().get(EVENT_HOMEASSISTANT_CLOSE, 0)
+
+    httpx_client = client.create_async_httpx_client(hass)
+    assert hass.bus.async_listeners().get(EVENT_HOMEASSISTANT_CLOSE, 0) == baseline + 1
+    assert not httpx_client.is_closed
+
+    hass.bus.async_fire(EVENT_HOMEASSISTANT_CLOSE)
+    await hass.async_block_till_done()
+    assert httpx_client.is_closed


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR resolves a memory leak Copilot was very very insistent about in https://github.com/home-assistant/core/pull/169689.

In particular, we have 3 integrations - `wolflink`, `discovergy` and `mcp` (and maybe four if the PR above is accepted: `glances`) which manually instantiate an httpx client. By default, these clients are kept around even after the integrations are unloaded, which is a memory leak risk. I'm not familiar enough with the codebase to assess if that's really a big deal or not, but here's the PR if that's something we should pay attention to.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
