### PR TITLE
Add Matter network topology WebSocket API

### DIFF
--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -380,6 +380,7 @@ def _serialize_topology(
     return result
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "matter/network_topology",
@@ -402,6 +403,7 @@ async def websocket_network_topology(
     connection.send_result(msg[ID], _serialize_topology(hass, matter, topology))
 
 
+@websocket_api.require_admin
 @websocket_api.websocket_command(
     {
         vol.Required(TYPE): "matter/subscribe_network_topology",
@@ -420,23 +422,44 @@ async def websocket_subscribe_network_topology(
     if not _topology_supported(connection, msg, matter):
         return
 
+    initial_sent = False
+    # updates are full snapshots, so only the newest buffered one matters
+    buffered: NetworkTopology | None = None
+
     @callback
     def forward_topology(event: EventType, topology: NetworkTopology) -> None:
+        nonlocal buffered
+        if not initial_sent:
+            buffered = topology
+            return
         connection.send_message(
             websocket_api.event_message(
                 msg[ID], _serialize_topology(hass, matter, topology)
             )
         )
 
-    # the initial fetch also opts this client in to topology events server-side
-    topology = await matter.matter_client.get_network_topology()
-    connection.subscriptions[msg[ID]] = matter.matter_client.subscribe_events(
+    # subscribe before the fetch: the fetch opts this client in server-side,
+    # and an update may arrive before the command result does
+    unsubscribe = matter.matter_client.subscribe_events(
         callback=forward_topology,
         event_filter=EventType.NETWORK_TOPOLOGY_UPDATED,
     )
+    try:
+        topology = await matter.matter_client.get_network_topology()
+    except Exception:
+        unsubscribe()
+        raise
+    connection.subscriptions[msg[ID]] = unsubscribe
     connection.send_result(msg[ID])
     connection.send_message(
         websocket_api.event_message(
             msg[ID], _serialize_topology(hass, matter, topology)
         )
     )
+    if buffered is not None:
+        connection.send_message(
+            websocket_api.event_message(
+                msg[ID], _serialize_topology(hass, matter, buffered)
+            )
+        )
+    initial_sent = True

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -4,17 +4,25 @@ from collections.abc import Callable, Coroutine
 from functools import wraps
 from typing import Any, Concatenate
 
+from matter_server.client.exceptions import ServerVersionTooOld
 from matter_server.client.models.node import MatterNode
 from matter_server.common.errors import MatterError
 from matter_server.common.helpers.util import dataclass_to_dict
+from matter_server.common.models import EventType, NetworkTopology
 import voluptuous as vol
 
 from homeassistant.components import websocket_api
-from homeassistant.components.websocket_api import ActiveConnection
+from homeassistant.components.websocket_api import ERR_NOT_SUPPORTED, ActiveConnection
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 
 from .adapter import MatterAdapter
-from .helpers import MissingNode, get_matter, node_from_ha_device_id
+from .helpers import (
+    MissingNode,
+    get_matter,
+    get_node_device_identifier,
+    node_from_ha_device_id,
+)
 
 ID = "id"
 TYPE = "type"
@@ -22,6 +30,9 @@ DEVICE_ID = "device_id"
 
 
 ERROR_NODE_NOT_FOUND = "node_not_found"
+
+# minimum server schema version that provides network topology
+TOPOLOGY_SCHEMA_VERSION = 13
 
 
 @callback
@@ -36,6 +47,8 @@ def async_register_api(hass: HomeAssistant) -> None:
     websocket_api.async_register_command(hass, websocket_open_commissioning_window)
     websocket_api.async_register_command(hass, websocket_remove_matter_fabric)
     websocket_api.async_register_command(hass, websocket_interview_node)
+    websocket_api.async_register_command(hass, websocket_network_topology)
+    websocket_api.async_register_command(hass, websocket_subscribe_network_topology)
 
 
 def async_get_node(
@@ -115,6 +128,8 @@ def async_handle_failed_command[**_P](
             connection.send_error(msg[ID], str(err.error_code), err.args[0])
         except MissingNode as err:
             connection.send_error(msg[ID], ERROR_NODE_NOT_FOUND, err.args[0])
+        except ServerVersionTooOld as err:
+            connection.send_error(msg[ID], ERR_NOT_SUPPORTED, err.args[0])
 
     return async_handle_failed_command_func
 
@@ -328,3 +343,100 @@ async def websocket_interview_node(
     """Interview a node."""
     await matter.matter_client.interview_node(node_id=node.node_id)
     connection.send_result(msg[ID])
+
+
+@callback
+def _topology_supported(
+    connection: ActiveConnection, msg: dict[str, Any], matter: MatterAdapter
+) -> bool:
+    """Check if the server supports network topology, send an error if not."""
+    server_info = matter.matter_client.server_info
+    if server_info is None or server_info.schema_version < TOPOLOGY_SCHEMA_VERSION:
+        connection.send_error(
+            msg[ID],
+            ERR_NOT_SUPPORTED,
+            "The Matter server does not support network topology "
+            f"(requires schema version {TOPOLOGY_SCHEMA_VERSION}).",
+        )
+        return False
+    return True
+
+
+@callback
+def _serialize_topology(
+    hass: HomeAssistant, matter: MatterAdapter, topology: NetworkTopology
+) -> dict[str, Any]:
+    """Serialize a topology snapshot, annotating nodes with HA device ids."""
+    server_info = matter.matter_client.server_info
+    dev_reg = dr.async_get(hass)
+    result: dict[str, Any] = dataclass_to_dict(topology)
+    for node in result["nodes"]:
+        device = None
+        if (node_id := node.get("node_id")) is not None and server_info is not None:
+            device = dev_reg.async_get_device(
+                identifiers={get_node_device_identifier(server_info, node_id)}
+            )
+        node["ha_device_id"] = device.id if device else None
+    return result
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/network_topology",
+        vol.Optional("refresh", default=False): bool,
+    }
+)
+@websocket_api.async_response
+@async_handle_failed_command
+@async_get_matter_adapter
+async def websocket_network_topology(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+) -> None:
+    """Get the network topology graph."""
+    if not _topology_supported(connection, msg, matter):
+        return
+    topology = await matter.matter_client.get_network_topology(refresh=msg["refresh"])
+    connection.send_result(msg[ID], _serialize_topology(hass, matter, topology))
+
+
+@websocket_api.websocket_command(
+    {
+        vol.Required(TYPE): "matter/subscribe_network_topology",
+    }
+)
+@websocket_api.async_response
+@async_handle_failed_command
+@async_get_matter_adapter
+async def websocket_subscribe_network_topology(
+    hass: HomeAssistant,
+    connection: ActiveConnection,
+    msg: dict[str, Any],
+    matter: MatterAdapter,
+) -> None:
+    """Subscribe to network topology updates."""
+    if not _topology_supported(connection, msg, matter):
+        return
+
+    @callback
+    def forward_topology(event: EventType, topology: NetworkTopology) -> None:
+        connection.send_message(
+            websocket_api.event_message(
+                msg[ID], _serialize_topology(hass, matter, topology)
+            )
+        )
+
+    # the initial fetch also opts this client in to topology events server-side
+    topology = await matter.matter_client.get_network_topology()
+    connection.subscriptions[msg[ID]] = matter.matter_client.subscribe_events(
+        callback=forward_topology,
+        event_filter=EventType.NETWORK_TOPOLOGY_UPDATED,
+    )
+    connection.send_result(msg[ID])
+    connection.send_message(
+        websocket_api.event_message(
+            msg[ID], _serialize_topology(hass, matter, topology)
+        )
+    )

--- a/homeassistant/components/matter/api.py
+++ b/homeassistant/components/matter/api.py
@@ -373,8 +373,9 @@ def _serialize_topology(
     for node in result["nodes"]:
         device = None
         if (node_id := node.get("node_id")) is not None and server_info is not None:
-            device = dev_reg.async_get_device(
-                identifiers={get_node_device_identifier(server_info, node_id)}
+            device = dev_reg.async_get_device_by_identifier(
+                get_node_device_identifier(server_info, node_id),
+                matter.config_entry.entry_id,
             )
         node["ha_device_id"] = device.id if device else None
     return result

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -76,6 +76,18 @@ def get_device_id(
     return f"{operational_instance_id}-{postfix}"
 
 
+def get_node_device_identifier(
+    server_info: ServerInfoMessage, node_id: int
+) -> tuple[str, str]:
+    """Return the device registry identifier for the node-level device of a node."""
+    fabric_id_hex = f"{server_info.compressed_fabric_id:016X}"
+    node_id_hex = f"{node_id:016X}"
+    return (
+        DOMAIN,
+        f"{ID_TYPE_DEVICE_ID}_{fabric_id_hex}-{node_id_hex}-MatterNodeDevice",
+    )
+
+
 @callback
 def node_from_ha_device_id(hass: HomeAssistant, ha_device_id: str) -> MatterNode | None:
     """Get node id from ha device id."""

--- a/homeassistant/components/matter/helpers.py
+++ b/homeassistant/components/matter/helpers.py
@@ -83,6 +83,18 @@ def get_device_id(
     return f"{operational_instance_id}-{postfix}"
 
 
+def get_node_device_identifier(
+    server_info: ServerInfoMessage, node_id: int
+) -> tuple[str, str]:
+    """Return the device registry identifier for the node-level device of a node."""
+    fabric_id_hex = f"{server_info.compressed_fabric_id:016X}"
+    node_id_hex = f"{node_id:016X}"
+    return (
+        DOMAIN,
+        f"{ID_TYPE_DEVICE_ID}_{fabric_id_hex}-{node_id_hex}-MatterNodeDevice",
+    )
+
+
 @callback
 def node_from_ha_device_id(hass: HomeAssistant, ha_device_id: str) -> MatterNode | None:
     """Get node id from ha device id."""

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -617,7 +617,6 @@ async def test_subscribe_network_topology(
     assert entry is not None
 
     topology = _mock_topology()
-    matter_client.get_network_topology = AsyncMock(return_value=topology)
 
     subscription_callback: Callable[[EventType, NetworkTopology], None] | None = None
     unsubscribe = MagicMock()
@@ -635,6 +634,17 @@ async def test_subscribe_network_topology(
 
     matter_client.subscribe_events.side_effect = capture_subscription
 
+    during_fetch = _mock_topology()
+    during_fetch.collected_at = 1767888030000
+
+    async def fetch_topology() -> NetworkTopology:
+        # an update arriving while the initial fetch is in flight is buffered
+        assert subscription_callback is not None
+        subscription_callback(EventType.NETWORK_TOPOLOGY_UPDATED, during_fetch)
+        return topology
+
+    matter_client.get_network_topology = AsyncMock(side_effect=fetch_topology)
+
     ws_client = await hass_ws_client(hass)
     await ws_client.send_json({ID: 1, TYPE: "matter/subscribe_network_topology"})
     msg = await ws_client.receive_json()
@@ -647,6 +657,11 @@ async def test_subscribe_network_topology(
     msg = await ws_client.receive_json()
     assert msg["type"] == "event"
     assert msg["event"] == _expected_topology(topology, [entry.id, None, None])
+
+    # the update buffered during the fetch is flushed right after
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == _expected_topology(during_fetch, [entry.id, None, None])
 
     # a topology update from the server is forwarded to the subscription
     updated = _mock_topology()
@@ -663,4 +678,36 @@ async def test_subscribe_network_topology(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
+    unsubscribe.assert_called_once_with()
+
+
+@pytest.mark.usefixtures("integration")
+async def test_subscribe_network_topology_fetch_failure(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    matter_client: MagicMock,
+) -> None:
+    """Test the event subscription is cleaned up when the initial fetch fails."""
+    matter_client.server_info.schema_version = 13
+    unsubscribe = MagicMock()
+
+    def capture_subscription(
+        callback: Callable[[EventType, NetworkTopology], None],
+        event_filter: EventType | None = None,
+        node_filter: int | None = None,
+        attr_path_filter: str | None = None,
+    ) -> MagicMock:
+        return unsubscribe
+
+    matter_client.subscribe_events.side_effect = capture_subscription
+    matter_client.get_network_topology = AsyncMock(
+        side_effect=ServerVersionTooOld("Command not available")
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: "matter/subscribe_network_topology"})
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
     unsubscribe.assert_called_once_with()

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -1,7 +1,9 @@
 """Test the api module."""
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, call
 
+from matter_server.client.exceptions import ServerVersionTooOld
 from matter_server.client.models.node import (
     MatterFabricData,
     NetworkType,
@@ -10,7 +12,14 @@ from matter_server.client.models.node import (
 )
 from matter_server.common.errors import InvalidCommand, NodeCommissionFailed
 from matter_server.common.helpers.util import dataclass_to_dict
-from matter_server.common.models import CommissioningParameters
+from matter_server.common.models import (
+    CommissioningParameters,
+    EventType,
+    NetworkTopology,
+    NetworkTopologyConnection,
+    NetworkTopologyNode,
+    TopologyDirectionInfo,
+)
 import pytest
 
 from homeassistant.components.matter.api import (
@@ -465,3 +474,193 @@ async def test_interview_node(
 
     assert not msg["success"]
     assert msg["error"]["code"] == ERROR_NODE_NOT_FOUND
+
+
+def _mock_topology() -> NetworkTopology:
+    """Return a mock topology with a known node, an unknown node and a border router."""
+    return NetworkTopology(
+        collected_at=1767888000000,
+        nodes=[
+            NetworkTopologyNode(
+                id="30",
+                kind="matter",
+                network_type="thread",
+                node_id=30,
+                role="router",
+                available=True,
+            ),
+            NetworkTopologyNode(
+                id="99",
+                kind="matter",
+                network_type="thread",
+                node_id=99,
+                role="end_device",
+                available=True,
+            ),
+            NetworkTopologyNode(
+                id="br_1122AABBCC334455",
+                kind="border_router",
+                network_type="thread",
+                role="router",
+                ext_address="1122AABBCC334455",
+                vendor_name="Apple",
+            ),
+        ],
+        connections=[
+            NetworkTopologyConnection(
+                source="30",
+                target="br_1122AABBCC334455",
+                network="thread",
+                strength="strong",
+                source_to_target=TopologyDirectionInfo(strength="strong", lqi=3),
+            ),
+        ],
+    )
+
+
+def _expected_topology(
+    topology: NetworkTopology, ha_device_ids: list[str | None]
+) -> dict:
+    """Return the expected ws payload for the given topology."""
+    expected = dataclass_to_dict(topology)
+    for node, ha_device_id in zip(expected["nodes"], ha_device_ids, strict=True):
+        node["ha_device_id"] = ha_device_id
+    return expected
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["mock_onoff_light"])
+async def test_network_topology(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test the network_topology command."""
+    matter_client.server_info.schema_version = 13
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+
+    topology = _mock_topology()
+    matter_client.get_network_topology = AsyncMock(return_value=topology)
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: "matter/network_topology"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    # node 30 maps to the registry device, node 99 and the border router do not
+    assert msg["result"] == _expected_topology(topology, [entry.id, None, None])
+    matter_client.get_network_topology.assert_called_once_with(refresh=False)
+
+    matter_client.get_network_topology.reset_mock()
+    await ws_client.send_json({ID: 2, TYPE: "matter/network_topology", "refresh": True})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    matter_client.get_network_topology.assert_called_once_with(refresh=True)
+
+
+@pytest.mark.parametrize(
+    "command", ["matter/network_topology", "matter/subscribe_network_topology"]
+)
+@pytest.mark.usefixtures("integration")
+async def test_network_topology_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    matter_client: MagicMock,
+    command: str,
+) -> None:
+    """Test the topology commands against a server without topology support."""
+    # the conftest default schema version (1) predates network topology
+    matter_client.get_network_topology = AsyncMock()
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: command})
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
+    matter_client.get_network_topology.assert_not_called()
+
+    # a version mismatch raised by the client also maps to not_supported
+    matter_client.server_info.schema_version = 13
+    matter_client.get_network_topology.side_effect = ServerVersionTooOld(
+        "Command not available due to too old server version"
+    )
+    await ws_client.send_json({ID: 2, TYPE: command})
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["mock_onoff_light"])
+async def test_subscribe_network_topology(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test the subscribe_network_topology command."""
+    matter_client.server_info.schema_version = 13
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+
+    topology = _mock_topology()
+    matter_client.get_network_topology = AsyncMock(return_value=topology)
+
+    subscription_callback: Callable[[EventType, NetworkTopology], None] | None = None
+    unsubscribe = MagicMock()
+
+    def capture_subscription(
+        callback: Callable[[EventType, NetworkTopology], None],
+        event_filter: EventType | None = None,
+        node_filter: int | None = None,
+        attr_path_filter: str | None = None,
+    ) -> MagicMock:
+        nonlocal subscription_callback
+        assert event_filter is EventType.NETWORK_TOPOLOGY_UPDATED
+        subscription_callback = callback
+        return unsubscribe
+
+    matter_client.subscribe_events.side_effect = capture_subscription
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: "matter/subscribe_network_topology"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    matter_client.get_network_topology.assert_called_once_with()
+    assert subscription_callback is not None
+
+    # the initial snapshot is pushed as the first event
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == _expected_topology(topology, [entry.id, None, None])
+
+    # a topology update from the server is forwarded to the subscription
+    updated = _mock_topology()
+    updated.collected_at = 1767888060000
+    updated.nodes = topology.nodes[:1]
+    updated.connections = []
+    subscription_callback(EventType.NETWORK_TOPOLOGY_UPDATED, updated)
+    msg = await ws_client.receive_json()
+
+    assert msg["type"] == "event"
+    assert msg["event"] == _expected_topology(updated, [entry.id])
+
+    await ws_client.send_json({ID: 2, TYPE: "unsubscribe_events", "subscription": 1})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    unsubscribe.assert_called_once_with()

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -533,10 +533,9 @@ async def test_network_topology(
 ) -> None:
     """Test the network_topology command."""
     matter_client.server_info.schema_version = 13
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 
@@ -604,10 +603,9 @@ async def test_subscribe_network_topology(
 ) -> None:
     """Test the subscribe_network_topology command."""
     matter_client.server_info.schema_version = 13
-    entry = device_registry.async_get_device(
-        identifiers={
-            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
-        }
+    entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice"),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
     assert entry is not None
 

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -612,7 +612,6 @@ async def test_subscribe_network_topology(
     assert entry is not None
 
     topology = _mock_topology()
-    matter_client.get_network_topology = AsyncMock(return_value=topology)
 
     subscription_callback: Callable[[EventType, NetworkTopology], None] | None = None
     unsubscribe = MagicMock()
@@ -630,6 +629,17 @@ async def test_subscribe_network_topology(
 
     matter_client.subscribe_events.side_effect = capture_subscription
 
+    during_fetch = _mock_topology()
+    during_fetch.collected_at = 1767888030000
+
+    async def fetch_topology() -> NetworkTopology:
+        # an update arriving while the initial fetch is in flight is buffered
+        assert subscription_callback is not None
+        subscription_callback(EventType.NETWORK_TOPOLOGY_UPDATED, during_fetch)
+        return topology
+
+    matter_client.get_network_topology = AsyncMock(side_effect=fetch_topology)
+
     ws_client = await hass_ws_client(hass)
     await ws_client.send_json({ID: 1, TYPE: "matter/subscribe_network_topology"})
     msg = await ws_client.receive_json()
@@ -642,6 +652,11 @@ async def test_subscribe_network_topology(
     msg = await ws_client.receive_json()
     assert msg["type"] == "event"
     assert msg["event"] == _expected_topology(topology, [entry.id, None, None])
+
+    # the update buffered during the fetch is flushed right after
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == _expected_topology(during_fetch, [entry.id, None, None])
 
     # a topology update from the server is forwarded to the subscription
     updated = _mock_topology()
@@ -658,4 +673,36 @@ async def test_subscribe_network_topology(
     msg = await ws_client.receive_json()
 
     assert msg["success"]
+    unsubscribe.assert_called_once_with()
+
+
+@pytest.mark.usefixtures("integration")
+async def test_subscribe_network_topology_fetch_failure(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    matter_client: MagicMock,
+) -> None:
+    """Test the event subscription is cleaned up when the initial fetch fails."""
+    matter_client.server_info.schema_version = 13
+    unsubscribe = MagicMock()
+
+    def capture_subscription(
+        callback: Callable[[EventType, NetworkTopology], None],
+        event_filter: EventType | None = None,
+        node_filter: int | None = None,
+        attr_path_filter: str | None = None,
+    ) -> MagicMock:
+        return unsubscribe
+
+    matter_client.subscribe_events.side_effect = capture_subscription
+    matter_client.get_network_topology = AsyncMock(
+        side_effect=ServerVersionTooOld("Command not available")
+    )
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: "matter/subscribe_network_topology"})
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
     unsubscribe.assert_called_once_with()

--- a/tests/components/matter/test_api.py
+++ b/tests/components/matter/test_api.py
@@ -1,7 +1,9 @@
 """Test the api module."""
 
+from collections.abc import Callable
 from unittest.mock import AsyncMock, MagicMock, call
 
+from matter_server.client.exceptions import ServerVersionTooOld
 from matter_server.client.models.node import (
     MatterFabricData,
     NetworkType,
@@ -10,7 +12,14 @@ from matter_server.client.models.node import (
 )
 from matter_server.common.errors import InvalidCommand, NodeCommissionFailed
 from matter_server.common.helpers.util import dataclass_to_dict
-from matter_server.common.models import CommissioningParameters
+from matter_server.common.models import (
+    CommissioningParameters,
+    EventType,
+    NetworkTopology,
+    NetworkTopologyConnection,
+    NetworkTopologyNode,
+    TopologyDirectionInfo,
+)
 import pytest
 
 from homeassistant.components.matter.api import (
@@ -460,3 +469,193 @@ async def test_interview_node(
 
     assert not msg["success"]
     assert msg["error"]["code"] == ERROR_NODE_NOT_FOUND
+
+
+def _mock_topology() -> NetworkTopology:
+    """Return a mock topology with a known node, an unknown node and a border router."""
+    return NetworkTopology(
+        collected_at=1767888000000,
+        nodes=[
+            NetworkTopologyNode(
+                id="30",
+                kind="matter",
+                network_type="thread",
+                node_id=30,
+                role="router",
+                available=True,
+            ),
+            NetworkTopologyNode(
+                id="99",
+                kind="matter",
+                network_type="thread",
+                node_id=99,
+                role="end_device",
+                available=True,
+            ),
+            NetworkTopologyNode(
+                id="br_1122AABBCC334455",
+                kind="border_router",
+                network_type="thread",
+                role="router",
+                ext_address="1122AABBCC334455",
+                vendor_name="Apple",
+            ),
+        ],
+        connections=[
+            NetworkTopologyConnection(
+                source="30",
+                target="br_1122AABBCC334455",
+                network="thread",
+                strength="strong",
+                source_to_target=TopologyDirectionInfo(strength="strong", lqi=3),
+            ),
+        ],
+    )
+
+
+def _expected_topology(
+    topology: NetworkTopology, ha_device_ids: list[str | None]
+) -> dict:
+    """Return the expected ws payload for the given topology."""
+    expected = dataclass_to_dict(topology)
+    for node, ha_device_id in zip(expected["nodes"], ha_device_ids, strict=True):
+        node["ha_device_id"] = ha_device_id
+    return expected
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["mock_onoff_light"])
+async def test_network_topology(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test the network_topology command."""
+    matter_client.server_info.schema_version = 13
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+
+    topology = _mock_topology()
+    matter_client.get_network_topology = AsyncMock(return_value=topology)
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: "matter/network_topology"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    # node 30 maps to the registry device, node 99 and the border router do not
+    assert msg["result"] == _expected_topology(topology, [entry.id, None, None])
+    matter_client.get_network_topology.assert_called_once_with(refresh=False)
+
+    matter_client.get_network_topology.reset_mock()
+    await ws_client.send_json({ID: 2, TYPE: "matter/network_topology", "refresh": True})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    matter_client.get_network_topology.assert_called_once_with(refresh=True)
+
+
+@pytest.mark.parametrize(
+    "command", ["matter/network_topology", "matter/subscribe_network_topology"]
+)
+@pytest.mark.usefixtures("integration")
+async def test_network_topology_not_supported(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    matter_client: MagicMock,
+    command: str,
+) -> None:
+    """Test the topology commands against a server without topology support."""
+    # the conftest default schema version (1) predates network topology
+    matter_client.get_network_topology = AsyncMock()
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: command})
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
+    matter_client.get_network_topology.assert_not_called()
+
+    # a version mismatch raised by the client also maps to not_supported
+    matter_client.server_info.schema_version = 13
+    matter_client.get_network_topology.side_effect = ServerVersionTooOld(
+        "Command not available due to too old server version"
+    )
+    await ws_client.send_json({ID: 2, TYPE: command})
+    msg = await ws_client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_supported"
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["mock_onoff_light"])
+async def test_subscribe_network_topology(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+    matter_client: MagicMock,
+) -> None:
+    """Test the subscribe_network_topology command."""
+    matter_client.server_info.schema_version = 13
+    entry = device_registry.async_get_device(
+        identifiers={
+            (DOMAIN, "deviceid_00000000000004D2-000000000000001E-MatterNodeDevice")
+        }
+    )
+    assert entry is not None
+
+    topology = _mock_topology()
+    matter_client.get_network_topology = AsyncMock(return_value=topology)
+
+    subscription_callback: Callable[[EventType, NetworkTopology], None] | None = None
+    unsubscribe = MagicMock()
+
+    def capture_subscription(
+        callback: Callable[[EventType, NetworkTopology], None],
+        event_filter: EventType | None = None,
+        node_filter: int | None = None,
+        attr_path_filter: str | None = None,
+    ) -> MagicMock:
+        nonlocal subscription_callback
+        assert event_filter is EventType.NETWORK_TOPOLOGY_UPDATED
+        subscription_callback = callback
+        return unsubscribe
+
+    matter_client.subscribe_events.side_effect = capture_subscription
+
+    ws_client = await hass_ws_client(hass)
+    await ws_client.send_json({ID: 1, TYPE: "matter/subscribe_network_topology"})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    matter_client.get_network_topology.assert_called_once_with()
+    assert subscription_callback is not None
+
+    # the initial snapshot is pushed as the first event
+    msg = await ws_client.receive_json()
+    assert msg["type"] == "event"
+    assert msg["event"] == _expected_topology(topology, [entry.id, None, None])
+
+    # a topology update from the server is forwarded to the subscription
+    updated = _mock_topology()
+    updated.collected_at = 1767888060000
+    updated.nodes = topology.nodes[:1]
+    updated.connections = []
+    subscription_callback(EventType.NETWORK_TOPOLOGY_UPDATED, updated)
+    msg = await ws_client.receive_json()
+
+    assert msg["type"] == "event"
+    assert msg["event"] == _expected_topology(updated, [entry.id])
+
+    await ws_client.send_json({ID: 2, TYPE: "unsubscribe_events", "subscription": 1})
+    msg = await ws_client.receive_json()
+
+    assert msg["success"]
+    unsubscribe.assert_called_once_with()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds two WebSocket commands to the Matter integration, relaying the network topology graph introduced in OHF Matter Server schema 13 ([matterjs-server#832](https://github.com/matter-js/matterjs-server/pull/832)) for the Matter network visualization ([OpenHomeFoundation roadmap #210](https://github.com/OpenHomeFoundation/roadmap/issues/210)):

- `matter/network_topology {refresh?}` — one-shot snapshot; `refresh: true` asks the server to re-read diagnostics from the devices first.
- `matter/subscribe_network_topology` — pushes the current snapshot as the first event, then forwards server-side `network_topology_updated` events.

Core stays a thin relay: the only enrichment is a `ha_device_id` per node (resolved via the device registry, `null` for nodes without a HA device such as border routers, Wi-Fi APs and unknown Thread devices). Servers with schema < 13 (including legacy python-matter-server) get a clean `not_supported` error, which the frontend renders as an upgrade hint.

Stacked on the `matter-python-client` 1.4.0 bump ([#179465](https://github.com/home-assistant/core/pull/179465)), which ships the topology models this relies on.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/OpenHomeFoundation/roadmap/issues/210
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53247

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

