### PR TITLE
Remove name field from Logitech Harmony Hub config flow

### DIFF
--- a/homeassistant/components/harmony/config_flow.py
+++ b/homeassistant/components/harmony/config_flow.py
@@ -38,9 +38,7 @@ from .util import (
 _LOGGER = logging.getLogger(__name__)
 
 DATA_SCHEMA = vol.Schema(
-    # Name field is no longer allowed in config flow schemas
-    # pylint: disable-next=home-assistant-config-flow-name-field
-    {vol.Required(CONF_HOST): str, vol.Required(CONF_NAME): str},
+    {vol.Required(CONF_HOST): str},
     extra=vol.ALLOW_EXTRA,
 )
 

--- a/homeassistant/components/harmony/strings.json
+++ b/homeassistant/components/harmony/strings.json
@@ -15,8 +15,7 @@
       },
       "user": {
         "data": {
-          "host": "[%key:common::config_flow::data::host%]",
-          "name": "Hub Name"
+          "host": "[%key:common::config_flow::data::host%]"
         },
         "data_description": {
           "host": "The hostname or IP address of your Logitech Harmony Hub."

--- a/tests/components/harmony/test_config_flow.py
+++ b/tests/components/harmony/test_config_flow.py
@@ -1,11 +1,12 @@
 """Test the Logitech Harmony Hub config flow."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
+import pytest
 
 from homeassistant import config_entries
-from homeassistant.components.harmony.config_flow import CannotConnect
 from homeassistant.components.harmony.const import DOMAIN, PREVIOUS_ACTIVE_ACTIVITY
 from homeassistant.const import CONF_HOST, CONF_NAME
 from homeassistant.core import HomeAssistant
@@ -23,7 +24,31 @@ def _get_mock_harmonyapi(connect=None, close=None):
     return harmonyapi_mock
 
 
-async def test_user_form(hass: HomeAssistant) -> None:
+@pytest.mark.parametrize(
+    ("user_input", "expected_data"),
+    [
+        pytest.param(
+            {"host": "1.2.3.4"},
+            {"host": "1.2.3.4", "name": "friend"},
+            id="host_only",
+        ),
+        pytest.param(
+            {"host": "1.2.3.4", "activity": "Watch TV", "delay_secs": 0.2},
+            {
+                "host": "1.2.3.4",
+                "name": "friend",
+                "activity": "Watch TV",
+                "delay_secs": 0.2,
+            },
+            id="with_extra_options",
+        ),
+    ],
+)
+async def test_user_form(
+    hass: HomeAssistant,
+    user_input: dict[str, Any],
+    expected_data: dict[str, Any],
+) -> None:
     """Test we get the user form."""
 
     result = await hass.config_entries.flow.async_init(
@@ -33,6 +58,7 @@ async def test_user_form(hass: HomeAssistant) -> None:
     assert result["errors"] == {}
 
     harmonyapi = _get_mock_harmonyapi(connect=True)
+    harmonyapi.name = "friend"
     with (
         patch(
             "homeassistant.components.harmony.util.HarmonyAPI",
@@ -45,13 +71,13 @@ async def test_user_form(hass: HomeAssistant) -> None:
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {"host": "1.2.3.4", "name": "friend"},
+            user_input,
         )
         await hass.async_block_till_done()
 
     assert result2["type"] is FlowResultType.CREATE_ENTRY
     assert result2["title"] == "friend"
-    assert result2["data"] == {"host": "1.2.3.4", "name": "friend"}
+    assert result2["data"] == expected_data
     assert len(mock_setup_entry.mock_calls) == 1
 
 
@@ -171,28 +197,40 @@ async def test_form_ssdp_aborts_before_checking_remoteid_if_host_known(
     assert result["type"] is FlowResultType.ABORT
 
 
-async def test_form_cannot_connect(hass: HomeAssistant) -> None:
-    """Test we handle cannot connect error."""
+@pytest.mark.parametrize(
+    ("side_effect", "error"),
+    [
+        pytest.param(None, "cannot_connect", id="cannot_connect"),
+        pytest.param(ValueError, "unknown", id="unknown"),
+    ],
+)
+async def test_form_errors(
+    hass: HomeAssistant,
+    side_effect: type[Exception] | None,
+    error: str,
+) -> None:
+    """Test we handle cannot connect and unknown errors."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
+    harmonyapi = _get_mock_harmonyapi(connect=False)
     with patch(
         "homeassistant.components.harmony.util.HarmonyAPI",
-        side_effect=CannotConnect,
+        return_value=harmonyapi,
+        side_effect=side_effect,
     ):
         result2 = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             {
                 "host": "1.2.3.4",
-                "name": "friend",
                 "activity": "Watch TV",
                 "delay_secs": 0.2,
             },
         )
 
     assert result2["type"] is FlowResultType.FORM
-    assert result2["errors"] == {"base": "cannot_connect"}
+    assert result2["errors"] == {"base": error}
 
 
 async def test_options_flow(hass: HomeAssistant, mock_hc, mock_write_config) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Remove the name field from the Logitech Harmony Hub config flow, as tracked in #168928 (part of home-assistant/epics#47). Config flow schemas should not include a name field, which is enforced by the `home-assistant-config-flow-name-field` pylint rule. The pylint disable comment was removed together with the field.

`validate_input` already derives the stored name through `find_best_name_for_remote`, which falls back to the name reported by the hub when the user did not provide one. That fallback now becomes the only path for the user flow, so `CONF_NAME` keeps being written to the entry data and `async_setup_entry` continues to read it unchanged. Existing entries are unaffected and no migration is needed. The SSDP discovery flow and the options flow are untouched.

The documentation does not mention the name field, so no documentation change is needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168928
- This PR is related to issue: home-assistant/epics#47
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
