### PR TITLE
Users will see a one-time message "Growatt service temporarily unavai…

### DIFF
--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -57,8 +57,10 @@ from .const import (
     DEPRECATED_URLS,
     DEVICE_SCAN_INTERVAL,
     DOMAIN,
+    LOGIN_FAILED,
     LOGIN_INVALID_AUTH_CODE,
     PLATFORMS,
+    SERVICE_UNAVAILABLE_RETRY_INTERVAL,
     SUPPORTED_DEVICE_TYPES,
     V1_DEVICE_TYPES,
 )
@@ -213,20 +215,43 @@ async def async_migrate_entry(
 
 
 async def _create_api_and_login(
-    hass: HomeAssistant, username: str, password: str, url: str
+    hass: HomeAssistant,
+    config_entry: GrowattConfigEntry,
+    username: str,
+    password: str,
+    url: str,
 ) -> tuple[growattServer.GrowattApi, dict]:
     """Create API instance and perform login.
 
     Returns both the API instance (with authenticated session) and the login
     response (containing user_id needed for subsequent API calls).
 
+    Raises ConfigEntryNotReady with 4-hour retry scheduling on 507 errors.
     """
     api = growattServer.GrowattApi(add_random_user_id=True, agent_identifier=username)
     api.server_url = url
 
-    login_response = await hass.async_add_executor_job(
-        _login_classic_api, api, username, password
-    )
+    try:
+        login_response = await hass.async_add_executor_job(
+            _login_classic_api, api, username, password
+        )
+    except ConfigEntryNotReady as err:
+        # Check if this is a 507 error (service unavailable)
+        if "507" in str(err):
+            # Track the last 507 error time
+            last_error_key = f"{DOMAIN}_last_507_error_{config_entry.entry_id}"
+            hass.data.setdefault(DOMAIN, {})[last_error_key] = datetime.datetime.now()
+            _LOGGER.warning(
+                "Growatt service temporarily unavailable (507), will retry in 4 hours"
+            )
+            # Schedule automatic retry after 4 hours
+            hass.loop.call_later(
+                SERVICE_UNAVAILABLE_RETRY_INTERVAL.total_seconds(),
+                lambda: hass.async_create_task(
+                    hass.config_entries.async_reload(config_entry.entry_id)
+                ),
+            )
+        raise
 
     return api, login_response
 
@@ -251,6 +276,12 @@ def _login_classic_api(
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="invalid_credentials",
+            )
+        if msg == LOGIN_FAILED:
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="login_failed",
+                translation_placeholders={"message": msg},
             )
         raise ConfigEntryError(
             translation_domain=DOMAIN,
@@ -358,7 +389,9 @@ async def async_setup_entry(
         else:
             # No cached API (normal setup or migration didn't run)
             # Create new API instance and login
-            api, _ = await _create_api_and_login(hass, username, password, url)
+            api, _ = await _create_api_and_login(
+                hass, config_entry, username, password, url
+            )
 
         # Get plant_id and devices using the authenticated session
         plant_id = config[CONF_PLANT_ID]

--- a/homeassistant/components/growatt_server/const.py
+++ b/homeassistant/components/growatt_server/const.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from homeassistant.const import Platform
 
 DEVICE_SCAN_INTERVAL = timedelta(hours=1)
+SERVICE_UNAVAILABLE_RETRY_INTERVAL = timedelta(hours=4)
 
 CONF_PLANT_ID = "plant_id"
 
@@ -41,6 +42,7 @@ PLATFORMS = [Platform.NUMBER, Platform.SENSOR, Platform.SWITCH]
 
 # Growatt Classic API error codes
 LOGIN_INVALID_AUTH_CODE = "502"
+LOGIN_FAILED = "507"
 
 
 # Config flow error types (also used as abort reasons)

--- a/homeassistant/components/growatt_server/coordinator.py
+++ b/homeassistant/components/growatt_server/coordinator.py
@@ -15,6 +15,7 @@ from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
     ConfigEntryAuthFailed,
+    ConfigEntryNotReady,
     HomeAssistantError,
     ServiceValidationError,
 )
@@ -27,7 +28,9 @@ from .const import (
     BATT_MODE_LOAD_FIRST,
     DEFAULT_URL,
     DOMAIN,
+    LOGIN_FAILED,
     LOGIN_INVALID_AUTH_CODE,
+    SERVICE_UNAVAILABLE_RETRY_INTERVAL,
     V1_DEVICE_TYPES,
 )
 from .models import GrowattRuntimeData
@@ -161,6 +164,12 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     raise ConfigEntryAuthFailed(
                         translation_domain=DOMAIN,
                         translation_key="invalid_credentials",
+                    )
+                if msg == LOGIN_FAILED:
+                    raise ConfigEntryNotReady(
+                        translation_domain=DOMAIN,
+                        translation_key="login_failed",
+                        translation_placeholders={"message": msg},
                     )
                 raise UpdateFailed(
                     translation_domain=DOMAIN,
@@ -336,6 +345,15 @@ class GrowattCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         """Asynchronously update data via library."""
         try:
             return await self.hass.async_add_executor_job(self._sync_update_data)
+        except ConfigEntryNotReady as err:
+            # Check if this is a 507 error (service unavailable)
+            if "507" in str(err):
+                # Schedule automatic retry after 4 hours for coordinator updates
+                self.hass.loop.call_later(
+                    SERVICE_UNAVAILABLE_RETRY_INTERVAL.total_seconds(),
+                    lambda: self.hass.async_create_task(self.async_refresh()),
+                )
+            raise
         except json.decoder.JSONDecodeError as err:
             raise UpdateFailed(
                 translation_domain=DOMAIN,

--- a/tests/components/growatt_server/test_init.py
+++ b/tests/components/growatt_server/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.growatt_server.const import (
     DEFAULT_PLANT_ID,
     DEVICE_SCAN_INTERVAL,
     DOMAIN,
+    LOGIN_FAILED,
     LOGIN_INVALID_AUTH_CODE,
 )
 from homeassistant.config_entries import ConfigEntryState
@@ -282,6 +283,53 @@ async def test_classic_api_coordinator_auth_failed_triggers_reauth(
     assert hass.states.get("sensor.tlx123456_output_power").state == STATE_UNAVAILABLE
 
 
+async def test_classic_api_coordinator_service_unavailable_retries(
+    hass: HomeAssistant,
+    mock_growatt_classic_api,
+    mock_config_entry_classic: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test 507 service unavailable during coordinator update triggers retry."""
+    mock_growatt_classic_api.device_list.return_value = [
+        {"deviceSn": "TLX123456", "deviceType": "tlx"}
+    ]
+    mock_growatt_classic_api.plant_info.return_value = {
+        "deviceList": [],
+        "totalEnergy": 1250.0,
+        "todayEnergy": 12.5,
+        "invTodayPpv": 2500,
+        "plantMoneyText": "123.45/USD",
+    }
+    mock_growatt_classic_api.tlx_detail.return_value = {
+        "data": {"deviceSn": "TLX123456"}
+    }
+
+    await setup_integration(hass, mock_config_entry_classic)
+    assert mock_config_entry_classic.state is ConfigEntryState.LOADED
+
+    # Service temporarily unavailable between updates
+    mock_growatt_classic_api.login.return_value = {
+        "success": False,
+        "msg": LOGIN_FAILED,
+    }
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    # Integration should remain loaded (ConfigEntryNotReady is transient)
+    assert mock_config_entry_classic.state is ConfigEntryState.LOADED
+    # Should NOT trigger a reauth flow
+    flows = hass.config_entries.flow.async_progress()
+    assert not any(
+        flow["context"]["source"] == "reauth"
+        and flow["context"]["entry_id"] == mock_config_entry_classic.entry_id
+        for flow in flows
+    )
+    # Entities should be unavailable but not logged out
+    assert hass.states.get("sensor.tlx123456_output_power").state == STATE_UNAVAILABLE
+
+
 async def test_classic_api_setup(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
@@ -435,6 +483,22 @@ async def test_classic_api_login_failures(
     await setup_integration(hass, mock_config_entry_classic)
 
     assert mock_config_entry_classic.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_classic_api_login_service_unavailable(
+    hass: HomeAssistant,
+    mock_growatt_classic_api,
+    mock_config_entry_classic: MockConfigEntry,
+) -> None:
+    """Test Classic API setup with 507 service unavailable error."""
+    mock_growatt_classic_api.login.return_value = {
+        "success": False,
+        "msg": LOGIN_FAILED,
+    }
+
+    await setup_integration(hass, mock_config_entry_classic)
+
+    assert mock_config_entry_classic.state is ConfigEntryState.SETUP_RETRY
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes issue #174789 by automatically attempt to reconnect every 4 hours until the login succeeds

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #174789 
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
