### PR TITLE
Add zone source exclusion option to Russound RIO

### DIFF
--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -16,8 +16,10 @@ from homeassistant.config_entries import (
     SOURCE_RECONFIGURE,
     ConfigFlow,
     ConfigFlowResult,
+    OptionsFlowWithReload,
 )
 from homeassistant.const import CONF_DEVICE, CONF_HOST, CONF_NAME, CONF_PORT, CONF_TYPE
+from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.selector import (
     SelectSelector,
@@ -26,8 +28,10 @@ from homeassistant.helpers.selector import (
 )
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 
+from . import RussoundConfigEntry
 from .const import (
     CONF_BAUDRATE,
+    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
     DEFAULT_BAUDRATE,
     DEFAULT_PORT,
     DOMAIN,
@@ -64,6 +68,15 @@ SERIAL_SCHEMA = vol.Schema(
     }
 )
 
+OPTIONS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(
+            CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+            default=True,
+        ): bool,
+    }
+)
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -84,10 +97,35 @@ async def _async_validate_connection(
     return controller
 
 
+class OptionsFlowHandler(OptionsFlowWithReload):
+    """Handle Russound RIO options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=self.add_suggested_values_to_schema(
+                OPTIONS_SCHEMA, self.config_entry.options
+            ),
+        )
+
+
 class FlowHandler(ConfigFlow, domain=DOMAIN):
     """Russound RIO configuration flow."""
 
     VERSION = 2
+
+    @staticmethod
+    @callback
+    @override
+    def async_get_options_flow(config_entry: RussoundConfigEntry) -> OptionsFlowHandler:
+        """Create the options flow."""
+        return OptionsFlowHandler()
 
     def __init__(self) -> None:
         """Initialize the config flow."""

--- a/homeassistant/components/russound_rio/config_flow.py
+++ b/homeassistant/components/russound_rio/config_flow.py
@@ -31,7 +31,7 @@ from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from . import RussoundConfigEntry
 from .const import (
     CONF_BAUDRATE,
-    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+    CONF_ZONE_SOURCE_EXCLUSION,
     DEFAULT_BAUDRATE,
     DEFAULT_PORT,
     DOMAIN,
@@ -71,7 +71,7 @@ SERIAL_SCHEMA = vol.Schema(
 OPTIONS_SCHEMA = vol.Schema(
     {
         vol.Optional(
-            CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+            CONF_ZONE_SOURCE_EXCLUSION,
             default=True,
         ): bool,
     }

--- a/homeassistant/components/russound_rio/const.py
+++ b/homeassistant/components/russound_rio/const.py
@@ -18,7 +18,7 @@ RUSSOUND_RIO_EXCEPTIONS = (
 )
 
 CONF_BAUDRATE = "baudrate"
-CONF_ENABLE_ZONE_SOURCE_EXCLUSION = "enable_zone_source_exclusion"
+CONF_ZONE_SOURCE_EXCLUSION = "zone_source_exclusion"
 TYPE_TCP = "tcp"
 TYPE_SERIAL = "serial"
 DEFAULT_BAUDRATE = 19200

--- a/homeassistant/components/russound_rio/const.py
+++ b/homeassistant/components/russound_rio/const.py
@@ -18,6 +18,7 @@ RUSSOUND_RIO_EXCEPTIONS = (
 )
 
 CONF_BAUDRATE = "baudrate"
+CONF_ENABLE_ZONE_SOURCE_EXCLUSION = "enable_zone_source_exclusion"
 TYPE_TCP = "tcp"
 TYPE_SERIAL = "serial"
 DEFAULT_BAUDRATE = 19200

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import RussoundConfigEntry, media_browser
 from .const import (
-    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+    CONF_ZONE_SOURCE_EXCLUSION,
     DOMAIN,
     RUSSOUND_MEDIA_TYPE_PRESET,
     SELECT_SOURCE_DELAY,
@@ -45,13 +45,13 @@ async def async_setup_entry(
     client = entry.runtime_data
     sources = client.sources
 
-    enable_zone_source_exclusion = entry.options.get(
-        CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+    zone_source_exclusion = entry.options.get(
+        CONF_ZONE_SOURCE_EXCLUSION,
         True,
     )
 
     async_add_entities(
-        RussoundZoneDevice(controller, zone_id, sources, enable_zone_source_exclusion)
+        RussoundZoneDevice(controller, zone_id, sources, zone_source_exclusion)
         for controller in client.controllers.values()
         for zone_id in controller.zones
     )
@@ -91,14 +91,14 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
         controller: Controller,
         zone_id: int,
         sources: dict[int, Source],
-        enable_zone_source_exclusion: bool,
+        zone_source_exclusion: bool,
     ) -> None:
         """Initialize the zone device."""
         super().__init__(controller, zone_id)
         _zone = self._zone
         self._sources = sources
         self._attr_unique_id = f"{self._primary_mac_address}-{_zone.device_str}"
-        self._enable_zone_source_exclusion = enable_zone_source_exclusion
+        self._zone_source_exclusion = zone_source_exclusion
 
     @property
     def _source(self) -> Source:
@@ -144,7 +144,7 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
                 is_feature_supported(
                     self._client.rio_version, FeatureFlag.SUPPORT_ZONE_SOURCE_EXCLUSION
                 )
-                and self._enable_zone_source_exclusion
+                and self._zone_source_exclusion
             )
             else self._sources.values()
         )

--- a/homeassistant/components/russound_rio/media_player.py
+++ b/homeassistant/components/russound_rio/media_player.py
@@ -23,7 +23,12 @@ from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import RussoundConfigEntry, media_browser
-from .const import DOMAIN, RUSSOUND_MEDIA_TYPE_PRESET, SELECT_SOURCE_DELAY
+from .const import (
+    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+    DOMAIN,
+    RUSSOUND_MEDIA_TYPE_PRESET,
+    SELECT_SOURCE_DELAY,
+)
 from .entity import RussoundBaseEntity, command
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,8 +45,13 @@ async def async_setup_entry(
     client = entry.runtime_data
     sources = client.sources
 
+    enable_zone_source_exclusion = entry.options.get(
+        CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+        True,
+    )
+
     async_add_entities(
-        RussoundZoneDevice(controller, zone_id, sources)
+        RussoundZoneDevice(controller, zone_id, sources, enable_zone_source_exclusion)
         for controller in client.controllers.values()
         for zone_id in controller.zones
     )
@@ -77,13 +87,18 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
     _attr_name = None
 
     def __init__(
-        self, controller: Controller, zone_id: int, sources: dict[int, Source]
+        self,
+        controller: Controller,
+        zone_id: int,
+        sources: dict[int, Source],
+        enable_zone_source_exclusion: bool,
     ) -> None:
         """Initialize the zone device."""
         super().__init__(controller, zone_id)
         _zone = self._zone
         self._sources = sources
         self._attr_unique_id = f"{self._primary_mac_address}-{_zone.device_str}"
+        self._enable_zone_source_exclusion = enable_zone_source_exclusion
 
     @property
     def _source(self) -> Source:
@@ -125,8 +140,11 @@ class RussoundZoneDevice(RussoundBaseEntity, MediaPlayerEntity):
                 for source_id, source in self._sources.items()
                 if source_id in self._zone.enabled_sources
             ]
-            if is_feature_supported(
-                self._client.rio_version, FeatureFlag.SUPPORT_ZONE_SOURCE_EXCLUSION
+            if (
+                is_feature_supported(
+                    self._client.rio_version, FeatureFlag.SUPPORT_ZONE_SOURCE_EXCLUSION
+                )
+                and self._enable_zone_source_exclusion
             )
             else self._sources.values()
         )

--- a/homeassistant/components/russound_rio/quality_scale.yaml
+++ b/homeassistant/components/russound_rio/quality_scale.yaml
@@ -47,10 +47,7 @@ rules:
   test-coverage: done
   integration-owner: done
   docs-installation-parameters: done
-  docs-configuration-parameters:
-    status: exempt
-    comment: |
-      This integration does not have an options flow.
+  docs-configuration-parameters: done
   # Gold
   entity-translations:
     status: exempt

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -111,10 +111,10 @@
     "step": {
       "init": {
         "data": {
-          "enable_zone_source_exclusion": "Enable zone source exclusion"
+          "zone_source_exclusion": "Zone source exclusion"
         },
         "data_description": {
-          "enable_zone_source_exclusion": "Exclude sources that are disabled for a zone from that zone's available source list. (Only available on compatible Russound devices)"
+          "zone_source_exclusion": "When enabled, Home Assistant hides sources that are disabled for a zone from the source list for that zone."
         }
       }
     }

--- a/homeassistant/components/russound_rio/strings.json
+++ b/homeassistant/components/russound_rio/strings.json
@@ -107,6 +107,18 @@
       "message": "Unsupported media type for Russound zone: {media_type}"
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "data": {
+          "enable_zone_source_exclusion": "Enable zone source exclusion"
+        },
+        "data_description": {
+          "enable_zone_source_exclusion": "Exclude sources that are disabled for a zone from that zone's available source list. (Only available on compatible Russound devices)"
+        }
+      }
+    }
+  },
   "selector": {
     "connection_type": {
       "options": {

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -5,7 +5,12 @@ from unittest.mock import AsyncMock
 
 import pytest
 
-from homeassistant.components.russound_rio.const import DOMAIN, TYPE_SERIAL, TYPE_TCP
+from homeassistant.components.russound_rio.const import (
+    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+    DOMAIN,
+    TYPE_SERIAL,
+    TYPE_TCP,
+)
 from homeassistant.config_entries import SOURCE_USER, SOURCE_ZEROCONF, ConfigFlowResult
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_TYPE
 from homeassistant.core import HomeAssistant
@@ -527,3 +532,41 @@ async def test_reconfigure_serial_unique_id_mismatch(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "wrong_device"
+
+
+async def test_options_flow(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+    mock_russound_client: AsyncMock,
+) -> None:
+    """Test the options flow and automatic reload."""
+    mock_config_entry.runtime_data = mock_russound_client
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_setup_entry.call_count == 1
+
+    result = await hass.config_entries.options.async_init(mock_config_entry.entry_id)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_ENABLE_ZONE_SOURCE_EXCLUSION: True,
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert (
+        result["data"]
+        == mock_config_entry.options
+        == {
+            CONF_ENABLE_ZONE_SOURCE_EXCLUSION: True,
+        }
+    )
+    assert mock_russound_client.disconnect.await_count == 1
+    assert mock_setup_entry.call_count == 2

--- a/tests/components/russound_rio/test_config_flow.py
+++ b/tests/components/russound_rio/test_config_flow.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from homeassistant.components.russound_rio.const import (
-    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
+    CONF_ZONE_SOURCE_EXCLUSION,
     DOMAIN,
     TYPE_SERIAL,
     TYPE_TCP,
@@ -555,7 +555,7 @@ async def test_options_flow(
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            CONF_ENABLE_ZONE_SOURCE_EXCLUSION: True,
+            CONF_ZONE_SOURCE_EXCLUSION: True,
         },
     )
     await hass.async_block_till_done()
@@ -565,7 +565,7 @@ async def test_options_flow(
         result["data"]
         == mock_config_entry.options
         == {
-            CONF_ENABLE_ZONE_SOURCE_EXCLUSION: True,
+            CONF_ZONE_SOURCE_EXCLUSION: True,
         }
     )
     assert mock_russound_client.disconnect.await_count == 1

--- a/tests/components/russound_rio/test_media_player.py
+++ b/tests/components/russound_rio/test_media_player.py
@@ -1,6 +1,6 @@
 """Tests for the Russound RIO media player."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aiorussound.const import FeatureFlag
 from aiorussound.exceptions import CommandError
@@ -9,6 +9,7 @@ import pytest
 
 from homeassistant.components.media_player import (
     ATTR_INPUT_SOURCE,
+    ATTR_INPUT_SOURCE_LIST,
     ATTR_MEDIA_CONTENT_ID,
     ATTR_MEDIA_CONTENT_TYPE,
     ATTR_MEDIA_SEEK_POSITION,
@@ -17,6 +18,9 @@ from homeassistant.components.media_player import (
     DOMAIN as MP_DOMAIN,
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
+)
+from homeassistant.components.russound_rio.const import (
+    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -347,3 +351,40 @@ async def test_play_media_unknown_type(
             },
             blocking=True,
         )
+
+
+@pytest.mark.parametrize(
+    ("enable_exclusion", "expected_sources"),
+    [
+        (False, ["Aux", "Spotify"]),
+        (True, ["Aux"]),
+    ],
+)
+async def test_source_list_exclusion(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_russound_client: AsyncMock,
+    enable_exclusion: bool,
+    expected_sources: list[str],
+) -> None:
+    """Test zone source exclusion."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        options={
+            CONF_ENABLE_ZONE_SOURCE_EXCLUSION: enable_exclusion,
+        },
+    )
+
+    mock_russound_client.controllers[1].zones[1].enabled_sources = [1]
+
+    with patch(
+        "homeassistant.components.russound_rio.media_player.is_feature_supported",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID_ZONE_1)
+    assert state is not None
+    assert state.attributes[ATTR_INPUT_SOURCE_LIST] == expected_sources

--- a/tests/components/russound_rio/test_media_player.py
+++ b/tests/components/russound_rio/test_media_player.py
@@ -1,6 +1,6 @@
 """Tests for the Russound RIO media player."""
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock
 
 from aiorussound.const import FeatureFlag
 from aiorussound.exceptions import CommandError
@@ -354,20 +354,22 @@ async def test_play_media_unknown_type(
 
 
 @pytest.mark.parametrize(
-    ("enable_exclusion", "expected_sources"),
+    ("rio_version", "enable_exclusion", "expected_sources"),
     [
-        (False, ["Aux", "Spotify"]),
-        (True, ["Aux"]),
+        ("1.06.00", True, ["Aux", "Spotify"]),
+        ("1.07.00", False, ["Aux", "Spotify"]),
+        ("1.07.00", True, ["Aux"]),
     ],
 )
 async def test_source_list_exclusion(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_russound_client: AsyncMock,
+    rio_version: str,
     enable_exclusion: bool,
     expected_sources: list[str],
 ) -> None:
-    """Test zone source exclusion."""
+    """Test zone source exclusion based on version and configuration."""
     mock_config_entry.add_to_hass(hass)
     hass.config_entries.async_update_entry(
         mock_config_entry,
@@ -376,14 +378,11 @@ async def test_source_list_exclusion(
         },
     )
 
+    mock_russound_client.rio_version = rio_version
     mock_russound_client.controllers[1].zones[1].enabled_sources = [1]
 
-    with patch(
-        "homeassistant.components.russound_rio.media_player.is_feature_supported",
-        return_value=True,
-    ):
-        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-        await hass.async_block_till_done()
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
 
     state = hass.states.get(ENTITY_ID_ZONE_1)
     assert state is not None

--- a/tests/components/russound_rio/test_media_player.py
+++ b/tests/components/russound_rio/test_media_player.py
@@ -19,9 +19,7 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
     SERVICE_SELECT_SOURCE,
 )
-from homeassistant.components.russound_rio.const import (
-    CONF_ENABLE_ZONE_SOURCE_EXCLUSION,
-)
+from homeassistant.components.russound_rio.const import CONF_ZONE_SOURCE_EXCLUSION
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     SERVICE_MEDIA_SEEK,
@@ -374,7 +372,7 @@ async def test_source_list_exclusion(
     hass.config_entries.async_update_entry(
         mock_config_entry,
         options={
-            CONF_ENABLE_ZONE_SOURCE_EXCLUSION: enable_exclusion,
+            CONF_ZONE_SOURCE_EXCLUSION: enable_exclusion,
         },
     )
 


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Implements an option flow with the option to disable to built in zone source exclusion check. This feature will only show enabled sources for a zone instead of showing all physical sources regardless of whether they are enabled. Some units don't report this properly resulting in broken behavior (https://github.com/home-assistant/core/issues/176800). As such, an option to disable the functionality has been added.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176800
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46990
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
