### PR TITLE
Handle malformed Spotify playback/devices payloads

### DIFF
--- a/homeassistant/components/spotify/coordinator.py
+++ b/homeassistant/components/spotify/coordinator.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import override
 
+from mashumaro.exceptions import MissingField
 from spotifyaio import (
     ContextType,
     Device,
@@ -116,6 +117,8 @@ class SpotifyCoordinator(DataUpdateCoordinator[SpotifyCoordinatorData]):
         self.update_interval = UPDATE_INTERVAL
         try:
             current = await self.client.get_playback()
+        except MissingField as err:
+            raise UpdateFailed("Error parsing Spotify playback response") from err
         except SpotifyConnectionError as err:
             raise UpdateFailed("Error communicating with Spotify API") from err
         if not current:
@@ -202,5 +205,7 @@ class SpotifyDeviceCoordinator(DataUpdateCoordinator[list[Device]]):
     async def _async_update_data(self) -> list[Device]:
         try:
             return await self._client.get_devices()
+        except MissingField as err:
+            raise UpdateFailed("Error parsing Spotify devices response") from err
         except SpotifyConnectionError as err:
             raise UpdateFailed from err

--- a/tests/components/spotify/test_media_player.py
+++ b/tests/components/spotify/test_media_player.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
+from mashumaro.exceptions import MissingField
 import pytest
 from spotifyaio import (
     PlaybackState,
@@ -58,6 +59,13 @@ from tests.common import (
     async_load_fixture,
     snapshot_platform,
 )
+
+
+def _missing_field_error() -> MissingField:
+    """Create a MissingField error for parser failure tests."""
+    err = MissingField.__new__(MissingField)
+    Exception.__init__(err, "missing field")
+    return err
 
 
 @pytest.mark.usefixtures("setup_credentials")
@@ -545,11 +553,19 @@ async def test_select_source(
 
 
 @pytest.mark.usefixtures("setup_credentials")
+@pytest.mark.parametrize(
+    "get_devices_error",
+    [
+        SpotifyConnectionError,
+        _missing_field_error(),
+    ],
+)
 async def test_source_devices(
     hass: HomeAssistant,
     mock_spotify: MagicMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
+    get_devices_error: Exception,
 ) -> None:
     """Test the Spotify media player available source devices."""
     await setup_integration(hass, mock_config_entry)
@@ -557,7 +573,7 @@ async def test_source_devices(
 
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["DESKTOP-BKC5SIK"]
 
-    mock_spotify.return_value.get_devices.side_effect = SpotifyConnectionError
+    mock_spotify.return_value.get_devices.side_effect = get_devices_error
     freezer.tick(timedelta(minutes=5))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
@@ -566,6 +582,30 @@ async def test_source_devices(
     assert state
     assert state.state != STATE_UNAVAILABLE
     assert state.attributes[ATTR_INPUT_SOURCE_LIST] == ["DESKTOP-BKC5SIK"]
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_playback_missing_field_keeps_entity_available(
+    hass: HomeAssistant,
+    mock_spotify: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test playback parser errors do not make the media player unavailable."""
+    await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get("media_player.spotify_spotify_1")
+    assert state
+    assert state.state == MediaPlayerState.PLAYING
+
+    mock_spotify.return_value.get_playback.side_effect = _missing_field_error()
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.spotify_spotify_1")
+    assert state
+    assert state.state == MediaPlayerState.PLAYING
 
 
 @pytest.mark.usefixtures("setup_credentials")


### PR DESCRIPTION
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add targeted handling for `mashumaro.exceptions.MissingField` errors raised by `spotifyaio` parsing in coordinator updates:

- Playback coordinator: convert malformed playback payload parsing failures into `UpdateFailed`.
- Device coordinator: convert malformed devices payload parsing failures into `UpdateFailed`.

This avoids unhandled `MissingField` tracebacks and keeps the entity available while reusing the coordinator's existing error-recovery behavior.

Also add regression tests for malformed playback/devices payloads.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr