### PR TITLE
Bump reolink_aio to 0.21.7 and adjust to new dual lens handeling

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -536,6 +536,33 @@ def migrate_entity_ids(
                 entity_reg.async_remove(entity.entity_id)
                 continue
 
+        # Can be removed in HA 2027.2
+        if (
+            host.api.is_dual_lens
+            and host.api.supported(1, "zoom_basic")
+            and not host.api.supported(0, "zoom_basic")
+        ):
+            id_parts = entity.unique_id.split("_", 2)
+            if len(id_parts) < 3:
+                continue
+            if id_parts[1] == "0" and id_parts[2] in {
+                "zoom",
+                "ptz_zoom_in",
+                "ptz_zoom_out",
+            }:
+                new_id = f"{host.unique_id}_1_{id_parts[2]}"
+                _LOGGER.debug(
+                    "Updating Reolink entity unique_id from %s to %s",
+                    entity.unique_id,
+                    new_id,
+                )
+                existing_entity = entity_reg.async_get_entity_id(
+                    entity.domain, entity.platform, new_id
+                )
+                if existing_entity is not None:
+                    entity_reg.async_remove(existing_entity)
+                entity_reg.async_update_entity(entity.entity_id, new_unique_id=new_id)
+
         if entity.device_id in ch_device_ids:
             ch = ch_device_ids[entity.device_id]
             id_parts = entity.unique_id.split("_", 2)

--- a/homeassistant/components/reolink/binary_sensor.py
+++ b/homeassistant/components/reolink/binary_sensor.py
@@ -324,7 +324,7 @@ async def async_setup_entry(
     api = reolink_data.host.api
 
     entities: list[BinarySensorEntity] = []
-    for channel in api.channels:
+    for channel in api.stream_channels:
         entities.extend(
             ReolinkPushBinarySensorEntity(reolink_data, channel, entity_description)
             for entity_description in BINARY_PUSH_SENSORS

--- a/homeassistant/components/reolink/camera.py
+++ b/homeassistant/components/reolink/camera.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 import logging
 from typing import override
 
-from reolink_aio.api import DUAL_LENS_SINGLE_MOTION_MODELS
-
 from homeassistant.components.camera import (
     Camera,
     CameraEntityDescription,
@@ -141,7 +139,7 @@ class ReolinkCamera(ReolinkChannelCoordinatorEntity, Camera):
         if "snapshots" not in entity_description.stream:
             self._attr_supported_features = CameraEntityFeature.STREAM
 
-        if self._host.api.model in DUAL_LENS_SINGLE_MOTION_MODELS:
+        if self._host.api.is_dual_lens:
             self._attr_translation_key = (
                 f"{entity_description.translation_key}_lens_{self._channel}"
             )

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -232,8 +232,8 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._dev_id)},
                 via_device=(DOMAIN, parent_dev_id),
-                name=f"{self._host.api.camera_name(channel)} lens {channel}",
-                model=self._host.api.camera_model(channel),
+                name=f"{self._host.api.camera_name(0)} lens {channel}",
+                model=self._host.api.camera_model(0),
                 manufacturer=self._host.api.manufacturer,
                 configuration_url=self._conf_url,
             )

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import override
 
-from reolink_aio.api import DUAL_LENS_DUAL_MOTION_MODELS, DUAL_LENS_MODELS, Chime, Host
+from reolink_aio.api import DUAL_LENS_DUAL_MOTION_MODELS, Chime, Host
 
 from homeassistant.core import callback
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
@@ -190,38 +190,34 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
                 f"{self._host.unique_id}_{channel}_{self.entity_description.key}"
             )
 
-        dev_ch = channel
-        if self._host.api.model in DUAL_LENS_MODELS:
-            dev_ch = 0
-
         if self._host.api.is_nvr:
-            if self._host.api.supported(dev_ch, "UID"):
+            if self._host.api.supported(channel, "UID"):
                 self._dev_id = (
-                    f"{self._host.unique_id}_{self._host.api.camera_uid(dev_ch)}"
+                    f"{self._host.unique_id}_{self._host.api.camera_uid(channel)}"
                 )
             else:
-                self._dev_id = f"{self._host.unique_id}_ch{dev_ch}"
+                self._dev_id = f"{self._host.unique_id}_ch{channel}"
 
             connections = set()
-            if mac := self._host.api.baichuan.mac_address(dev_ch):
+            if mac := self._host.api.baichuan.mac_address(channel):
                 connections.add((CONNECTION_NETWORK_MAC, mac))
 
             if self._conf_url is None:
                 conf_url = None
             else:
-                conf_url = f"{self._conf_url}/?ch={dev_ch}"
+                conf_url = f"{self._conf_url}/?ch={channel}"
 
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._dev_id)},
                 connections=connections,
                 via_device=(DOMAIN, self._host.unique_id),
-                name=self._host.api.camera_name(dev_ch),
-                model=self._host.api.camera_model(dev_ch),
-                model_id=self._host.api.item_number(dev_ch),
+                name=self._host.api.camera_name(channel),
+                model=self._host.api.camera_model(channel),
+                model_id=self._host.api.item_number(channel),
                 manufacturer=self._host.api.manufacturer,
-                hw_version=self._host.api.camera_hardware_version(dev_ch),
-                sw_version=self._host.api.camera_sw_version(dev_ch),
-                serial_number=self._host.api.camera_uid(dev_ch),
+                hw_version=self._host.api.camera_hardware_version(channel),
+                sw_version=self._host.api.camera_sw_version(channel),
+                serial_number=self._host.api.camera_uid(channel),
                 configuration_url=conf_url,
             )
 
@@ -236,7 +232,7 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._dev_id)},
                 via_device=(DOMAIN, parent_dev_id),
-                name=f"{self._host.api.camera_name(dev_ch)} lens {channel}",
+                name=f"{self._host.api.camera_name(channel)} lens {channel}",
                 model=self._host.api.camera_model(channel),
                 manufacturer=self._host.api.manufacturer,
                 configuration_url=self._conf_url,

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.21.6"]
+  "requirements": ["reolink-aio==0.21.7"]
 }

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.21.4"]
+  "requirements": ["reolink-aio==0.21.5"]
 }

--- a/homeassistant/components/reolink/manifest.json
+++ b/homeassistant/components/reolink/manifest.json
@@ -20,5 +20,5 @@
   "iot_class": "local_push",
   "loggers": ["reolink_aio"],
   "quality_scale": "platinum",
-  "requirements": ["reolink-aio==0.21.5"]
+  "requirements": ["reolink-aio==0.21.6"]
 }

--- a/homeassistant/components/reolink/media_source.py
+++ b/homeassistant/components/reolink/media_source.py
@@ -4,7 +4,6 @@ import datetime as dt
 import logging
 from typing import override
 
-from reolink_aio.api import DUAL_LENS_MODELS
 from reolink_aio.enums import VodRequestType
 from reolink_aio.typings import VOD_trigger
 
@@ -218,7 +217,7 @@ class ReolinkVODMediaSource(MediaSource):
                 if device.name_by_user is not None:
                     device_name = device.name_by_user
 
-                if host.api.model in DUAL_LENS_MODELS:
+                if host.api.is_dual_lens:
                     device_name = f"{device_name} lens {ch}"
 
                 children.append(
@@ -305,7 +304,7 @@ class ReolinkVODMediaSource(MediaSource):
             )
 
         title = host.api.camera_name(channel)
-        if host.api.model in DUAL_LENS_MODELS:
+        if host.api.is_dual_lens:
             title = f"{host.api.camera_name(channel)} lens {channel}"
 
         return BrowseMediaSource(
@@ -355,7 +354,7 @@ class ReolinkVODMediaSource(MediaSource):
         ]
 
         title = f"{host.api.camera_name(channel)} {res_name(stream)}"
-        if host.api.model in DUAL_LENS_MODELS:
+        if host.api.is_dual_lens:
             title = f"{host.api.camera_name(channel)} lens {channel} {res_name(stream)}"
 
         return BrowseMediaSource(
@@ -444,7 +443,7 @@ class ReolinkVODMediaSource(MediaSource):
         title = (
             f"{host.api.camera_name(channel)} {res_name(stream)} {year}/{month}/{day}"
         )
-        if host.api.model in DUAL_LENS_MODELS:
+        if host.api.is_dual_lens:
             title = (
                 f"{host.api.camera_name(channel)} lens"
                 f" {channel} {res_name(stream)}"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2922,7 +2922,7 @@ renault-api==0.5.12
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.21.6
+reolink-aio==0.21.7
 
 # homeassistant.components.radio_frequency
 rf-protocols==4.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2922,7 +2922,7 @@ renault-api==0.5.12
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.21.4
+reolink-aio==0.21.5
 
 # homeassistant.components.radio_frequency
 rf-protocols==4.3.0

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2922,7 +2922,7 @@ renault-api==0.5.12
 renson-endura-delta==1.7.2
 
 # homeassistant.components.reolink
-reolink-aio==0.21.5
+reolink-aio==0.21.6
 
 # homeassistant.components.radio_frequency
 rf-protocols==4.3.0

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -98,6 +98,7 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.is_nvr = True
     host_mock.is_hub = False
     host_mock.is_battery = False
+    host_mock.is_dual_lens = False
     host_mock.mac_address = TEST_MAC
     host_mock.uid = TEST_UID
     host_mock.onvif_enabled = True

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -90,6 +90,7 @@ async def test_dual_lens_sub_devices(
     """Test dual lens camera with separate sensors per lens uses lens sub-devices."""
     reolink_host.model = TEST_DUO_MODEL
     reolink_host.is_nvr = False
+    reolink_host.is_dual_lens = True
     reolink_host.channels = [0, 1]
     reolink_host.stream_channels = [0, 1]
     # a Reolink Duo reports a junk name like "2" for the second channel,

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -484,6 +484,74 @@ async def test_migrate_entity_ids(
     assert device_registry.async_get_device(identifiers={(DOMAIN, new_dev_id)})
 
 
+async def test_migrate_entity_id_zoom(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test entity ids that need to be migrated."""
+    domain = Platform.NUMBER
+    original_id = f"{TEST_UID}_0_zoom"
+    new_id = f"{TEST_UID}_1_zoom"
+
+    def mock_supported(ch, capability):
+        if capability == "UID" and ch is None:
+            return True
+        if capability == "UID":
+            return False
+        if capability in ["zoom_basic", "zoom"] and ch == 0:
+            return False
+        return True
+
+    reolink_host.channels = [0]
+    reolink_host.stream_channels = [0, 1]
+    reolink_host.is_dual_lens = True
+    reolink_host.supported = mock_supported
+
+    entity_registry.async_get_or_create(
+        domain=domain,
+        platform=DOMAIN,
+        unique_id=new_id,
+        config_entry=config_entry,
+        suggested_object_id=new_id,
+        disabled_by=None,
+        original_name="NEEDS_REMOVAL",
+    )
+
+    entity_registry.async_get_or_create(
+        domain=domain,
+        platform=DOMAIN,
+        unique_id=f"{TEST_UID}_0_zoom",
+        config_entry=config_entry,
+        suggested_object_id=original_id,
+        disabled_by=None,
+        original_name="NEEDS_MIGRATION",
+    )
+
+    entity_registry.async_get_or_create(
+        domain=Platform.UPDATE,
+        platform=DOMAIN,
+        unique_id=f"{TEST_UID}_firmware",
+        config_entry=config_entry,
+        suggested_object_id=f"{TEST_UID}_firmware",
+        disabled_by=None,
+    )
+
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id)
+    entity_id = entity_registry.async_get_entity_id(domain, DOMAIN, new_id)
+    assert entity_registry.async_get(entity_id).original_name == "NEEDS_REMOVAL"
+
+    # setup CH 0 and host entities/device
+    with patch("homeassistant.components.reolink.PLATFORMS", [domain]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get_entity_id(domain, DOMAIN, original_id) is None
+    entity_id = entity_registry.async_get_entity_id(domain, DOMAIN, new_id)
+    assert entity_registry.async_get(entity_id).original_name == "NEEDS_MIGRATION"
+
+
 async def test_migrate_with_already_existing_device(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/reolink/test_media_source.py
+++ b/tests/components/reolink/test_media_source.py
@@ -149,6 +149,7 @@ async def test_browsing(
     entry_id = config_entry.entry_id
     reolink_host.supported.return_value = 1
     reolink_host.model = "Reolink TrackMix PoE"
+    reolink_host.is_dual_lens = True
     reolink_host.is_nvr = False
 
     with patch("homeassistant.components.reolink.PLATFORMS", [Platform.CAMERA]):
@@ -263,6 +264,7 @@ async def test_browsing(
     )
 
     reolink_host.model = TEST_HOST_MODEL
+    reolink_host.is_dual_lens = False
 
     # browse event trigger person on a NVR
     reolink_host.is_nvr = True


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Bump reolink_aio to 0.21.7 which changes the way in which dual lens camera's are handeld.
Dual lens cams are now automatically detected without relaying on model name matching.
Furthermore some supported features have moved from channel 0 to channel 1 acording to the latest Reolink models:
For instance the Reolink OMVI3i has 2 stream channels, 0 is a fixed wide angle lens (2 lenses stiched together), 1 is the third lens which can rotate (PTZ). On this model PTZ commands to channel 0 will produce errors while PTZ commands to channel 1 will rotate that lens. On older Reolink models it did not matter which channel was sent.
This is a adjustment for a new upcomming model which will have 2 independently movable channels.

Therefore some adjustments are needed in HA and a migration of the zoom entities from channel 0 to channel 1.

Reolink_aio bump:
**Additions:**
- [Add synchronize_time method](https://github.com/starkillerOG/reolink_aio/commit/64fbbe5da53b535973e1ff89dd23c0170a2b3512)
- [Add sync_time capability flag](https://github.com/starkillerOG/reolink_aio/commit/0c6ea12af233ecb38bc3972512286c36e42bb6fd)
- [Add Baichuan capability detection of Zoom](https://github.com/starkillerOG/reolink_aio/commit/d886605886275ac1cf1de930bb8f09aa0aa3169b)
- [Add StartZoomFocus Baichuan fallback](https://github.com/starkillerOG/reolink_aio/commit/5e8d3289677f5514b168ee23946325cc79982cdd)
- [Add is_dual_lens property](https://github.com/starkillerOG/reolink_aio/commit/4e445ffeaefc3a27f847b898d7ac9bb07d2e001f)
- [Add GetAiCfg Baichuan fallback for auto tracking](https://github.com/starkillerOG/reolink_aio/commit/d8cc18fdaf1ea4fed20b4fbae731836dd0db84c7)
- [Add GetPtzTraceSection Baichuan fallback for auto track limits](https://github.com/starkillerOG/reolink_aio/commit/72d098553ccfac0d1415791d0e77e882819601bf)
- [Add SetAiCfg Baichuan fallback for auto tracking](https://github.com/starkillerOG/reolink_aio/commit/9ba78fab7d00233428aa08f5dbf344db810eaf13)
- [Add SetPtzTraceSection Baichuan fallback for auto track limits](https://github.com/starkillerOG/reolink_aio/commit/a508391f98dfcaa7a51b61a234e77eae104c7d19)
- [Add ext_stream capability flag and ensure ext_stream uses FLV or RTMP](https://github.com/starkillerOG/reolink_aio/commit/ed82e507eac42dcd02f5834cbd6a058fd9e6425f)
- [Add Anti-Flicker support](https://github.com/starkillerOG/reolink_aio/commit/8cfced46e50c706d53533612f52c71fa66b3871f)
- [Add pre_record_fps_list and improve pre_record capability detection (Altas PT Ultra)](https://github.com/starkillerOG/reolink_aio/commit/fa56ce35ed698f0f3abe79e444bf968d47b7acde)

**Bug fixes:**
- Re-work dual lens handeling
  - [Improve Baichuan stream_channel detection](https://github.com/starkillerOG/reolink_aio/commit/60c268a056d12affd6927e876fcefb1d91b6adf8)
  - [Remove DUAL_LENS_SINGLE_MOTION_MODELS and relay on Baichuan stream_channel detection](https://github.com/starkillerOG/reolink_aio/commit/dc44db8c71629905bc76accef08d22a0494ce0d6)
  - [Fix channels/stream_channels for dual lens Baichuan cameras (Argus Track)](https://github.com/starkillerOG/reolink_aio/commit/ce915f619ca3b3a3ae8d5c65317df6d1a8a3e3f1)
  - [Privacy mask for all stream_channels](https://github.com/starkillerOG/reolink_aio/commit/7b140dafc687558b90111193f54fae6e0de401dd)
  - [Baichuan AbilityInfo split between channel and stream_channel capabilities](https://github.com/starkillerOG/reolink_aio/commit/abf312b5af754e175ab9abd34e48abb153ca7e6d)
  - [Fix baichuan abilities for NVRs](https://github.com/starkillerOG/reolink_aio/commit/bf598fb41b886c360f42cffd746b6c2ef3807b74)
  - [ensure stream_channels is checked from baichuan channelNum](https://github.com/starkillerOG/reolink_aio/commit/3c1e75c4aa44363dee94fe7cd16afb93ae2a2ede)
  - [Trust Baichuan channel info over HTTP channel info](https://github.com/starkillerOG/reolink_aio/commit/8ebec9adeb56d0767d35ee89a1f84f0b746dc3f6)
  - [PTZ capabilities per stream channel](https://github.com/starkillerOG/reolink_aio/commit/33562ffadc41831ce09b3290792d9b144697c39a)
  - [Fix PTZ functions for second lens of dual lens cameras](https://github.com/starkillerOG/reolink_aio/commit/6c173030bd37ba6c51b452ff4893fe1b0e0b7791)
  - [Add some stream_channel capabilities only once](https://github.com/starkillerOG/reolink_aio/commit/9b6f3993bf1e99e77e4b1a9d6d51c6177150635a)
- [Fix smart_AI detection in GetEvents](https://github.com/starkillerOG/reolink_aio/commit/cd38ccc54bc6e80c43d5975ede8ef1ce9194c35f)
- [Ensure Baichuan LoginError/ConnectionError are raised for baichuan only](https://github.com/starkillerOG/reolink_aio/commit/a487c8954c64888a64c3581dbef4c0b2dff287fb)
- [Fix Baichuan "supportDingDongCtrl" overwrite when multiple doorbells connected](https://github.com/starkillerOG/reolink_aio/commit/53c1289ce2931aef54b0dae20b180aff14820885)
- [Fix support for DUAL_LENS_DUAL_MOTION_MODELS](https://github.com/starkillerOG/reolink_aio/commit/3c4c2ea4fc1fa0d616899c8660fa69402a57d329)
- [Fix sending double messages with get_host_data](https://github.com/starkillerOG/reolink_aio/commit/daef9fa05dcccef7b92886317e00b87cbcc22c69)


**Optimizations:**
- [Spelling](https://github.com/starkillerOG/reolink_aio/commit/37a02e46f187e9f33f17db6e479aebabc205f17d)

**Full Changelog**: https://github.com/starkillerOG/reolink_aio/compare/0.21.4...0.21.7

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/176726 fixes #177051
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
