### PR TITLE
Improve Opower authentication failure handling

### DIFF
--- a/homeassistant/components/opower/config_flow.py
+++ b/homeassistant/components/opower/config_flow.py
@@ -8,6 +8,7 @@ from opower import (
     CannotConnect,
     InvalidAuth,
     MfaChallenge,
+    MfaCodeRejected,
     MfaHandlerBase,
     Opower,
     create_cookie_jar,
@@ -94,6 +95,8 @@ class OpowerConfigFlow(ConfigFlow, domain=DOMAIN):
             except MfaChallenge as exc:
                 self.mfa_handler = exc.handler
                 return await self.async_step_mfa_options()
+            except MfaCodeRejected:
+                errors["base"] = "mfa_transaction_rejected"
             except InvalidAuth:
                 errors["base"] = "invalid_auth"
             except CannotConnect:
@@ -210,6 +213,8 @@ class OpowerConfigFlow(ConfigFlow, domain=DOMAIN):
         except MfaChallenge as exc:
             self.mfa_handler = exc.handler
             return await self.async_step_mfa_options()
+        except MfaCodeRejected:
+            errors["base"] = "mfa_transaction_rejected"
         except InvalidAuth:
             errors["base"] = "invalid_auth"
         except CannotConnect:

--- a/homeassistant/components/opower/coordinator.py
+++ b/homeassistant/components/opower/coordinator.py
@@ -10,8 +10,12 @@ from opower import (
     AggregateType,
     CostRead,
     Forecast,
+    InvalidCredentials,
     MeterType,
+    MfaCodeRejected,
     Opower,
+    PasswordExpired,
+    ProtocolError,
     ReadResolution,
     create_cookie_jar,
 )
@@ -107,9 +111,16 @@ class OpowerCoordinator(DataUpdateCoordinator[dict[str, OpowerData]]):
             # Given the infrequent updating (every 12h)
             # assume previous session has expired and re-login.
             await self.api.async_login()
-        except (InvalidAuth, MfaChallenge) as err:
+        except (InvalidCredentials, PasswordExpired, MfaChallenge) as err:
             _LOGGER.error("Error during login: %s", err)
             raise ConfigEntryAuthFailed from err
+        except (InvalidAuth, MfaCodeRejected, ProtocolError) as err:
+            _LOGGER.error("Temporary or protocol error during login: %s", err)
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="login_error",
+                translation_placeholders={"error": str(err)},
+            ) from err
         except CannotConnect as err:
             _LOGGER.error("Error during login: %s", err)
             raise UpdateFailed(

--- a/homeassistant/components/opower/manifest.json
+++ b/homeassistant/components/opower/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["opower"],
   "quality_scale": "platinum",
-  "requirements": ["opower==0.18.6"]
+  "requirements": ["opower==0.19.0"]
 }

--- a/homeassistant/components/opower/strings.json
+++ b/homeassistant/components/opower/strings.json
@@ -7,7 +7,8 @@
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "invalid_mfa_code": "The security code is incorrect. Please try again."
+      "invalid_mfa_code": "The security code is incorrect. Please try again.",
+      "mfa_transaction_rejected": "The provider rejected the MFA transaction. Your saved TOTP secret has not been marked invalid; wait for a fresh code window and try again."
     },
     "step": {
       "credentials": {

--- a/tests/components/opower/test_init.py
+++ b/tests/components/opower/test_init.py
@@ -2,7 +2,13 @@
 
 from unittest.mock import AsyncMock
 
-from opower.exceptions import ApiException, CannotConnect, InvalidAuth
+from opower.exceptions import (
+    ApiException,
+    CannotConnect,
+    InvalidAuth,
+    InvalidCredentials,
+    MfaCodeRejected,
+)
 import pytest
 
 from homeassistant.components.opower.const import DOMAIN
@@ -44,7 +50,15 @@ async def test_setup_unload_entry(
         ),
         (
             InvalidAuth(),
+            ConfigEntryState.SETUP_RETRY,
+        ),
+        (
+            InvalidCredentials(),
             ConfigEntryState.SETUP_ERROR,
+        ),
+        (
+            MfaCodeRejected(),
+            ConfigEntryState.SETUP_RETRY,
         ),
     ],
 )


### PR DESCRIPTION
Depends on the proposed opower 0.19.0 release from stephenbrady/opower. Keeps ambiguous MFA and protocol failures retryable, while only explicit credential/password failures trigger reauthentication. Adds a clear setup message for rejected automatic TOTP transactions.