### PR TITLE
Fix homekit_controller sending zero brightness for low brightness values

### DIFF
--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -188,8 +188,12 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         characteristics: dict[str, Any] = {}
 
         if brightness is not None:
-            characteristics[CharacteristicsTypes.BRIGHTNESS] = int(
-                brightness * 100 / 255
+            # Never send 0 for a nonzero requested brightness; some devices
+            # such as Nanoleaf Essentials treat brightness 0 with on as full
+            # brightness. Brightness 0 is already handled as turn_off by the
+            # light component.
+            characteristics[CharacteristicsTypes.BRIGHTNESS] = max(
+                1, int(brightness * 100 / 255)
             )
 
         # If they send both temperature and hs_color, and the device

--- a/homeassistant/components/homekit_controller/light.py
+++ b/homeassistant/components/homekit_controller/light.py
@@ -188,10 +188,9 @@ class HomeKitLight(HomeKitEntity, LightEntity):
         characteristics: dict[str, Any] = {}
 
         if brightness is not None:
-            # Never send 0 for a nonzero requested brightness; some devices
-            # such as Nanoleaf Essentials treat brightness 0 with on as full
-            # brightness. Brightness 0 is already handled as turn_off by the
-            # light component.
+            # Some devices such as Nanoleaf Essentials treat brightness 0
+            # with on as full brightness; a real brightness 0 is handled
+            # as turn_off by the light component.
             characteristics[CharacteristicsTypes.BRIGHTNESS] = max(
                 1, int(brightness * 100 / 255)
             )

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -60,6 +60,34 @@ def create_lightbulb_service_with_color_temp(accessory: Accessory) -> Service:
     return service
 
 
+async def test_turn_on_low_brightness_no_zero(
+    hass: HomeAssistant, get_next_aid: Callable[[], int]
+) -> None:
+    """Test low brightness values never send 0 percent to the device.
+
+    Sending brightness 0 with on results in full brightness on some
+    devices such as Nanoleaf Essentials bulbs.
+    """
+    helper = await setup_test_component(
+        hass, get_next_aid(), create_lightbulb_service_with_hs
+    )
+
+    for brightness in (1, 2, 3):
+        await hass.services.async_call(
+            "light",
+            "turn_on",
+            {"entity_id": "light.testdevice", "brightness": brightness},
+            blocking=True,
+        )
+        helper.async_assert_service_values(
+            ServicesTypes.LIGHTBULB,
+            {
+                CharacteristicsTypes.ON: True,
+                CharacteristicsTypes.BRIGHTNESS: 1,
+            },
+        )
+
+
 async def test_switch_change_light_state(
     hass: HomeAssistant, get_next_aid: Callable[[], int]
 ) -> None:

--- a/tests/components/homekit_controller/test_light.py
+++ b/tests/components/homekit_controller/test_light.py
@@ -7,6 +7,7 @@ from aiohomekit.model import Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.services import Service, ServicesTypes
 from aiohomekit.testing import FakeController
+import pytest
 
 from homeassistant.components.homekit_controller.const import KNOWN_DEVICES
 from homeassistant.components.light import (
@@ -60,8 +61,9 @@ def create_lightbulb_service_with_color_temp(accessory: Accessory) -> Service:
     return service
 
 
+@pytest.mark.parametrize("brightness", [1, 2, 3])
 async def test_turn_on_low_brightness_no_zero(
-    hass: HomeAssistant, get_next_aid: Callable[[], int]
+    hass: HomeAssistant, get_next_aid: Callable[[], int], brightness: int
 ) -> None:
     """Test low brightness values never send 0 percent to the device.
 
@@ -72,20 +74,19 @@ async def test_turn_on_low_brightness_no_zero(
         hass, get_next_aid(), create_lightbulb_service_with_hs
     )
 
-    for brightness in (1, 2, 3):
-        await hass.services.async_call(
-            "light",
-            "turn_on",
-            {"entity_id": "light.testdevice", "brightness": brightness},
-            blocking=True,
-        )
-        helper.async_assert_service_values(
-            ServicesTypes.LIGHTBULB,
-            {
-                CharacteristicsTypes.ON: True,
-                CharacteristicsTypes.BRIGHTNESS: 1,
-            },
-        )
+    await hass.services.async_call(
+        "light",
+        "turn_on",
+        {"entity_id": "light.testdevice", "brightness": brightness},
+        blocking=True,
+    )
+    helper.async_assert_service_values(
+        ServicesTypes.LIGHTBULB,
+        {
+            CharacteristicsTypes.ON: True,
+            CharacteristicsTypes.BRIGHTNESS: 1,
+        },
+    )
 
 
 async def test_switch_change_light_state(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Requesting a brightness below 3 in homekit_controller converted to 0 percent, which was then written together with on true; Nanoleaf Essentials bulbs and strips treat that combination as full brightness. The conversion now floors at 1 percent for any nonzero requested brightness, brightness 0 is already routed to turn_off by the light component so the device can never receive a contradictory write.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #159391
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
