### PR TITLE
Stop conversation agent bloating exposed_entities with transient entities

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -37,6 +37,7 @@ from home_assistant_intents import (
 import yaml
 
 from homeassistant.components.homeassistant.exposed_entities import (
+    async_get_should_expose,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -878,7 +879,7 @@ class DefaultAgent(ConversationEntity):
         entity_registry = er.async_get(self.hass)
 
         for state in self.hass.states.async_all():
-            entity_exposed = async_should_expose(self.hass, DOMAIN, state.entity_id)
+            entity_exposed = async_get_should_expose(self.hass, DOMAIN, state.entity_id)
             if exposed and (not entity_exposed):
                 # Required exposed, entity is not
                 continue

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -197,15 +197,27 @@ async def async_setup_default_agent(
     await get_agent_manager(hass).async_setup_default_agent(agent)
 
     @callback
+    def async_freeze_exposure(entity_id: str) -> None:
+        """Persist the exposure of an entity, freezing it at its current default.
+
+        Entities without a registry entry are stored by entity_id in a store that
+        is never pruned, so freezing transient ones (e.g. geo_location) would
+        accumulate records forever. Their exposure is computed on demand instead.
+        """
+        if er.async_get(hass).async_get(entity_id) is None:
+            return
+        async_should_expose(hass, DOMAIN, entity_id)
+
+    @callback
     def async_entity_state_listener(event: Event[EventStateChangedData]) -> None:
         """Set expose flag on new entities."""
-        async_should_expose(hass, DOMAIN, event.data["entity_id"])
+        async_freeze_exposure(event.data["entity_id"])
 
     @callback
     def async_hass_started(hass: HomeAssistant) -> None:
         """Set expose flag on all entities."""
         for state in hass.states.async_all():
-            async_should_expose(hass, DOMAIN, state.entity_id)
+            async_freeze_exposure(state.entity_id)
         async_track_state_added_domain(hass, MATCH_ALL, async_entity_state_listener)
 
     ha_start.async_at_started(hass, async_hass_started)

--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -37,7 +37,7 @@ from home_assistant_intents import (
 import yaml
 
 from homeassistant.components.homeassistant.exposed_entities import (
-    async_get_should_expose,
+    async_calculate_should_expose,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -879,7 +879,9 @@ class DefaultAgent(ConversationEntity):
         entity_registry = er.async_get(self.hass)
 
         for state in self.hass.states.async_all():
-            entity_exposed = async_get_should_expose(self.hass, DOMAIN, state.entity_id)
+            entity_exposed = async_calculate_should_expose(
+                self.hass, DOMAIN, state.entity_id
+            )
             if exposed and (not entity_exposed):
                 # Required exposed, entity is not
                 continue

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -3,6 +3,7 @@
 from collections.abc import Callable, Mapping
 import dataclasses
 from itertools import chain
+import logging
 from typing import Any, TypedDict
 
 import voluptuous as vol
@@ -14,10 +15,13 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback, split_ent
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import get_device_class
+from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.storage import Store
 from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import DATA_EXPOSED_ENTITIES, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 KNOWN_ASSISTANTS = ("cloud.alexa", "cloud.google_assistant", "conversation")
 
@@ -122,6 +126,42 @@ class ExposedEntities:
         websocket_api.async_register_command(self._hass, ws_expose_new_entities_set)
         websocket_api.async_register_command(self._hass, ws_list_exposed_entities)
         await self._async_load_data()
+        async_at_started(self._hass, self._async_prune_legacy_entities)
+
+    @callback
+    def _async_prune_legacy_entities(self, hass: HomeAssistant) -> None:
+        """Remove auto-created settings for legacy entities that no longer exist.
+
+        Legacy entities (without a unique_id) are stored by entity_id and are
+        never cleaned up when the entity disappears. Transient entities such as
+        geo_location get a record auto-created every time one appears and can
+        accumulate indefinitely.
+
+        Only drop records for entities that no longer exist (neither a current
+        state nor in the entity registry) and that are not exposed to any
+        assistant, so an explicit "expose this entity" setting is never lost.
+        """
+        entity_registry = er.async_get(self._hass)
+        stale_entity_ids = [
+            entity_id
+            for entity_id, exposed_entity in self.entities.items()
+            if self._hass.states.get(entity_id) is None
+            and entity_id not in entity_registry.entities
+            and not any(
+                settings.get("should_expose")
+                for settings in exposed_entity.assistants.values()
+            )
+        ]
+        if not stale_entity_ids:
+            return
+
+        for entity_id in stale_entity_ids:
+            del self.entities[entity_id]
+
+        _LOGGER.debug(
+            "Pruned %s stale legacy exposed entity setting(s)", len(stale_entity_ids)
+        )
+        self._async_schedule_save()
 
     @callback
     def async_listen_entity_updates(
@@ -253,10 +293,9 @@ class ExposedEntities:
                 should_expose = registry_entry.options[assistant]["should_expose"]
                 return should_expose
 
-        if self.async_get_expose_new_entities(assistant):
-            should_expose = self._is_default_exposed(entity_id, registry_entry)
-        else:
-            should_expose = False
+        should_expose = self._async_compute_default_should_expose(
+            assistant, entity_id, registry_entry
+        )
 
         assistant_options: ReadOnlyDict[str, Any] | dict[str, Any]
         assistant_options = registry_entry.options.get(assistant, {})
@@ -266,6 +305,27 @@ class ExposedEntities:
         )
 
         return should_expose
+
+    @callback
+    def async_get_should_expose(self, assistant: str, entity_id: str) -> bool:
+        """Return True if an entity should be exposed, without persisting defaults."""
+        should_expose: bool
+
+        entity_registry = er.async_get(self._hass)
+        if registry_entry := entity_registry.async_get(entity_id):
+            options: Mapping[str, Any] = registry_entry.options.get(assistant, {})
+            if "should_expose" in options:
+                should_expose = options["should_expose"]
+                return should_expose
+            return self._async_compute_default_should_expose(
+                assistant, entity_id, registry_entry
+            )
+        if (
+            exposed_entity := self.entities.get(entity_id)
+        ) and "should_expose" in exposed_entity.assistants.get(assistant, {}):
+            should_expose = exposed_entity.assistants[assistant]["should_expose"]
+            return should_expose
+        return self._async_compute_default_should_expose(assistant, entity_id, None)
 
     def _async_should_expose_legacy_entity(
         self, assistant: str, entity_id: str
@@ -280,10 +340,9 @@ class ExposedEntities:
                 should_expose = exposed_entity.assistants[assistant]["should_expose"]
                 return should_expose
 
-        if self.async_get_expose_new_entities(assistant):
-            should_expose = self._is_default_exposed(entity_id, None)
-        else:
-            should_expose = False
+        should_expose = self._async_compute_default_should_expose(
+            assistant, entity_id, None
+        )
 
         if exposed_entity:
             new_exposed_entity = self._update_exposed_entity(
@@ -297,6 +356,15 @@ class ExposedEntities:
         self._async_schedule_save()
 
         return should_expose
+
+    @callback
+    def _async_compute_default_should_expose(
+        self, assistant: str, entity_id: str, registry_entry: er.RegistryEntry | None
+    ) -> bool:
+        """Compute default exposure for an entity without persisting it."""
+        if self.async_get_expose_new_entities(assistant):
+            return self._is_default_exposed(entity_id, registry_entry)
+        return False
 
     def _is_default_exposed(
         self, entity_id: str, registry_entry: er.RegistryEntry | None
@@ -516,6 +584,15 @@ def async_should_expose(hass: HomeAssistant, assistant: str, entity_id: str) -> 
     """Return True if an entity should be exposed to an assistant."""
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     return exposed_entities.async_should_expose(assistant, entity_id)
+
+
+@callback
+def async_get_should_expose(
+    hass: HomeAssistant, assistant: str, entity_id: str
+) -> bool:
+    """Return True if an entity should be exposed, without persisting defaults."""
+    exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
+    return exposed_entities.async_get_should_expose(assistant, entity_id)
 
 
 @callback

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -65,6 +65,10 @@ DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES = {
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
 }
 
+# Domains that can be exposed by default via their device class, so a stored
+# "should_expose: False" for one may be a user opt-out rather than noise.
+DEVICE_CLASS_EXPOSED_DOMAINS = {"binary_sensor", "sensor"}
+
 DEFAULT_EXPOSED_ASSISTANT = {
     "conversation": True,
 }
@@ -138,8 +142,8 @@ class ExposedEntities:
         accumulate indefinitely.
 
         Only drop records for entities that no longer exist (neither a current
-        state nor in the entity registry) and that are not exposed to any
-        assistant, so an explicit "expose this entity" setting is never lost.
+        state nor in the entity registry) and that carry no user intent, so an
+        explicit exposure choice is never lost.
         """
         entity_registry = er.async_get(self._hass)
         stale_entity_ids = [
@@ -147,10 +151,7 @@ class ExposedEntities:
             for entity_id, exposed_entity in self.entities.items()
             if self._hass.states.get(entity_id) is None
             and entity_id not in entity_registry.entities
-            and not any(
-                settings.get("should_expose")
-                for settings in exposed_entity.assistants.values()
-            )
+            and not self._legacy_entity_has_user_intent(entity_id, exposed_entity)
         ]
         if not stale_entity_ids:
             return
@@ -162,6 +163,29 @@ class ExposedEntities:
             "Pruned %s stale legacy exposed entity setting(s)", len(stale_entity_ids)
         )
         self._async_schedule_save()
+
+    @callback
+    def _legacy_entity_has_user_intent(
+        self, entity_id: str, exposed_entity: ExposedEntity
+    ) -> bool:
+        """Return True if a legacy record holds an exposure choice worth keeping."""
+        if any(
+            settings.get("should_expose")
+            for settings in exposed_entity.assistants.values()
+        ):
+            # Explicitly exposed to at least one assistant
+            return True
+
+        # A stored "should_expose: False" is indistinguishable from an
+        # auto-created default. It is only meaningful as an opt-out if the
+        # entity could be exposed by default, which depends on its domain (and,
+        # for sensors, a device class we cannot know while it is absent). Keep
+        # the record when the domain can be default-exposed to avoid silently
+        # reversing an opt-out if the entity returns.
+        domain = split_entity_id(entity_id)[0]
+        return (
+            domain in DEFAULT_EXPOSED_DOMAINS or domain in DEVICE_CLASS_EXPOSED_DOMAINS
+        )
 
     @callback
     def async_listen_entity_updates(

--- a/homeassistant/components/homeassistant/exposed_entities.py
+++ b/homeassistant/components/homeassistant/exposed_entities.py
@@ -3,7 +3,6 @@
 from collections.abc import Callable, Mapping
 import dataclasses
 from itertools import chain
-import logging
 from typing import Any, TypedDict
 
 import voluptuous as vol
@@ -15,13 +14,10 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback, split_ent
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import get_device_class
-from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.storage import Store
 from homeassistant.util.read_only_dict import ReadOnlyDict
 
 from .const import DATA_EXPOSED_ENTITIES, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
 
 KNOWN_ASSISTANTS = ("cloud.alexa", "cloud.google_assistant", "conversation")
 
@@ -64,10 +60,6 @@ DEFAULT_EXPOSED_SENSOR_DEVICE_CLASSES = {
     SensorDeviceClass.TEMPERATURE,
     SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
 }
-
-# Domains that can be exposed by default via their device class, so a stored
-# "should_expose: False" for one may be a user opt-out rather than noise.
-DEVICE_CLASS_EXPOSED_DOMAINS = {"binary_sensor", "sensor"}
 
 DEFAULT_EXPOSED_ASSISTANT = {
     "conversation": True,
@@ -130,62 +122,6 @@ class ExposedEntities:
         websocket_api.async_register_command(self._hass, ws_expose_new_entities_set)
         websocket_api.async_register_command(self._hass, ws_list_exposed_entities)
         await self._async_load_data()
-        async_at_started(self._hass, self._async_prune_legacy_entities)
-
-    @callback
-    def _async_prune_legacy_entities(self, hass: HomeAssistant) -> None:
-        """Remove auto-created settings for legacy entities that no longer exist.
-
-        Legacy entities (without a unique_id) are stored by entity_id and are
-        never cleaned up when the entity disappears. Transient entities such as
-        geo_location get a record auto-created every time one appears and can
-        accumulate indefinitely.
-
-        Only drop records for entities that no longer exist (neither a current
-        state nor in the entity registry) and that carry no user intent, so an
-        explicit exposure choice is never lost.
-        """
-        entity_registry = er.async_get(self._hass)
-        stale_entity_ids = [
-            entity_id
-            for entity_id, exposed_entity in self.entities.items()
-            if self._hass.states.get(entity_id) is None
-            and entity_id not in entity_registry.entities
-            and not self._legacy_entity_has_user_intent(entity_id, exposed_entity)
-        ]
-        if not stale_entity_ids:
-            return
-
-        for entity_id in stale_entity_ids:
-            del self.entities[entity_id]
-
-        _LOGGER.debug(
-            "Pruned %s stale legacy exposed entity setting(s)", len(stale_entity_ids)
-        )
-        self._async_schedule_save()
-
-    @callback
-    def _legacy_entity_has_user_intent(
-        self, entity_id: str, exposed_entity: ExposedEntity
-    ) -> bool:
-        """Return True if a legacy record holds an exposure choice worth keeping."""
-        if any(
-            settings.get("should_expose")
-            for settings in exposed_entity.assistants.values()
-        ):
-            # Explicitly exposed to at least one assistant
-            return True
-
-        # A stored "should_expose: False" is indistinguishable from an
-        # auto-created default. It is only meaningful as an opt-out if the
-        # entity could be exposed by default, which depends on its domain (and,
-        # for sensors, a device class we cannot know while it is absent). Keep
-        # the record when the domain can be default-exposed to avoid silently
-        # reversing an opt-out if the entity returns.
-        domain = split_entity_id(entity_id)[0]
-        return (
-            domain in DEFAULT_EXPOSED_DOMAINS or domain in DEVICE_CLASS_EXPOSED_DOMAINS
-        )
 
     @callback
     def async_listen_entity_updates(
@@ -331,8 +267,8 @@ class ExposedEntities:
         return should_expose
 
     @callback
-    def async_get_should_expose(self, assistant: str, entity_id: str) -> bool:
-        """Return True if an entity should be exposed, without persisting defaults."""
+    def async_calculate_should_expose(self, assistant: str, entity_id: str) -> bool:
+        """Return True if an entity should be exposed, without persisting anything."""
         should_expose: bool
 
         entity_registry = er.async_get(self._hass)
@@ -605,18 +541,23 @@ def async_expose_entity(
 
 @callback
 def async_should_expose(hass: HomeAssistant, assistant: str, entity_id: str) -> bool:
-    """Return True if an entity should be exposed to an assistant."""
+    """Return True if an entity should be exposed to an assistant.
+
+    The calculated default is persisted, freezing the entity's exposure at the
+    value it had the first time it was checked. Use
+    async_calculate_should_expose instead when only reading the value.
+    """
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
     return exposed_entities.async_should_expose(assistant, entity_id)
 
 
 @callback
-def async_get_should_expose(
+def async_calculate_should_expose(
     hass: HomeAssistant, assistant: str, entity_id: str
 ) -> bool:
-    """Return True if an entity should be exposed, without persisting defaults."""
+    """Return True if an entity should be exposed, without persisting anything."""
     exposed_entities = hass.data[DATA_EXPOSED_ENTITIES]
-    return exposed_entities.async_get_should_expose(assistant, entity_id)
+    return exposed_entities.async_calculate_should_expose(assistant, entity_id)
 
 
 @callback

--- a/tests/components/conversation/test_default_agent.py
+++ b/tests/components/conversation/test_default_agent.py
@@ -27,6 +27,7 @@ from homeassistant.components.conversation.default_agent import METADATA_CUSTOM_
 from homeassistant.components.conversation.models import ConversationInput
 from homeassistant.components.cover import SERVICE_OPEN_COVER
 from homeassistant.components.homeassistant.exposed_entities import (
+    async_calculate_should_expose,
     async_get_assistant_settings,
 )
 from homeassistant.components.intent import (
@@ -341,7 +342,7 @@ async def test_expose_flag_automatically_set(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test DefaultAgent sets the expose flag on all entities automatically."""
+    """Test DefaultAgent sets the expose flag on registry entities automatically."""
     assert await async_setup_component(hass, "homeassistant", {})
 
     light = entity_registry.async_get_or_create("light", "demo", "1234")
@@ -354,21 +355,36 @@ async def test_expose_flag_automatically_set(
     with patch("homeassistant.components.http.HomeAssistantHTTP.start"):
         await hass.async_start()
 
-    # After setting up conversation, the expose flag should now be set on all entities
+    # After setting up conversation, the expose flag should now be set on all
+    # entities in the entity registry
     assert async_get_assistant_settings(hass, conversation.DOMAIN) == {
-        "conversation.home_assistant": {"should_expose": False},
         light.entity_id: {"should_expose": True},
         test.entity_id: {"should_expose": False},
     }
 
-    # New entities will automatically have the expose flag set
-    new_light = "light.demo_2345"
-    hass.states.async_set(new_light, "test")
+    # New entities in the entity registry will automatically have the flag set
+    new_light = entity_registry.async_get_or_create("light", "demo", "2345")
+    hass.states.async_set(new_light.entity_id, "test")
     await hass.async_block_till_done()
     assert async_get_assistant_settings(hass, conversation.DOMAIN) == {
-        "conversation.home_assistant": {"should_expose": False},
         light.entity_id: {"should_expose": True},
-        new_light: {"should_expose": True},
+        new_light.entity_id: {"should_expose": True},
+        test.entity_id: {"should_expose": False},
+    }
+
+    # Entities without a registry entry are stored by entity_id in a store that is
+    # never pruned, so their exposure is computed on demand and never persisted
+    hass.states.async_set("light.legacy", "test")
+    hass.states.async_set("geo_location.transient", "test")
+    await hass.async_block_till_done()
+
+    assert async_calculate_should_expose(hass, conversation.DOMAIN, "light.legacy")
+    assert not async_calculate_should_expose(
+        hass, conversation.DOMAIN, "geo_location.transient"
+    )
+    assert async_get_assistant_settings(hass, conversation.DOMAIN) == {
+        light.entity_id: {"should_expose": True},
+        new_light.entity_id: {"should_expose": True},
         test.entity_id: {"should_expose": False},
     }
 

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -128,6 +128,34 @@ async def test_load_preferences(hass: HomeAssistant) -> None:
     assert exposed_entities.entities == exposed_entities2.entities
 
 
+async def test_prune_legacy_entities_on_start(hass: HomeAssistant) -> None:
+    """Test stale auto-created legacy entity settings are pruned on start."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+
+    # Auto-created record for a transient entity that no longer exists
+    exposed_entities.entities["geo_location.stale_strike"] = ExposedEntity(
+        assistants={"conversation": {"should_expose": False}}
+    )
+    # Auto-created record for a transient entity that still has a state
+    hass.states.async_set("geo_location.live_strike", "1")
+    exposed_entities.entities["geo_location.live_strike"] = ExposedEntity(
+        assistants={"conversation": {"should_expose": False}}
+    )
+    # Explicit user exposure for an entity that no longer exists
+    exposed_entities.entities["light.gone_but_exposed"] = ExposedEntity(
+        assistants={"conversation": {"should_expose": True}}
+    )
+
+    exposed_entities._async_prune_legacy_entities(hass)
+
+    assert set(exposed_entities.entities) == {
+        "geo_location.live_strike",
+        "light.gone_but_exposed",
+    }
+
+
 async def test_expose_entity(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -11,6 +11,7 @@ from homeassistant.components.homeassistant.exposed_entities import (
     async_expose_entity,
     async_get_assistant_settings,
     async_get_entity_settings,
+    async_get_should_expose,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -147,13 +148,54 @@ async def test_prune_legacy_entities_on_start(hass: HomeAssistant) -> None:
     exposed_entities.entities["light.gone_but_exposed"] = ExposedEntity(
         assistants={"conversation": {"should_expose": True}}
     )
+    # Explicit opt-out for a default-exposed domain that is currently absent;
+    # keep it so the choice is not reversed if the entity returns.
+    exposed_entities.entities["light.gone_opted_out"] = ExposedEntity(
+        assistants={"conversation": {"should_expose": False}}
+    )
 
     exposed_entities._async_prune_legacy_entities(hass)
 
     assert set(exposed_entities.entities) == {
         "geo_location.live_strike",
         "light.gone_but_exposed",
+        "light.gone_opted_out",
     }
+
+
+async def test_get_should_expose_does_not_persist(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test async_get_should_expose evaluates exposure without persisting."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
+
+    # Registry entity without a conversation option (light is exposed by default)
+    registry_light = entity_registry.async_get_or_create("light", "demo", "1234")
+    assert "conversation" not in registry_light.options
+
+    # Legacy entity (no registry entry) without a stored record
+    legacy_entity_id = "light.legacy"
+
+    # The read-only lookup returns the default but writes nothing, for both the
+    # registry-backed and legacy paths.
+    assert async_get_should_expose(hass, "conversation", registry_light.entity_id)
+    assert async_get_should_expose(hass, "conversation", legacy_entity_id)
+    assert (
+        "conversation"
+        not in entity_registry.async_get(registry_light.entity_id).options
+    )
+    assert legacy_entity_id not in exposed_entities.entities
+
+    # The writing variant does persist, for contrast.
+    assert async_should_expose(hass, "conversation", registry_light.entity_id)
+    assert async_should_expose(hass, "conversation", legacy_entity_id)
+    assert entity_registry.async_get(registry_light.entity_id).options[
+        "conversation"
+    ] == {"should_expose": True}
+    assert legacy_entity_id in exposed_entities.entities
 
 
 async def test_expose_entity(

--- a/tests/components/homeassistant/test_exposed_entities.py
+++ b/tests/components/homeassistant/test_exposed_entities.py
@@ -8,10 +8,10 @@ from homeassistant.components.homeassistant.exposed_entities import (
     DATA_EXPOSED_ENTITIES,
     ExposedEntities,
     ExposedEntity,
+    async_calculate_should_expose,
     async_expose_entity,
     async_get_assistant_settings,
     async_get_entity_settings,
-    async_get_should_expose,
     async_listen_entity_updates,
     async_should_expose,
 )
@@ -129,45 +129,11 @@ async def test_load_preferences(hass: HomeAssistant) -> None:
     assert exposed_entities.entities == exposed_entities2.entities
 
 
-async def test_prune_legacy_entities_on_start(hass: HomeAssistant) -> None:
-    """Test stale auto-created legacy entity settings are pruned on start."""
-    assert await async_setup_component(hass, DOMAIN, {})
-
-    exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
-
-    # Auto-created record for a transient entity that no longer exists
-    exposed_entities.entities["geo_location.stale_strike"] = ExposedEntity(
-        assistants={"conversation": {"should_expose": False}}
-    )
-    # Auto-created record for a transient entity that still has a state
-    hass.states.async_set("geo_location.live_strike", "1")
-    exposed_entities.entities["geo_location.live_strike"] = ExposedEntity(
-        assistants={"conversation": {"should_expose": False}}
-    )
-    # Explicit user exposure for an entity that no longer exists
-    exposed_entities.entities["light.gone_but_exposed"] = ExposedEntity(
-        assistants={"conversation": {"should_expose": True}}
-    )
-    # Explicit opt-out for a default-exposed domain that is currently absent;
-    # keep it so the choice is not reversed if the entity returns.
-    exposed_entities.entities["light.gone_opted_out"] = ExposedEntity(
-        assistants={"conversation": {"should_expose": False}}
-    )
-
-    exposed_entities._async_prune_legacy_entities(hass)
-
-    assert set(exposed_entities.entities) == {
-        "geo_location.live_strike",
-        "light.gone_but_exposed",
-        "light.gone_opted_out",
-    }
-
-
-async def test_get_should_expose_does_not_persist(
+async def test_calculate_should_expose_does_not_persist(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
 ) -> None:
-    """Test async_get_should_expose evaluates exposure without persisting."""
+    """Test async_calculate_should_expose evaluates exposure without persisting."""
     assert await async_setup_component(hass, DOMAIN, {})
 
     exposed_entities: ExposedEntities = hass.data[DATA_EXPOSED_ENTITIES]
@@ -181,8 +147,8 @@ async def test_get_should_expose_does_not_persist(
 
     # The read-only lookup returns the default but writes nothing, for both the
     # registry-backed and legacy paths.
-    assert async_get_should_expose(hass, "conversation", registry_light.entity_id)
-    assert async_get_should_expose(hass, "conversation", legacy_entity_id)
+    assert async_calculate_should_expose(hass, "conversation", registry_light.entity_id)
+    assert async_calculate_should_expose(hass, "conversation", legacy_entity_id)
     assert (
         "conversation"
         not in entity_registry.async_get(registry_light.entity_id).options


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The built-in Assist conversation agent probes `async_should_expose()` for every entity in the state machine — on start, on every state-added event, and while rebuilding its slot lists. That call **persists a `should_expose` record as a side effect**, and nothing ever prunes it. Throwaway entities such as `geo_location` (a new one per lightning strike, weather warning, or device dumped into the home zone) therefore leave a permanent record behind every time they briefly appear.

In the linked issue the `homeassistant.exposed_entities` store had grown to **115,282 records — 99.9% `geo_location` — against ~230 real entities and only 4 actually exposed**. The bloat rides along in every backup/migration and drives the reported memory growth.

This PR stops the conversation agent from creating those records in the first place:

- Add `async_calculate_should_expose()` — a read-only variant that computes default exposure **without** persisting a record. The shared default computation is factored out into a helper and reused by the existing `async_should_expose()` paths, so their behavior is unchanged.
- Use it when rebuilding the agent's slot lists (`_get_entity_name_tuples`), so recognition no longer writes storage records as a side effect.
- Only freeze exposure for entities that have an entity registry entry. `async_setup_default_agent` calls the writing `async_should_expose()` for every entity at start and for every state-added event, and that is what actually creates the records. For a registry entity the value lives in the registry's options and is removed along with the entity, so it cannot accumulate; for an entity without a registry entry it lands in the legacy store keyed by `entity_id`, which is never pruned. Exposure for those is computed on demand instead — as it already was everywhere that reads it.

### Behavior change

Entities **without a `unique_id`** are no longer frozen at their creation-time default. The practical effect: turning off "expose new entities" now also unexposes those entities, where previously a stored value kept them exposed. Entities in the entity registry are unaffected, and no explicit "expose this entity" setting is ever touched. `test_expose_flag_automatically_set` is updated to pin the new contract (including that a legacy entity is still exposed by default — just not persisted).

### Not in this PR

Cleaning up the records that already exist. That is #175413, which sweeps orphaned legacy records using the same orphaned-timestamp scheme as the entity registry (`CLEANUP_INTERVAL`/`ORPHANED_ENTITY_KEEP_SECONDS`), and so cannot reverse an explicit opt-out the way a one-shot startup prune can. An earlier revision of this PR carried such a prune; it has been dropped in favour of that PR. The two changes touch different parts of `exposed_entities.py` and merge cleanly — this one stops the growth, that one cleans up the existing pile.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: #172026, #175413
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

