### PR TITLE
Melcloud atw on/off capability

### DIFF
--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -426,17 +426,16 @@ class AtwDeviceZoneClimate(MelCloudClimate):
 
     def _target_operation_mode(self, hvac_mode: HVACMode) -> str:
         """Return the zone operation mode for a direction, preserving the method."""
-        current = self._zone.operation_mode
         if hvac_mode == HVACMode.HEAT:
-            if current == ZONE_OPERATION_MODE_COOL_FLOW:
+            if self._zone.operation_mode == ZONE_OPERATION_MODE_COOL_FLOW:
                 return ZONE_OPERATION_MODE_HEAT_FLOW
-            if current in HEAT_OPERATION_MODES:
-                return current
+            if self._zone.operation_mode in HEAT_OPERATION_MODES:
+                return self._zone.operation_mode
             return ZONE_OPERATION_MODE_HEAT_THERMOSTAT
-        if current == ZONE_OPERATION_MODE_HEAT_FLOW:
+        if self._zone.operation_mode == ZONE_OPERATION_MODE_HEAT_FLOW:
             return ZONE_OPERATION_MODE_COOL_FLOW
-        if current in COOL_OPERATION_MODES:
-            return current
+        if self._zone.operation_mode in COOL_OPERATION_MODES:
+            return self._zone.operation_mode
         return ZONE_OPERATION_MODE_COOL_THERMOSTAT
 
     @override

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -421,8 +421,7 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         await self._zone.set_operation_mode(self._target_operation_mode(hvac_mode))
         if not self._device.power:
             await self.coordinator.async_set({PROPERTY_POWER: True})
-        else:
-            await self.coordinator.async_request_refresh()
+        await self.coordinator.async_request_refresh()
 
     def _target_operation_mode(self, hvac_mode: HVACMode) -> str:
         """Return the zone operation mode for a direction, preserving the method."""

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -69,16 +69,6 @@ COOL_OPERATION_MODES = {
 }
 
 
-def zone_can_heat(zone: Zone) -> bool:
-    """Return True if the zone supports any heating operation mode."""
-    return any(mode in HEAT_OPERATION_MODES for mode in zone.operation_modes)
-
-
-def zone_can_cool(zone: Zone) -> bool:
-    """Return True if the zone supports any cooling operation mode."""
-    return any(mode in COOL_OPERATION_MODES for mode in zone.operation_modes)
-
-
 ATW_ZONE_HVAC_ACTION_LOOKUP = {
     atw.STATUS_IDLE: HVACAction.IDLE,
     atw.STATUS_HEAT_ZONES: HVACAction.HEATING,
@@ -396,9 +386,9 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         self._attr_device_info = self.coordinator.zone_device_info(atw_zone)
 
         self._attr_hvac_modes = [HVACMode.OFF]
-        if zone_can_heat(atw_zone):
+        if any(mode in HEAT_OPERATION_MODES for mode in atw_zone.operation_modes):
             self._attr_hvac_modes.append(HVACMode.HEAT)
-        if zone_can_cool(atw_zone):
+        if any(mode in COOL_OPERATION_MODES for mode in atw_zone.operation_modes):
             self._attr_hvac_modes.append(HVACMode.COOL)
 
     @property
@@ -435,11 +425,7 @@ class AtwDeviceZoneClimate(MelCloudClimate):
             await self.coordinator.async_request_refresh()
 
     def _target_operation_mode(self, hvac_mode: HVACMode) -> str:
-        """Return the zone operation mode for a direction, preserving the method.
-
-        Keeps the current control method (thermostat/flow) when the target
-        direction has an equivalent, else falls back to the thermostat variant.
-        """
+        """Return the zone operation mode for a direction, preserving the method."""
         current = self._zone.operation_mode
         if hvac_mode == HVACMode.HEAT:
             if current == ZONE_OPERATION_MODE_COOL_FLOW:

--- a/homeassistant/components/melcloud/climate.py
+++ b/homeassistant/components/melcloud/climate.py
@@ -6,10 +6,14 @@ from pymelcloud import DEVICE_TYPE_ATA, DEVICE_TYPE_ATW, AtaDevice, AtwDevice
 import pymelcloud.ata_device as ata
 import pymelcloud.atw_device as atw
 from pymelcloud.atw_device import (
-    PROPERTY_ZONE_1_OPERATION_MODE,
-    PROPERTY_ZONE_2_OPERATION_MODE,
+    ZONE_OPERATION_MODE_COOL_FLOW,
+    ZONE_OPERATION_MODE_COOL_THERMOSTAT,
+    ZONE_OPERATION_MODE_CURVE,
+    ZONE_OPERATION_MODE_HEAT_FLOW,
+    ZONE_OPERATION_MODE_HEAT_THERMOSTAT,
     Zone,
 )
+from pymelcloud.device import PROPERTY_POWER
 import voluptuous as vol
 
 from homeassistant.components.climate import (
@@ -53,7 +57,27 @@ ATW_ZONE_HVAC_MODE_LOOKUP = {
     atw.ZONE_STATUS_HEAT: HVACMode.HEAT,
     atw.ZONE_STATUS_COOL: HVACMode.COOL,
 }
-ATW_ZONE_HVAC_MODE_REVERSE_LOOKUP = {v: k for k, v in ATW_ZONE_HVAC_MODE_LOOKUP.items()}
+
+HEAT_OPERATION_MODES = {
+    ZONE_OPERATION_MODE_HEAT_THERMOSTAT,
+    ZONE_OPERATION_MODE_HEAT_FLOW,
+    ZONE_OPERATION_MODE_CURVE,
+}
+COOL_OPERATION_MODES = {
+    ZONE_OPERATION_MODE_COOL_THERMOSTAT,
+    ZONE_OPERATION_MODE_COOL_FLOW,
+}
+
+
+def zone_can_heat(zone: Zone) -> bool:
+    """Return True if the zone supports any heating operation mode."""
+    return any(mode in HEAT_OPERATION_MODES for mode in zone.operation_modes)
+
+
+def zone_can_cool(zone: Zone) -> bool:
+    """Return True if the zone supports any cooling operation mode."""
+    return any(mode in COOL_OPERATION_MODES for mode in zone.operation_modes)
+
 
 ATW_ZONE_HVAC_ACTION_LOOKUP = {
     atw.STATUS_IDLE: HVACAction.IDLE,
@@ -351,7 +375,11 @@ class AtwDeviceZoneClimate(MelCloudClimate):
 
     _attr_max_temp = 30
     _attr_min_temp = 10
-    _attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_OFF
+        | ClimateEntityFeature.TURN_ON
+    )
 
     def __init__(
         self,
@@ -367,6 +395,12 @@ class AtwDeviceZoneClimate(MelCloudClimate):
         self._attr_unique_id = f"{self.coordinator.device.serial}-{atw_zone.zone_index}"
         self._attr_device_info = self.coordinator.zone_device_info(atw_zone)
 
+        self._attr_hvac_modes = [HVACMode.OFF]
+        if zone_can_heat(atw_zone):
+            self._attr_hvac_modes.append(HVACMode.HEAT)
+        if zone_can_cool(atw_zone):
+            self._attr_hvac_modes.append(HVACMode.COOL)
+
     @property
     @override
     def extra_state_attributes(self) -> dict[str, Any]:
@@ -381,36 +415,53 @@ class AtwDeviceZoneClimate(MelCloudClimate):
     @override
     def hvac_mode(self) -> HVACMode:
         """Return hvac operation ie. heat, cool mode."""
-        # Use zone status (heat/cool/idle) not operation_mode (heat-thermostat/etc.)
-        status = self._zone.status
-        if not self._device.power or status is None:
+        if not self._device.power:
             return HVACMode.OFF
-        return ATW_ZONE_HVAC_MODE_LOOKUP.get(status, HVACMode.OFF)
+        if self._zone.operation_mode in COOL_OPERATION_MODES:
+            return HVACMode.COOL
+        return HVACMode.HEAT
 
     @override
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set new target hvac mode."""
         if hvac_mode == HVACMode.OFF:
-            await self.coordinator.async_set({"power": False})
+            await self.coordinator.async_set({PROPERTY_POWER: False})
             return
 
-        operation_mode = ATW_ZONE_HVAC_MODE_REVERSE_LOOKUP.get(hvac_mode)
-        if operation_mode is None:
-            raise ValueError(f"Invalid hvac_mode [{hvac_mode}]")
-
-        if self._zone.zone_index == 1:
-            props = {PROPERTY_ZONE_1_OPERATION_MODE: operation_mode}
+        await self._zone.set_operation_mode(self._target_operation_mode(hvac_mode))
+        if not self._device.power:
+            await self.coordinator.async_set({PROPERTY_POWER: True})
         else:
-            props = {PROPERTY_ZONE_2_OPERATION_MODE: operation_mode}
-        if self.hvac_mode == HVACMode.OFF:
-            props["power"] = True
-        await self.coordinator.async_set(props)
+            await self.coordinator.async_request_refresh()
 
-    @property
+    def _target_operation_mode(self, hvac_mode: HVACMode) -> str:
+        """Return the zone operation mode for a direction, preserving the method.
+
+        Keeps the current control method (thermostat/flow) when the target
+        direction has an equivalent, else falls back to the thermostat variant.
+        """
+        current = self._zone.operation_mode
+        if hvac_mode == HVACMode.HEAT:
+            if current == ZONE_OPERATION_MODE_COOL_FLOW:
+                return ZONE_OPERATION_MODE_HEAT_FLOW
+            if current in HEAT_OPERATION_MODES:
+                return current
+            return ZONE_OPERATION_MODE_HEAT_THERMOSTAT
+        if current == ZONE_OPERATION_MODE_HEAT_FLOW:
+            return ZONE_OPERATION_MODE_COOL_FLOW
+        if current in COOL_OPERATION_MODES:
+            return current
+        return ZONE_OPERATION_MODE_COOL_THERMOSTAT
+
     @override
-    def hvac_modes(self) -> list[HVACMode]:
-        """Return the list of available hvac operation modes."""
-        return [self.hvac_mode]
+    async def async_turn_on(self) -> None:
+        """Turn the entity on."""
+        await self.coordinator.async_set({PROPERTY_POWER: True})
+
+    @override
+    async def async_turn_off(self) -> None:
+        """Turn the entity off."""
+        await self.coordinator.async_set({PROPERTY_POWER: False})
 
     @property
     @override

--- a/tests/components/melcloud/conftest.py
+++ b/tests/components/melcloud/conftest.py
@@ -23,6 +23,11 @@ def _build_mock_zone(zone_index: int) -> MagicMock:
     zone.room_temperature = 21.5 + zone_index
     zone.zone_flow_temperature = 35.0 + zone_index
     zone.zone_return_temperature = 30.0 + zone_index
+    zone.status = "heat"
+    zone.operation_mode = "heat-flow"
+    zone.operation_modes = ["heat-thermostat", "heat-flow", "curve"]
+    zone.target_temperature = 21.0
+    zone.set_operation_mode = AsyncMock()
     return zone
 
 
@@ -35,6 +40,10 @@ def _build_mock_atw_device() -> MagicMock:
     device.serial = MOCK_SERIAL
     device.name = "Ecodan"
     device.units = [{"model": "ATW-Unit", "serial": "unit-serial-1"}]
+    device.power = True
+    device.temperature_increment = 0.5
+    device.status = "heat_zones"
+    device.set = AsyncMock()
 
     # Binary sensor properties
     device.boiler_status = True

--- a/tests/components/melcloud/snapshots/test_climate.ambr
+++ b/tests/components/melcloud/snapshots/test_climate.ambr
@@ -1,0 +1,71 @@
+# serializer version: 1
+# name: test_all_entities[climate.ecodan_zone_1-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 30,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 10,
+      <ClimateEntityCapabilityAttribute.TARGET_TEMP_STEP: 'target_temp_step'>: 0.5,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'climate',
+    'entity_category': None,
+    'entity_id': 'climate.ecodan_zone_1',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': None,
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': None,
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': <ClimateEntityFeature: 385>,
+    'translation_key': None,
+    'unique_id': 'ABC123456-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[climate.ecodan_zone_1-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 22.5,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ecodan Zone 1',
+      <ClimateEntityStateAttribute.HVAC_ACTION: 'hvac_action'>: <HVACAction.HEATING: 'heating'>,
+      <ClimateEntityCapabilityAttribute.HVAC_MODES: 'hvac_modes'>: list([
+        <HVACMode.OFF: 'off'>,
+        <HVACMode.HEAT: 'heat'>,
+      ]),
+      <ClimateEntityCapabilityAttribute.MAX_TEMP: 'max_temp'>: 30,
+      <ClimateEntityCapabilityAttribute.MIN_TEMP: 'min_temp'>: 10,
+      'status': <HVACMode.HEAT: 'heat'>,
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <ClimateEntityFeature: 385>,
+      <ClimateEntityCapabilityAttribute.TARGET_TEMP_STEP: 'target_temp_step'>: 0.5,
+      <ClimateEntityStateAttribute.TEMPERATURE: 'temperature'>: 21.0,
+    }),
+    'context': <ANY>,
+    'entity_id': 'climate.ecodan_zone_1',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat',
+  })
+# ---

--- a/tests/components/melcloud/test_climate.py
+++ b/tests/components/melcloud/test_climate.py
@@ -1,5 +1,6 @@
 """Test the MELCloud climate platform."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pytest
@@ -22,6 +23,7 @@ from tests.common import MockConfigEntry, snapshot_platform
 
 ZONE_CLIMATE_ENTITY = "climate.ecodan_zone_1"
 
+HEAT_ONLY_MODES = ["heat-thermostat", "heat-flow", "curve"]
 HEAT_COOL_MODES = [
     "heat-thermostat",
     "heat-flow",
@@ -43,72 +45,61 @@ async def test_all_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.parametrize(
+    ("operation_modes", "expected_hvac_modes"),
+    [
+        (HEAT_ONLY_MODES, [HVACMode.OFF, HVACMode.HEAT]),
+        (HEAT_COOL_MODES, [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL]),
+    ],
+)
 @pytest.mark.usefixtures("mock_get_devices")
-async def test_hvac_modes_heat_only(
-    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+async def test_hvac_modes(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+    operation_modes: list[str],
+    expected_hvac_modes: list[HVACMode],
 ) -> None:
-    """A heat-only zone exposes only OFF and HEAT."""
+    """The hvac modes reflect the zone's heating/cooling capability."""
+    mock_atw_device.zones[0].operation_modes = operation_modes
     await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
     state = hass.states.get(ZONE_CLIMATE_ENTITY)
     assert state is not None
-    assert state.attributes["hvac_modes"] == [HVACMode.OFF, HVACMode.HEAT]
+    assert state.attributes["hvac_modes"] == expected_hvac_modes
 
 
+@pytest.mark.parametrize(
+    ("service", "service_data", "expected_power"),
+    [
+        (SERVICE_TURN_ON, {}, True),
+        (SERVICE_TURN_OFF, {}, False),
+        (SERVICE_SET_HVAC_MODE, {"hvac_mode": HVACMode.OFF}, False),
+    ],
+)
 @pytest.mark.usefixtures("mock_get_devices")
-async def test_turn_off(
+async def test_power(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_atw_device: MagicMock,
+    service: str,
+    service_data: dict[str, Any],
+    expected_power: bool,
 ) -> None:
-    """Turning off powers the device down."""
+    """Turning the zone on/off toggles the device power."""
     await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
     await hass.services.async_call(
         CLIMATE_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY},
+        service,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, **service_data},
         blocking=True,
     )
-    mock_atw_device.set.assert_awaited_with({"power": False})
-
-
-@pytest.mark.usefixtures("mock_get_devices")
-async def test_turn_on(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_atw_device: MagicMock,
-) -> None:
-    """Turning on powers the device up."""
-    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY},
-        blocking=True,
-    )
-    mock_atw_device.set.assert_awaited_with({"power": True})
-
-
-@pytest.mark.usefixtures("mock_get_devices")
-async def test_set_hvac_mode_heat(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_atw_device: MagicMock,
-) -> None:
-    """Setting hvac_mode HEAT keeps the current control method."""
-    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, "hvac_mode": HVACMode.HEAT},
-        blocking=True,
-    )
-    mock_atw_device.zones[0].set_operation_mode.assert_awaited_once_with("heat-flow")
-    mock_atw_device.set.assert_not_called()
+    mock_atw_device.set.assert_awaited_with({"power": expected_power})
 
 
 @pytest.mark.parametrize(
     ("current_mode", "hvac_mode", "expected_mode"),
     [
+        ("heat-flow", HVACMode.HEAT, "heat-flow"),
         ("heat-flow", HVACMode.COOL, "cool-flow"),
         ("heat-thermostat", HVACMode.COOL, "cool-thermostat"),
         ("curve", HVACMode.COOL, "cool-thermostat"),
@@ -117,7 +108,7 @@ async def test_set_hvac_mode_heat(
     ],
 )
 @pytest.mark.usefixtures("mock_get_devices")
-async def test_set_hvac_mode_preserves_method(
+async def test_set_hvac_mode(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_atw_device: MagicMock,
@@ -125,7 +116,7 @@ async def test_set_hvac_mode_preserves_method(
     hvac_mode: HVACMode,
     expected_mode: str,
 ) -> None:
-    """Switching direction preserves the flow/thermostat method where possible."""
+    """Setting a direction selects the operation mode, preserving the method."""
     zone = mock_atw_device.zones[0]
     zone.operation_modes = HEAT_COOL_MODES
     zone.operation_mode = current_mode
@@ -138,23 +129,6 @@ async def test_set_hvac_mode_preserves_method(
     )
     zone.set_operation_mode.assert_awaited_once_with(expected_mode)
     mock_atw_device.set.assert_not_called()
-
-
-@pytest.mark.usefixtures("mock_get_devices")
-async def test_set_hvac_mode_off(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_atw_device: MagicMock,
-) -> None:
-    """Setting hvac_mode OFF powers the device down."""
-    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, "hvac_mode": HVACMode.OFF},
-        blocking=True,
-    )
-    mock_atw_device.set.assert_awaited_with({"power": False})
 
 
 @pytest.mark.usefixtures("mock_get_devices")

--- a/tests/components/melcloud/test_climate.py
+++ b/tests/components/melcloud/test_climate.py
@@ -1,0 +1,176 @@
+"""Test the MELCloud climate platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    HVACMode,
+)
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_platform
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+ZONE_CLIMATE_ENTITY = "climate.ecodan_zone_1"
+
+HEAT_COOL_MODES = [
+    "heat-thermostat",
+    "heat-flow",
+    "curve",
+    "cool-thermostat",
+    "cool-flow",
+]
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_get_devices")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all climate entities with snapshot."""
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_hvac_modes_heat_only(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """A heat-only zone exposes only OFF and HEAT."""
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    state = hass.states.get(ZONE_CLIMATE_ENTITY)
+    assert state is not None
+    assert state.attributes["hvac_modes"] == [HVACMode.OFF, HVACMode.HEAT]
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_turn_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Turning off powers the device down."""
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY},
+        blocking=True,
+    )
+    mock_atw_device.set.assert_awaited_with({"power": False})
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_turn_on(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Turning on powers the device up."""
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY},
+        blocking=True,
+    )
+    mock_atw_device.set.assert_awaited_with({"power": True})
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_set_hvac_mode_heat(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Setting hvac_mode HEAT keeps the current control method."""
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, "hvac_mode": HVACMode.HEAT},
+        blocking=True,
+    )
+    mock_atw_device.zones[0].set_operation_mode.assert_awaited_once_with("heat-flow")
+    mock_atw_device.set.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("current_mode", "hvac_mode", "expected_mode"),
+    [
+        ("heat-flow", HVACMode.COOL, "cool-flow"),
+        ("heat-thermostat", HVACMode.COOL, "cool-thermostat"),
+        ("curve", HVACMode.COOL, "cool-thermostat"),
+        ("cool-flow", HVACMode.HEAT, "heat-flow"),
+        ("cool-thermostat", HVACMode.HEAT, "heat-thermostat"),
+    ],
+)
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_set_hvac_mode_preserves_method(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+    current_mode: str,
+    hvac_mode: HVACMode,
+    expected_mode: str,
+) -> None:
+    """Switching direction preserves the flow/thermostat method where possible."""
+    zone = mock_atw_device.zones[0]
+    zone.operation_modes = HEAT_COOL_MODES
+    zone.operation_mode = current_mode
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, "hvac_mode": hvac_mode},
+        blocking=True,
+    )
+    zone.set_operation_mode.assert_awaited_once_with(expected_mode)
+    mock_atw_device.set.assert_not_called()
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_set_hvac_mode_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Setting hvac_mode OFF powers the device down."""
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, "hvac_mode": HVACMode.OFF},
+        blocking=True,
+    )
+    mock_atw_device.set.assert_awaited_with({"power": False})
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_set_hvac_mode_powers_on_when_off(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Setting a direction while powered off also powers on."""
+    mock_atw_device.power = False
+    await setup_platform(hass, mock_config_entry, [Platform.CLIMATE])
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ZONE_CLIMATE_ENTITY, "hvac_mode": HVACMode.HEAT},
+        blocking=True,
+    )
+    mock_atw_device.zones[0].set_operation_mode.assert_awaited_once_with("heat-flow")
+    mock_atw_device.set.assert_awaited_with({"power": True})


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
Adds the ability to turn an Air-to-Water (ATW / Ecodan) heat pump on and off from its `climate` entities — something the MELCloud app allows but the integration previously did not.

Changes to the ATW zone climate entity (`AtwDeviceZoneClimate`):

  - Adds `ClimateEntityFeature.TURN_ON` / `TURN_OFF` and `HVACMode.OFF`. Previously `hvac_modes` returned only a single mode, so the system could not be switched off from Home Assistant.
  - `hvac_modes` is now derived from the zone's capabilities: `[off, heat]`, plus `cool` on cooling-capable systems.
  - On/off toggles the device power. MELCloud exposes a single system-wide power state, so turning a zone off also stops the other zones and the hot water tank — matching the hardware and the app.

This also fixes a latent bug: the previous `async_set_hvac_mode` wrote a zone *status* string (e.g. `"heat"`) into the integer `OperationModeZone*` field. Direction changes now route through `Zone.set_operation_mode`, which maps mode names to the correct integer.

No dependency or manifest changes, and ATA (air-to-air) behaviour is unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/155691
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46995
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
