### PR TITLE
Use version_pending to finalize HAOS update state

### DIFF
--- a/homeassistant/components/hassio/update.py
+++ b/homeassistant/components/hassio/update.py
@@ -257,7 +257,9 @@ class SupervisorOSUpdateEntity(HassioOSEntity, UpdateEntity):
     def installed_version(self) -> str | None:
         """Return the installed version."""
         assert self.coordinator.data.os is not None
-        return self.coordinator.data.os.version
+        return (
+            self.coordinator.data.os.version_pending or self.coordinator.data.os.version
+        )
 
     @property
     @override

--- a/tests/components/hassio/test_update.py
+++ b/tests/components/hassio/test_update.py
@@ -71,6 +71,7 @@ def mock_all(
         os_info.return_value,
         version="1.0.0dev2221",
         version_latest="1.0.0dev2222",
+        version_pending=None,
         update_available=True,
     )
     supervisor_info.return_value = replace(
@@ -540,10 +541,11 @@ async def test_update_os(
     await hass.async_block_till_done()
 
     async def mock_os_update(*args: Any) -> None:
-        """Simulate Supervisor reporting the new version after the update."""
+        """Simulate Supervisor keeping version stable while pending version updates."""
         os_info.return_value = replace(
             os_info.return_value,
-            version="1.0.0dev2222",
+            version="1.0.0dev2221",
+            version_pending="1.0.0dev2222",
             update_available=False,
         )
 
@@ -560,8 +562,8 @@ async def test_update_os(
     mock_create_backup.assert_not_called()
     supervisor_client.os.update.assert_called_once_with(OSUpdate(version=None))
 
-    # The coordinator is refreshed after install so the new version
-    # shows up immediately
+    # The coordinator refresh reflects the new pending version while
+    # the base version remains unchanged.
     state = hass.states.get("update.home_assistant_operating_system_update")
     assert state is not None
     assert state.state == "off"


### PR DESCRIPTION
## Breaking change


## Proposed change
This PR updates the HA OS update entity to use the new `version_pending` field from Supervisor OS info.

When an OS update is installed, Supervisor keeps `version` unchanged and sets `version_pending` to the target version. Using `version_pending` as the effective installed version ensures the update entity turns off correctly after the update flow completes.

Tests were updated to reflect the correct sequence:
1. Before update: `version_pending` is `None`, and `version != latest_version`.
2. After update: `version` remains unchanged, and `version_pending = latest_version`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/supervisor/pull/7006
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls\?q\=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/\#creating-the-perfect-pr
