### PR TITLE
fix legacy device trackers not updating amount of people at home

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -854,7 +854,17 @@ class Device(RestoreEntity):
             attributes[ATTR_BATTERY] = self.battery
 
         if self._state == STATE_HOME:
-            attributes[DeviceTrackerEntityStateAttribute.IN_ZONES] = [ENTITY_ID_HOME]
+            if self.gps is not None:
+                in_zones = zone.async_in_zones(
+                    self.hass, self.gps[0], self.gps[1], self.gps_accuracy
+                )[1]
+                if ENTITY_ID_HOME not in in_zones:
+                    in_zones.insert(0, ENTITY_ID_HOME)
+                attributes[DeviceTrackerEntityStateAttribute.IN_ZONES] = in_zones
+            else:
+                attributes[DeviceTrackerEntityStateAttribute.IN_ZONES] = [
+                    ENTITY_ID_HOME
+                ]
             if (
                 self.gps is None
                 and (home_zone := self.hass.states.get(ENTITY_ID_HOME)) is not None

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -855,6 +855,15 @@ class Device(RestoreEntity):
 
         if self._state == STATE_HOME:
             attributes[DeviceTrackerEntityStateAttribute.IN_ZONES] = [ENTITY_ID_HOME]
+            if self.gps is None and (
+                home_zone := self.hass.states.get(ENTITY_ID_HOME)
+            ) is not None:
+                attributes[EntityStateAttribute.LATITUDE] = home_zone.attributes.get(
+                    EntityStateAttribute.LATITUDE
+                )
+                attributes[EntityStateAttribute.LONGITUDE] = home_zone.attributes.get(
+                    EntityStateAttribute.LONGITUDE
+                )
 
         return attributes
 

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -45,7 +45,7 @@ from homeassistant.helpers.event import (
     async_track_utc_time_change,
 )
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.typing import ConfigType, GPSType, StateType
+from homeassistant.helpers.typing import ConfigType, GPSType
 from homeassistant.setup import (
     SetupPhases,
     async_notify_setup_error,
@@ -855,9 +855,10 @@ class Device(RestoreEntity):
 
         if self._state == STATE_HOME:
             attributes[DeviceTrackerEntityStateAttribute.IN_ZONES] = [ENTITY_ID_HOME]
-            if self.gps is None and (
-                home_zone := self.hass.states.get(ENTITY_ID_HOME)
-            ) is not None:
+            if (
+                self.gps is None
+                and (home_zone := self.hass.states.get(ENTITY_ID_HOME)) is not None
+            ):
                 attributes[EntityStateAttribute.LATITUDE] = home_zone.attributes.get(
                     EntityStateAttribute.LATITUDE
                 )

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -853,6 +853,9 @@ class Device(RestoreEntity):
         if self.battery is not None:
             attributes[ATTR_BATTERY] = self.battery
 
+        if self._state == STATE_HOME:
+            attributes[DeviceTrackerEntityStateAttribute.IN_ZONES] = [ENTITY_ID_HOME]
+
         return attributes
 
     @property

--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -839,9 +839,9 @@ class Device(RestoreEntity):
     @final
     @property
     @override
-    def state_attributes(self) -> dict[str, StateType]:
+    def state_attributes(self) -> dict[str, Any]:
         """Return the device state attributes."""
-        attributes: dict[str, StateType] = {
+        attributes: dict[str, Any] = {
             DeviceTrackerEntityStateAttribute.SOURCE_TYPE: self.source_type
         }
 

--- a/tests/components/device_tracker/test_init.py
+++ b/tests/components/device_tracker/test_init.py
@@ -585,6 +585,7 @@ async def test_see_passive_zone_state(
     assert attrs.get("longitude") == 2
     assert attrs.get("gps_accuracy") == 0
     assert attrs.get("source_type") == SourceType.ROUTER
+    assert attrs.get("in_zones") == ["zone.home"]
 
     mock_legacy_device_scanner.leave_home("dev1")
 
@@ -605,6 +606,84 @@ async def test_see_passive_zone_state(
     assert attrs.get("longitude") is None
     assert attrs.get("gps_accuracy") is None
     assert attrs.get("source_type") == SourceType.ROUTER
+    assert "in_zones" not in attrs
+
+
+async def test_legacy_see_populates_person_and_zone(
+    hass: HomeAssistant,
+    yaml_devices: str,
+) -> None:
+    """Test that legacy device_tracker.see updates person in_zones and zone.home count."""
+    home_lat, home_lon = 32.87336, -117.22743
+    assert await async_setup_component(
+        hass,
+        zone.DOMAIN,
+        {
+            zone.DOMAIN: {
+                "name": "Home",
+                "latitude": home_lat,
+                "longitude": home_lon,
+                "radius": 250,
+            }
+        },
+    )
+    assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+    assert await async_setup_component(
+        hass,
+        "person",
+        {
+            "person": [
+                {
+                    "id": "1234",
+                    "name": "tracked person",
+                    "device_trackers": "device_tracker.tracked_phone",
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    common.async_see(
+        hass,
+        dev_id="tracked_phone",
+        location_name=STATE_HOME,
+    )
+    await hass.async_block_till_done()
+
+    tracker_state = hass.states.get("device_tracker.tracked_phone")
+    assert tracker_state.state == STATE_HOME
+    assert tracker_state.attributes["in_zones"] == ["zone.home"]
+    assert tracker_state.attributes["latitude"] == home_lat
+    assert tracker_state.attributes["longitude"] == home_lon
+
+    person_state = hass.states.get("person.tracked_person")
+    assert person_state.state == STATE_HOME
+    assert person_state.attributes["in_zones"] == ["zone.home"]
+    assert person_state.attributes["latitude"] == home_lat
+    assert person_state.attributes["longitude"] == home_lon
+
+    home_zone_state = hass.states.get("zone.home")
+    assert home_zone_state.state == "1"
+    assert home_zone_state.attributes["persons"] == ["person.tracked_person"]
+
+    common.async_see(
+        hass,
+        dev_id="tracked_phone",
+        location_name=STATE_NOT_HOME,
+    )
+    await hass.async_block_till_done()
+
+    tracker_state = hass.states.get("device_tracker.tracked_phone")
+    assert tracker_state.state == STATE_NOT_HOME
+    assert "in_zones" not in tracker_state.attributes
+
+    person_state = hass.states.get("person.tracked_person")
+    assert person_state.state == STATE_NOT_HOME
+    assert person_state.attributes["in_zones"] == []
+
+    home_zone_state = hass.states.get("zone.home")
+    assert home_zone_state.state == "0"
+    assert home_zone_state.attributes["persons"] == []
 
 
 @patch("homeassistant.components.device_tracker.const.LOGGER.warning")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
This is a minimum-viable fix for the broken legacy device trackers reported in #175376. I chose this minimal effort because legacy device trackers are scheduled to be removed soon anyway.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #175376
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
