### PR TITLE
Add Room Average Temperature sensor to Lyric integration

### DIFF
--- a/homeassistant/components/lyric/sensor.py
+++ b/homeassistant/components/lyric/sensor.py
@@ -133,6 +133,14 @@ ACCESSORY_SENSORS: list[LyricSensorAccessoryEntityDescription] = [
         value_fn=lambda room, _: room.room_avg_humidity,
         suitable_fn=lambda _, accessory: accessory.type == "IndoorAirSensor",
     ),
+    LyricSensorAccessoryEntityDescription(
+        key="room_average_temperature",
+        translation_key="room_average_temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        state_class=SensorStateClass.MEASUREMENT,
+        value_fn=lambda room, _: room.room_avg_temp,
+        suitable_fn=lambda _, accessory: accessory.type == "IndoorAirSensor",
+    ),
 ]
 
 

--- a/homeassistant/components/lyric/strings.json
+++ b/homeassistant/components/lyric/strings.json
@@ -61,6 +61,9 @@
       "outdoor_temperature": {
         "name": "Outdoor temperature"
       },
+      "room_average_temperature": {
+        "name": "Room average temperature"
+      },
       "room_humidity": {
         "name": "Room humidity"
       },


### PR DESCRIPTION
Resideo's priority endpoint reports a room-level average temperature (roomAvgTemp) alongside the per-accessory temperature already exposed as Room Temperature. This was parsed but never surfaced. Adds it as a sibling entry to the existing Room Humidity sensor, which already uses the same room-level (not accessory-level) value.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->



## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Resideo's priority endpoint reports a room-level average temperature
(`roomAvgTemp`/`avgTemperature`) alongside the per-accessory temperature already
exposed as Room Temperature. This was parsed but never surfaced. Adds it as a
sibling entry to the existing Room Humidity sensor, which already uses the same
room-level (not accessory-level) value.

Dependency note: this needs both #177022 (coordinator actually fetching room data)
and the pending aiolyric field-name fix (`room_avg_temp` currently reads the wrong
JSON key) to show real data. Safe to merge independently — it'll just report
`unavailable` until both land, same as the existing Room Humidity sensor already
does today.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177010, #177022
- Companion library fix (required for this sensor to report real data): aiolyric PR fixing `room_avg_temp`'s JSON key (part of `timmo001/aiolyric#165`)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46986
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ x] I understand the code I am submitting and can explain how it works.
- [ x] The code change is tested and works locally.
- [ x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x ] There is no commented out code in this PR.
- [ x] I have followed the [development checklist][dev-checklist]
- [x ] I have followed the [perfect PR recommendations][perfect-pr]
- [ x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io](https://github.com/home-assistant/home-assistant.io)
Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46986

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
