### PR TITLE
Validate via_device_id in device registry

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -895,22 +895,6 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                     composite_splits.setdefault(old_id, {})[config_entry_id] = split[
                         "id"
                     ]
-            # Rewrite via_device_id links that pointed at a now-split composite parent
-            # to a live split: the parent's split in the child's own config entry when
-            # there is one, otherwise any of the parent's splits, so the link never
-            # dangles on the removed composite id. A link to a retained unsplit parent is
-            # left unchanged; a link to a dropped parent is detached below.
-            for device in devices:
-                if (
-                    splits := composite_splits.get(device["via_device_id"])
-                ) is not None:
-                    device["via_device_id"] = splits.get(
-                        device["config_entry_id"], next(iter(splits.values()))
-                    )
-                elif device["via_device_id"] in dropped_device_ids:
-                    # The parent was dropped (no config entries); detach the link as
-                    # async_remove_device would, so it does not dangle on a removed id.
-                    device["via_device_id"] = None
             old_data["devices"] = devices
             # A split inherited the composite's disabled_by, which may not match its
             # single config entry (e.g. a split owned by an enabled entry must not stay
@@ -926,6 +910,40 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                         _migrate_device_disabled_by(
                             split, config_entry.disabled_by is not None
                         )
+
+            def _split_for_via_device(
+                config_entry_id: str, splits: dict[str, str]
+            ) -> str:
+                """Pick the split for via device."""
+                if (split_id := splits.get(config_entry_id)) is not None:
+                    return split_id
+                config_entries = self.hass.config_entries
+                self_entry = config_entries.async_get_entry(config_entry_id)
+                if self_entry is not None:
+                    for split_entry_id, split_id in splits.items():
+                        split_entry = config_entries.async_get_entry(split_entry_id)
+                        if (
+                            split_entry is not None
+                            and split_entry.domain == self_entry.domain
+                        ):
+                            return split_id
+                return next(iter(splits.values()))
+
+            # Rewrite via_device_id links that pointed at a now-split composite parent
+            # to a live split, so the link never dangles on the removed composite id.
+            # The domain rung needs the config entries, which are initialized above
+            # whenever splits exist. A link to a retained unsplit parent is left
+            # unchanged; a link to a dropped parent is detached.
+            for device in devices:
+                if (
+                    splits := composite_splits.get(device["via_device_id"])
+                ) is not None:
+                    device["via_device_id"] = _split_for_via_device(
+                        device["config_entry_id"], splits
+                    )
+                elif device["via_device_id"] in dropped_device_ids:
+                    device["via_device_id"] = None
+
             deleted_devices: list[dict[str, Any]] = []
             for device in old_data["deleted_devices"]:
                 # One target per config entry. config_entries_subentries was a set, so
@@ -1497,6 +1515,43 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             self.devices.get_devices_for_composite_device_id(device_id)
         )
 
+    @callback
+    def _resolve_via_device_id(
+        self, via_device_id: str, config_entry_id: str
+    ) -> str | None:
+        """Resolve a via_device_id to the id of a registered device.
+
+        The id of a pre-migration composite device is resolved to one of the devices
+        it was split into - preferring the split owned by config_entry_id, then one
+        owned by the same domain, then any of them. Returns None for an unknown id.
+        """
+        if via_device_id in self.devices:
+            return via_device_id
+        if splits := self.devices.get_devices_for_composite_device_id(via_device_id):
+            # The composite resolution can be removed in HA Core 2027.8
+            report_usage(
+                f"passes the id of a pre-migration composite device {via_device_id} "
+                "as `via_device_id`; pass the id of a single device instead, e.g. "
+                "one returned by async_get_device_by_identifier",
+                core_behavior=ReportBehavior.LOG,
+                breaks_in_ha_version="2027.8",
+            )
+            for split in splits:
+                if split.config_entry_id == config_entry_id:
+                    return split.id
+            if (
+                config_entry := self.hass.config_entries.async_get_entry(
+                    config_entry_id
+                )
+            ) is not None and (
+                split_in_domain := self._first_device_in_domain(
+                    splits, config_entry.domain
+                )
+            ) is not None:
+                return split_in_domain.id
+            return splits[0].id
+        return None
+
     def _substitute_name_placeholders(
         self,
         domain: str,
@@ -1627,6 +1682,18 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         }
 
         device_info_type = _determine_device_info_type(config_entry, device_info)
+
+        if via_device_id is not UNDEFINED and via_device_id is not None:
+            resolved_via_device_id = self._resolve_via_device_id(
+                via_device_id, config_entry_id
+            )
+            if resolved_via_device_id is None:
+                raise DeviceInfoError(
+                    config_entry.domain,
+                    device_info,
+                    f"via_device_id {via_device_id} is not a registered device id",
+                )
+            via_device_id = resolved_via_device_id
 
         if identifiers is None or identifiers is UNDEFINED:
             identifiers = set()
@@ -2030,6 +2097,16 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             else old.config_entry_id
         )
         is_move = effective_config_entry_id != old.config_entry_id
+
+        if via_device_id is not UNDEFINED and via_device_id is not None:
+            resolved_via_device_id = self._resolve_via_device_id(
+                via_device_id, effective_config_entry_id
+            )
+            if resolved_via_device_id is None:
+                raise HomeAssistantError(
+                    f"Can't link device to unknown via device {via_device_id}"
+                )
+            via_device_id = resolved_via_device_id
 
         added_connections: set[tuple[str, str]] | None = None
         added_identifiers: set[tuple[str, str]] | None = None

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1683,18 +1683,6 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
 
         device_info_type = _determine_device_info_type(config_entry, device_info)
 
-        if via_device_id is not UNDEFINED and via_device_id is not None:
-            resolved_via_device_id = self._resolve_via_device_id(
-                via_device_id, config_entry_id
-            )
-            if resolved_via_device_id is None:
-                raise DeviceInfoError(
-                    config_entry.domain,
-                    device_info,
-                    f"via_device_id {via_device_id} is not a registered device id",
-                )
-            via_device_id = resolved_via_device_id
-
         if identifiers is None or identifiers is UNDEFINED:
             identifiers = set()
 
@@ -1708,6 +1696,18 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
             identifiers=identifiers,
             config_entry_id=config_entry_id,
         )
+
+        if via_device_id is not UNDEFINED and via_device_id is not None:
+            resolved_via_device_id = self._resolve_via_device_id(
+                via_device_id, config_entry_id
+            )
+            if resolved_via_device_id is None:
+                raise DeviceInfoError(
+                    config_entry.domain,
+                    device_info,
+                    f"via_device_id {via_device_id} is not a registered device id",
+                )
+            via_device_id = resolved_via_device_id
 
         is_new = False
 

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -64,7 +64,7 @@ EVENT_DEVICE_REGISTRY_UPDATED: EventType[EventDeviceRegistryUpdatedData] = Event
 )
 STORAGE_KEY = "core.device_registry"
 STORAGE_VERSION_MAJOR = 3
-STORAGE_VERSION_MINOR = 1
+STORAGE_VERSION_MINOR = 2
 
 CLEANUP_DELAY = 10
 
@@ -836,12 +836,6 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
             # the registries are loaded.
             migrated_at = utcnow().isoformat()
             devices: list[dict[str, Any]] = []
-            # Ids of active devices dropped for lacking a config entry; a retained
-            # child's via_device_id pointing at one is detached below.
-            dropped_device_ids: set[str] = set()
-            # old composite id -> {config entry id -> new split id}, to rewrite
-            # via_device_id links pointing at a split parent
-            composite_splits: dict[str, dict[str, str]] = {}
             # Active splits whose copied disabled_by must be reconciled against their
             # single config entry once the config entries are loaded
             migrated_active_splits: list[dict[str, Any]] = []
@@ -866,7 +860,6 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                 ]
                 if not pairs:
                     # Drop devices that have no config entry / subentry pairs
-                    dropped_device_ids.add(device["id"])
                     continue
                 if len(pairs) == 1:
                     config_entry_id, subentry_id = pairs[0]
@@ -892,9 +885,6 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                     split["has_composite_identifiers"] = True
                     devices.append(split)
                     migrated_active_splits.append(split)
-                    composite_splits.setdefault(old_id, {})[config_entry_id] = split[
-                        "id"
-                    ]
             old_data["devices"] = devices
             # A split inherited the composite's disabled_by, which may not match its
             # single config entry (e.g. a split owned by an enabled entry must not stay
@@ -910,39 +900,6 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
                         _migrate_device_disabled_by(
                             split, config_entry.disabled_by is not None
                         )
-
-            def _split_for_via_device(
-                config_entry_id: str, splits: dict[str, str]
-            ) -> str:
-                """Pick the split for via device."""
-                if (split_id := splits.get(config_entry_id)) is not None:
-                    return split_id
-                config_entries = self.hass.config_entries
-                self_entry = config_entries.async_get_entry(config_entry_id)
-                if self_entry is not None:
-                    for split_entry_id, split_id in splits.items():
-                        split_entry = config_entries.async_get_entry(split_entry_id)
-                        if (
-                            split_entry is not None
-                            and split_entry.domain == self_entry.domain
-                        ):
-                            return split_id
-                return next(iter(splits.values()))
-
-            # Rewrite via_device_id links that pointed at a now-split composite parent
-            # to a live split, so the link never dangles on the removed composite id.
-            # The domain rung needs the config entries, which are initialized above
-            # whenever splits exist. A link to a retained unsplit parent is left
-            # unchanged; a link to a dropped parent is detached.
-            for device in devices:
-                if (
-                    splits := composite_splits.get(device["via_device_id"])
-                ) is not None:
-                    device["via_device_id"] = _split_for_via_device(
-                        device["config_entry_id"], splits
-                    )
-                elif device["via_device_id"] in dropped_device_ids:
-                    device["via_device_id"] = None
 
             deleted_devices: list[dict[str, Any]] = []
             for device in old_data["deleted_devices"]:
@@ -992,6 +949,61 @@ class DeviceRegistryStore(storage.Store[dict[str, list[dict[str, Any]]]]):
             for migrated in (*devices, *deleted_devices):
                 migrated.pop("config_entries", None)
                 migrated.pop("config_entries_subentries", None)
+
+        if old_major_version < 3 or (old_major_version == 3 and old_minor_version < 2):
+            # Version 3.2, introduced in 2026.8, rewrites via_device_id links that do
+            # not reference a live device. A link to a composite parent split by the
+            # version 3 migration is remapped to one of the splits; any other stale
+            # link is detached.
+            device_ids = {device["id"] for device in old_data["devices"]}
+            # old composite id -> {config entry id -> split id}
+            composite_splits: dict[str, dict[str, str]] = {}
+            for device in old_data["devices"]:
+                if (composite_id := device["composite_device_id"]) is not None:
+                    composite_splits.setdefault(composite_id, {})[
+                        device["config_entry_id"]
+                    ] = device["id"]
+
+            def _split_for_via_device(
+                config_entry_id: str, splits: dict[str, str]
+            ) -> str:
+                """Pick the split for via device: same entry, same domain, any."""
+                if (split_id := splits.get(config_entry_id)) is not None:
+                    return split_id
+                config_entries = self.hass.config_entries
+                self_entry = config_entries.async_get_entry(config_entry_id)
+                if self_entry is not None:
+                    for split_entry_id, split_id in splits.items():
+                        split_entry = config_entries.async_get_entry(split_entry_id)
+                        if (
+                            split_entry is not None
+                            and split_entry.domain == self_entry.domain
+                        ):
+                            return split_id
+                return next(iter(splits.values()))
+
+            stale_via_devices = [
+                device
+                for device in old_data["devices"]
+                if device["via_device_id"] is not None
+                and device["via_device_id"] not in device_ids
+            ]
+            # The domain rung of the split resolution needs the config entries, which
+            # load concurrently, so wait for them only when a link must be remapped
+            if any(
+                device["via_device_id"] in composite_splits
+                for device in stale_via_devices
+            ):
+                await self.hass.config_entries.async_wait_initialized()
+            for device in stale_via_devices:
+                if (
+                    splits := composite_splits.get(device["via_device_id"])
+                ) is not None:
+                    device["via_device_id"] = _split_for_via_device(
+                        device["config_entry_id"], splits
+                    )
+                else:
+                    device["via_device_id"] = None
 
         if old_major_version > 3:
             raise NotImplementedError

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1968,6 +1968,16 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 "Cannot define both merge_identifiers and new_identifiers"
             )
 
+        if (
+            via_device_id is not UNDEFINED
+            and via_device_id is not None
+            and via_device_id not in self.devices
+            and not self.devices.get_devices_for_composite_device_id(via_device_id)
+        ):
+            raise HomeAssistantError(
+                f"Can't link device to unknown via device {via_device_id}"
+            )
+
         # A device belongs to exactly one config entry and subentry:
         # - add_config_entry_id (with an optional add_config_subentry_id) records a
         #   transient pending move to that config entry and subentry; on its own it does
@@ -2099,14 +2109,10 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         is_move = effective_config_entry_id != old.config_entry_id
 
         if via_device_id is not UNDEFINED and via_device_id is not None:
-            resolved_via_device_id = self._resolve_via_device_id(
+            # Existence was already validated, so this cannot be None
+            via_device_id = self._resolve_via_device_id(
                 via_device_id, effective_config_entry_id
             )
-            if resolved_via_device_id is None:
-                raise HomeAssistantError(
-                    f"Can't link device to unknown via device {via_device_id}"
-                )
-            via_device_id = resolved_via_device_id
 
         added_connections: set[tuple[str, str]] | None = None
         added_identifiers: set[tuple[str, str]] | None = None

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2086,128 +2086,6 @@ async def test_migration_detaches_via_device_of_dropped_parent(
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_migration_rewrites_via_device_of_split_parent(
-    hass: HomeAssistant, hass_storage: dict[str, Any]
-) -> None:
-    """A child's via link to a split composite parent is rewritten to a live split.
-
-    The parent's split in the child's own config entry is preferred, then one owned
-    by the child's domain, then any split - the same ladder the via_device
-    resolution uses.
-    """
-    entry_test = MockConfigEntry(domain="test")
-    entry_test.add_to_hass(hass)
-    entry_matter = MockConfigEntry(domain="matter")
-    entry_matter.add_to_hass(hass)
-    entry_matter_2 = MockConfigEntry(domain="matter")
-    entry_matter_2.add_to_hass(hass)
-    entry_other = MockConfigEntry(domain="other")
-    entry_other.add_to_hass(hass)
-
-    def _device(**overrides: Any) -> dict[str, Any]:
-        device = {
-            "area_id": None,
-            "config_entries": [entry_test.entry_id],
-            "config_entries_subentries": {entry_test.entry_id: [None]},
-            "configuration_url": None,
-            "connections": [],
-            "created_at": "1970-01-01T00:00:00+00:00",
-            "disabled_by": None,
-            "entry_type": None,
-            "hw_version": None,
-            "id": "device0000000000000000000000000",
-            "identifiers": [["test", "1"]],
-            "labels": [],
-            "manufacturer": None,
-            "model": None,
-            "name": None,
-            "model_id": None,
-            "modified_at": "1970-01-01T00:00:00+00:00",
-            "name_by_user": None,
-            "primary_config_entry": entry_test.entry_id,
-            "serial_number": None,
-            "sw_version": None,
-            "via_device_id": None,
-        }
-        return device | overrides
-
-    composite_id = "composite0000000000000000000000"
-    hass_storage[dr.STORAGE_KEY] = {
-        "version": 1,
-        "minor_version": 12,
-        "key": dr.STORAGE_KEY,
-        "data": {
-            "devices": [
-                # Parent spanning two config entries -> split by the migration
-                _device(
-                    id=composite_id,
-                    config_entries=[entry_test.entry_id, entry_matter.entry_id],
-                    config_entries_subentries={
-                        entry_test.entry_id: [None],
-                        entry_matter.entry_id: [None],
-                    },
-                    identifiers=[["test", "hub"]],
-                ),
-                # Child owned by a config entry that owns a split
-                _device(
-                    id="childentry000000000000000000000",
-                    config_entries=[entry_matter.entry_id],
-                    config_entries_subentries={entry_matter.entry_id: [None]},
-                    identifiers=[["matter", "child1"]],
-                    primary_config_entry=entry_matter.entry_id,
-                    via_device_id=composite_id,
-                ),
-                # Child owned by another config entry of a split's domain
-                _device(
-                    id="childdomain00000000000000000000",
-                    config_entries=[entry_matter_2.entry_id],
-                    config_entries_subentries={entry_matter_2.entry_id: [None]},
-                    identifiers=[["matter", "child2"]],
-                    primary_config_entry=entry_matter_2.entry_id,
-                    via_device_id=composite_id,
-                ),
-                # Child sharing neither config entry nor domain with a split
-                _device(
-                    id="childother000000000000000000000",
-                    config_entries=[entry_other.entry_id],
-                    config_entries_subentries={entry_other.entry_id: [None]},
-                    identifiers=[["other", "child3"]],
-                    primary_config_entry=entry_other.entry_id,
-                    via_device_id=composite_id,
-                ),
-            ],
-            "deleted_devices": [],
-        },
-    }
-
-    dr.async_setup(hass)
-    await dr.async_load(hass)
-    registry = dr.async_get(hass)
-
-    splits = {
-        split.config_entry_id: split
-        for split in registry.async_get_devices_for_composite_device_id(composite_id)
-    }
-    test_split = splits[entry_test.entry_id]
-    matter_split = splits[entry_matter.entry_id]
-
-    # The child in a config entry owning a split links to that split
-    child_same_entry = registry.async_get("childentry000000000000000000000")
-    assert child_same_entry is not None
-    assert child_same_entry.via_device_id == matter_split.id
-
-    # The child in another config entry of a split's domain links to that split
-    child_same_domain = registry.async_get("childdomain00000000000000000000")
-    assert child_same_domain is not None
-    assert child_same_domain.via_device_id == matter_split.id
-
-    # The child sharing neither config entry nor domain links to the first split
-    child_other = registry.async_get("childother000000000000000000000")
-    assert child_other is not None
-    assert child_other.via_device_id == test_split.id
-
-
-@pytest.mark.parametrize("load_registries", [False])
 async def test_migration_collapses_multi_subentry_device(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
@@ -5340,11 +5218,14 @@ async def test_migration_remaps_via_device_id_to_split(
 ) -> None:
     """A child's via_device_id is remapped to a live parent split.
 
-    To the split in the child's own config entry when the parent spanned it, otherwise to
-    one of the parent's splits - never left dangling on the removed composite id.
+    To the split in the child's own config entry when the parent spanned it, then to a
+    split owned by the child's domain, otherwise to one of the parent's splits - never
+    left dangling on the removed composite id.
     """
     entry_a = MockConfigEntry(domain="dom_a")
     entry_a.add_to_hass(hass)
+    entry_a2 = MockConfigEntry(domain="dom_a")
+    entry_a2.add_to_hass(hass)
     entry_b = MockConfigEntry(domain="dom_b")
     entry_b.add_to_hass(hass)
     entry_c = MockConfigEntry(domain="dom_c")
@@ -5394,6 +5275,13 @@ async def test_migration_remaps_via_device_id_to_split(
                     [["dom_a", "c"]],
                     "parent000000000000000000000000",
                 ),
+                # child in another config entry of dom_a, which the parent does not span
+                _device(
+                    "childa200000000000000000000000",
+                    [entry_a2.entry_id],
+                    [["dom_a", "c2"]],
+                    "parent000000000000000000000000",
+                ),
                 # child in a config entry the parent does not span
                 _device(
                     "childc000000000000000000000000",
@@ -5421,6 +5309,12 @@ async def test_migration_remaps_via_device_id_to_split(
     child = registry.async_get_device(identifiers={("dom_a", "c")})
     assert child is not None
     assert child.via_device_id == parent_a.id
+
+    # The child in entry_a2, which the parent did not span, points at the parent's
+    # split owned by its domain
+    child_a2 = registry.async_get_device(identifiers={("dom_a", "c2")})
+    assert child_a2 is not None
+    assert child_a2.via_device_id == parent_a.id
 
     # The child in entry_c, which the parent did not span, points at one of the parent's
     # splits rather than the removed composite id

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -2086,6 +2086,128 @@ async def test_migration_detaches_via_device_of_dropped_parent(
 
 
 @pytest.mark.parametrize("load_registries", [False])
+async def test_migration_rewrites_via_device_of_split_parent(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """A child's via link to a split composite parent is rewritten to a live split.
+
+    The parent's split in the child's own config entry is preferred, then one owned
+    by the child's domain, then any split - the same ladder the via_device
+    resolution uses.
+    """
+    entry_test = MockConfigEntry(domain="test")
+    entry_test.add_to_hass(hass)
+    entry_matter = MockConfigEntry(domain="matter")
+    entry_matter.add_to_hass(hass)
+    entry_matter_2 = MockConfigEntry(domain="matter")
+    entry_matter_2.add_to_hass(hass)
+    entry_other = MockConfigEntry(domain="other")
+    entry_other.add_to_hass(hass)
+
+    def _device(**overrides: Any) -> dict[str, Any]:
+        device = {
+            "area_id": None,
+            "config_entries": [entry_test.entry_id],
+            "config_entries_subentries": {entry_test.entry_id: [None]},
+            "configuration_url": None,
+            "connections": [],
+            "created_at": "1970-01-01T00:00:00+00:00",
+            "disabled_by": None,
+            "entry_type": None,
+            "hw_version": None,
+            "id": "device0000000000000000000000000",
+            "identifiers": [["test", "1"]],
+            "labels": [],
+            "manufacturer": None,
+            "model": None,
+            "name": None,
+            "model_id": None,
+            "modified_at": "1970-01-01T00:00:00+00:00",
+            "name_by_user": None,
+            "primary_config_entry": entry_test.entry_id,
+            "serial_number": None,
+            "sw_version": None,
+            "via_device_id": None,
+        }
+        return device | overrides
+
+    composite_id = "composite0000000000000000000000"
+    hass_storage[dr.STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 12,
+        "key": dr.STORAGE_KEY,
+        "data": {
+            "devices": [
+                # Parent spanning two config entries -> split by the migration
+                _device(
+                    id=composite_id,
+                    config_entries=[entry_test.entry_id, entry_matter.entry_id],
+                    config_entries_subentries={
+                        entry_test.entry_id: [None],
+                        entry_matter.entry_id: [None],
+                    },
+                    identifiers=[["test", "hub"]],
+                ),
+                # Child owned by a config entry that owns a split
+                _device(
+                    id="childentry000000000000000000000",
+                    config_entries=[entry_matter.entry_id],
+                    config_entries_subentries={entry_matter.entry_id: [None]},
+                    identifiers=[["matter", "child1"]],
+                    primary_config_entry=entry_matter.entry_id,
+                    via_device_id=composite_id,
+                ),
+                # Child owned by another config entry of a split's domain
+                _device(
+                    id="childdomain00000000000000000000",
+                    config_entries=[entry_matter_2.entry_id],
+                    config_entries_subentries={entry_matter_2.entry_id: [None]},
+                    identifiers=[["matter", "child2"]],
+                    primary_config_entry=entry_matter_2.entry_id,
+                    via_device_id=composite_id,
+                ),
+                # Child sharing neither config entry nor domain with a split
+                _device(
+                    id="childother000000000000000000000",
+                    config_entries=[entry_other.entry_id],
+                    config_entries_subentries={entry_other.entry_id: [None]},
+                    identifiers=[["other", "child3"]],
+                    primary_config_entry=entry_other.entry_id,
+                    via_device_id=composite_id,
+                ),
+            ],
+            "deleted_devices": [],
+        },
+    }
+
+    dr.async_setup(hass)
+    await dr.async_load(hass)
+    registry = dr.async_get(hass)
+
+    splits = {
+        split.config_entry_id: split
+        for split in registry.async_get_devices_for_composite_device_id(composite_id)
+    }
+    test_split = splits[entry_test.entry_id]
+    matter_split = splits[entry_matter.entry_id]
+
+    # The child in a config entry owning a split links to that split
+    child_same_entry = registry.async_get("childentry000000000000000000000")
+    assert child_same_entry is not None
+    assert child_same_entry.via_device_id == matter_split.id
+
+    # The child in another config entry of a split's domain links to that split
+    child_same_domain = registry.async_get("childdomain00000000000000000000")
+    assert child_same_domain is not None
+    assert child_same_domain.via_device_id == matter_split.id
+
+    # The child sharing neither config entry nor domain links to the first split
+    child_other = registry.async_get("childother000000000000000000000")
+    assert child_other is not None
+    assert child_other.via_device_id == test_split.id
+
+
+@pytest.mark.parametrize("load_registries", [False])
 async def test_migration_collapses_multi_subentry_device(
     hass: HomeAssistant, hass_storage: dict[str, Any]
 ) -> None:
@@ -3868,6 +3990,145 @@ async def test_get_or_create_via_device_none(
     assert relinked.via_device_id is None
 
 
+async def test_get_or_create_unknown_via_device_id_raises_cleanly(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """An unknown via_device_id raises without inserting a device."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    removed = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("hue", "removed")}
+    )
+    device_registry.async_remove_device(removed.id)
+
+    with pytest.raises(dr.DeviceInfoError, match="is not a registered device id"):
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={("hue", "device")},
+            via_device_id="unknown-device-id",
+        )
+
+    # The id of a removed device is stale and rejected the same way
+    with pytest.raises(dr.DeviceInfoError, match="is not a registered device id"):
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={("hue", "device")},
+            via_device_id=removed.id,
+        )
+
+    assert device_registry.async_get_device(identifiers={("hue", "device")}) is None
+    assert len(device_registry.devices) == 0
+
+
+async def test_update_device_unknown_via_device_id_raises(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """An unknown via_device_id raises on update, leaving the device unchanged."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("hue", "device")}
+    )
+
+    with pytest.raises(
+        HomeAssistantError, match="unknown via device unknown-device-id"
+    ):
+        device_registry.async_update_device(
+            device.id, via_device_id="unknown-device-id"
+        )
+
+    assert device_registry.async_get(device.id).via_device_id is None
+
+
+async def test_get_or_create_composite_via_device_id_resolved(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A composite via_device_id resolves to a split: same entry, same domain, any."""
+    entry_1 = MockConfigEntry(domain="test")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="matter")
+    entry_2.add_to_hass(hass)
+    entry_3 = MockConfigEntry(domain="matter")
+    entry_3.add_to_hass(hass)
+    entry_4 = MockConfigEntry(domain="other")
+    entry_4.add_to_hass(hass)
+    split_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "hub")}
+    )
+    split_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "hub")}
+    )
+    old_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry.devices[split_1.id] = attr.evolve(
+        split_1, composite_device_id=old_id
+    )
+    device_registry.devices[split_2.id] = attr.evolve(
+        split_2, composite_device_id=old_id
+    )
+
+    # A child in a config entry owning a split resolves to that split
+    child = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id,
+        identifiers={("matter", "child")},
+        via_device_id=old_id,
+    )
+    assert child.via_device_id == split_2.id
+    assert "passes the id of a pre-migration composite device" in caplog.text
+
+    # A child in another config entry of a split's domain resolves to that split
+    domain_child = device_registry.async_get_or_create(
+        config_entry_id=entry_3.entry_id,
+        identifiers={("matter", "child")},
+        via_device_id=old_id,
+    )
+    assert domain_child.via_device_id == split_2.id
+
+    # A child sharing neither config entry nor domain falls back to any split
+    other_child = device_registry.async_get_or_create(
+        config_entry_id=entry_4.entry_id,
+        identifiers={("other", "child")},
+        via_device_id=old_id,
+    )
+    assert other_child.via_device_id == split_1.id
+
+
+async def test_update_device_composite_via_device_id_resolved(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A composite via_device_id resolves to a split on update."""
+    entry_1 = MockConfigEntry(domain="test")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="test")
+    entry_2.add_to_hass(hass)
+    split_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "hub")}
+    )
+    split_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "hub")}
+    )
+    old_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry.devices[split_1.id] = attr.evolve(
+        split_1, composite_device_id=old_id
+    )
+    device_registry.devices[split_2.id] = attr.evolve(
+        split_2, composite_device_id=old_id
+    )
+    child = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "child")}
+    )
+
+    updated = device_registry.async_update_device(child.id, via_device_id=old_id)
+
+    assert updated.via_device_id == split_2.id
+    assert "passes the id of a pre-migration composite device" in caplog.text
+
+
 async def test_via_device_prefers_same_config_entry(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -4145,6 +4406,10 @@ async def test_update(
     """Verify that we can update some attributes of a device."""
     created_at = datetime.fromisoformat("2024-01-01T01:00:00+00:00")
     freezer.move_to(created_at)
+    via_device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("hue", "via")},
+    )
     update_events = async_capture_events(hass, dr.EVENT_DEVICE_REGISTRY_UPDATED)
     entry = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
@@ -4180,7 +4445,7 @@ async def test_update(
             serial_number="serial_no",
             suggested_area="suggested_area",
             sw_version="version",
-            via_device_id="98765B",
+            via_device_id=via_device.id,
         )
 
     assert mock_save.call_count == 1
@@ -4207,7 +4472,7 @@ async def test_update(
         serial_number="serial_no",
         suggested_area="suggested_area",
         sw_version="version",
-        via_device_id="98765B",
+        via_device_id=via_device.id,
     )
 
     assert device_registry.async_get_device(identifiers={("hue", "456")}) is None

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -3918,6 +3918,29 @@ async def test_update_device_unknown_via_device_id_raises(
     assert device_registry.async_get(device.id).via_device_id is None
 
 
+async def test_update_device_unknown_via_device_id_raises_before_removal(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """An unknown via_device_id raises before a removal in the same call."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("hue", "device")}
+    )
+
+    with pytest.raises(
+        HomeAssistantError, match="unknown via device unknown-device-id"
+    ):
+        device_registry.async_update_device(
+            device.id,
+            remove_config_entry_id=config_entry.entry_id,
+            via_device_id="unknown-device-id",
+        )
+
+    # The device was not removed
+    assert device_registry.async_get(device.id) == device
+
+
 async def test_get_or_create_composite_via_device_id_resolved(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
@@ -7970,6 +7993,62 @@ async def test_composite_move_clears_sibling_pending_moves(
             is None
         )
     assert device_registry.async_get(device_2.id) is None
+
+
+async def test_composite_move_unknown_via_device_id_keeps_sibling_moves(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """An unknown via_device_id raises before a move clears sibling pending moves."""
+    entry_1 = MockConfigEntry(domain="test")
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry(domain="test")
+    entry_2.add_to_hass(hass)
+    entry_target = MockConfigEntry(domain="test")
+    entry_target.add_to_hass(hass)
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id, identifiers={("test", "shared")}
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id, identifiers={("test", "shared")}
+    )
+    old_id = "composite00000000000000000000ab"
+    # Simulate a migration split: both devices carry the pre-migration composite id
+    device_registry.devices[device_1.id] = attr.evolve(
+        device_1, composite_device_id=old_id
+    )
+    device_registry.devices[device_2.id] = attr.evolve(
+        device_2, composite_device_id=old_id
+    )
+
+    # Arm a deferred move on the composite id: fans out to both splits
+    with patch.object(dr, "_current_integration_domain", return_value="test"):
+        device_registry.async_update_device(
+            old_id, add_config_entry_id=entry_target.entry_id
+        )
+
+    # The failed call must not move the device or clear the sibling's pending move
+    with (
+        patch.object(dr, "_current_integration_domain", return_value="test"),
+        pytest.raises(HomeAssistantError, match="unknown via device unknown-device-id"),
+    ):
+        device_registry.async_update_device(
+            device_1.id,
+            remove_config_entry_id=entry_1.entry_id,
+            via_device_id="unknown-device-id",
+        )
+    assert device_registry.async_get(device_1.id).config_entry_id == entry_1.entry_id
+    assert device_registry.async_get(device_1.id)._pending_move is not None
+    assert device_registry.async_get(device_2.id)._pending_move is not None
+
+    # The armed moves are intact and can still complete
+    with patch.object(dr, "_current_integration_domain", return_value="test"):
+        device_registry.async_update_device(
+            device_1.id, remove_config_entry_id=entry_1.entry_id
+        )
+    assert (
+        device_registry.async_get(device_1.id).config_entry_id == entry_target.entry_id
+    )
+    assert device_registry.async_get(device_2.id)._pending_move is None
 
 
 async def test_add_and_remove_config_entry_in_one_call(

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -5347,6 +5347,139 @@ async def test_migration_remaps_via_device_id_to_split(
 
 
 @pytest.mark.parametrize("load_registries", [False])
+async def test_migration_from_3_1_rewrites_stale_via_device_id(
+    hass: HomeAssistant, hass_storage: dict[str, Any]
+) -> None:
+    """Stale via_device_id links are remapped or detached when migrating from 3.1."""
+    entry_a = MockConfigEntry(domain="dom_a")
+    entry_a.add_to_hass(hass)
+    entry_a2 = MockConfigEntry(domain="dom_a")
+    entry_a2.add_to_hass(hass)
+    entry_b = MockConfigEntry(domain="dom_b")
+    entry_b.add_to_hass(hass)
+    entry_c = MockConfigEntry(domain="dom_c")
+    entry_c.add_to_hass(hass)
+    composite_id = "composite000000000000000000000"
+
+    def _device(
+        id_: str,
+        config_entry_id: str,
+        identifiers: list[list[str]],
+        via: str | None,
+        composite: str | None = None,
+    ) -> dict[str, Any]:
+        return {
+            "area_id": None,
+            "config_entry_id": config_entry_id,
+            "config_subentry_id": None,
+            "configuration_url": None,
+            "connections": [],
+            "created_at": "1970-01-01T00:00:00+00:00",
+            "disabled_by": None,
+            "entry_type": None,
+            "hw_version": None,
+            "id": id_,
+            "identifiers": identifiers,
+            "labels": [],
+            "composite_device_id": composite,
+            "composite_primary_config_entry": None,
+            "split_at": None,
+            "manufacturer": None,
+            "model": None,
+            "model_id": None,
+            "modified_at": "1970-01-01T00:00:00+00:00",
+            "name_by_user": None,
+            "name": None,
+            "has_composite_identifiers": composite is not None,
+            "primary_config_entry": config_entry_id,
+            "serial_number": None,
+            "sw_version": None,
+            "via_device_id": via,
+        }
+
+    hass_storage[dr.STORAGE_KEY] = {
+        "version": 3,
+        "minor_version": 1,
+        "key": dr.STORAGE_KEY,
+        "data": {
+            "devices": [
+                _device(
+                    "splita000000000000000000000000",
+                    entry_a.entry_id,
+                    [["dom_a", "p"]],
+                    None,
+                    composite=composite_id,
+                ),
+                _device(
+                    "splitb000000000000000000000000",
+                    entry_b.entry_id,
+                    [["dom_b", "p"]],
+                    None,
+                    composite=composite_id,
+                ),
+                # composite link from an entry the parent spans: its split
+                _device(
+                    "childa000000000000000000000000",
+                    entry_a.entry_id,
+                    [["dom_a", "c"]],
+                    composite_id,
+                ),
+                # composite link from another entry of a split's domain: that split
+                _device(
+                    "childa200000000000000000000000",
+                    entry_a2.entry_id,
+                    [["dom_a", "c2"]],
+                    composite_id,
+                ),
+                # composite link sharing neither entry nor domain: any split
+                _device(
+                    "childc000000000000000000000000",
+                    entry_c.entry_id,
+                    [["dom_c", "c"]],
+                    composite_id,
+                ),
+                # link to an unknown device: detached
+                _device(
+                    "childx000000000000000000000000",
+                    entry_a.entry_id,
+                    [["dom_a", "cx"]],
+                    "unknown0000000000000000000000",
+                ),
+                # link to a live device: kept
+                _device(
+                    "childl000000000000000000000000",
+                    entry_a.entry_id,
+                    [["dom_a", "cl"]],
+                    "splitb000000000000000000000000",
+                ),
+            ],
+            "deleted_devices": [],
+        },
+    }
+    dr.async_setup(hass)
+    await dr.async_load(hass)
+    registry = dr.async_get(hass)
+
+    assert (
+        registry.devices["childa000000000000000000000000"].via_device_id
+        == "splita000000000000000000000000"
+    )
+    assert (
+        registry.devices["childa200000000000000000000000"].via_device_id
+        == "splita000000000000000000000000"
+    )
+    assert registry.devices["childc000000000000000000000000"].via_device_id in {
+        "splita000000000000000000000000",
+        "splitb000000000000000000000000",
+    }
+    assert registry.devices["childx000000000000000000000000"].via_device_id is None
+    assert (
+        registry.devices["childl000000000000000000000000"].via_device_id
+        == "splitb000000000000000000000000"
+    )
+
+
+@pytest.mark.parametrize("load_registries", [False])
 @pytest.mark.parametrize(
     ("composite_disabled_by", "expected_split_enabled", "expected_split_disabled"),
     [


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Validate `via_device_id` in device registry.

Always uniformly resolve composite device ids.

Context: https://github.com/home-assistant/core/pull/176986#discussion_r3622631984

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
