### PR TITLE
Add reconfigure flow for Electrolux integration

### DIFF
--- a/homeassistant/components/electrolux/config_flow.py
+++ b/homeassistant/components/electrolux/config_flow.py
@@ -97,6 +97,33 @@ class ElectroluxConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self._show_form(step_id="reauth_confirm", errors=errors)
 
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        errors: dict[str, str] = {}
+
+        if user_input:
+            try:
+                token_manager = await _authenticate_user(user_input)
+            except InvalidCredentialsException, BadCredentialsException:
+                errors["base"] = "invalid_auth"
+            except FailedConnectionException:
+                errors["base"] = "cannot_connect"
+            else:
+                await self.async_set_unique_id(token_manager.get_user_id())
+                self._abort_if_unique_id_mismatch()
+                return self.async_update_reload_and_abort(
+                    self._get_reconfigure_entry(),
+                    data_updates={
+                        CONF_ACCESS_TOKEN: user_input[CONF_ACCESS_TOKEN],
+                        CONF_REFRESH_TOKEN: user_input[CONF_REFRESH_TOKEN],
+                        CONF_API_KEY: user_input[CONF_API_KEY],
+                    },
+                )
+
+        return self._show_form(step_id="reconfigure", errors=errors)
+
     def _show_form(self, step_id: str, errors: dict[str, str]) -> ConfigFlowResult:
         return self.async_show_form(
             step_id=step_id,

--- a/homeassistant/components/electrolux/quality_scale.yaml
+++ b/homeassistant/components/electrolux/quality_scale.yaml
@@ -68,7 +68,7 @@ rules:
   entity-translations: todo
   exception-translations: todo
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices: todo
 

--- a/homeassistant/components/electrolux/strings.json
+++ b/homeassistant/components/electrolux/strings.json
@@ -3,6 +3,7 @@
     "abort": {
       "already_configured": "This Electrolux account is already configured.",
       "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]",
       "unique_id_mismatch": "The provided credentials don't belong to the account the configuration entry was set up with originally."
     },
     "error": {
@@ -23,6 +24,20 @@
         },
         "description": "Please go to the [developer portal]({portal_link}) to generate new access and refresh tokens, then paste them below.",
         "title": "Reauthenticate your Electrolux Group account"
+      },
+      "reconfigure": {
+        "data": {
+          "access_token": "[%key:common::config_flow::data::access_token%]",
+          "api_key": "[%key:common::config_flow::data::api_key%]",
+          "refresh_token": "Refresh token"
+        },
+        "data_description": {
+          "access_token": "The new access token from Electrolux Group for Developer after reconfiguration.",
+          "api_key": "Your Electrolux Group for Developer API key.",
+          "refresh_token": "The refresh token used to renew your access token."
+        },
+        "description": "Please go to the [developer portal]({portal_link}) to generate new access and refresh tokens, then paste them below.",
+        "title": "Reconfigure your Electrolux Group account"
       },
       "user": {
         "data": {

--- a/tests/components/electrolux/test_config_flow.py
+++ b/tests/components/electrolux/test_config_flow.py
@@ -312,3 +312,140 @@ async def test_reauth_mismatched_entry(
 
     assert result["type"] is data_entry_flow.FlowResultType.ABORT
     assert result["reason"] == "unique_id_mismatch"
+
+
+async def test_reconfigure_successful(
+    hass: HomeAssistant,
+    mock_appliance_client: AsyncMock,
+    mock_token_manager: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the reconfigure step succeeds and updates the config entry."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=valid_user_input
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    assert mock_config_entry.data == valid_user_input
+
+
+@pytest.mark.parametrize(
+    ("exception", "error_name"),
+    [
+        (InvalidCredentialsException(), "invalid_auth"),
+    ],
+)
+async def test_reconfigure_missing_credentials_error(
+    hass: HomeAssistant,
+    mock_appliance_client: AsyncMock,
+    mock_token_manager: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    error_name: str,
+) -> None:
+    """Test reconfigure flow with invalid authentication."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_token_manager.ensure_credentials.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=invalid_user_input
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": error_name}
+
+    mock_token_manager.ensure_credentials.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=valid_user_input
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    assert mock_config_entry.data == valid_user_input
+
+
+@pytest.mark.parametrize(
+    ("exception", "error_name"),
+    [
+        (BadCredentialsException(), "invalid_auth"),
+        (FailedConnectionException(), "cannot_connect"),
+    ],
+)
+async def test_reconfigure_connection_error(
+    hass: HomeAssistant,
+    mock_appliance_client: AsyncMock,
+    mock_token_manager: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    exception: Exception,
+    error_name: str,
+) -> None:
+    """Test reconfigure flow with bad credentials."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_appliance_client.test_connection.side_effect = exception
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=invalid_user_input
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_appliance_client.test_connection.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=valid_user_input
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+    assert mock_config_entry.data == valid_user_input
+
+
+async def test_reconfigure_mismatched_entry(
+    hass: HomeAssistant,
+    mock_appliance_client: AsyncMock,
+    mock_token_manager: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test reconfigure flow mismatched user id error."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+
+    assert result["type"] is data_entry_flow.FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+
+    mock_token_manager.get_user_id.return_value = "different_user_id"
+    mock_appliance_client.test_connection.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input=valid_user_input
+    )
+
+    assert result["type"] is data_entry_flow.FlowResultType.ABORT
+    assert result["reason"] == "unique_id_mismatch"

--- a/tests/components/electrolux/test_config_flow.py
+++ b/tests/components/electrolux/test_config_flow.py
@@ -1,5 +1,6 @@
 """Unit test for Electrolux config flow."""
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock
 
 from electrolux_group_developer_sdk.auth.invalid_credentials_exception import (
@@ -314,10 +315,9 @@ async def test_reauth_mismatched_entry(
     assert result["reason"] == "unique_id_mismatch"
 
 
+@pytest.mark.usefixtures("mock_appliance_client", "mock_token_manager")
 async def test_reconfigure_successful(
     hass: HomeAssistant,
-    mock_appliance_client: AsyncMock,
-    mock_token_manager: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the reconfigure step succeeds and updates the config entry."""
@@ -338,62 +338,30 @@ async def test_reconfigure_successful(
     assert mock_config_entry.data == valid_user_input
 
 
+def _get_ensure_credentials(*, mock_token_manager: AsyncMock, **_) -> AsyncMock:
+    """Get the ensure_credentials method from the mock token manager."""
+    return mock_token_manager.ensure_credentials
+
+
+def _get_test_connection(*, mock_appliance_client: AsyncMock, **_) -> AsyncMock:
+    """Get the test_connection method from the mock appliance client."""
+    return mock_appliance_client.test_connection
+
+
 @pytest.mark.parametrize(
-    ("exception", "error_name"),
+    ("get_mock", "exception", "error_name"),
     [
-        (InvalidCredentialsException(), "invalid_auth"),
+        (_get_ensure_credentials, InvalidCredentialsException(), "invalid_auth"),
+        (_get_test_connection, BadCredentialsException(), "invalid_auth"),
+        (_get_test_connection, FailedConnectionException(), "cannot_connect"),
     ],
 )
-async def test_reconfigure_missing_credentials_error(
+async def test_reconfigure_error(
     hass: HomeAssistant,
     mock_appliance_client: AsyncMock,
     mock_token_manager: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    exception: Exception,
-    error_name: str,
-) -> None:
-    """Test reconfigure flow with invalid authentication."""
-    mock_config_entry.add_to_hass(hass)
-
-    result = await mock_config_entry.start_reconfigure_flow(hass)
-
-    assert result["type"] is data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-
-    mock_token_manager.ensure_credentials.side_effect = exception
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=invalid_user_input
-    )
-
-    assert result["type"] is data_entry_flow.FlowResultType.FORM
-    assert result["step_id"] == "reconfigure"
-    assert result["errors"] == {"base": error_name}
-
-    mock_token_manager.ensure_credentials.side_effect = None
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input=valid_user_input
-    )
-
-    assert result["type"] is data_entry_flow.FlowResultType.ABORT
-    assert result["reason"] == "reconfigure_successful"
-
-    assert mock_config_entry.data == valid_user_input
-
-
-@pytest.mark.parametrize(
-    ("exception", "error_name"),
-    [
-        (BadCredentialsException(), "invalid_auth"),
-        (FailedConnectionException(), "cannot_connect"),
-    ],
-)
-async def test_reconfigure_connection_error(
-    hass: HomeAssistant,
-    mock_appliance_client: AsyncMock,
-    mock_token_manager: AsyncMock,
-    mock_config_entry: MockConfigEntry,
+    get_mock: Callable[..., AsyncMock],
     exception: Exception,
     error_name: str,
 ) -> None:
@@ -405,7 +373,10 @@ async def test_reconfigure_connection_error(
     assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
 
-    mock_appliance_client.test_connection.side_effect = exception
+    get_mock(
+        mock_appliance_client=mock_appliance_client,
+        mock_token_manager=mock_token_manager,
+    ).side_effect = exception
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=invalid_user_input
@@ -413,8 +384,12 @@ async def test_reconfigure_connection_error(
 
     assert result["type"] is data_entry_flow.FlowResultType.FORM
     assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": error_name}
 
-    mock_appliance_client.test_connection.side_effect = None
+    get_mock(
+        mock_appliance_client=mock_appliance_client,
+        mock_token_manager=mock_token_manager,
+    ).side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=valid_user_input
@@ -426,9 +401,9 @@ async def test_reconfigure_connection_error(
     assert mock_config_entry.data == valid_user_input
 
 
+@pytest.mark.usefixtures("mock_appliance_client")
 async def test_reconfigure_mismatched_entry(
     hass: HomeAssistant,
-    mock_appliance_client: AsyncMock,
     mock_token_manager: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -441,7 +416,6 @@ async def test_reconfigure_mismatched_entry(
     assert result["step_id"] == "reconfigure"
 
     mock_token_manager.get_user_id.return_value = "different_user_id"
-    mock_appliance_client.test_connection.side_effect = None
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], user_input=valid_user_input


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for the reconfigure flow for the Electrolux integration, allowing users to change the credentials associated with the Electrolux integration.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
