### PR TITLE
Normalize empty MCP target arguments

### DIFF
--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -58,7 +58,7 @@ def _normalize_hass_target_arguments(
     tool: llm.Tool | None, arguments: dict[str, Any]
 ) -> dict[str, Any]:
     """Remove empty target arguments from Home Assistant intent tool calls."""
-    while isinstance(tool, llm.NamespacedTool):
+    if isinstance(tool, llm.NamespacedTool):
         tool = tool.tool
 
     if not isinstance(tool, llm.IntentTool):

--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -31,6 +31,7 @@ SNAPSHOT_RESOURCE_URI = "homeassistant://assist/context-snapshot"
 SNAPSHOT_RESOURCE_URL = AnyUrl(SNAPSHOT_RESOURCE_URI)
 SNAPSHOT_RESOURCE_MIME_TYPE = "text/plain"
 LIVE_CONTEXT_TOOL_NAME = "GetLiveContext"
+TARGET_ARGUMENTS = ("name", "area", "floor")
 
 
 def _has_live_context_tool(llm_api: llm.APIInstance) -> bool:
@@ -51,6 +52,36 @@ def _format_tool(
             "properties": input_schema["properties"],
         },
     )
+
+
+def _normalize_hass_target_arguments(
+    tool: llm.Tool | None, arguments: dict[str, Any]
+) -> dict[str, Any]:
+    """Remove empty target arguments from Home Assistant intent tool calls."""
+    while isinstance(tool, llm.NamespacedTool):
+        tool = tool.tool
+
+    if not isinstance(tool, llm.IntentTool):
+        return arguments
+
+    target_arguments = {
+        key: arguments[key] for key in TARGET_ARGUMENTS if key in arguments
+    }
+    empty_target_arguments = {
+        key
+        for key, value in target_arguments.items()
+        if isinstance(value, str) and not value.strip()
+    }
+    if not empty_target_arguments or not any(
+        isinstance(value, str) and value.strip() for value in target_arguments.values()
+    ):
+        return arguments
+
+    return {
+        key: value
+        for key, value in arguments.items()
+        if key not in empty_target_arguments
+    }
 
 
 async def create_server(
@@ -150,9 +181,13 @@ async def create_server(
         return [_format_tool(tool, llm_api.custom_serializer) for tool in llm_api.tools]
 
     @server.call_tool()  # type: ignore[untyped-decorator]
-    async def call_tool(name: str, arguments: dict) -> Sequence[types.TextContent]:
+    async def call_tool(
+        name: str, arguments: dict[str, Any]
+    ) -> Sequence[types.TextContent]:
         """Handle calling tools."""
         llm_api = await get_api_instance()
+        tool = next((tool for tool in llm_api.tools if tool.name == name), None)
+        arguments = _normalize_hass_target_arguments(tool, arguments)
         tool_input = llm.ToolInput(tool_name=name, tool_args=arguments)
         _LOGGER.debug("Tool call: %s(%s)", tool_input.tool_name, tool_input.tool_args)
 

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -513,10 +513,9 @@ async def test_mcp_tool_call(
     assert state
     assert state.state == STATE_OFF
 
-    if isinstance(llm_hass_api, list):
-        llm.async_register_api(
-            hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
-        )
+    llm.async_register_api(
+        hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+    )
 
     async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
         result = await session.call_tool(

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -15,6 +15,7 @@ import mcp.client.sse
 import mcp.client.streamable_http
 from mcp.shared.exceptions import McpError
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.conversation import DOMAIN as CONVERSATION_DOMAIN
 from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
@@ -391,16 +392,120 @@ async def test_mcp_tools_list(
     assert tool.inputSchema
     assert tool.inputSchema.get("type") == "object"
     properties = tool.inputSchema.get("properties")
-    assert properties.get("name") == {"type": "string"}
+    for field in ("name", "area", "floor"):
+        assert properties.get(field) == {"type": "string"}
+    assert "required" not in tool.inputSchema
 
 
-@pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])
+@pytest.mark.parametrize(
+    ("llm_hass_api", "tool_name"),
+    [
+        pytest.param(
+            TEST_LLM_API_ID,
+            "HassCustomTool",
+            id="plain",
+        ),
+        pytest.param(
+            [llm.LLM_API_ASSIST, TEST_LLM_API_ID],
+            "test-api__HassCustomTool",
+            id="namespaced",
+        ),
+    ],
+)
+async def test_mcp_tool_call_preserves_non_intent_tool_arguments(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+    tool_name: str,
+) -> None:
+    """Test target arguments are not normalized based on the tool name."""
+    received_arguments: list[dict[str, Any]] = []
+
+    class HassCustomTool(llm.Tool):
+        """Test non-intent tool whose name resembles an intent tool."""
+
+        name = "HassCustomTool"
+        parameters = vol.Schema(
+            {
+                vol.Optional("name"): str,
+                vol.Optional("area"): str,
+                vol.Optional("floor"): str,
+            }
+        )
+
+        async def async_call(
+            self,
+            _hass: HomeAssistant,
+            tool_input: llm.ToolInput,
+            _llm_context: llm.LLMContext,
+        ) -> dict[str, Any]:
+            """Record the arguments received through MCP."""
+            received_arguments.append(tool_input.tool_args)
+            return {"success": True}
+
+    class CustomLLMAPI(llm.API):
+        """Test API exposing a non-intent Hass-named tool."""
+
+        async def async_get_api_instance(
+            self, llm_context: llm.LLMContext
+        ) -> llm.APIInstance:
+            """Return the custom tool API instance."""
+            return llm.APIInstance(
+                api=self,
+                api_prompt="Test prompt",
+                llm_context=llm_context,
+                tools=[HassCustomTool()],
+            )
+
+    llm.async_register_api(
+        hass, CustomLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+    )
+    arguments = {"name": "kitchen light", "area": "", "floor": " \t "}
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.call_tool(name=tool_name, arguments=arguments)
+
+    assert not result.isError
+    assert received_arguments == [arguments]
+
+
+@pytest.mark.parametrize(
+    ("llm_hass_api", "tool_name"),
+    [
+        pytest.param(llm.LLM_API_ASSIST, "HassTurnOn", id="assist"),
+        pytest.param(STATELESS_LLM_API, "HassTurnOn", id="stateless"),
+        pytest.param(
+            [llm.LLM_API_ASSIST, TEST_LLM_API_ID],
+            "assist__HassTurnOn",
+            id="namespaced",
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "arguments",
+    [
+        pytest.param({"name": "kitchen light"}, id="omitted-empty-targets"),
+        pytest.param(
+            {"name": "kitchen light", "area": ""},
+            id="mixed-valid-empty-string-target",
+        ),
+        pytest.param(
+            {"name": "kitchen light", "floor": " \t "},
+            id="mixed-valid-whitespace-target",
+        ),
+    ],
+)
 async def test_mcp_tool_call(
     hass: HomeAssistant,
     setup_integration: None,
     mcp_url: str,
     mcp_client: Any,
     hass_supervisor_access_token: str,
+    arguments: dict[str, str],
+    llm_hass_api: str | list[str],
+    tool_name: str,
 ) -> None:
     """Test the tool call endpoint."""
 
@@ -408,10 +513,15 @@ async def test_mcp_tool_call(
     assert state
     assert state.state == STATE_OFF
 
+    if isinstance(llm_hass_api, list):
+        llm.async_register_api(
+            hass, MockLLMAPI(hass=hass, id=TEST_LLM_API_ID, name="Test API")
+        )
+
     async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
         result = await session.call_tool(
-            name="HassTurnOn",
-            arguments={"name": "kitchen light"},
+            name=tool_name,
+            arguments=arguments,
         )
 
     assert not result.isError
@@ -426,6 +536,35 @@ async def test_mcp_tool_call(
     state = hass.states.get("light.kitchen")
     assert state
     assert state.state == STATE_ON
+
+
+async def test_mcp_tool_call_rejects_all_empty_targets(
+    hass: HomeAssistant,
+    setup_integration: None,
+    mcp_url: str,
+    mcp_client: Any,
+    hass_supervisor_access_token: str,
+) -> None:
+    """Test all empty target arguments are left for strict validation."""
+
+    state = hass.states.get("light.kitchen")
+    assert state
+    assert state.state == STATE_OFF
+
+    async with mcp_client(hass, mcp_url, hass_supervisor_access_token) as session:
+        result = await session.call_tool(
+            name="HassTurnOn",
+            arguments={"name": "", "area": " \t "},
+        )
+
+    assert result.isError
+    assert len(result.content) == 1
+    assert result.content[0].type == "text"
+    assert "Error calling tool" in result.content[0].text
+
+    state = hass.states.get("light.kitchen")
+    assert state
+    assert state.state == STATE_OFF
 
 
 async def test_mcp_tool_call_failed(

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -397,6 +397,7 @@ async def test_mcp_tools_list(
     assert "required" not in tool.inputSchema
 
 
+@pytest.mark.usefixtures("setup_integration")
 @pytest.mark.parametrize(
     ("llm_hass_api", "tool_name"),
     [
@@ -414,7 +415,6 @@ async def test_mcp_tools_list(
 )
 async def test_mcp_tool_call_preserves_non_intent_tool_arguments(
     hass: HomeAssistant,
-    setup_integration: None,
     mcp_url: str,
     mcp_client: Any,
     hass_supervisor_access_token: str,
@@ -537,9 +537,9 @@ async def test_mcp_tool_call(
     assert state.state == STATE_ON
 
 
+@pytest.mark.usefixtures("setup_integration")
 async def test_mcp_tool_call_rejects_all_empty_targets(
     hass: HomeAssistant,
-    setup_integration: None,
     mcp_url: str,
     mcp_client: Any,
     hass_supervisor_access_token: str,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


### Problem and root cause

The MCP schema exposes `name`, `area`, and `floor` as optional strings. Omitting an unused selector is valid, but some LLM/MCP clients instead materialize every optional string property as `""` or whitespace. The MCP server forwarded those values unchanged to the selected tool.

`IntentTool` deliberately validates every supplied target slot as a non-empty string. As a result, a call such as 
```json
{"name": "Kitchen Light", "area": "", "floor": ""}
```
failed on the unrelated empty fields before Home Assistant could use the valid `name` target. The fields were not required, and the values were empty strings rather than JSON `null`; the failure came from treating a client representation of an omitted optional target as a real intent slot.

### How this fixes it

The shared MCP `call_tool` handler now:

1. Resolves the exact selected tool from `llm_api.tools`.
2. Unwraps the single `NamespacedTool` layer added by `MergedAPI` and verifies that the underlying tool is an `IntentTool`.
3. Examines only the intent target arguments `name`, `area`, and `floor`.
4. When at least one non-empty target exists, removes empty or whitespace-only target values before creating `ToolInput`.
5. Leaves calls where every supplied target is empty unchanged, allowing the existing strict intent validation to reject them.

The lookup is type-based rather than name-based, so a custom non-intent tool named `Hass*` keeps its arguments unchanged.

### Why this approach

- **Keep canonical intent validation strict:** allowing empty strings in the Home Assistant intent schemas would affect callers outside MCP and would make an empty target valid globally.
- **Normalize at the compatibility boundary:** the mismatch is introduced by how an MCP client serializes omitted optional properties, so the MCP boundary is the narrowest place to restore omission semantics.
- **Preserve safety:** an all-empty target set is never converted into a targetless action; it continues to fail validation.
- **Avoid relying on schema hints alone:** adding `minLength` would reject the incompatible payload earlier, but it would not recover a call that already contains another valid target.
- **Cover every MCP transport consistently:** normalization in the shared dispatch path applies to SSE, Streamable HTTP, Assist, stateless APIs, and namespaced multi-API tools without transport-specific copies.
- **Avoid false positives:** checking the resolved tool type prevents unrelated custom tools from being modified based only on a `Hass`-like name.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177109
- This PR is related to issue: #145525
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

### Test results

- Baseline: `47 passed, 2 warnings` in `tests/components/mcp_server/test_http.py`.
- Focused local run after the single-namespace unwrapping refinement: `67 passed, 2 warnings in 16.31s` with `uv run pytest -q tests/components/mcp_server/test_http.py`.
- Changed-file hooks all pass: Ruff check/format, codespell, no-commit-to-branch, prettier, mypy, and pylint.
- GitHub Actions on head `9ea55ee2`: 33 check runs completed with zero failures. MCP server tests, prek, mypy, both pylint jobs, hassfest, requirements, coverage uploads, and repository policy checks succeeded; conditionally inapplicable jobs were skipped.
- `git diff --check HEAD^` passes.
- `uv run prek run --all-files` passed Ruff check/format, codespell, zizmor, JSON, branch, YAML, and prettier. The all-files mypy invocation stopped on the existing `homeassistant/util/event_type.py` / `.pyi` duplicate-module pair; the subsequent all-files pylint process entered a prek pipe wait and was stopped. Both hooks pass for the changed production and test files.

### Review follow-up

This replacement incorporates the automated review feedback from #177089: normalization is based on the selected tool type rather than its name, and plain/namespaced non-intent behavior is verified through the public MCP call path.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
