### PR TITLE
Add diagnostics platform to Google Health

### DIFF
--- a/homeassistant/components/google_health/diagnostics.py
+++ b/homeassistant/components/google_health/diagnostics.py
@@ -1,0 +1,60 @@
+"""Diagnostics support for Google Health."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_ACCESS_TOKEN
+from homeassistant.core import HomeAssistant
+
+from . import GoogleHealthConfigEntry
+
+TO_REDACT = {
+    CONF_ACCESS_TOKEN,
+    "refresh_token",
+    "client_id",
+    "client_secret",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: GoogleHealthConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    data = entry.runtime_data
+
+    activity_diagnostics = None
+    if (activity_coordinator := data.activity_coordinator) is not None:
+        activity_data = activity_coordinator.data
+        activity_diagnostics = {
+            "last_update_success": activity_coordinator.last_update_success,
+            "steps": activity_data.steps is not None,
+            "distance": activity_data.distance is not None,
+            "active_energy_burned": activity_data.active_energy_burned is not None,
+            "total_calories": activity_data.total_calories is not None,
+            "floors": activity_data.floors is not None,
+        }
+
+    body_diagnostics = None
+    if (body_coordinator := data.body_coordinator) is not None:
+        body_data = body_coordinator.data
+        body_diagnostics = {
+            "last_update_success": body_coordinator.last_update_success,
+            "weight": body_data.weight is not None,
+            "resting_heart_rate": body_data.resting_heart_rate is not None,
+            "body_fat": body_data.body_fat is not None,
+        }
+
+    sleep_diagnostics = None
+    if (sleep_coordinator := data.sleep_coordinator) is not None:
+        sleep_data = sleep_coordinator.data
+        sleep_diagnostics = {
+            "last_update_success": sleep_coordinator.last_update_success,
+            "sleep": sleep_data.sleep is not None,
+        }
+
+    return {
+        "config_entry": async_redact_data(dict(entry.data), TO_REDACT),
+        "activity_coordinator": activity_diagnostics,
+        "body_coordinator": body_diagnostics,
+        "sleep_coordinator": sleep_diagnostics,
+    }

--- a/homeassistant/components/google_health/quality_scale.yaml
+++ b/homeassistant/components/google_health/quality_scale.yaml
@@ -49,7 +49,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info:
     status: exempt
     comment: This integration does not support discovery.

--- a/tests/components/google_health/snapshots/test_diagnostics.ambr
+++ b/tests/components/google_health/snapshots/test_diagnostics.ambr
@@ -1,0 +1,121 @@
+# serializer version: 1
+# name: test_diagnostics_empty_data
+  dict({
+    'activity_coordinator': dict({
+      'active_energy_burned': False,
+      'distance': False,
+      'floors': False,
+      'last_update_success': True,
+      'steps': False,
+      'total_calories': False,
+    }),
+    'body_coordinator': dict({
+      'body_fat': False,
+      'last_update_success': True,
+      'resting_heart_rate': False,
+      'weight': False,
+    }),
+    'config_entry': dict({
+      'auth_implementation': 'google_health',
+      'token': dict({
+        'access_token': '**REDACTED**',
+        'expires_at': 1784819180,
+        'refresh_token': '**REDACTED**',
+        'scope': 'https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/userinfo.profile',
+        'token_type': 'Bearer',
+      }),
+    }),
+    'sleep_coordinator': dict({
+      'last_update_success': True,
+      'sleep': False,
+    }),
+  })
+# ---
+# name: test_diagnostics_full_data
+  dict({
+    'activity_coordinator': dict({
+      'active_energy_burned': True,
+      'distance': True,
+      'floors': True,
+      'last_update_success': True,
+      'steps': True,
+      'total_calories': True,
+    }),
+    'body_coordinator': dict({
+      'body_fat': True,
+      'last_update_success': True,
+      'resting_heart_rate': True,
+      'weight': True,
+    }),
+    'config_entry': dict({
+      'auth_implementation': 'google_health',
+      'token': dict({
+        'access_token': '**REDACTED**',
+        'expires_at': 1784819179,
+        'refresh_token': '**REDACTED**',
+        'scope': 'https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/userinfo.profile',
+        'token_type': 'Bearer',
+      }),
+    }),
+    'sleep_coordinator': dict({
+      'last_update_success': True,
+      'sleep': True,
+    }),
+  })
+# ---
+# name: test_diagnostics_partial_scopes[scopes0]
+  dict({
+    'activity_coordinator': dict({
+      'active_energy_burned': True,
+      'distance': True,
+      'floors': True,
+      'last_update_success': True,
+      'steps': True,
+      'total_calories': True,
+    }),
+    'body_coordinator': None,
+    'config_entry': dict({
+      'auth_implementation': 'google_health',
+      'token': dict({
+        'access_token': '**REDACTED**',
+        'expires_at': 1784819180,
+        'refresh_token': '**REDACTED**',
+        'scope': 'https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly',
+        'token_type': 'Bearer',
+      }),
+    }),
+    'sleep_coordinator': None,
+  })
+# ---
+# name: test_diagnostics_update_failed
+  dict({
+    'activity_coordinator': dict({
+      'active_energy_burned': True,
+      'distance': True,
+      'floors': True,
+      'last_update_success': False,
+      'steps': True,
+      'total_calories': True,
+    }),
+    'body_coordinator': dict({
+      'body_fat': True,
+      'last_update_success': True,
+      'resting_heart_rate': True,
+      'weight': True,
+    }),
+    'config_entry': dict({
+      'auth_implementation': 'google_health',
+      'token': dict({
+        'access_token': '**REDACTED**',
+        'expires_at': 1784819180,
+        'refresh_token': '**REDACTED**',
+        'scope': 'https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/userinfo.profile',
+        'token_type': 'Bearer',
+      }),
+    }),
+    'sleep_coordinator': dict({
+      'last_update_success': True,
+      'sleep': True,
+    }),
+  })
+# ---

--- a/tests/components/google_health/snapshots/test_diagnostics.ambr
+++ b/tests/components/google_health/snapshots/test_diagnostics.ambr
@@ -19,7 +19,7 @@
       'auth_implementation': 'google_health',
       'token': dict({
         'access_token': '**REDACTED**',
-        'expires_at': 1784819180,
+        'expires_at': 1784764800,
         'refresh_token': '**REDACTED**',
         'scope': 'https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/userinfo.profile',
         'token_type': 'Bearer',
@@ -51,7 +51,7 @@
       'auth_implementation': 'google_health',
       'token': dict({
         'access_token': '**REDACTED**',
-        'expires_at': 1784819179,
+        'expires_at': 1784764800,
         'refresh_token': '**REDACTED**',
         'scope': 'https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/userinfo.profile',
         'token_type': 'Bearer',
@@ -78,7 +78,7 @@
       'auth_implementation': 'google_health',
       'token': dict({
         'access_token': '**REDACTED**',
-        'expires_at': 1784819180,
+        'expires_at': 1784764800,
         'refresh_token': '**REDACTED**',
         'scope': 'https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly',
         'token_type': 'Bearer',
@@ -107,7 +107,7 @@
       'auth_implementation': 'google_health',
       'token': dict({
         'access_token': '**REDACTED**',
-        'expires_at': 1784819180,
+        'expires_at': 1784764800,
         'refresh_token': '**REDACTED**',
         'scope': 'https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly https://www.googleapis.com/auth/googlehealth.profile.readonly https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly https://www.googleapis.com/auth/googlehealth.sleep.readonly https://www.googleapis.com/auth/userinfo.profile',
         'token_type': 'Bearer',

--- a/tests/components/google_health/test_diagnostics.py
+++ b/tests/components/google_health/test_diagnostics.py
@@ -17,6 +17,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
+pytestmark = pytest.mark.freeze_time("2026-07-22 00:00:00+00:00")
+
 
 @pytest.mark.usefixtures("mock_google_health_client")
 async def test_diagnostics_full_data(

--- a/tests/components/google_health/test_diagnostics.py
+++ b/tests/components/google_health/test_diagnostics.py
@@ -1,0 +1,131 @@
+"""Tests for the diagnostics data provided by the Google Health integration."""
+
+from collections.abc import Awaitable, Callable
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from google_health_api.exceptions import GoogleHealthApiError
+from google_health_api.model import ListDataPointResult, _ListDataPointsModel
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.google_health.coordinator import POLLING_INTERVAL
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from tests.common import MockConfigEntry, async_fire_time_changed
+from tests.components.diagnostics import get_diagnostics_for_config_entry
+from tests.typing import ClientSessionGenerator
+
+
+@pytest.mark.usefixtures("mock_google_health_client")
+async def test_diagnostics_full_data(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics output when all coordinators have data."""
+    assert await integration_setup()
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry
+    )
+
+    assert diagnostics == snapshot
+
+
+async def test_diagnostics_empty_data(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_google_health_client: AsyncMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics output when coordinators have no data."""
+    # Mock all coordinator endpoints to return None or empty data
+    mock_google_health_client.steps.today.return_value = None
+    mock_google_health_client.distance.today.return_value = None
+    mock_google_health_client.active_energy_burned.today.return_value = None
+    mock_google_health_client.total_calories.today.return_value = None
+    mock_google_health_client.floors.today.return_value = None
+
+    mock_google_health_client.weight.list.return_value = ListDataPointResult(
+        _ListDataPointsModel(data_points=[])
+    )
+    mock_google_health_client.daily_resting_heart_rate.list.return_value = (
+        ListDataPointResult(_ListDataPointsModel(data_points=[]))
+    )
+    mock_google_health_client.body_fat.list.return_value = ListDataPointResult(
+        _ListDataPointsModel(data_points=[])
+    )
+
+    mock_google_health_client.sleep.list.return_value = ListDataPointResult(
+        _ListDataPointsModel(data_points=[])
+    )
+
+    assert await integration_setup()
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry
+    )
+
+    assert diagnostics == snapshot
+
+
+async def test_diagnostics_update_failed(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    mock_google_health_client: AsyncMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics output when coordinator update fails."""
+    assert await integration_setup()
+
+    # Trigger update failure on next refresh for activity coordinator
+    mock_google_health_client.steps.today.side_effect = GoogleHealthApiError(
+        "API Error"
+    )
+
+    async_fire_time_changed(
+        hass,
+        dt_util.utcnow() + POLLING_INTERVAL + timedelta(seconds=1),
+    )
+    await hass.async_block_till_done()
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry
+    )
+
+    assert diagnostics == snapshot
+
+
+@pytest.mark.usefixtures("mock_google_health_client")
+@pytest.mark.parametrize(
+    "scopes",
+    [
+        [
+            "https://www.googleapis.com/auth/googlehealth.profile.readonly",
+            "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly",
+        ]
+    ],
+)
+async def test_diagnostics_partial_scopes(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test diagnostics when only a subset of scopes is authorized."""
+    assert await integration_setup()
+
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry
+    )
+
+    assert diagnostics == snapshot

--- a/tests/components/google_health/test_diagnostics.py
+++ b/tests/components/google_health/test_diagnostics.py
@@ -17,9 +17,8 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.components.diagnostics import get_diagnostics_for_config_entry
 from tests.typing import ClientSessionGenerator
 
-pytestmark = pytest.mark.freeze_time("2026-07-22 00:00:00+00:00")
 
-
+@pytest.mark.freeze_time("2026-07-22 00:00:00+00:00")
 @pytest.mark.usefixtures("mock_google_health_client")
 async def test_diagnostics_full_data(
     hass: HomeAssistant,
@@ -38,6 +37,7 @@ async def test_diagnostics_full_data(
     assert diagnostics == snapshot
 
 
+@pytest.mark.freeze_time("2026-07-22 00:00:00+00:00")
 async def test_diagnostics_empty_data(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -77,6 +77,7 @@ async def test_diagnostics_empty_data(
     assert diagnostics == snapshot
 
 
+@pytest.mark.freeze_time("2026-07-22 00:00:00+00:00")
 async def test_diagnostics_update_failed(
     hass: HomeAssistant,
     hass_client: ClientSessionGenerator,
@@ -106,6 +107,7 @@ async def test_diagnostics_update_failed(
     assert diagnostics == snapshot
 
 
+@pytest.mark.freeze_time("2026-07-22 00:00:00+00:00")
 @pytest.mark.usefixtures("mock_google_health_client")
 @pytest.mark.parametrize(
     "scopes",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a diagnostics platform to the Google Health integration.
The diagnostics payload provides:
- Redacted config entry data (access token, refresh token, client ID, client secret recursively redacted using `async_redact_data`).
- Boolean indicators for the presence of activity data, body measurements, and sleep sessions across the three coordinators (Activity, Body, Sleep) to ensure user health data privacy (Withings-style).
- Status of the last update for each active coordinator via `last_update_success`.

This ensures that developers can debug data fetching and scope issues without exposing sensitive health information.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Describe detail context.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.
  
  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
