### PR TITLE
Fix swallowed exceptions in action handlers for Slack

### DIFF
--- a/homeassistant/components/slack/notify.py
+++ b/homeassistant/components/slack/notify.py
@@ -20,6 +20,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import ATTR_ICON, CONF_PATH
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import aiohttp_client, config_validation as cv, template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
@@ -34,6 +35,7 @@ from .const import (
     ATTR_USERNAME,
     CONF_DEFAULT_CHANNEL,
     DATA_CLIENT,
+    DOMAIN,
     SLACK_DATA,
 )
 from .utils import upload_file_to_slack
@@ -278,10 +280,12 @@ class SlackNotificationService(BaseNotificationService):
 
         try:
             DATA_SCHEMA(data)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except vol.Invalid as err:
-            _LOGGER.error("Invalid message data: %s", err)
-            data = {}
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="invalid_message_data",
+                translation_placeholders={"error": str(err)},
+            ) from err
 
         title = kwargs.get(ATTR_TITLE)
         targets = _async_sanitize_channel_names(

--- a/homeassistant/components/slack/strings.json
+++ b/homeassistant/components/slack/strings.json
@@ -32,5 +32,10 @@
         "name": "Do not disturb until"
       }
     }
+  },
+  "exceptions": {
+    "invalid_message_data": {
+      "message": "Invalid message data: {error}"
+    }
   }
 }

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from homeassistant.components import notify
 from homeassistant.components.slack import DOMAIN
 from homeassistant.components.slack.notify import (
@@ -10,6 +12,7 @@ from homeassistant.components.slack.notify import (
     SlackNotificationService,
 )
 from homeassistant.const import ATTR_ICON, CONF_API_KEY, CONF_NAME, CONF_PLATFORM
+from homeassistant.exceptions import ServiceValidationError
 
 from . import CONF_DATA
 
@@ -108,3 +111,17 @@ async def test_message_as_reply() -> None:
     mock_fn.assert_called_once()
     _, kwargs = mock_fn.call_args
     assert kwargs["thread_ts"] == expected_ts
+
+
+async def test_invalid_message_data() -> None:
+    """Tests that invalid message data raises an error and sends no message."""
+    mock_client = Mock()
+    mock_client.chat_postMessage = AsyncMock()
+    service = SlackNotificationService(None, mock_client, CONF_DATA)
+
+    with pytest.raises(ServiceValidationError) as exc_info:
+        await service.async_send_message("test", data={"not_a_valid_key": "value"})
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "invalid_message_data"
+    mock_client.chat_postMessage.assert_not_called()

--- a/tests/components/slack/test_notify.py
+++ b/tests/components/slack/test_notify.py
@@ -1,127 +1,138 @@
 """Test slack notifications."""
 
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock
 
 import pytest
 
 from homeassistant.components import notify
 from homeassistant.components.slack import DOMAIN
-from homeassistant.components.slack.notify import (
-    ATTR_THREAD_TS,
-    CONF_DEFAULT_CHANNEL,
-    SlackNotificationService,
-)
-from homeassistant.const import ATTR_ICON, CONF_API_KEY, CONF_NAME, CONF_PLATFORM
+from homeassistant.components.slack.notify import ATTR_THREAD_TS
+from homeassistant.const import ATTR_ICON
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 
-from . import CONF_DATA
+from . import CONF_DATA, TEAM_ID, mock_connection
 
-SERVICE_NAME = f"notify_{DOMAIN}"
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker
 
-DEFAULT_CONFIG = {
-    notify.DOMAIN: [
-        {
-            CONF_PLATFORM: DOMAIN,
-            CONF_NAME: SERVICE_NAME,
-            CONF_API_KEY: "12345",
-            CONF_DEFAULT_CHANNEL: "channel",
-        }
-    ]
-}
+SERVICE_NAME = "test_team"
 
 
-async def test_message_includes_default_emoji() -> None:
-    """Tests that default icon is used when no message icon is given."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    expected_icon = ":robot_face:"
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: expected_icon}
+async def _async_setup_notify_service(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    entry_data: dict[str, str],
+) -> AsyncMock:
+    """Set up the slack integration and mock the message client."""
+    entry = MockConfigEntry(domain=DOMAIN, data=entry_data, unique_id=TEAM_ID)
+    entry.add_to_hass(hass)
+    mock_connection(aioclient_mock)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.services.has_service(notify.DOMAIN, SERVICE_NAME)
+    mock_fn = AsyncMock()
+    entry.runtime_data.client.chat_postMessage = mock_fn
+    return mock_fn
+
+
+@pytest.mark.parametrize(
+    ("entry_icon", "service_data", "expected_key", "expected_icon"),
+    [
+        pytest.param(
+            ":robot_face:",
+            {notify.ATTR_MESSAGE: "test"},
+            "icon_emoji",
+            ":robot_face:",
+            id="default_emoji",
+        ),
+        pytest.param(
+            "default_icon",
+            {notify.ATTR_MESSAGE: "test", notify.ATTR_DATA: {ATTR_ICON: ":new:"}},
+            "icon_emoji",
+            ":new:",
+            id="emoji_overrides_default",
+        ),
+        pytest.param(
+            "https://example.com/hass.png",
+            {notify.ATTR_MESSAGE: "test"},
+            "icon_url",
+            "https://example.com/hass.png",
+            id="default_icon_url",
+        ),
+        pytest.param(
+            "default_icon",
+            {
+                notify.ATTR_MESSAGE: "test",
+                notify.ATTR_DATA: {ATTR_ICON: "https://example.com/hass.png"},
+            },
+            "icon_url",
+            "https://example.com/hass.png",
+            id="icon_url_overrides_default",
+        ),
+    ],
+)
+async def test_message_icon(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    entry_icon: str,
+    service_data: dict[str, str],
+    expected_key: str,
+    expected_icon: str,
+) -> None:
+    """Test that the message icon comes from the entry data or the service data."""
+    mock_fn = await _async_setup_notify_service(
+        hass, aioclient_mock, CONF_DATA | {ATTR_ICON: entry_icon}
     )
 
-    await service.async_send_message("test")
-
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["icon_emoji"] == expected_icon
-
-
-async def test_message_emoji_overrides_default() -> None:
-    """Tests that overriding the default icon emoji when sending a message works."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: "default_icon"}
+    await hass.services.async_call(
+        notify.DOMAIN, SERVICE_NAME, service_data, blocking=True
     )
 
-    expected_icon = ":new:"
-    await service.async_send_message("test", data={"icon": expected_icon})
-
-    mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
     _, kwargs = mock_fn.call_args
-    assert kwargs["icon_emoji"] == expected_icon
+    assert kwargs[expected_key] == expected_icon
 
 
-async def test_message_includes_default_icon_url() -> None:
-    """Tests that overriding the default icon url when sending a message works."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    expected_icon = "https://example.com/hass.png"
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: expected_icon}
-    )
-
-    await service.async_send_message("test")
-
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["icon_url"] == expected_icon
-
-
-async def test_message_icon_url_overrides_default() -> None:
-    """Tests that overriding the default icon url when sending a message works."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    service = SlackNotificationService(
-        None, mock_client, CONF_DATA | {ATTR_ICON: "default_icon"}
-    )
-
-    expected_icon = "https://example.com/hass.png"
-    await service.async_send_message("test", data={ATTR_ICON: expected_icon})
-
-    mock_fn = mock_client.chat_postMessage
-    mock_fn.assert_called_once()
-    _, kwargs = mock_fn.call_args
-    assert kwargs["icon_url"] == expected_icon
-
-
-async def test_message_as_reply() -> None:
+async def test_message_as_reply(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Tests that a message pointer will be passed to Slack if specified."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    service = SlackNotificationService(None, mock_client, CONF_DATA)
+    mock_fn = await _async_setup_notify_service(hass, aioclient_mock, CONF_DATA)
 
     expected_ts = "1624146685.064129"
-    await service.async_send_message("test", data={ATTR_THREAD_TS: expected_ts})
+    await hass.services.async_call(
+        notify.DOMAIN,
+        SERVICE_NAME,
+        {
+            notify.ATTR_MESSAGE: "test",
+            notify.ATTR_DATA: {ATTR_THREAD_TS: expected_ts},
+        },
+        blocking=True,
+    )
 
-    mock_fn = mock_client.chat_postMessage
     mock_fn.assert_called_once()
     _, kwargs = mock_fn.call_args
     assert kwargs["thread_ts"] == expected_ts
 
 
-async def test_invalid_message_data() -> None:
+async def test_invalid_message_data(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
     """Tests that invalid message data raises an error and sends no message."""
-    mock_client = Mock()
-    mock_client.chat_postMessage = AsyncMock()
-    service = SlackNotificationService(None, mock_client, CONF_DATA)
+    mock_fn = await _async_setup_notify_service(hass, aioclient_mock, CONF_DATA)
 
     with pytest.raises(ServiceValidationError) as exc_info:
-        await service.async_send_message("test", data={"not_a_valid_key": "value"})
+        await hass.services.async_call(
+            notify.DOMAIN,
+            SERVICE_NAME,
+            {
+                notify.ATTR_MESSAGE: "test",
+                notify.ATTR_DATA: {"not_a_valid_key": "value"},
+            },
+            blocking=True,
+        )
 
     assert exc_info.value.translation_domain == DOMAIN
     assert exc_info.value.translation_key == "invalid_message_data"
-    mock_client.chat_postMessage.assert_not_called()
+    mock_fn.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fix the swallowed exception in the Slack notify action handler, as tracked in #170639 (part of home-assistant/epics#64).

When the `data` payload of a `notify.slack` action call failed schema validation, `async_send_message` only logged the error and continued with an empty `data` dict. The message was still sent, but without the requested blocks, icon, thread or file upload, and the user got no feedback in the UI about what went wrong. The handler now raises `ServiceValidationError` with a translated message that includes the validation error, so the action call fails visibly and automations stop instead of silently sending a degraded message. This is the behavior the epic asks for: invalid input aborts the action with user feedback.

The `# pylint: disable-next=home-assistant-action-swallowed-exception` comment was removed together with the log-and-continue branch. The corresponding translation key was added to `strings.json`, and a new test asserts that invalid message data raises `ServiceValidationError` and that no message is sent.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170639
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
