### PR TITLE
Improve Spotify refresh-token reauth handling

### DIFF
--- a/homeassistant/components/spotify/__init__.py
+++ b/homeassistant/components/spotify/__init__.py
@@ -7,7 +7,11 @@ from spotifyaio import SpotifyClient
 
 from homeassistant.const import CONF_ACCESS_TOKEN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -53,6 +57,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: SpotifyConfigEntry) -> b
 
     try:
         await session.async_ensure_token_valid()
+    except OAuth2TokenRequestReauthError as err:
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="oauth2_token_reauth_required",
+        ) from err
     except aiohttp.ClientError as err:
         raise ConfigEntryNotReady from err
 
@@ -61,7 +70,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: SpotifyConfigEntry) -> b
     spotify.authenticate(session.token[CONF_ACCESS_TOKEN])
 
     async def _refresh_token() -> str:
-        await session.async_ensure_token_valid()
+        try:
+            await session.async_ensure_token_valid()
+        except OAuth2TokenRequestReauthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="oauth2_token_reauth_required",
+            ) from err
         token = session.token[CONF_ACCESS_TOKEN]
         if TYPE_CHECKING:
             assert isinstance(token, str)

--- a/homeassistant/components/spotify/config_flow.py
+++ b/homeassistant/components/spotify/config_flow.py
@@ -53,12 +53,20 @@ class SpotifyFlowHandler(
 
         await self.async_set_unique_id(current_user.user_id)
 
+        # Store user ID and auth implementation for reauth flow
+        entry_data = {
+            **data,
+            CONF_NAME: name,
+            "id": current_user.user_id,
+            "auth_implementation": data["auth_implementation"],
+        }
+
         if self.source == SOURCE_REAUTH:
             self._abort_if_unique_id_mismatch(reason="reauth_account_mismatch")
             return self.async_update_reload_and_abort(
-                self._get_reauth_entry(), title=name, data=data
+                self._get_reauth_entry(), title=name, data=entry_data
             )
-        return self.async_create_entry(title=name, data={**data, CONF_NAME: name})
+        return self.async_create_entry(title=name, data=entry_data)
 
     async def async_step_reauth(
         self, entry_data: Mapping[str, Any]
@@ -74,7 +82,7 @@ class SpotifyFlowHandler(
         if user_input is None:
             return self.async_show_form(
                 step_id="reauth_confirm",
-                description_placeholders={"account": reauth_entry.data["id"]},
+                description_placeholders={"account": reauth_entry.title},
                 errors={},
             )
 

--- a/homeassistant/components/spotify/coordinator.py
+++ b/homeassistant/components/spotify/coordinator.py
@@ -19,7 +19,11 @@ from spotifyaio import (
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import (
+    ConfigEntryAuthFailed,
+    ConfigEntryError,
+    OAuth2TokenRequestReauthError,
+)
 from homeassistant.helpers.config_entry_oauth2_flow import OAuth2Session
 from homeassistant.helpers.issue_registry import IssueSeverity, async_create_issue
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -95,6 +99,11 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
         """Set up the coordinator."""
         try:
             self.current_user = await self.client.get_current_user()
+        except OAuth2TokenRequestReauthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="oauth2_token_reauth_required",
+            ) from err
         except SpotifyForbiddenError as err:
             async_create_issue(
                 self.hass,
@@ -116,6 +125,11 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
         self.update_interval = UPDATE_INTERVAL
         try:
             current = await self.client.get_playback()
+        except OAuth2TokenRequestReauthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="oauth2_token_reauth_required",
+            ) from err
         except SpotifyConnectionError as err:
             raise UpdateFailed("Error communicating with Spotify API") from err
         if not current:
@@ -147,6 +161,11 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
                     # playback state update
                     try:
                         self._playlist = await self.client.get_playlist(context.uri)
+                    except OAuth2TokenRequestReauthError as err:
+                        raise ConfigEntryAuthFailed(
+                            translation_domain=DOMAIN,
+                            translation_key="oauth2_token_reauth_required",
+                        ) from err
                     except SpotifyNotFoundError:
                         _LOGGER.debug(
                             "Spotify playlist '%s' not found. "
@@ -202,5 +221,10 @@ class SpotifyDeviceCoordinator(DataUpdateCoordinator[list[Device]]):
     async def _async_update_data(self) -> list[Device]:
         try:
             return await self._client.get_devices()
+        except OAuth2TokenRequestReauthError as err:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="oauth2_token_reauth_required",
+            ) from err
         except SpotifyConnectionError as err:
             raise UpdateFailed from err

--- a/homeassistant/components/spotify/coordinator.py
+++ b/homeassistant/components/spotify/coordinator.py
@@ -5,7 +5,6 @@ from datetime import datetime, timedelta
 import logging
 from typing import override
 
-from mashumaro.exceptions import MissingField
 from spotifyaio import (
     ContextType,
     Device,
@@ -126,8 +125,6 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
         self.update_interval = UPDATE_INTERVAL
         try:
             current = await self.client.get_playback()
-        except MissingField as err:
-            raise UpdateFailed("Error parsing Spotify playback response") from err
         except OAuth2TokenRequestReauthError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
@@ -224,8 +221,6 @@ class SpotifyDeviceCoordinator(DataUpdateCoordinator[list[Device]]):
     async def _async_update_data(self) -> list[Device]:
         try:
             return await self._client.get_devices()
-        except MissingField as err:
-            raise UpdateFailed("Error parsing Spotify devices response") from err
         except OAuth2TokenRequestReauthError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/spotify/coordinator.py
+++ b/homeassistant/components/spotify/coordinator.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import override
 
+from mashumaro.exceptions import MissingField
 from spotifyaio import (
     ContextType,
     Device,
@@ -125,6 +126,8 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
         self.update_interval = UPDATE_INTERVAL
         try:
             current = await self.client.get_playback()
+        except MissingField as err:
+            raise UpdateFailed("Error parsing Spotify playback response") from err
         except OAuth2TokenRequestReauthError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
@@ -221,6 +224,8 @@ class SpotifyDeviceCoordinator(DataUpdateCoordinator[list[Device]]):
     async def _async_update_data(self) -> list[Device]:
         try:
             return await self._client.get_devices()
+        except MissingField as err:
+            raise UpdateFailed("Error parsing Spotify devices response") from err
         except OAuth2TokenRequestReauthError as err:
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,

--- a/homeassistant/components/spotify/strings.json
+++ b/homeassistant/components/spotify/strings.json
@@ -42,7 +42,7 @@
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
     },
     "oauth2_token_reauth_required": {
-      "message": "[%key:common::exceptions::oauth2_token_reauth_required::message%]"
+      "message": "[%key:component::homeassistant::exceptions::oauth2_helper_reauth_required::message%]"
     }
   },
   "issues": {

--- a/homeassistant/components/spotify/strings.json
+++ b/homeassistant/components/spotify/strings.json
@@ -40,6 +40,9 @@
   "exceptions": {
     "oauth2_implementation_unavailable": {
       "message": "[%key:common::exceptions::oauth2_implementation_unavailable::message%]"
+    },
+    "oauth2_token_reauth_required": {
+      "message": "[%key:common::exceptions::oauth2_token_reauth_required::message%]"
     }
   },
   "issues": {

--- a/tests/components/spotify/test_init.py
+++ b/tests/components/spotify/test_init.py
@@ -6,8 +6,9 @@ import pytest
 from spotifyaio import SpotifyConnectionError, SpotifyForbiddenError
 
 from homeassistant.components.spotify.const import DOMAIN
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import OAuth2TokenRequestReauthError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
@@ -16,6 +17,11 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 from . import setup_integration
 
 from tests.common import MockConfigEntry
+
+
+def _oauth_token_reauth_error() -> OAuth2TokenRequestReauthError:
+    """Create a token reauth error for tests."""
+    return OAuth2TokenRequestReauthError(domain=DOMAIN, request_info=MagicMock())
 
 
 @pytest.mark.usefixtures("setup_credentials")
@@ -92,3 +98,38 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("setup_credentials")
+@pytest.mark.parametrize(
+    "method",
+    [
+        "get_current_user",
+        "get_playback",
+        "get_devices",
+    ],
+)
+async def test_oauth_token_expiration_triggers_reauth(
+    hass: HomeAssistant,
+    mock_spotify: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    method: str,
+) -> None:
+    """Test that token reauth failures trigger a config-entry reauth flow."""
+    getattr(mock_spotify.return_value, method).side_effect = _oauth_token_reauth_error()
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    flow = flows[0]
+    assert flow["step_id"] == "reauth_confirm"
+    assert flow["handler"] == DOMAIN
+    assert flow["context"]["source"] == SOURCE_REAUTH
+    assert flow["context"]["entry_id"] == mock_config_entry.entry_id
+
+

--- a/tests/components/spotify/test_media_player.py
+++ b/tests/components/spotify/test_media_player.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
-from mashumaro.exceptions import MissingField
 import pytest
 from spotifyaio import (
     PlaybackState,
@@ -59,13 +58,6 @@ from tests.common import (
     async_load_fixture,
     snapshot_platform,
 )
-
-
-def _missing_field_error() -> MissingField:
-    """Create a MissingField error for parser failure tests."""
-    err = MissingField.__new__(MissingField)
-    Exception.__init__(err, "missing field")
-    return err
 
 
 @pytest.mark.usefixtures("setup_credentials")
@@ -553,19 +545,11 @@ async def test_select_source(
 
 
 @pytest.mark.usefixtures("setup_credentials")
-@pytest.mark.parametrize(
-    "get_devices_error",
-    [
-        SpotifyConnectionError,
-        _missing_field_error(),
-    ],
-)
 async def test_source_devices(
     hass: HomeAssistant,
     mock_spotify: MagicMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
-    get_devices_error: Exception,
 ) -> None:
     """Test the Spotify media player available source devices."""
     await setup_integration(hass, mock_config_entry)
@@ -573,7 +557,7 @@ async def test_source_devices(
 
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["DESKTOP-BKC5SIK"]
 
-    mock_spotify.return_value.get_devices.side_effect = get_devices_error
+    mock_spotify.return_value.get_devices.side_effect = SpotifyConnectionError
     freezer.tick(timedelta(minutes=5))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -582,30 +566,6 @@ async def test_source_devices(
     assert state
     assert state.state != STATE_UNAVAILABLE
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["DESKTOP-BKC5SIK"]
-
-
-@pytest.mark.usefixtures("setup_credentials")
-async def test_playback_missing_field_keeps_entity_available(
-    hass: HomeAssistant,
-    mock_spotify: MagicMock,
-    mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
-) -> None:
-    """Test playback parser errors do not make the media player unavailable."""
-    await setup_integration(hass, mock_config_entry)
-
-    state = hass.states.get("media_player.spotify_spotify_1")
-    assert state
-    assert state.state == MediaPlayerState.PLAYING
-
-    mock_spotify.return_value.get_playback.side_effect = _missing_field_error()
-    freezer.tick(timedelta(seconds=30))
-    async_fire_time_changed(hass)
-    await hass.async_block_till_done()
-
-    state = hass.states.get("media_player.spotify_spotify_1")
-    assert state
-    assert state.state == MediaPlayerState.PLAYING
 
 
 @pytest.mark.usefixtures("setup_credentials")

--- a/tests/components/spotify/test_media_player.py
+++ b/tests/components/spotify/test_media_player.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+from mashumaro.exceptions import MissingField
 import pytest
 from spotifyaio import (
     PlaybackState,
@@ -58,6 +59,13 @@ from tests.common import (
     async_load_fixture,
     snapshot_platform,
 )
+
+
+def _missing_field_error() -> MissingField:
+    """Create a MissingField error for parser failure tests."""
+    err = MissingField.__new__(MissingField)
+    Exception.__init__(err, "missing field")
+    return err
 
 
 @pytest.mark.usefixtures("setup_credentials")
@@ -545,11 +553,19 @@ async def test_select_source(
 
 
 @pytest.mark.usefixtures("setup_credentials")
+@pytest.mark.parametrize(
+    "get_devices_error",
+    [
+        SpotifyConnectionError,
+        _missing_field_error(),
+    ],
+)
 async def test_source_devices(
     hass: HomeAssistant,
     mock_spotify: MagicMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    get_devices_error: Exception,
 ) -> None:
     """Test the Spotify media player available source devices."""
     await setup_integration(hass, mock_config_entry)
@@ -557,7 +573,7 @@ async def test_source_devices(
 
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["DESKTOP-BKC5SIK"]
 
-    mock_spotify.return_value.get_devices.side_effect = SpotifyConnectionError
+    mock_spotify.return_value.get_devices.side_effect = get_devices_error
     freezer.tick(timedelta(minutes=5))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -566,6 +582,30 @@ async def test_source_devices(
     assert state
     assert state.state != STATE_UNAVAILABLE
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["DESKTOP-BKC5SIK"]
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_playback_missing_field_keeps_entity_available(
+    hass: HomeAssistant,
+    mock_spotify: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test playback parser errors do not make the media player unavailable."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("media_player.spotify_spotify_1")
+    assert state
+    assert state.state == MediaPlayerState.PLAYING
+
+    mock_spotify.return_value.get_playback.side_effect = _missing_field_error()
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.spotify_spotify_1")
+    assert state
+    assert state.state == MediaPlayerState.PLAYING
 
 
 @pytest.mark.usefixtures("setup_credentials")


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve Spotify auth failure handling by mapping refresh-token reauth failures to `ConfigEntryAuthFailed` with a translated key across setup and coordinators.

This also stores stable config-entry metadata (`id` and `auth_implementation`) needed during reauth updates, improves the reauth confirm placeholder, and adds coverage for refresh-token expiration flows.

Additionally, this includes handling for malformed Spotify API payloads (`mashumaro.exceptions.MissingField`) during playback and device refreshes so coordinator updates fail gracefully instead of surfacing unexpected traceback errors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176888
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr