### PR TITLE
Fix swallowed exceptions in action handlers for Yeelight

### DIFF
--- a/homeassistant/components/yeelight/light.py
+++ b/homeassistant/components/yeelight/light.py
@@ -51,6 +51,7 @@ from .const import (
     CONF_TRANSITION,
     DATA_CUSTOM_EFFECTS_KEY,
     DATA_UPDATED,
+    DOMAIN,
     MODELS_WITH_DELAYED_ON_TRANSITION,
     POWER_STATE_CHANGE_TIME,
 )
@@ -605,9 +606,15 @@ class YeelightBaseLight(YeelightEntity, LightEntity):
         """Set the music mode on or off."""
         try:
             await self._async_set_music_mode(music_mode)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except AssertionError as ex:
-            _LOGGER.error("Unable to turn on music mode, consider disabling it: %s", ex)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="set_music_mode_failed",
+                translation_placeholders={
+                    "name": self.device.name,
+                    "error": str(ex) or type(ex).__name__,
+                },
+            ) from ex
 
     @_async_cmd
     async def _async_set_music_mode(self, music_mode) -> None:

--- a/homeassistant/components/yeelight/strings.json
+++ b/homeassistant/components/yeelight/strings.json
@@ -43,6 +43,11 @@
       }
     }
   },
+  "exceptions": {
+    "set_music_mode_failed": {
+      "message": "Unable to set music mode for {name}, consider disabling the music mode option: {error}"
+    }
+  },
   "options": {
     "step": {
       "init": {

--- a/homeassistant/components/yeelight/strings.json
+++ b/homeassistant/components/yeelight/strings.json
@@ -45,7 +45,7 @@
   },
   "exceptions": {
     "set_music_mode_failed": {
-      "message": "Unable to set music mode for {name}, consider disabling the music mode option: {error}"
+      "message": "Unable to set music mode for {name}: {error}. Consider disabling the music mode option."
     }
   },
   "options": {

--- a/tests/components/yeelight/test_light.py
+++ b/tests/components/yeelight/test_light.py
@@ -454,15 +454,16 @@ async def test_services(hass: HomeAssistant, caplog: pytest.LogCaptureFixture) -
 
     # set_music_mode failure enable
     mocked_bulb.async_start_music = MagicMock(side_effect=AssertionError)
-    assert "Unable to turn on music mode, consider disabling it" not in caplog.text
-    await hass.services.async_call(
-        DOMAIN,
-        SERVICE_SET_MUSIC_MODE,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_MODE_MUSIC: "true"},
-        blocking=True,
-    )
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_MUSIC_MODE,
+            {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_MODE_MUSIC: "true"},
+            blocking=True,
+        )
     assert mocked_bulb.async_start_music.mock_calls == [call()]
-    assert "Unable to turn on music mode, consider disabling it" in caplog.text
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == "set_music_mode_failed"
 
     # set_music_mode disable
     await _async_test_service(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix a swallowed exception in the Yeelight action handlers, as tracked in #170651 (part of home-assistant/epics#64). `async_set_music_mode` caught `AssertionError` and only logged it, so the user got no feedback in the UI when the action failed and automations continued as if it had succeeded. It now raises `HomeAssistantError` with a translated message instead, and the `pylint: disable-next=home-assistant-action-swallowed-exception` comment is removed. This was the only suppression site in the integration.

This matches the integration's established error handling: the `_async_cmd` wrapper already raises `HomeAssistantError` for `TimeoutError`, `OSError`, and `BulbException`, so music mode failures from those errors propagate today. This change only brings `AssertionError` in line with that behavior. The same applies to the internal `async_set_music_mode` call in `async_turn_on` (when the music mode option is enabled): that path already propagates `HomeAssistantError` from `_async_cmd` for the other error types, so no new failure mode is introduced there.

The existing failure test is flipped from a `caplog` assertion to `pytest.raises(HomeAssistantError)` and now also verifies the translation domain and key.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170651
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
