### PR TITLE
Replace gps3 dependency with inline GPSD client

### DIFF
--- a/homeassistant/components/gpsd/__init__.py
+++ b/homeassistant/components/gpsd/__init__.py
@@ -1,28 +1,28 @@
 """The GPSD integration."""
 
-from gps3.agps3threaded import AGPS3mechanism
-
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 
+from .gpsd_client import GPSDClient
+
 PLATFORMS: list[Platform] = [Platform.SENSOR]
 
-type GPSDConfigEntry = ConfigEntry[AGPS3mechanism]
+type GPSDConfigEntry = ConfigEntry[GPSDClient]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: GPSDConfigEntry) -> bool:
     """Set up GPSD from a config entry."""
-    agps_thread = AGPS3mechanism()
-    entry.runtime_data = agps_thread
+    client = GPSDClient()
+    entry.runtime_data = client
 
-    def setup_agps() -> None:
+    def setup() -> None:
         host = entry.data.get(CONF_HOST)
         port = entry.data.get(CONF_PORT)
-        agps_thread.stream_data(host, port)
-        agps_thread.run_thread()
+        client.stream_data(host, port)
+        client.run_thread()
 
-    await hass.async_add_executor_job(setup_agps)
+    await hass.async_add_executor_job(setup)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -32,13 +32,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GPSDConfigEntry) -> bool
 async def async_unload_entry(hass: HomeAssistant, entry: GPSDConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        agps_thread = entry.runtime_data
-        await hass.async_add_executor_job(
-            lambda: agps_thread.stream_data(
-                host=entry.data.get(CONF_HOST),
-                port=entry.data.get(CONF_PORT),
-                enable=False,
-            )
-        )
+        client = entry.runtime_data
+        client.stream_data(enable=False)
 
     return unload_ok

--- a/homeassistant/components/gpsd/config_flow.py
+++ b/homeassistant/components/gpsd/config_flow.py
@@ -3,7 +3,6 @@
 import socket
 from typing import Any, override
 
-from gps3.agps3threaded import GPSD_PORT as DEFAULT_PORT, HOST as DEFAULT_HOST
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
@@ -11,6 +10,7 @@ from homeassistant.const import CONF_HOST, CONF_NAME, CONF_PORT
 from homeassistant.helpers import config_validation as cv
 
 from .const import DOMAIN
+from .gpsd_client import DEFAULT_HOST, DEFAULT_PORT
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {

--- a/homeassistant/components/gpsd/gpsd_client.py
+++ b/homeassistant/components/gpsd/gpsd_client.py
@@ -1,0 +1,83 @@
+"""Minimal threaded gpsd client for Home Assistant."""
+
+import json
+import select
+import socket
+import threading
+
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 2947
+
+
+class DataStream:
+    """Holds the latest gpsd data with attribute access matching gps3.DataStream."""
+
+    def __init__(self):
+        self.mode = 0
+        self.lat = "n/a"
+        self.lon = "n/a"
+        self.alt = "n/a"
+        self.time = "n/a"
+        self.speed = "n/a"
+        self.climb = "n/a"
+        self.satellites = "n/a"
+
+    def _apply(self, data):
+        for key, value in data.items():
+            if hasattr(self, key):
+                setattr(self, key, value)
+
+
+class GPSDClient:
+    """Threaded gpsd client. API mirrors gps3.agps3threaded.AGPS3mechanism."""
+
+    def __init__(self):
+        self.data_stream = DataStream()
+        self._sock = None
+        self._thread = None
+        self._running = False
+
+    def stream_data(self, host=DEFAULT_HOST, port=DEFAULT_PORT, enable=True):
+        if enable:
+            self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            self._sock.settimeout(5)
+            self._sock.connect((host, port))
+            self._sock.sendall(b'?WATCH={"enable":true,"json":true}\n')
+        else:
+            self._running = False
+            if self._sock:
+                try:
+                    self._sock.close()
+                except OSError:
+                    pass
+
+    def run_thread(self):
+        self._running = True
+        self._thread = threading.Thread(target=self._read_loop, daemon=True)
+        self._thread.start()
+
+    def _read_loop(self):
+        buf = b""
+        while self._running:
+            try:
+                ready = select.select([self._sock], [], [], 1.0)
+                if not ready[0]:
+                    continue
+                chunk = self._sock.recv(4096)
+                if not chunk:
+                    break
+                buf += chunk
+                while b"\n" in buf:
+                    line, buf = buf.split(b"\n", 1)
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        message = json.loads(line)
+                        if message.get("class") in ("TPV", "SKY"):
+                            self.data_stream._apply(message)
+                    except json.JSONDecodeError:
+                        pass
+            except (socket.timeout, OSError):
+                break

--- a/homeassistant/components/gpsd/manifest.json
+++ b/homeassistant/components/gpsd/manifest.json
@@ -4,7 +4,5 @@
   "codeowners": ["@fabaff", "@jrieger"],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/gpsd",
-  "iot_class": "local_polling",
-  "loggers": ["gps3"],
-  "requirements": ["gps3==0.33.3"]
+  "iot_class": "local_polling"
 }

--- a/homeassistant/components/gpsd/sensor.py
+++ b/homeassistant/components/gpsd/sensor.py
@@ -6,8 +6,6 @@ from datetime import datetime
 import logging
 from typing import override
 
-from gps3.agps3threaded import AGPS3mechanism
-
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -32,6 +30,7 @@ from homeassistant.util import dt as dt_util
 
 from . import GPSDConfigEntry
 from .const import DOMAIN
+from .gpsd_client import GPSDClient
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,15 +44,15 @@ DEFAULT_NAME = "GPS"
 _MODE_VALUES = {2: "2d_fix", 3: "3d_fix"}
 
 
-def count_total_satellites_fn(agps_thread: AGPS3mechanism) -> int | None:
+def count_total_satellites_fn(client: GPSDClient) -> int | None:
     """Count the number of total satellites."""
-    satellites = agps_thread.data_stream.satellites
+    satellites = client.data_stream.satellites
     return None if satellites == "n/a" else len(satellites)
 
 
-def count_used_satellites_fn(agps_thread: AGPS3mechanism) -> int | None:
+def count_used_satellites_fn(client: GPSDClient) -> int | None:
     """Count the number of used satellites."""
-    satellites = agps_thread.data_stream.satellites
+    satellites = client.data_stream.satellites
     if satellites == "n/a":
         return None
 
@@ -66,7 +65,7 @@ def count_used_satellites_fn(agps_thread: AGPS3mechanism) -> int | None:
 class GpsdSensorDescription(SensorEntityDescription):
     """Class describing GPSD sensor entities."""
 
-    value_fn: Callable[[AGPS3mechanism], StateType | datetime]
+    value_fn: Callable[[GPSDClient], StateType | datetime]
 
 
 SENSOR_TYPES: tuple[GpsdSensorDescription, ...] = (
@@ -77,20 +76,20 @@ SENSOR_TYPES: tuple[GpsdSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.ENUM,
         options=list(_MODE_VALUES.values()),
-        value_fn=lambda agps_thread: _MODE_VALUES.get(agps_thread.data_stream.mode),
+        value_fn=lambda client: _MODE_VALUES.get(client.data_stream.mode),
     ),
     GpsdSensorDescription(
         key=ATTR_LATITUDE,
         translation_key=ATTR_LATITUDE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda agps_thread: agps_thread.data_stream.lat,
+        value_fn=lambda client: client.data_stream.lat,
         entity_registry_enabled_default=False,
     ),
     GpsdSensorDescription(
         key=ATTR_LONGITUDE,
         translation_key=ATTR_LONGITUDE,
         entity_category=EntityCategory.DIAGNOSTIC,
-        value_fn=lambda agps_thread: agps_thread.data_stream.lon,
+        value_fn=lambda client: client.data_stream.lon,
         entity_registry_enabled_default=False,
     ),
     GpsdSensorDescription(
@@ -99,7 +98,7 @@ SENSOR_TYPES: tuple[GpsdSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.DISTANCE,
         native_unit_of_measurement=UnitOfLength.METERS,
-        value_fn=lambda agps_thread: agps_thread.data_stream.alt,
+        value_fn=lambda client: client.data_stream.alt,
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
     ),
@@ -108,8 +107,8 @@ SENSOR_TYPES: tuple[GpsdSensorDescription, ...] = (
         translation_key=ATTR_TIME,
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.TIMESTAMP,
-        value_fn=lambda agps_thread: dt_util.parse_datetime(
-            agps_thread.data_stream.time
+        value_fn=lambda client: dt_util.parse_datetime(
+            client.data_stream.time
         ),
         entity_registry_enabled_default=False,
     ),
@@ -119,7 +118,7 @@ SENSOR_TYPES: tuple[GpsdSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.SPEED,
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
-        value_fn=lambda agps_thread: agps_thread.data_stream.speed,
+        value_fn=lambda client: client.data_stream.speed,
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
     ),
@@ -129,7 +128,7 @@ SENSOR_TYPES: tuple[GpsdSensorDescription, ...] = (
         entity_category=EntityCategory.DIAGNOSTIC,
         device_class=SensorDeviceClass.SPEED,
         native_unit_of_measurement=UnitOfSpeed.METERS_PER_SECOND,
-        value_fn=lambda agps_thread: agps_thread.data_stream.climb,
+        value_fn=lambda client: client.data_stream.climb,
         suggested_display_precision=2,
         entity_registry_enabled_default=False,
     ),
@@ -179,7 +178,7 @@ class GpsdSensor(SensorEntity):
 
     def __init__(
         self,
-        agps_thread: AGPS3mechanism,
+        client: GPSDClient,
         unique_id: str,
         description: GpsdSensorDescription,
     ) -> None:
@@ -191,11 +190,11 @@ class GpsdSensor(SensorEntity):
         )
         self._attr_unique_id = f"{unique_id}-{self.entity_description.key}"
 
-        self.agps_thread = agps_thread
+        self._client = client
 
     @property
     @override
     def native_value(self) -> StateType | datetime:
         """Return the state of GPSD."""
-        value = self.entity_description.value_fn(self.agps_thread)
+        value = self.entity_description.value_fn(self._client)
         return None if value == "n/a" else value


### PR DESCRIPTION
## Problem

The `gps3` library (v0.33.3) is unmaintained and contains a race condition bug in its internal buffer handling. The `next()` method in `agps3.py` calls `self._buf.split('\n', 1)` without guarding against the case where the buffer contains no newline. When the first chunk received from gpsd does not include a trailing newline, this raises a `ValueError` that causes all gpsd sensor entities to stay in `unknown` state on integration startup. Recovery requires restarting the HA container.

## Solution

Replaced the external `gps3` dependency with an inline `GPSDClient` (~80 lines) that reimplements the same threaded socket client using only stdlib modules (`socket`, `select`, `threading`, `json`). Key improvements:

- Incremental JSON line parsing with a properly guarded `b'\n'` split that handles partial reads safely — no more crash on first chunk
- Same `DataStream` attribute naming as gps3 for minimal diff
- Zero external dependencies beyond stdlib

## Changes

| File | Change |
|------|--------|
| `gpsd_client.py` | **New** — inline threaded GPSD client |
| `__init__.py` | Use `GPSDClient` instead of `AGPS3mechanism` |
| `sensor.py` | Use `GPSDClient` instead of `AGPS3mechanism` |
| `config_flow.py` | Import `DEFAULT_HOST`/`DEFAULT_PORT` from local `gpsd_client` |
| `manifest.json` | Remove `gps3==0.33.3` requirement and `gps3` logger |