### PR TITLE
Add exception translations for iZone setup and coordinator

### DIFF
--- a/homeassistant/components/izone/__init__.py
+++ b/homeassistant/components/izone/__init__.py
@@ -55,7 +55,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: IZoneConfigEntry) -> boo
     try:
         discovery = await async_ensure_discovery(hass)
     except (OSError, RuntimeError) as err:
-        raise ConfigEntryNotReady("iZone discovery service failed to start") from err
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="discovery_start_failed",
+        ) from err
 
     # Heal legacy / host-less entries here (not in migrate) so ConfigEntryNotReady
     # can retry. Upstream pairs migrate→data={} with this setup-time rebind.
@@ -64,7 +67,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: IZoneConfigEntry) -> boo
             endpoints = await async_discover_all_endpoints(hass)
         except OSError as err:
             raise ConfigEntryNotReady(
-                "iZone discovery failed while resolving legacy config entry"
+                translation_domain=DOMAIN,
+                translation_key="discovery_failed_legacy",
             ) from err
 
         excluded_uids = yaml_excluded_uids(hass)
@@ -82,13 +86,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: IZoneConfigEntry) -> boo
 
         if not eligible:
             raise ConfigEntryNotReady(
-                "No eligible iZone controller found to bind to legacy config entry"
+                translation_domain=DOMAIN,
+                translation_key="no_eligible_controller",
             )
 
         if len(eligible) > 1:
             raise ConfigEntryError(
-                "Multiple eligible iZone controllers found for a legacy config entry; "
-                "delete this entry and re-add each controller individually"
+                translation_domain=DOMAIN,
+                translation_key="multiple_eligible_controllers",
             )
 
         endpoint = eligible[0]
@@ -104,15 +109,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: IZoneConfigEntry) -> boo
     elif CONF_HOST not in entry.data:
         uid = entry.unique_id
         if not isinstance(uid, str):
-            raise ConfigEntryError("iZone config entry is missing unique_id")
+            raise ConfigEntryError(
+                translation_domain=DOMAIN,
+                translation_key="missing_unique_id",
+            )
         try:
             resolved = await async_discover_endpoint(hass, uid)
         except OSError as err:
             raise ConfigEntryNotReady(
-                "iZone discovery failed while resolving config entry host"
+                translation_domain=DOMAIN,
+                translation_key="discovery_failed_host",
             ) from err
         if resolved is None:
-            raise ConfigEntryNotReady(f"No iZone controller found for unique_id {uid}")
+            raise ConfigEntryNotReady(
+                translation_domain=DOMAIN,
+                translation_key="controller_not_found",
+                translation_placeholders={"uid": uid},
+            )
         hass.config_entries.async_update_entry(
             entry,
             data={**entry.data, CONF_HOST: resolved.host},
@@ -120,9 +133,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: IZoneConfigEntry) -> boo
 
     uid = entry.unique_id
     if not isinstance(uid, str):
-        raise ConfigEntryError("iZone config entry is missing unique_id")
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="missing_unique_id",
+        )
     if CONF_HOST not in entry.data:
-        raise ConfigEntryError("iZone config entry is missing host")
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="missing_host",
+        )
 
     host: str = entry.data[CONF_HOST]
 
@@ -143,14 +162,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: IZoneConfigEntry) -> boo
         )
     except pizone.UnpairedBridgeError as err:
         raise ConfigEntryError(
-            "iZone bridge is not paired with an air conditioner"
+            translation_domain=DOMAIN,
+            translation_key="bridge_unpaired",
         ) from err
     except ConnectionError as err:
         raise ConfigEntryNotReady(
-            f"Unable to connect to iZone controller at {host}"
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+            translation_placeholders={"host": host},
         ) from err
     except pizone.ControllerCommandError as err:
-        raise ConfigEntryError(f"iZone controller at {host} rejected setup") from err
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="setup_rejected",
+            translation_placeholders={"host": host},
+        ) from err
 
     entry.async_on_unload(controller.close)
 

--- a/homeassistant/components/izone/coordinator.py
+++ b/homeassistant/components/izone/coordinator.py
@@ -53,8 +53,14 @@ class IZoneCoordinator(DataUpdateCoordinator[pizone.Controller]):
             await self.controller.refresh_all()
         except ConnectionError as err:
             raise UpdateFailed(
-                f"Error communicating with iZone controller: {err}"
+                translation_domain=DOMAIN,
+                translation_key="update_failed",
+                translation_placeholders={"error": str(err)},
             ) from err
         except pizone.ControllerCommandError as err:
-            raise UpdateFailed(f"iZone controller rejected refresh: {err}") from err
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="refresh_rejected",
+                translation_placeholders={"error": str(err)},
+            ) from err
         return self.controller

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -21,11 +21,50 @@
     }
   },
   "exceptions": {
+    "bridge_unpaired": {
+      "message": "iZone bridge is not paired with an air conditioner"
+    },
+    "cannot_connect": {
+      "message": "Unable to connect to iZone controller at {host}"
+    },
     "command_rejected": {
       "message": "Controller {uid} rejected command: {error}"
     },
+    "controller_not_found": {
+      "message": "No iZone controller found for unique_id {uid}"
+    },
+    "discovery_failed_host": {
+      "message": "iZone discovery failed while resolving config entry host"
+    },
+    "discovery_failed_legacy": {
+      "message": "iZone discovery failed while resolving legacy config entry"
+    },
+    "discovery_start_failed": {
+      "message": "iZone discovery service failed to start"
+    },
+    "missing_host": {
+      "message": "iZone config entry is missing host"
+    },
+    "missing_unique_id": {
+      "message": "iZone config entry is missing unique_id"
+    },
+    "multiple_eligible_controllers": {
+      "message": "Multiple eligible iZone controllers found for a legacy config entry; delete this entry and re-add each controller individually"
+    },
+    "no_eligible_controller": {
+      "message": "No eligible iZone controller found to bind to legacy config entry"
+    },
+    "refresh_rejected": {
+      "message": "iZone controller rejected refresh: {error}"
+    },
+    "setup_rejected": {
+      "message": "iZone controller at {host} rejected setup"
+    },
     "unable_to_connect": {
       "message": "Unable to connect to controller {uid}"
+    },
+    "update_failed": {
+      "message": "Error communicating with iZone controller: {error}"
     }
   },
   "services": {

--- a/tests/components/izone/test_init.py
+++ b/tests/components/izone/test_init.py
@@ -7,9 +7,11 @@ from pizone import ControllerCommandError, ControllerEndpoint, UnpairedBridgeErr
 import pytest
 
 from homeassistant.components.izone.const import DOMAIN
+from homeassistant.components.izone.coordinator import IZoneCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import async_load_yaml_exclude, create_mock_controller
 
@@ -283,6 +285,8 @@ async def test_setup_missing_host_not_found_retries(
 
     assert not await hass.config_entries.async_setup(entry.entry_id)
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_key == "controller_not_found"
+    assert entry.error_reason_translation_placeholders == {"uid": "000000001"}
     mock_discovery_service.create_controller.assert_not_awaited()
 
 
@@ -307,6 +311,7 @@ async def test_setup_legacy_domain_unique_id_discovery_oserror_retries(
         assert not await hass.config_entries.async_setup(entry.entry_id)
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_key == "discovery_failed_legacy"
 
 
 async def test_setup_missing_host_discover_oserror_retries(
@@ -329,14 +334,33 @@ async def test_setup_missing_host_discover_oserror_retries(
         assert not await hass.config_entries.async_setup(entry.entry_id)
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
+    assert entry.error_reason_translation_key == "discovery_failed_host"
 
 
 @pytest.mark.parametrize(
-    ("side_effect", "expected_state"),
+    ("side_effect", "expected_state", "translation_key", "placeholders"),
     [
-        (ConnectionError("offline"), ConfigEntryState.SETUP_RETRY),
-        (UnpairedBridgeError("unpaired"), ConfigEntryState.SETUP_ERROR),
-        (ControllerCommandError("rejected"), ConfigEntryState.SETUP_ERROR),
+        pytest.param(
+            ConnectionError("offline"),
+            ConfigEntryState.SETUP_RETRY,
+            "cannot_connect",
+            {"host": "192.0.2.1"},
+            id="connection-error",
+        ),
+        pytest.param(
+            UnpairedBridgeError("unpaired"),
+            ConfigEntryState.SETUP_ERROR,
+            "bridge_unpaired",
+            None,
+            id="unpaired-bridge",
+        ),
+        pytest.param(
+            ControllerCommandError("rejected"),
+            ConfigEntryState.SETUP_ERROR,
+            "setup_rejected",
+            {"host": "192.0.2.1"},
+            id="command-rejected",
+        ),
     ],
 )
 async def test_setup_create_controller_errors(
@@ -346,6 +370,8 @@ async def test_setup_create_controller_errors(
     mock_discovery_service: Mock,
     side_effect: Exception,
     expected_state: ConfigEntryState,
+    translation_key: str,
+    placeholders: dict[str, str] | None,
 ) -> None:
     """create_controller failures map to retry vs error entry states."""
     mock_config_entry.add_to_hass(hass)
@@ -353,6 +379,8 @@ async def test_setup_create_controller_errors(
 
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is expected_state
+    assert mock_config_entry.error_reason_translation_key == translation_key
+    assert mock_config_entry.error_reason_translation_placeholders == placeholders
 
 
 async def test_setup_discovery_bind_failure_retries(
@@ -375,6 +403,7 @@ async def test_setup_discovery_bind_failure_retries(
         assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.error_reason_translation_key == "discovery_start_failed"
 
 
 async def test_setup_first_refresh_failure_closes_controller(
@@ -390,6 +419,36 @@ async def test_setup_first_refresh_failure_closes_controller(
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_controller.close.assert_awaited()
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "translation_key"),
+    [
+        pytest.param(ConnectionError("gone"), "update_failed", id="connection-error"),
+        pytest.param(
+            ControllerCommandError("rejected"),
+            "refresh_rejected",
+            id="command-rejected",
+        ),
+    ],
+)
+async def test_coordinator_refresh_errors_are_translated(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_controller: Mock,
+    side_effect: Exception,
+    translation_key: str,
+) -> None:
+    """Coordinator refresh failures raise translated UpdateFailed."""
+    mock_config_entry.add_to_hass(hass)
+    mock_controller.refresh_all = AsyncMock(side_effect=side_effect)
+    coordinator = IZoneCoordinator(hass, mock_config_entry, mock_controller)
+
+    with pytest.raises(UpdateFailed) as err:
+        await coordinator._async_update_data()
+
+    assert err.value.translation_key == translation_key
+    assert err.value.translation_placeholders == {"error": str(side_effect)}
 
 
 async def test_setup_platform_failure_closes_controller(

--- a/tests/components/izone/test_init.py
+++ b/tests/components/izone/test_init.py
@@ -7,11 +7,9 @@ from pizone import ControllerCommandError, ControllerEndpoint, UnpairedBridgeErr
 import pytest
 
 from homeassistant.components.izone.const import DOMAIN
-from homeassistant.components.izone.coordinator import IZoneCoordinator
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .conftest import async_load_yaml_exclude, create_mock_controller
 
@@ -406,49 +404,27 @@ async def test_setup_discovery_bind_failure_retries(
     assert mock_config_entry.error_reason_translation_key == "discovery_start_failed"
 
 
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(ConnectionError("gone"), id="connection-error"),
+        pytest.param(ControllerCommandError("rejected"), id="command-rejected"),
+    ],
+)
 async def test_setup_first_refresh_failure_closes_controller(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_create_discovery: AsyncMock,
     mock_controller: Mock,
+    side_effect: Exception,
 ) -> None:
     """A failed first refresh closes the controller and retries setup."""
     mock_config_entry.add_to_hass(hass)
-    mock_controller.refresh_all = AsyncMock(side_effect=ConnectionError("gone"))
+    mock_controller.refresh_all = AsyncMock(side_effect=side_effect)
 
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
     mock_controller.close.assert_awaited()
-
-
-@pytest.mark.parametrize(
-    ("side_effect", "translation_key"),
-    [
-        pytest.param(ConnectionError("gone"), "update_failed", id="connection-error"),
-        pytest.param(
-            ControllerCommandError("rejected"),
-            "refresh_rejected",
-            id="command-rejected",
-        ),
-    ],
-)
-async def test_coordinator_refresh_errors_are_translated(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mock_controller: Mock,
-    side_effect: Exception,
-    translation_key: str,
-) -> None:
-    """Coordinator refresh failures raise translated UpdateFailed."""
-    mock_config_entry.add_to_hass(hass)
-    mock_controller.refresh_all = AsyncMock(side_effect=side_effect)
-    coordinator = IZoneCoordinator(hass, mock_config_entry, mock_controller)
-
-    with pytest.raises(UpdateFailed) as err:
-        await coordinator._async_update_data()
-
-    assert err.value.translation_key == translation_key
-    assert err.value.translation_placeholders == {"error": str(side_effect)}
 
 
 async def test_setup_platform_failure_closes_controller(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Translate iZone setup and coordinator failure messages that currently raise
`ConfigEntryNotReady`, `ConfigEntryError`, and `UpdateFailed` with hardcoded
English strings.

Entity command failures already use `translation_domain` / `translation_key`
(`command_rejected`, `unable_to_connect`). This PR extends the same pattern to
entry setup and coordinator refresh failures, and adds the matching
`exceptions` strings.

This is a prerequisite for marking `exception-translations: done` on the iZone
quality scale scorecard (#177131): that scorecard rule gates pylint
`W7417` (`home-assistant-exception-not-translated`).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177131 (quality scale scorecard; keep `exception-translations` as `todo` until this lands)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
