### PR TITLE
Clamp sub display precision overshoot in climate temperature validation

### DIFF
--- a/homeassistant/components/climate/__init__.py
+++ b/homeassistant/components/climate/__init__.py
@@ -26,7 +26,10 @@ from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.temperature import display_temp as show_temp
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
-from homeassistant.util.unit_conversion import TemperatureConverter
+from homeassistant.util.unit_conversion import (
+    TemperatureConverter,
+    TemperatureDeltaConverter,
+)
 
 from .const import (  # noqa: F401
     ATTR_CURRENT_HUMIDITY,
@@ -823,11 +826,24 @@ async def async_service_temperature_set(
             translation_key="low_temp_higher_than_high_temp",
         )
 
+    # min_temp/max_temp are shown rounded to the display precision (a step
+    # in the Home Assistant unit), so a request equal to a displayed limit
+    # can convert back to a value just outside the real limit. Clamp
+    # overshoots smaller than one display step to the limit; the maximum
+    # genuine display-rounding error is half a step.
+    tolerance = TemperatureDeltaConverter.convert(
+        entity.precision, hass.config.units.temperature_unit, temp_unit
+    )
     for value, temp in service_call.data.items():
         if value in CONVERTIBLE_ATTRIBUTE:
-            kwargs[value] = check_temp = TemperatureConverter.convert(
+            converted_temp = TemperatureConverter.convert(
                 temp, hass.config.units.temperature_unit, temp_unit
             )
+            if max_temp < converted_temp < max_temp + tolerance:
+                converted_temp = max_temp
+            elif min_temp - tolerance < converted_temp < min_temp:
+                converted_temp = min_temp
+            kwargs[value] = check_temp = converted_temp
 
             _LOGGER.debug(
                 "Check valid temperature %d %s (%d %s) in range %d %s - %d %s",

--- a/tests/components/cielo_home/conftest.py
+++ b/tests/components/cielo_home/conftest.py
@@ -71,6 +71,7 @@ def mock_cielo_device_api() -> Generator[MagicMock]:
     device_api.min_temp.return_value = 10
     device_api.max_temp.return_value = 35
     device_api.target_temperature_step.return_value = 1
+    device_api.precision.return_value = 1
     device_api.hvac_mode.return_value = HVACMode.COOL
     device_api.hvac_modes.return_value = [HVACMode.OFF, HVACMode.COOL]
     device_api.mode_supports_temperature.return_value = True

--- a/tests/components/climate/test_init.py
+++ b/tests/components/climate/test_init.py
@@ -36,9 +36,15 @@ from homeassistant.components.climate.const import (
     SWING_HORIZONTAL_ON,
     ClimateEntityFeature,
 )
-from homeassistant.const import ATTR_TEMPERATURE, PRECISION_WHOLE, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_TEMPERATURE,
+    PRECISION_TENTHS,
+    PRECISION_WHOLE,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM
 
 from tests.common import (
     MockConfigEntry,
@@ -569,6 +575,179 @@ async def test_humidity_validation(
             },
             blocking=True,
         )
+
+
+async def _setup_bounded_climate(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    features: ClimateEntityFeature = ClimateEntityFeature.TARGET_TEMPERATURE,
+    precision: float | None = None,
+) -> MockClimateEntity:
+    """Set up a climate entity with temperature limits of 9.7 to 32.2."""
+
+    class MockClimateEntityTemp(MockClimateEntity):
+        """Mock climate class with a bounded temperature range."""
+
+        _attr_supported_features = features
+        _attr_min_temp = 9.7
+        _attr_max_temp = 32.2
+        _attr_temperature_unit = UnitOfTemperature.CELSIUS
+
+        def set_temperature(self, **kwargs: Any) -> None:
+            """Set new target temperature."""
+            if ATTR_TEMPERATURE in kwargs:
+                self._attr_target_temperature = kwargs[ATTR_TEMPERATURE]
+            if ATTR_TARGET_TEMP_HIGH in kwargs:
+                self._attr_target_temperature_high = kwargs[ATTR_TARGET_TEMP_HIGH]
+                self._attr_target_temperature_low = kwargs[ATTR_TARGET_TEMP_LOW]
+
+    test_climate = MockClimateEntityTemp(
+        name="Test",
+        unique_id="unique_climate_test",
+    )
+    if precision is not None:
+        test_climate._attr_precision = precision
+    setup_test_component_platform(
+        hass, DOMAIN, entities=[test_climate], from_config_entry=True
+    )
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    return test_climate
+
+
+async def _assert_temp_out_of_range(hass: HomeAssistant, data: dict[str, Any]) -> None:
+    """Assert the set temperature service call raises temp_out_of_range."""
+    with pytest.raises(ServiceValidationError) as exc:
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {"entity_id": "climate.test", **data},
+            blocking=True,
+        )
+    assert exc.value.translation_key == "temp_out_of_range"
+
+
+@pytest.mark.parametrize(
+    ("requested_temp_f", "expected_temp_c"),
+    [(90, 32.2), (49, 9.7)],
+)
+async def test_temperature_validation_unit_conversion_clamp(
+    hass: HomeAssistant,
+    register_test_integration: MockConfigEntry,
+    requested_temp_f: float,
+    expected_temp_c: float,
+) -> None:
+    """Test near limit temperatures from unit conversion clamp to the limit.
+
+    The limits are displayed rounded in the user's unit, so requesting the
+    displayed limit can convert to a value just outside the real limit.
+    """
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    test_climate = await _setup_bounded_climate(hass, register_test_integration)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {"entity_id": "climate.test", ATTR_TEMPERATURE: requested_temp_f},
+        blocking=True,
+    )
+    assert test_climate.target_temperature == expected_temp_c
+
+
+@pytest.mark.parametrize("requested_temp_f", [91, 48])
+async def test_temperature_validation_out_of_range_not_clamped(
+    hass: HomeAssistant,
+    register_test_integration: MockConfigEntry,
+    requested_temp_f: float,
+) -> None:
+    """Test temperatures beyond the display precision still raise."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    await _setup_bounded_climate(hass, register_test_integration)
+
+    await _assert_temp_out_of_range(hass, {ATTR_TEMPERATURE: requested_temp_f})
+
+
+async def test_temperature_validation_same_unit_clamp(
+    hass: HomeAssistant, register_test_integration: MockConfigEntry
+) -> None:
+    """Test sub display precision overshoot clamps without unit conversion."""
+    test_climate = await _setup_bounded_climate(hass, register_test_integration)
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {"entity_id": "climate.test", ATTR_TEMPERATURE: 32.25},
+        blocking=True,
+    )
+    assert test_climate.target_temperature == 32.2
+
+
+async def test_temperature_validation_same_unit_out_of_range(
+    hass: HomeAssistant, register_test_integration: MockConfigEntry
+) -> None:
+    """Test overshoot beyond the display precision raises without conversion."""
+    await _setup_bounded_climate(hass, register_test_integration)
+
+    await _assert_temp_out_of_range(hass, {ATTR_TEMPERATURE: 32.31})
+
+
+async def test_temperature_validation_range_clamp(
+    hass: HomeAssistant, register_test_integration: MockConfigEntry
+) -> None:
+    """Test near limit low and high targets clamp to the limits."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    test_climate = await _setup_bounded_climate(
+        hass,
+        register_test_integration,
+        features=ClimateEntityFeature.TARGET_TEMPERATURE_RANGE,
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {
+            "entity_id": "climate.test",
+            ATTR_TARGET_TEMP_LOW: 49,
+            ATTR_TARGET_TEMP_HIGH: 90,
+        },
+        blocking=True,
+    )
+    assert test_climate.target_temperature_low == 9.7
+    assert test_climate.target_temperature_high == 32.2
+
+    await _assert_temp_out_of_range(
+        hass, {ATTR_TARGET_TEMP_LOW: 50, ATTR_TARGET_TEMP_HIGH: 91}
+    )
+
+
+async def test_temperature_validation_precision_override_clamp(
+    hass: HomeAssistant, register_test_integration: MockConfigEntry
+) -> None:
+    """Test the clamp tolerance follows the entity precision override."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    test_climate = await _setup_bounded_climate(
+        hass, register_test_integration, precision=PRECISION_TENTHS
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_TEMPERATURE,
+        {"entity_id": "climate.test", ATTR_TEMPERATURE: 90},
+        blocking=True,
+    )
+    assert test_climate.target_temperature == 32.2
+
+
+async def test_temperature_validation_precision_override_out_of_range(
+    hass: HomeAssistant, register_test_integration: MockConfigEntry
+) -> None:
+    """Test overshoot beyond an overridden precision raises."""
+    hass.config.units = US_CUSTOMARY_SYSTEM
+    await _setup_bounded_climate(
+        hass, register_test_integration, precision=PRECISION_TENTHS
+    )
+
+    await _assert_temp_out_of_range(hass, {ATTR_TEMPERATURE: 90.2})
 
 
 async def test_temperature_validation(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Climate limits are displayed rounded to the display precision in the user's unit, so requesting the displayed limit can convert back to a value just outside the real limit; an Ecobee with a real maximum of 32.2 C shows 90 F, and requesting 90 F converts to 32.222 C which failed validation with temp_out_of_range. The user is rejected for asking for exactly what the interface offered.

The set temperature validation now clamps converted requests to the limit when the overshoot is smaller than one display step, converted into the entity unit with TemperatureDeltaConverter; anything beyond one display step still raises as before. The maximum genuine display rounding error is half a step, so a full step gives float headroom without an epsilon. This also resolves float precision rejections like #141891 where the converted value misses the limit by a rounding ulp.

Behavior change to be aware of: values within one display step past a limit are now silently clamped instead of raising, including on the path where no unit conversion happens. Values the device cannot represent at display granularity were previously rejected; nothing out of range is ever sent to the device. This intentionally does not address integrations that report wrong limits or mode dependent limits, those are separate bug classes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #160823
- This PR is related to issue: #141891, #138758
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
