### PR TITLE
Add iZone quality scale scorecard

### DIFF
--- a/homeassistant/components/izone/quality_scale.yaml
+++ b/homeassistant/components/izone/quality_scale.yaml
@@ -1,0 +1,76 @@
+rules:
+  # Bronze — post Phase 2a (#176751) + docs removal (#46923).
+  # Do not set manifest quality_scale until Bronze is complete
+  # (test-before-configure still todo).
+  action-setup:
+    status: exempt
+    comment: Only entity services via async_register_entity_service; no domain services that must be registered in async_setup.
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-conditions:
+    status: exempt
+    comment: This integration does not provide conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not provide triggers.
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: todo
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: todo
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: No options flow; setup has no user-facing configuration parameters beyond discovery/confirm.
+  docs-installation-parameters:
+    status: exempt
+    comment: Setup is discovery/confirm only; no installation parameters form.
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: todo
+  parallel-updates: todo
+  reauthentication-flow:
+    status: exempt
+    comment: Local LAN integration with no authentication credentials.
+  test-coverage: todo
+
+  # Gold
+  devices: done
+  diagnostics: todo
+  discovery-update-info: todo
+  discovery: done
+  docs-data-update: todo
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: done
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: todo
+  entity-category: todo
+  entity-device-class: todo
+  entity-disabled-by-default: todo
+  entity-translations: todo
+  exception-translations: done
+  icon-translations: todo
+  reconfiguration-flow: todo
+  repair-issues: todo
+  stale-devices: todo
+
+  # Platinum
+  async-dependency: todo
+  inject-websession: done
+  strict-typing: todo

--- a/homeassistant/components/izone/quality_scale.yaml
+++ b/homeassistant/components/izone/quality_scale.yaml
@@ -30,7 +30,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: done
+  action-exceptions: todo
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
@@ -50,7 +50,7 @@ rules:
   # Gold
   devices: done
   diagnostics: done
-  discovery-update-info: todo
+  discovery-update-info: done
   discovery: done
   docs-data-update: todo
   docs-examples: todo

--- a/homeassistant/components/izone/quality_scale.yaml
+++ b/homeassistant/components/izone/quality_scale.yaml
@@ -30,7 +30,7 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: todo
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt
@@ -49,7 +49,7 @@ rules:
 
   # Gold
   devices: done
-  diagnostics: todo
+  diagnostics: done
   discovery-update-info: todo
   discovery: done
   docs-data-update: todo

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -16,6 +16,9 @@
         "data": {
           "selected_controller_uid": "Controller"
         },
+        "data_description": {
+          "selected_controller_uid": "Select the controller to set up now. Controllers you skip stay available under Settings > Devices & services."
+        },
         "description": "Multiple unconfigured iZone controllers were found:\n{controllers}\n\nChoose the controller you want to set up now. Any controller you do not select will remain available as a discovered device you can set up later under **Settings** > **Devices & services**."
       }
     }

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -481,7 +481,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "isy994",
     "itach",
     "itunes",
-    "izone",
     "jellyfin",
     "joaoapps_join",
     "juicenet",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an iZone `quality_scale.yaml` scorecard against the current `dev` runtime (post Phase 2a rewrite in #176751), and remove `izone` from `INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE`.

This does **not** set `quality_scale` in the manifest yet. Bronze is not claimed until `test-before-configure` is finished (config flow currently creates the entry from discovery without an HTTP/pairing probe).

Also adds the missing `config.step.select_controller.data_description.selected_controller_uid` string so config-flow tests pass.

### Bronze scorecard (current `dev`)

| Rule | Status |
| --- | --- |
| action-setup | exempt |
| appropriate-polling | done |
| brands | done |
| common-modules | done |
| config-flow-test-coverage | done |
| config-flow | done |
| dependency-transparency | done |
| docs-actions | done |
| docs-conditions | exempt |
| docs-high-level-description | done |
| docs-installation-instructions | done |
| docs-removal-instructions | done |
| docs-triggers | exempt |
| entity-event-setup | done |
| entity-unique-id | done |
| has-entity-name | done |
| runtime-data | done |
| test-before-configure | todo |
| test-before-setup | done |
| unique-config-entry | done |

Bronze blocker before claiming the tier: `test-before-configure`.

Silver/Gold/Platinum are filled conservatively. Already `done` after recent merges include `diagnostics` (#177255), `discovery-update-info`, and `exception-translations` (#177159). Higher-tier gaps left `todo` include `action-exceptions` (airflow service still accepts non-multiples of 5), `log-when-unavailable`, `test-coverage`, `docs-supported-functions`, and `icon-translations`. `docs-installation-parameters` stays `exempt` until #177163 and home-assistant/home-assistant.io#47026 land.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176751 (runtime rewrite), #177159 (exception translations), #177255 (diagnostics), home-assistant/home-assistant.io#46923 (docs removal)
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/46923
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


Made with [Cursor](https://cursor.com)
