### PR TITLE
Repair missing DTS on initial stream keyframe

### DIFF
--- a/homeassistant/components/stream/worker.py
+++ b/homeassistant/components/stream/worker.py
@@ -471,6 +471,28 @@ class PeekIterator(Iterator[av.Packet]):
             yield packet
 
 
+def repair_initial_missing_dts(packets: PeekIterator) -> None:
+    """Repair a missing DTS on the initial video keyframe."""
+    buffered_packets = packets.peek()
+    first_video_packet = next(
+        (packet for packet in buffered_packets if packet.stream.type == "video"), None
+    )
+    if (
+        first_video_packet is None
+        or not first_video_packet.is_keyframe
+        or first_video_packet.dts is not None
+    ):
+        return
+
+    next_video_packet = next(
+        (packet for packet in buffered_packets if packet.stream.type == "video"), None
+    )
+    if next_video_packet is None or next_video_packet.dts is None:
+        return
+
+    first_video_packet.dts = next_video_packet.dts - (next_video_packet.duration or 1)
+
+
 class TimestampValidator:
     """Validate ordering of timestamps for packets in a stream."""
 
@@ -630,8 +652,9 @@ def stream_worker(
         int(1 / video_stream.time_base),  # type: ignore[operator]
         int(1 / audio_stream.time_base) if audio_stream else 1,  # type: ignore[operator]
     )
+    unvalidated_packets = PeekIterator(container.demux((video_stream, audio_stream)))
     container_packets = PeekIterator(
-        filter(dts_validator.is_valid, container.demux((video_stream, audio_stream)))
+        filter(dts_validator.is_valid, unvalidated_packets)
     )
 
     def is_video(packet: av.Packet) -> Any:
@@ -645,6 +668,7 @@ def stream_worker(
     # Use a peeking iterator to peek into the start of the stream, ensuring
     # everything looks good, then go back to the start when muxing below.
     try:
+        repair_initial_missing_dts(unvalidated_packets)
         # Get the required bitstream filter
         audio_bsf = get_audio_bitstream_filter(container_packets.peek(), audio_stream)
         # Advance to the first keyframe for muxing, then rewind so the muxing

--- a/tests/components/stream/test_worker.py
+++ b/tests/components/stream/test_worker.py
@@ -519,6 +519,23 @@ async def test_skip_initial_bad_packets(hass: HomeAssistant) -> None:
     assert len(decoded_stream.audio_packets) == 0
 
 
+async def test_repair_initial_keyframe_missing_dts(hass: HomeAssistant) -> None:
+    """Test a missing DTS on the initial keyframe is repaired."""
+
+    packets = list(PacketSequence(TEST_SEQUENCE_LENGTH))
+    first_packet = packets[0]
+    assert first_packet.is_keyframe
+    expected_dts = first_packet.dts
+    first_packet.dts = first_packet.pts = None
+
+    decoded_stream = await async_decode_stream(hass, packets)
+
+    assert len(decoded_stream.video_packets) == len(packets)
+    assert decoded_stream.video_packets[0].dts == expected_dts
+    assert decoded_stream.video_packets[0].pts == expected_dts
+    assert len(decoded_stream.audio_packets) == 0
+
+
 async def test_too_many_initial_bad_packets_fails(hass: HomeAssistant) -> None:
     """Test initial bad packets are too high, causing it to never start."""
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The stream worker currently validates packet DTS values before applying its
existing RTSP timestamp repair. If the initial video keyframe has no DTS, the
timestamp validator discards it and Home Assistant has to wait for the next
keyframe before the stream can start.

This change inspects the unvalidated packets and reconstructs a missing DTS on
the initial video keyframe from the following video packet. The repaired packet
then passes through the existing timestamp validator and the normal first-frame
PTS/DTS adjustment. Packets outside this specific startup case continue to use
the existing validation behavior.

A regression test verifies that an initial keyframe without PTS/DTS is retained
and receives the expected timestamps instead of being discarded.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: https://trac.ffmpeg.org/ticket/5018
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
