### PR TITLE
Add reconfiguration flow to ouman_eh_800

### DIFF
--- a/homeassistant/components/ouman_eh_800/config_flow.py
+++ b/homeassistant/components/ouman_eh_800/config_flow.py
@@ -38,6 +38,34 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
 
     VERSION = 1
 
+    async def _async_validate_input(self, user_input: dict[str, Any]) -> dict[str, str]:
+        """Normalize the URL, check for duplicates and test the connection.
+
+        Mutates user_input to hold the normalized URL. Returns form errors,
+        empty if validation succeeded.
+        """
+        try:
+            user_input[CONF_URL] = _normalize_url(user_input[CONF_URL])
+        except ValueError:
+            return {CONF_URL: "invalid_url"}
+        self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
+        client = OumanEh800Client(
+            session=async_get_clientsession(self.hass),
+            username=user_input[CONF_USERNAME],
+            password=user_input[CONF_PASSWORD],
+            address=user_input[CONF_URL],
+        )
+        try:
+            await client.login()
+        except OumanClientCommunicationError:
+            return {"base": "cannot_connect"}
+        except OumanClientAuthenticationError:
+            return {"base": "invalid_auth"}
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            return {"base": "unknown"}
+        return {}
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -45,36 +73,33 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
         """Handle the initial step."""
         errors: dict[str, str] = {}
         if user_input is not None:
-            try:
-                user_input[CONF_URL] = _normalize_url(user_input[CONF_URL])
-            except ValueError:
-                errors[CONF_URL] = "invalid_url"
-            else:
-                self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
-                client = OumanEh800Client(
-                    session=async_get_clientsession(self.hass),
-                    username=user_input[CONF_USERNAME],
-                    password=user_input[CONF_PASSWORD],
-                    address=user_input[CONF_URL],
-                )
-                try:
-                    await client.login()
-                except OumanClientCommunicationError:
-                    errors["base"] = "cannot_connect"
-                except OumanClientAuthenticationError:
-                    errors["base"] = "invalid_auth"
-                except Exception:
-                    _LOGGER.exception("Unexpected exception")
-                    errors["base"] = "unknown"
-                else:
-                    return self.async_create_entry(
-                        title="Ouman EH-800", data=user_input
-                    )
+            if not (errors := await self._async_validate_input(user_input)):
+                return self.async_create_entry(title="Ouman EH-800", data=user_input)
 
         return self.async_show_form(
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 STEP_USER_DATA_SCHEMA, user_input
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reconfiguration of the integration."""
+        reconfigure_entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if not (errors := await self._async_validate_input(user_input)):
+                return self.async_update_reload_and_abort(
+                    reconfigure_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input or reconfigure_entry.data
             ),
             errors=errors,
         )

--- a/homeassistant/components/ouman_eh_800/quality_scale.yaml
+++ b/homeassistant/components/ouman_eh_800/quality_scale.yaml
@@ -70,7 +70,7 @@ rules:
   entity-translations: done
   exception-translations: todo
   icon-translations: done
-  reconfiguration-flow: todo
+  reconfiguration-flow: done
   repair-issues: todo
   stale-devices:
     status: exempt

--- a/homeassistant/components/ouman_eh_800/strings.json
+++ b/homeassistant/components/ouman_eh_800/strings.json
@@ -1,7 +1,8 @@
 {
   "config": {
     "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
@@ -10,6 +11,18 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reconfigure": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "url": "[%key:common::config_flow::data::url%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::ouman_eh_800::config::step::user::data_description::password%]",
+          "url": "[%key:component::ouman_eh_800::config::step::user::data_description::url%]",
+          "username": "[%key:component::ouman_eh_800::config::step::user::data_description::username%]"
+        }
+      },
       "user": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",

--- a/tests/components/ouman_eh_800/test_config_flow.py
+++ b/tests/components/ouman_eh_800/test_config_flow.py
@@ -154,3 +154,103 @@ async def test_user_flow_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_ouman_client")
+@pytest.mark.parametrize(
+    "new_input",
+    [
+        pytest.param(
+            {
+                CONF_URL: "http://192.168.1.200",
+                CONF_USERNAME: "new-user",
+                CONF_PASSWORD: "new-pass",
+            },
+            id="new_url_and_credentials",
+        ),
+        pytest.param(
+            {**USER_INPUT, CONF_PASSWORD: "new-pass"},
+            id="same_url_new_password",
+        ),
+    ],
+)
+async def test_reconfigure_flow_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    new_input: dict[str, str],
+) -> None:
+    """Test a successful reconfiguration updates the entry data."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], new_input
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+    assert mock_config_entry.data == new_input
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_error"),
+    [
+        (OumanClientCommunicationError("Connection failed"), "cannot_connect"),
+        (OumanClientAuthenticationError("Invalid credentials"), "invalid_auth"),
+        (RuntimeError("Unexpected"), "unknown"),
+    ],
+)
+async def test_reconfigure_flow_errors_recover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ouman_client: AsyncMock,
+    error: Exception,
+    expected_error: str,
+) -> None:
+    """Test that reconfigure errors are surfaced and the flow can recover."""
+    mock_config_entry.add_to_hass(hass)
+    mock_ouman_client.login.side_effect = error
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}
+
+    mock_ouman_client.login.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reconfigure_successful"
+
+
+@pytest.mark.usefixtures("mock_ouman_client")
+async def test_reconfigure_flow_already_configured(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test aborting when reconfiguring to the URL of another entry."""
+    mock_config_entry.add_to_hass(hass)
+    other_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Ouman EH-800",
+        data={**USER_INPUT, CONF_URL: "http://192.168.1.200"},
+    )
+    other_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {**USER_INPUT, CONF_URL: "http://192.168.1.200"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a reconfiguration flow to the Ouman EH-800 integration, allowing users to update the device URL and credentials from the UI without removing and re-adding the config entry. This is useful when the device gets a new IP address or its credentials change.

The URL normalization, duplicate-entry check, and connection test are shared between the user and reconfigure steps via a common validation helper. Reconfiguring to a URL that belongs to another config entry aborts with `already_configured`, while keeping the same URL (e.g. only changing the password) is allowed. Marks the `reconfiguration-flow` quality scale rule as done.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
