### PR TITLE
Add iZone user config flow for manual host and LAN search

### DIFF
--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -101,6 +101,16 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
                 continue
             self.hass.config_entries.flow.async_abort(flow["flow_id"])
 
+    @callback
+    def _async_user_setup_host_only(self) -> bool:
+        """Return True when Add integration should skip Search.
+
+        Host-only is for when a loaded entry already owns shared discovery.
+        A failed/aborted search may leave the UDP service running briefly; still
+        offer Search until an entry is loaded so the user can try again.
+        """
+        return bool(self.hass.config_entries.async_loaded_entries(DOMAIN))
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -112,7 +122,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         self._async_abort_other_user_flows()
 
-        discovery_active = izone_discovery.discovery_service_active(self.hass)
+        host_only = self._async_user_setup_host_only()
         errors = dict(self._user_form_errors)
         self._user_form_errors = {}
         defaults = dict(self._user_form_defaults)
@@ -120,7 +130,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         form_defaults = defaults or (user_input or {})
 
         if user_input is not None:
-            if discovery_active:
+            if host_only:
                 host = str(user_input.get(CONF_HOST, "")).strip()
                 if not host:
                     errors[CONF_HOST] = "required"
@@ -141,7 +151,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user",
             data_schema=self._user_setup_schema(
-                discovery_active=discovery_active,
+                host_only=host_only,
                 defaults=form_defaults,
             ),
             errors=errors or None,
@@ -161,6 +171,10 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             _LOGGER.debug("No controllers found")
             self._user_form_errors = {"base": "no_devices_found"}
             self._user_form_defaults = {CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST}
+            # Search started discovery; drop it when nothing is using it so the
+            # follow-up form (and a later Add integration) can offer Search again.
+            if not self._async_user_setup_host_only():
+                await izone_discovery.async_stop_discovery(self.hass)
             return await self.async_step_user(None)
 
         self._user_discovered_endpoints = self._async_get_unconfigured_endpoints(
@@ -342,11 +356,11 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     def _user_setup_schema(
         self,
         *,
-        discovery_active: bool,
+        host_only: bool,
         defaults: Mapping[str, Any],
     ) -> vol.Schema:
-        """Build the user step schema for discovery-active vs idle paths."""
-        if discovery_active:
+        """Build the user step schema for host-only vs search/manual paths."""
+        if host_only:
             host_default: Any = defaults.get(CONF_HOST, vol.UNDEFINED)
             return vol.Schema(
                 {
@@ -380,7 +394,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _async_probe_host_and_confirm(self, host: str) -> ConfigFlowResult:
         """Validate *host* and continue to confirm when a controller responds."""
         self._async_abort_entries_match({CONF_HOST: host})
-        discovery_active = izone_discovery.discovery_service_active(self.hass)
+        host_only = self._async_user_setup_host_only()
         try:
             endpoint = await izone_discovery.async_discover_by_host(self.hass, host)
         except OSError:
@@ -393,7 +407,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if endpoint is None:
             self._user_form_errors = {"base": "cannot_connect"}
-            if discovery_active:
+            if host_only:
                 self._user_form_defaults = {CONF_HOST: host}
             else:
                 self._user_form_defaults = {

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -1,6 +1,6 @@
 """Config flow for izone."""
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 import logging
 from typing import Any, Self, override
 
@@ -27,6 +27,9 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 SELECTED_CONTROLLER_UID = "selected_controller_uid"
+CONF_SETUP_METHOD = "setup_method"
+SETUP_METHOD_SEARCH = "search"
+SETUP_METHOD_MANUAL_HOST = "manual_host"
 
 
 def _flow_uid_for_matching(flow: ConfigFlow) -> str | None:
@@ -44,6 +47,13 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _user_discovered_endpoints: list[pizone.ControllerEndpoint] | None = None
     _discovered_controller_ip: str | None = None
+    _user_form_errors: dict[str, str]
+    _user_form_defaults: dict[str, Any]
+
+    def __init__(self) -> None:
+        """Initialize flow instance state."""
+        self._user_form_errors = {}
+        self._user_form_defaults = {}
 
     @override
     def is_matching(self, other_flow: Self) -> bool:
@@ -83,30 +93,75 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         # not misleadingly show "No devices found" when setup is actually in progress.
         return self.async_abort(reason="discovery_started")
 
+    @callback
+    def _async_abort_other_user_flows(self) -> None:
+        """Drop stale interactive user flows (e.g. after a browser refresh)."""
+        for flow in self._async_in_progress(include_uninitialized=True):
+            if flow["context"].get("source") != config_entries.SOURCE_USER:
+                continue
+            self.hass.config_entries.flow.async_abort(flow["flow_id"])
+
     @override
     async def async_step_user(
-        self, _user_input: dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """User-started flow: offer configuration choices for discovered controllers.
-
-        Discovery is started if not yet running, then a fresh discovery cycle is triggered
-        and this step waits briefly for replies.
+        """User-started flow: search the LAN or enter a controller host manually.
 
         While this interactive flow is active, runtime integration discovery remains
         blocked by ``_async_blocks_runtime_integration_discovery`` to avoid UI races.
         """
+        self._async_abort_other_user_flows()
 
-        if self._async_in_progress(include_uninitialized=True):
-            return self.async_abort(reason="already_in_progress")
+        discovery_active = izone_discovery.discovery_service_active(self.hass)
+        errors = dict(self._user_form_errors)
+        self._user_form_errors = {}
+        defaults = dict(self._user_form_defaults)
+        self._user_form_defaults = {}
+        form_defaults = defaults or (user_input or {})
 
+        if user_input is not None:
+            if discovery_active:
+                host = str(user_input.get(CONF_HOST, "")).strip()
+                if not host:
+                    errors[CONF_HOST] = "required"
+                else:
+                    return await self._async_probe_host_and_confirm(host)
+            else:
+                setup_method = user_input.get(CONF_SETUP_METHOD, SETUP_METHOD_SEARCH)
+                host = str(user_input.get(CONF_HOST, "")).strip()
+
+                if setup_method == SETUP_METHOD_MANUAL_HOST:
+                    if not host:
+                        errors[CONF_HOST] = "required"
+                    else:
+                        return await self._async_probe_host_and_confirm(host)
+                else:
+                    return await self.async_step_discover()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self._user_setup_schema(
+                discovery_active=discovery_active,
+                defaults=form_defaults,
+            ),
+            errors=errors or None,
+        )
+
+    async def async_step_discover(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Broadcast discovery and offer unconfigured controllers."""
         try:
             endpoints = await izone_discovery.async_discover_all_endpoints(self.hass)
         except OSError:
             _LOGGER.debug("Unable to start iZone discovery service", exc_info=True)
             return self.async_abort(reason="discovery_failed")
+
         if not endpoints:
             _LOGGER.debug("No controllers found")
-            return self.async_abort(reason="no_devices_found")
+            self._user_form_errors = {"base": "no_devices_found"}
+            self._user_form_defaults = {CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST}
+            return await self.async_step_user(None)
 
         self._user_discovered_endpoints = self._async_get_unconfigured_endpoints(
             endpoints
@@ -245,29 +300,112 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Confirm adding a controller found via HomeKit or discovery."""
+        if user_input is not None:
+            return await self._async_finalize_confirm()
+
+        controller_uid = self.unique_id
+        assert isinstance(controller_uid, str)
+        if self._async_is_readding_ignored_controller(controller_uid):
+            return await self.async_step_confirm_ignored()
+        return self._async_show_confirm_form("confirm")
+
+    async def async_step_confirm_ignored(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Confirm re-adding a controller that was previously ignored."""
+        if user_input is not None:
+            return await self._async_finalize_confirm()
+        return self._async_show_confirm_form("confirm_ignored")
+
+    @callback
+    def _async_show_confirm_form(self, step_id: str) -> ConfigFlowResult:
+        """Show the confirm-only form for the given step."""
         controller_uid = self.unique_id
         host = self._discovered_controller_ip
         assert isinstance(controller_uid, str)
         assert controller_uid
         assert host is not None
-
-        if user_input is None:
-            self.context["title_placeholders"] = {
-                "name": self._entry_title(controller_uid),
-            }
-            return self.async_show_form(
-                step_id="confirm",
-                description_placeholders={
-                    "controller_uid": controller_uid,
-                    "host": str(host),
-                },
-            )
-
-        return await self._async_create_controller_entry(
-            pizone.ControllerEndpoint(uid=controller_uid, host=str(host))
+        self._set_confirm_only()
+        self.context["title_placeholders"] = {
+            "name": self._entry_title(controller_uid),
+        }
+        return self.async_show_form(
+            step_id=step_id,
+            description_placeholders={
+                "controller_uid": controller_uid,
+                "host": str(host),
+            },
         )
 
     # -- Private helpers
+
+    def _user_setup_schema(
+        self,
+        *,
+        discovery_active: bool,
+        defaults: Mapping[str, Any],
+    ) -> vol.Schema:
+        """Build the user step schema for discovery-active vs idle paths."""
+        if discovery_active:
+            host_default: Any = defaults.get(CONF_HOST, vol.UNDEFINED)
+            return vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=host_default): str,
+                }
+            )
+
+        method_default = defaults.get(CONF_SETUP_METHOD, SETUP_METHOD_SEARCH)
+        host_default = defaults.get(CONF_HOST, "")
+        return vol.Schema(
+            {
+                vol.Required(CONF_SETUP_METHOD, default=method_default): SelectSelector(
+                    SelectSelectorConfig(
+                        options=[
+                            SelectOptionDict(
+                                value=SETUP_METHOD_SEARCH,
+                                label="Search for devices",
+                            ),
+                            SelectOptionDict(
+                                value=SETUP_METHOD_MANUAL_HOST,
+                                label="Enter host",
+                            ),
+                        ],
+                        mode=SelectSelectorMode.LIST,
+                    )
+                ),
+                vol.Optional(CONF_HOST, default=host_default): str,
+            }
+        )
+
+    async def _async_probe_host_and_confirm(self, host: str) -> ConfigFlowResult:
+        """Validate *host* and continue to confirm when a controller responds."""
+        self._async_abort_entries_match({CONF_HOST: host})
+        discovery_active = izone_discovery.discovery_service_active(self.hass)
+        try:
+            endpoint = await izone_discovery.async_discover_by_host(self.hass, host)
+        except OSError:
+            _LOGGER.debug("Unable to start iZone discovery service", exc_info=True)
+            return self.async_abort(reason="discovery_failed")
+        except pizone.UnpairedBridgeError:
+            return self.async_abort(reason="unpaired_bridge")
+        except pizone.ControllerAlreadyClaimedError:
+            return self.async_abort(reason="already_configured")
+
+        if endpoint is None:
+            self._user_form_errors = {"base": "cannot_connect"}
+            if discovery_active:
+                self._user_form_defaults = {CONF_HOST: host}
+            else:
+                self._user_form_defaults = {
+                    CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST,
+                    CONF_HOST: host,
+                }
+            return await self.async_step_user(None)
+
+        await self.async_set_unique_id(endpoint.uid)
+        self._abort_if_unique_id_configured()
+        self._discovered_controller_ip = endpoint.host
+        return await self.async_step_confirm()
 
     @callback
     def _async_schedule_integration_discovery_flow(
@@ -311,9 +449,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> list[pizone.ControllerEndpoint]:
         """Return sorted unconfigured endpoints for the interactive user flow."""
         endpoints = self._filter_yaml_exclude(self.hass, endpoints)
-        # include_ignore=True ensures controllers whose entries have been explicitly
-        # ignored by the user (SOURCE_IGNORE) are not re-offered as configurable.
-        configured_uids = self._async_current_ids(include_ignore=True)
+        configured_uids = self._async_current_ids(include_ignore=False)
         return sorted(
             (
                 endpoint
@@ -322,6 +458,27 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
             key=lambda endpoint: (endpoint.uid, endpoint.host),
         )
+
+    async def _async_finalize_confirm(self) -> ConfigFlowResult:
+        """Validate confirm state and create the config entry."""
+        controller_uid = self.unique_id
+        host = self._discovered_controller_ip
+        assert isinstance(controller_uid, str)
+        assert controller_uid
+        assert host is not None
+        return await self._async_create_controller_entry(
+            pizone.ControllerEndpoint(uid=controller_uid, host=str(host))
+        )
+
+    @callback
+    def _async_is_readding_ignored_controller(self, controller_uid: str) -> bool:
+        """Return True when the user is explicitly re-adding an ignored controller."""
+        if self.context.get("source") != config_entries.SOURCE_USER:
+            return False
+        entry = self.hass.config_entries.async_entry_for_domain_unique_id(
+            self.handler, controller_uid
+        )
+        return entry is not None and entry.source == config_entries.SOURCE_IGNORE
 
     async def _async_create_controller_entry(
         self,

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -47,13 +47,6 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _user_discovered_endpoints: list[pizone.ControllerEndpoint] | None = None
     _discovered_controller_ip: str | None = None
-    _user_form_errors: dict[str, str]
-    _user_form_defaults: dict[str, Any]
-
-    def __init__(self) -> None:
-        """Initialize flow instance state."""
-        self._user_form_errors = {}
-        self._user_form_defaults = {}
 
     @override
     def is_matching(self, other_flow: Self) -> bool:
@@ -111,6 +104,23 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         return bool(self.hass.config_entries.async_loaded_entries(DOMAIN))
 
+    @callback
+    def _async_show_user_form(
+        self,
+        *,
+        errors: dict[str, str] | None = None,
+        defaults: Mapping[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Show the user setup form (search/manual or host-only)."""
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self._user_setup_schema(
+                host_only=self._async_user_setup_host_only(),
+                defaults=defaults or {},
+            ),
+            errors=errors or None,
+        )
+
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -122,14 +132,9 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         self._async_abort_other_user_flows()
 
-        host_only = self._async_user_setup_host_only()
-        errors = dict(self._user_form_errors)
-        self._user_form_errors = {}
-        defaults = dict(self._user_form_defaults)
-        self._user_form_defaults = {}
-        form_defaults = defaults or (user_input or {})
-
+        errors: dict[str, str] = {}
         if user_input is not None:
+            host_only = self._async_user_setup_host_only()
             if host_only:
                 host = str(user_input.get(CONF_HOST, "")).strip()
                 if not host:
@@ -148,13 +153,9 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
                 else:
                     return await self.async_step_discover()
 
-        return self.async_show_form(
-            step_id="user",
-            data_schema=self._user_setup_schema(
-                host_only=host_only,
-                defaults=form_defaults,
-            ),
+        return self._async_show_user_form(
             errors=errors or None,
+            defaults=user_input,
         )
 
     async def async_step_discover(
@@ -169,13 +170,14 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if not endpoints:
             _LOGGER.debug("No controllers found")
-            self._user_form_errors = {"base": "no_devices_found"}
-            self._user_form_defaults = {CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST}
             # Search started discovery; drop it when nothing is using it so the
             # follow-up form (and a later Add integration) can offer Search again.
             if not self._async_user_setup_host_only():
                 await izone_discovery.async_stop_discovery(self.hass)
-            return await self.async_step_user(None)
+            return self._async_show_user_form(
+                errors={"base": "no_devices_found"},
+                defaults={CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST},
+            )
 
         self._user_discovered_endpoints = self._async_get_unconfigured_endpoints(
             endpoints
@@ -401,15 +403,17 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="already_configured")
 
         if endpoint is None:
-            self._user_form_errors = {"base": "cannot_connect"}
             if host_only:
-                self._user_form_defaults = {CONF_HOST: host}
+                defaults: dict[str, Any] = {CONF_HOST: host}
             else:
-                self._user_form_defaults = {
+                defaults = {
                     CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST,
                     CONF_HOST: host,
                 }
-            return await self.async_step_user(None)
+            return self._async_show_user_form(
+                errors={"base": "cannot_connect"},
+                defaults=defaults,
+            )
 
         await self.async_set_unique_id(endpoint.uid)
         self._abort_if_unique_id_configured()

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -47,6 +47,7 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _user_discovered_endpoints: list[pizone.ControllerEndpoint] | None = None
     _discovered_controller_ip: str | None = None
+    _host_only: bool | None = None
 
     @override
     def is_matching(self, other_flow: Self) -> bool:
@@ -112,10 +113,12 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         defaults: Mapping[str, Any] | None = None,
     ) -> ConfigFlowResult:
         """Show the user setup form (search/manual or host-only)."""
+        # Latch so submit matches the schema the user saw (loaded-entry can change).
+        self._host_only = self._async_user_setup_host_only()
         return self.async_show_form(
             step_id="user",
             data_schema=self._user_setup_schema(
-                host_only=self._async_user_setup_host_only(),
+                host_only=self._host_only,
                 defaults=defaults or {},
             ),
             errors=errors or None,
@@ -134,7 +137,11 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         errors: dict[str, str] = {}
         if user_input is not None:
-            host_only = self._async_user_setup_host_only()
+            host_only = (
+                self._host_only
+                if self._host_only is not None
+                else self._async_user_setup_host_only()
+            )
             if host_only:
                 host = str(user_input.get(CONF_HOST, "")).strip()
                 if not host:
@@ -170,8 +177,8 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if not endpoints:
             _LOGGER.debug("No controllers found")
-            # Search started discovery; drop it when nothing is using it so the
-            # follow-up form (and a later Add integration) can offer Search again.
+            # Empty search started discovery solely for this scan; stop it when no
+            # loaded entry needs the shared listener.
             if not self._async_user_setup_host_only():
                 await izone_discovery.async_stop_discovery(self.hass)
             return self._async_show_user_form(
@@ -227,15 +234,12 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             if (primary := by_uid.get(selected_uid)) is None:
                 return self.async_abort(reason="no_devices_found")
 
-            for endpoint in self._user_discovered_endpoints:
-                if endpoint.uid == primary.uid:
-                    continue
-                # Using integration_discovery lets HA's deduplication guard prevent stacking
-                # flows for UIDs already in progress or already configured.
-                self._async_schedule_integration_discovery_flow(
-                    endpoint.uid,
-                    endpoint.host,
-                )
+            # Skip ignored UIDs (include_ignore=True); integration_discovery cannot
+            # re-offer them — only SOURCE_USER can replace SOURCE_IGNORE.
+            self._async_fan_out_discovered_endpoints(
+                self._user_discovered_endpoints,
+                selected_uid=primary.uid,
+            )
             return await self._async_create_controller_entry(primary)
 
         controllers_lines = "\n".join(
@@ -391,7 +395,11 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
     async def _async_probe_host_and_confirm(self, host: str) -> ConfigFlowResult:
         """Validate *host* and continue to confirm when a controller responds."""
         self._async_abort_entries_match({CONF_HOST: host})
-        host_only = self._async_user_setup_host_only()
+        host_only = (
+            self._host_only
+            if self._host_only is not None
+            else self._async_user_setup_host_only()
+        )
         try:
             endpoint = await izone_discovery.async_discover_by_host(self.hass, host)
         except OSError:

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -401,6 +401,11 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             return self.async_abort(reason="unpaired_bridge")
         except pizone.ControllerAlreadyClaimedError:
             return self.async_abort(reason="already_configured")
+        except Exception:  # noqa: BLE001 - content-shaped probe errors until pizone 1.3.9
+            # Manual host can hit non-iZone HTTP bodies; pizone._probe still lets
+            # content-shaped errors propagate (harden in 1.3.9).
+            _LOGGER.debug("Unexpected error probing iZone host %s", host, exc_info=True)
+            endpoint = None
 
         if endpoint is None:
             if host_only:

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -374,17 +374,12 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             {
                 vol.Required(CONF_SETUP_METHOD, default=method_default): SelectSelector(
                     SelectSelectorConfig(
-                        options=[
-                            SelectOptionDict(
-                                value=SETUP_METHOD_SEARCH,
-                                label="Search for devices",
-                            ),
-                            SelectOptionDict(
-                                value=SETUP_METHOD_MANUAL_HOST,
-                                label="Enter host",
-                            ),
-                        ],
+                        translation_key="setup_method",
                         mode=SelectSelectorMode.LIST,
+                        options=[
+                            SETUP_METHOD_SEARCH,
+                            SETUP_METHOD_MANUAL_HOST,
+                        ],
                     )
                 ),
                 vol.Optional(CONF_HOST, default=host_default): str,

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -416,6 +416,18 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             )
 
         await self.async_set_unique_id(endpoint.uid)
+        # Manual host can be a repair path when UDP cannot update CONF_HOST; abort with
+        # an explicit reason so the side-effect is visible (not a reconfigure flow).
+        if (
+            existing := self.hass.config_entries.async_entry_for_domain_unique_id(
+                self.handler, endpoint.uid
+            )
+        ) is not None and existing.data.get(CONF_HOST) != endpoint.host:
+            self._abort_if_unique_id_configured(
+                updates={CONF_HOST: endpoint.host},
+                error="already_configured_host_updated",
+                description_placeholders={"host": endpoint.host},
+            )
         self._abort_if_unique_id_configured()
         self._discovered_controller_ip = endpoint.host
         return await self.async_step_confirm()

--- a/homeassistant/components/izone/config_flow.py
+++ b/homeassistant/components/izone/config_flow.py
@@ -1,6 +1,7 @@
 """Config flow for izone."""
 
-from collections.abc import Iterable, Mapping
+import asyncio
+from collections.abc import Iterable
 import logging
 from typing import Any, Self, override
 
@@ -27,9 +28,12 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 
 SELECTED_CONTROLLER_UID = "selected_controller_uid"
-CONF_SETUP_METHOD = "setup_method"
-SETUP_METHOD_SEARCH = "search"
-SETUP_METHOD_MANUAL_HOST = "manual_host"
+
+STEP_MANUAL_HOST_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST): vol.All(str, vol.Length(min=1)),
+    }
+)
 
 
 def _flow_uid_for_matching(flow: ConfigFlow) -> str | None:
@@ -47,7 +51,11 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     _user_discovered_endpoints: list[pizone.ControllerEndpoint] | None = None
     _discovered_controller_ip: str | None = None
-    _host_only: bool | None = None
+    _discovery_task: asyncio.Task[None] | None = None
+    _broadcast_endpoints: dict[str, pizone.ControllerEndpoint] | None = None
+    _discovery_failed: bool = False
+    # True when Add integration skipped Search because an entry already owns discovery.
+    _manual_host_additional: bool = False
 
     @override
     def is_matching(self, other_flow: Self) -> bool:
@@ -105,25 +113,6 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         return bool(self.hass.config_entries.async_loaded_entries(DOMAIN))
 
-    @callback
-    def _async_show_user_form(
-        self,
-        *,
-        errors: dict[str, str] | None = None,
-        defaults: Mapping[str, Any] | None = None,
-    ) -> ConfigFlowResult:
-        """Show the user setup form (search/manual or host-only)."""
-        # Latch so submit matches the schema the user saw (loaded-entry can change).
-        self._host_only = self._async_user_setup_host_only()
-        return self.async_show_form(
-            step_id="user",
-            data_schema=self._user_setup_schema(
-                host_only=self._host_only,
-                defaults=defaults or {},
-            ),
-            errors=errors or None,
-        )
-
     @override
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -135,69 +124,141 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         self._async_abort_other_user_flows()
 
-        errors: dict[str, str] = {}
-        if user_input is not None:
-            host_only = (
-                self._host_only
-                if self._host_only is not None
-                else self._async_user_setup_host_only()
-            )
-            if host_only:
-                host = str(user_input.get(CONF_HOST, "")).strip()
-                if not host:
-                    errors[CONF_HOST] = "required"
-                else:
-                    return await self._async_probe_host_and_confirm(host)
-            else:
-                setup_method = user_input.get(CONF_SETUP_METHOD, SETUP_METHOD_SEARCH)
-                host = str(user_input.get(CONF_HOST, "")).strip()
+        if self._async_user_setup_host_only():
+            self._manual_host_additional = True
+            return await self.async_step_manual_host()
 
-                if setup_method == SETUP_METHOD_MANUAL_HOST:
-                    if not host:
-                        errors[CONF_HOST] = "required"
-                    else:
-                        return await self._async_probe_host_and_confirm(host)
-                else:
-                    return await self.async_step_discover()
-
-        return self._async_show_user_form(
-            errors=errors or None,
-            defaults=user_input,
+        return self.async_show_menu(
+            step_id="user",
+            menu_options=["discover", "manual_host"],
         )
+
+    async def _async_run_broadcast_discovery(self) -> None:
+        """Run LAN broadcast discovery for the progress step."""
+        self._discovery_failed = False
+        try:
+            self._broadcast_endpoints = (
+                await izone_discovery.async_discover_all_endpoints(self.hass)
+            )
+        except OSError:
+            _LOGGER.debug("Unable to start iZone discovery service", exc_info=True)
+            self._discovery_failed = True
+            self._broadcast_endpoints = None
 
     async def async_step_discover(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Broadcast discovery and offer unconfigured controllers."""
-        try:
-            endpoints = await izone_discovery.async_discover_all_endpoints(self.hass)
-        except OSError:
-            _LOGGER.debug("Unable to start iZone discovery service", exc_info=True)
-            return self.async_abort(reason="discovery_failed")
+        """Broadcast discovery with a progress UI, then offer controllers."""
+        if self._discovery_task is None:
+            self._discovery_task = self.hass.async_create_task(
+                self._async_run_broadcast_discovery()
+            )
+            return self.async_show_progress(
+                step_id="discover",
+                progress_action="discover",
+                progress_task=self._discovery_task,
+            )
 
+        if not self._discovery_task.done():
+            return self.async_show_progress(
+                step_id="discover",
+                progress_action="discover",
+                progress_task=self._discovery_task,
+            )
+
+        self._discovery_task = None
+        if self._discovery_failed:
+            return self.async_show_progress_done(next_step_id="discovery_failed")
+
+        endpoints = self._broadcast_endpoints or {}
         if not endpoints:
             _LOGGER.debug("No controllers found")
             # Empty search started discovery solely for this scan; stop it when no
             # loaded entry needs the shared listener.
             if not self._async_user_setup_host_only():
                 await izone_discovery.async_stop_discovery(self.hass)
-            return self._async_show_user_form(
-                errors={"base": "no_devices_found"},
-                defaults={CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST},
-            )
+            return self.async_show_progress_done(next_step_id="no_devices")
 
         self._user_discovered_endpoints = self._async_get_unconfigured_endpoints(
             endpoints
         )
         if not self._user_discovered_endpoints:
-            return self.async_abort(reason="already_configured")
+            return self.async_show_progress_done(next_step_id="already_configured")
         if len(self._user_discovered_endpoints) > 1:
-            return await self.async_step_select_controller()
+            return self.async_show_progress_done(next_step_id="select_controller")
 
         sole = self._user_discovered_endpoints[0]
         await self.async_set_unique_id(sole.uid)
         self._discovered_controller_ip = sole.host
-        return await self.async_step_confirm()
+        return self.async_show_progress_done(next_step_id="confirm")
+
+    async def async_step_discovery_failed(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Abort after broadcast discovery failed to start."""
+        return self.async_abort(reason="discovery_failed")
+
+    async def async_step_already_configured(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Abort when broadcast discovery only found configured controllers."""
+        return self.async_abort(reason="already_configured")
+
+    async def async_step_no_devices(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Nudge manual host entry when broadcast discovery finds nothing."""
+        # Error string covers this path; keep the default host-entry description.
+        self._manual_host_additional = False
+        return self._async_show_manual_host_form(errors={"base": "no_devices_found"})
+
+    async def async_step_manual_host(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Enter a controller IP address or hostname."""
+        return await self._async_manual_host(user_input)
+
+    async def async_step_manual_host_additional(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Enter another controller's address when one is already set up."""
+        self._manual_host_additional = True
+        return await self._async_manual_host(user_input)
+
+    async def _async_manual_host(
+        self, user_input: dict[str, Any] | None
+    ) -> ConfigFlowResult:
+        """Shared manual-host submit / show logic."""
+        if user_input is not None:
+            host = user_input[CONF_HOST].strip()
+            if not host:
+                return self._async_show_manual_host_form(
+                    errors={CONF_HOST: "required"},
+                    suggested_values=user_input,
+                )
+            return await self._async_probe_host_and_confirm(host)
+
+        return self._async_show_manual_host_form()
+
+    @callback
+    def _async_show_manual_host_form(
+        self,
+        *,
+        errors: dict[str, str] | None = None,
+        suggested_values: dict[str, Any] | None = None,
+    ) -> ConfigFlowResult:
+        """Show the manual host entry form."""
+        # Separate step_id so both descriptions stay fully translatable.
+        step_id = (
+            "manual_host_additional" if self._manual_host_additional else "manual_host"
+        )
+        return self.async_show_form(
+            step_id=step_id,
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_MANUAL_HOST_SCHEMA, suggested_values
+            ),
+            errors=errors,
+        )
 
     async def async_step_select_controller(
         self, user_input: dict[str, Any] | None = None
@@ -359,47 +420,9 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
 
     # -- Private helpers
 
-    def _user_setup_schema(
-        self,
-        *,
-        host_only: bool,
-        defaults: Mapping[str, Any],
-    ) -> vol.Schema:
-        """Build the user step schema for host-only vs search/manual paths."""
-        if host_only:
-            host_default: Any = defaults.get(CONF_HOST, vol.UNDEFINED)
-            return vol.Schema(
-                {
-                    vol.Required(CONF_HOST, default=host_default): str,
-                }
-            )
-
-        method_default = defaults.get(CONF_SETUP_METHOD, SETUP_METHOD_SEARCH)
-        host_default = defaults.get(CONF_HOST, "")
-        return vol.Schema(
-            {
-                vol.Required(CONF_SETUP_METHOD, default=method_default): SelectSelector(
-                    SelectSelectorConfig(
-                        translation_key="setup_method",
-                        mode=SelectSelectorMode.LIST,
-                        options=[
-                            SETUP_METHOD_SEARCH,
-                            SETUP_METHOD_MANUAL_HOST,
-                        ],
-                    )
-                ),
-                vol.Optional(CONF_HOST, default=host_default): str,
-            }
-        )
-
     async def _async_probe_host_and_confirm(self, host: str) -> ConfigFlowResult:
         """Validate *host* and continue to confirm when a controller responds."""
         self._async_abort_entries_match({CONF_HOST: host})
-        host_only = (
-            self._host_only
-            if self._host_only is not None
-            else self._async_user_setup_host_only()
-        )
         try:
             endpoint = await izone_discovery.async_discover_by_host(self.hass, host)
         except OSError:
@@ -416,16 +439,9 @@ class IZoneConfigFlow(ConfigFlow, domain=DOMAIN):
             endpoint = None
 
         if endpoint is None:
-            if host_only:
-                defaults: dict[str, Any] = {CONF_HOST: host}
-            else:
-                defaults = {
-                    CONF_SETUP_METHOD: SETUP_METHOD_MANUAL_HOST,
-                    CONF_HOST: host,
-                }
-            return self._async_show_user_form(
+            return self._async_show_manual_host_form(
                 errors={"base": "cannot_connect"},
-                defaults=defaults,
+                suggested_values={CONF_HOST: host},
             )
 
         await self.async_set_unique_id(endpoint.uid)

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -238,10 +238,12 @@ async def async_discover_endpoint(
 @callback
 def discovery_service_active(hass: HomeAssistant) -> bool:
     """Return True when the shared discovery service is running or starting."""
-    slot = hass.data.get(DATA_DISCOVERY_SERVICE)
-    if isinstance(slot, DiscoveryRuntime):
+    state = hass.data.get(DATA_DISCOVERY_SERVICE)
+    if not isinstance(state, DiscoveryServiceState):
+        return False
+    if state.runtime is not None:
         return True
-    return isinstance(slot, asyncio.Future) and not slot.done()
+    return state.starting is not None and not state.starting.done()
 
 
 async def async_discover_by_host(

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -235,6 +235,31 @@ async def async_discover_endpoint(
     return await service.discover_by_uid(uid)
 
 
+@callback
+def discovery_service_active(hass: HomeAssistant) -> bool:
+    """Return True when the shared discovery service is running or starting."""
+    slot = hass.data.get(DATA_DISCOVERY_SERVICE)
+    if isinstance(slot, DiscoveryRuntime):
+        return True
+    return isinstance(slot, asyncio.Future) and not slot.done()
+
+
+async def async_discover_by_host(
+    hass: HomeAssistant, host: str
+) -> pizone.ControllerEndpoint | None:
+    """HTTP-probe a controller at *host* for config-flow validation.
+
+    Starts shared discovery if needed.
+
+    Raises:
+        OSError: Discovery UDP socket could not be bound.
+        UnpairedBridgeError: Probed UID is the unpaired placeholder.
+        ControllerAlreadyClaimedError: Host or UID is already claimed on the service.
+    """
+    service = await async_ensure_discovery(hass)
+    return await service.discover_by_host(host)
+
+
 async def async_maybe_stop_discovery(hass: HomeAssistant) -> None:
     """Stop discovery when nothing actionable remains.
 

--- a/homeassistant/components/izone/discovery.py
+++ b/homeassistant/components/izone/discovery.py
@@ -235,17 +235,6 @@ async def async_discover_endpoint(
     return await service.discover_by_uid(uid)
 
 
-@callback
-def discovery_service_active(hass: HomeAssistant) -> bool:
-    """Return True when the shared discovery service is running or starting."""
-    state = hass.data.get(DATA_DISCOVERY_SERVICE)
-    if not isinstance(state, DiscoveryServiceState):
-        return False
-    if state.runtime is not None:
-        return True
-    return state.starting is not None and not state.starting.done()
-
-
 async def async_discover_by_host(
     hass: HomeAssistant, host: str
 ) -> pizone.ControllerEndpoint | None:

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -5,18 +5,34 @@
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "discovery_failed": "Failed to start iZone discovery. Make sure your network is properly configured.",
       "discovery_started": "iZone discovery has started. Your controllers will appear as discovered devices under Settings \u003e Devices \u0026 services.",
-      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]"
+      "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
+      "unpaired_bridge": "This iZone bridge is not paired with an air conditioner."
+    },
+    "error": {
+      "cannot_connect": "Unable to connect to an iZone controller at that address.",
+      "no_devices_found": "No iZone controllers were found on your network. Enter the controller IP address below or check your network settings.",
+      "required": "Enter the controller IP address or hostname."
     },
     "flow_title": "{name}",
     "step": {
       "confirm": {
         "description": "Do you want to set up iZone?\n\nController UID: {controller_uid}\nController IP: {host}"
       },
+      "confirm_ignored": {
+        "description": "This iZone controller was previously ignored. Do you want to set it up?\n\nController UID: {controller_uid}\nController IP: {host}"
+      },
       "select_controller": {
         "data": {
           "selected_controller_uid": "Controller"
         },
         "description": "Multiple unconfigured iZone controllers were found:\n{controllers}\n\nChoose the controller you want to set up now. Any controller you do not select will remain available as a discovered device you can set up later under **Settings** > **Devices & services**."
+      },
+      "user": {
+        "data": {
+          "host": "Controller IP address or hostname",
+          "setup_method": "Setup method"
+        },
+        "description": "Choose how to find your iZone controller."
       }
     }
   },

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -44,6 +44,14 @@
       "message": "Unable to connect to controller {uid}"
     }
   },
+  "selector": {
+    "setup_method": {
+      "options": {
+        "manual_host": "Enter host",
+        "search": "Search for devices"
+      }
+    }
+  },
   "services": {
     "airflow_max": {
       "description": "Sets the airflow maximum percent for a zone.",

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -15,12 +15,27 @@
       "required": "Enter the controller IP address or hostname."
     },
     "flow_title": "{name}",
+    "progress": {
+      "discover": "Searching for devices on the local network..."
+    },
     "step": {
       "confirm": {
         "description": "Do you want to set up iZone?\n\nController UID: {controller_uid}\nController IP: {host}"
       },
       "confirm_ignored": {
         "description": "This iZone controller was previously ignored. Do you want to set it up?\n\nController UID: {controller_uid}\nController IP: {host}"
+      },
+      "manual_host": {
+        "data": {
+          "host": "Controller IP address or hostname"
+        },
+        "description": "Enter the IP address or hostname of your iZone controller."
+      },
+      "manual_host_additional": {
+        "data": {
+          "host": "[%key:component::izone::config::step::manual_host::data::host%]"
+        },
+        "description": "Another iZone controller is already set up. Controllers on the same network are usually found automatically. If yours does not appear, enter its IP address or hostname below."
       },
       "select_controller": {
         "data": {
@@ -29,11 +44,10 @@
         "description": "Multiple unconfigured iZone controllers were found:\n{controllers}\n\nChoose the controller you want to set up now. Any other controller not previously ignored will remain available as a discovered device you can set up later under **Settings** > **Devices & services**."
       },
       "user": {
-        "data": {
-          "host": "Controller IP address or hostname",
-          "setup_method": "Setup method"
-        },
-        "description": "Add an iZone controller."
+        "menu_options": {
+          "discover": "Search for devices",
+          "manual_host": "Enter host"
+        }
       }
     }
   },
@@ -43,14 +57,6 @@
     },
     "unable_to_connect": {
       "message": "Unable to connect to controller {uid}"
-    }
-  },
-  "selector": {
-    "setup_method": {
-      "options": {
-        "manual_host": "Enter host",
-        "search": "Search for devices"
-      }
     }
   },
   "services": {

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "already_configured_host_updated": "This iZone controller is already set up. Its address has been updated to {host}.",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "discovery_failed": "Failed to start iZone discovery. Make sure your network is properly configured.",
       "discovery_started": "iZone discovery has started. Your controllers will appear as discovered devices under Settings \u003e Devices \u0026 services.",

--- a/homeassistant/components/izone/strings.json
+++ b/homeassistant/components/izone/strings.json
@@ -26,14 +26,14 @@
         "data": {
           "selected_controller_uid": "Controller"
         },
-        "description": "Multiple unconfigured iZone controllers were found:\n{controllers}\n\nChoose the controller you want to set up now. Any controller you do not select will remain available as a discovered device you can set up later under **Settings** > **Devices & services**."
+        "description": "Multiple unconfigured iZone controllers were found:\n{controllers}\n\nChoose the controller you want to set up now. Any other controller not previously ignored will remain available as a discovered device you can set up later under **Settings** > **Devices & services**."
       },
       "user": {
         "data": {
           "host": "Controller IP address or hostname",
           "setup_method": "Setup method"
         },
-        "description": "Choose how to find your iZone controller."
+        "description": "Add an iZone controller."
       }
     }
   },

--- a/tests/components/izone/conftest.py
+++ b/tests/components/izone/conftest.py
@@ -211,6 +211,9 @@ def mock_discovery_service(mock_controller: Mock) -> Mock:
     service.discover_by_uid = AsyncMock(
         return_value=endpoint_from_controller(mock_controller)
     )
+    service.discover_by_host = AsyncMock(
+        return_value=endpoint_from_controller(mock_controller)
+    )
     service.create_controller = AsyncMock(return_value=mock_controller)
     return service
 

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -2,8 +2,10 @@
 
 from collections.abc import Generator
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
+import pizone
 import pytest
 
 from homeassistant import config_entries
@@ -29,6 +31,24 @@ def _make_homekit_info(md: str, host: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(properties={"md": md}, host=host)
 
 
+def _user_search_input() -> dict[str, str]:
+    """Return user-step input that triggers broadcast discovery."""
+    return {config_flow.CONF_SETUP_METHOD: config_flow.SETUP_METHOD_SEARCH}
+
+
+def _user_manual_host_input(host: str) -> dict[str, str]:
+    """Return user-step input for manual host entry."""
+    return {
+        config_flow.CONF_SETUP_METHOD: config_flow.SETUP_METHOD_MANUAL_HOST,
+        CONF_HOST: host,
+    }
+
+
+async def _configure_user_search(hass: HomeAssistant, flow_id: str) -> dict[str, Any]:
+    """Submit the user step choosing broadcast discovery."""
+    return await hass.config_entries.flow.async_configure(flow_id, _user_search_input())
+
+
 @pytest.fixture(autouse=True)
 def mock_izone_timeouts() -> Generator[None]:
     """Mock iZone idle-stop delay to speed up tests."""
@@ -50,7 +70,11 @@ async def test_user_discovery_success(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
+        progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        assert progress[0]["context"].get("confirm_only") is True
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
@@ -72,6 +96,8 @@ async def test_user_discovery_default_selects_first_and_queues_other(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "select_controller"
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done(wait_background_tasks=True)
@@ -111,7 +137,11 @@ async def test_broadcast_skips_already_configured_controller(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
+        progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        assert progress[0]["context"].get("confirm_only") is True
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
@@ -135,7 +165,11 @@ async def test_user_discovery_skips_yaml_excluded_controllers(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
+        progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        assert progress[0]["context"].get("confirm_only") is True
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
         await hass.async_block_till_done()
 
@@ -159,6 +193,8 @@ async def test_broadcast_multiple_unconfigured_shows_choice(
         )
 
         assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "select_controller"
         schema_keys = list(result["data_schema"].schema.keys())
         assert len(schema_keys) == 1
@@ -199,6 +235,9 @@ async def test_select_controller_aborts_when_choices_missing(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "select_controller"
 
     # Public configure cannot clear flow-local discovery state; poke the in-progress
     # instance so the empty-choices abort path is exercised.
@@ -222,6 +261,9 @@ async def test_select_controller_aborts_when_uid_not_in_choices(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "select_controller"
 
     # Schema validation rejects unknown UIDs; call the step directly with a UID that
     # is not in the discovered set to cover the step's own abort.
@@ -246,6 +288,9 @@ async def test_select_controller_creates_selected_uid_and_queues_others(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "select_controller"
 
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -285,20 +330,18 @@ async def test_broadcast_aborts_when_all_discovered_are_configured(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_user_flow_aborts_when_all_discovered_are_ignored(
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_flow_offers_ignored_controller_for_setup(
     hass: HomeAssistant,
 ) -> None:
-    """User flow aborts when every discovered controller has been explicitly ignored.
-
-    _async_get_unconfigured_controllers uses include_ignore=True so controllers
-    whose entries carry SOURCE_IGNORE are not re-offered as configurable, respecting
-    the user's earlier choice to dismiss them.
-    """
+    """Ignored controllers appear in the user picker and can be set up again."""
     ignored_controller = create_mock_controller("000000001", "192.0.2.1")
     MockConfigEntry(
         domain=DOMAIN,
@@ -311,9 +354,32 @@ async def test_user_flow_aborts_when_all_discovered_are_ignored(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "confirm_ignored"
+        progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        assert progress[0]["context"].get("confirm_only") is True
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "000000001"
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_confirm_uses_confirm_only(hass: HomeAssistant) -> None:
+    """Confirm step is confirm-only so closing the dialog dismisses silently."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    with patch_discovered_controllers(controller):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await _configure_user_search(hass, result["flow_id"])
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+    progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert progress[0]["context"].get("confirm_only") is True
 
 
 async def test_import_aborts_when_another_izone_flow_in_progress(
@@ -326,7 +392,7 @@ async def test_import_aborts_when_another_izone_flow_in_progress(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
     assert user_flow["type"] is FlowResultType.FORM
-    assert user_flow["step_id"] == "confirm"
+    assert user_flow["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -382,6 +448,8 @@ async def test_user_flow_aborts_when_discovery_bind_fails(hass: HomeAssistant) -
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_failed"
@@ -505,6 +573,8 @@ async def test_homekit_aborts_while_user_confirm_is_open(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         assert user_flow["type"] is FlowResultType.FORM
+        assert user_flow["step_id"] == "user"
+        user_flow = await _configure_user_search(hass, user_flow["flow_id"])
         assert user_flow["step_id"] == "confirm"
 
         result = await hass.config_entries.flow.async_init(
@@ -517,10 +587,10 @@ async def test_homekit_aborts_while_user_confirm_is_open(
     assert result["reason"] == "already_in_progress"
 
 
-async def test_user_broadcast_aborts_when_homekit_flow_in_progress(
+async def test_user_flow_continues_when_homekit_flow_in_progress(
     hass: HomeAssistant,
 ) -> None:
-    """Test user broadcast discovery aborts when a HomeKit flow is already active."""
+    """Manual user setup is allowed while a discovered-device flow is open."""
     controller = create_mock_controller("000000001", "192.0.2.3")
     with patch_discovered_controllers(controller):
         homekit_flow = await hass.config_entries.flow.async_init(
@@ -536,10 +606,97 @@ async def test_user_broadcast_aborts_when_homekit_flow_in_progress(
             DOMAIN,
             context={"source": config_entries.SOURCE_USER},
         )
-        result = user_flow
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_in_progress"
+    assert user_flow["type"] is FlowResultType.FORM
+    assert user_flow["step_id"] == "user"
+
+
+async def test_user_flow_continues_when_integration_discovery_in_progress(
+    hass: HomeAssistant,
+) -> None:
+    """Manual user setup is allowed while an integration discovery confirm is open."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    with patch_discovered_controllers(controller):
+        discovery_flow = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_INTEGRATION_DISCOVERY,
+                "unique_id": "000000001",
+            },
+            data={CONF_HOST: "192.0.2.1"},
+        )
+        assert discovery_flow["step_id"] == "confirm"
+
+        user_flow = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+        )
+
+    assert user_flow["type"] is FlowResultType.FORM
+    assert user_flow["step_id"] == "user"
+
+
+async def test_new_user_flow_replaces_stale_user_flow(
+    hass: HomeAssistant,
+) -> None:
+    """A fresh user flow replaces an earlier one left open (e.g. after refresh)."""
+    with patch(
+        "homeassistant.components.izone.discovery.discovery_service_active",
+        return_value=False,
+    ):
+        first = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert first["step_id"] == "user"
+
+        second = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert second["type"] is FlowResultType.FORM
+    assert second["step_id"] == "user"
+    assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
+    assert (
+        hass.config_entries.flow.async_progress_by_handler(DOMAIN)[0]["flow_id"]
+        == second["flow_id"]
+    )
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_new_user_flow_replaces_stale_confirm_after_ignore(
+    hass: HomeAssistant,
+) -> None:
+    """Re-setup after ignore works when an earlier confirm flow was left open."""
+    ignored_controller = create_mock_controller("000000001", "192.0.2.1")
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ignored_controller.device_uid,
+        source=config_entries.SOURCE_IGNORE,
+        data={},
+    ).add_to_hass(hass)
+
+    with patch_discovered_controllers(ignored_controller):
+        stale = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        stale = await _configure_user_search(hass, stale["flow_id"])
+        assert stale["step_id"] == "confirm_ignored"
+
+        replacement = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert replacement["step_id"] == "user"
+
+        replacement = await _configure_user_search(hass, replacement["flow_id"])
+        assert replacement["step_id"] == "confirm_ignored"
+        result = await hass.config_entries.flow.async_configure(
+            replacement["flow_id"], {}
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "000000001"
+    assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 0
 
 
 async def test_homekit_aborts_when_uid_already_configured(
@@ -692,15 +849,213 @@ async def test_homekit_aborts_when_discovery_bind_fails(hass: HomeAssistant) -> 
     assert result["reason"] == "discovery_failed"
 
 
-async def test_user_flow_aborts_when_no_controllers_found(hass: HomeAssistant) -> None:
-    """User flow aborts when broadcast discovery returns no controllers."""
+async def test_user_flow_returns_to_form_when_no_controllers_found(
+    hass: HomeAssistant,
+) -> None:
+    """User flow loops back to the setup form when broadcast discovery finds nothing."""
     with patch_discovered_controllers([]):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "no_devices_found"}
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_manual_host_success(hass: HomeAssistant) -> None:
+    """Manual host entry probes the bridge and continues to confirm."""
+    controller = create_mock_controller("000000001", "192.0.2.55")
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.async_discover_by_host",
+            new=AsyncMock(return_value=endpoint_from_controller(controller)),
+        ),
+        patch(
+            "homeassistant.components.izone.discovery.discovery_service_active",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["step_id"] == "user"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.55")
+        )
+        assert result["step_id"] == "confirm"
+        progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        assert progress[0]["context"].get("confirm_only") is True
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_HOST: "192.0.2.55"}
+
+
+async def test_user_blank_host_submits_search(hass: HomeAssistant) -> None:
+    """Leaving the host blank triggers broadcast discovery."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    with (
+        patch_discovered_controllers(controller),
+        patch(
+            "homeassistant.components.izone.discovery.discovery_service_active",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                config_flow.CONF_SETUP_METHOD: config_flow.SETUP_METHOD_SEARCH,
+                CONF_HOST: "",
+            },
+        )
+
+    assert result["step_id"] == "confirm"
+
+
+async def test_user_manual_host_required_when_enter_host_selected(
+    hass: HomeAssistant,
+) -> None:
+    """Enter host without an address shows a field error."""
+    with patch(
+        "homeassistant.components.izone.discovery.discovery_service_active",
+        return_value=False,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("")
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_HOST: "required"}
+
+
+async def test_user_manual_host_unreachable(hass: HomeAssistant) -> None:
+    """Unreachable manual host returns to the user form with an error."""
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.async_discover_by_host",
+            new=AsyncMock(return_value=None),
+        ),
+        patch(
+            "homeassistant.components.izone.discovery.discovery_service_active",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.99")
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_user_manual_host_already_configured_aborts(hass: HomeAssistant) -> None:
+    """Re-entering a host for an existing controller aborts before probing."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000025841",
+        data={CONF_HOST: "10.0.0.90"},
+        version=2,
+    ).add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.async_discover_by_host",
+        ) as mock_discover_by_host,
+        patch(
+            "homeassistant.components.izone.discovery.discovery_service_active",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "10.0.0.90"}
+        )
+
+    mock_discover_by_host.assert_not_called()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_manual_host_claimed_controller_aborts(hass: HomeAssistant) -> None:
+    """Claim-cache collision aborts when HA has no matching host entry yet."""
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.async_discover_by_host",
+            new=AsyncMock(
+                side_effect=pizone.ControllerAlreadyClaimedError(
+                    "Controller 000025841 already created"
+                )
+            ),
+        ),
+        patch(
+            "homeassistant.components.izone.discovery.discovery_service_active",
+            return_value=True,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "10.0.0.90"}
+        )
 
     assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "no_devices_found"
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_flow_host_only_when_discovery_active(hass: HomeAssistant) -> None:
+    """When discovery is already active, the user step asks for a host only."""
+    with patch(
+        "homeassistant.components.izone.discovery.discovery_service_active",
+        return_value=True,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+
+    assert result["step_id"] == "user"
+    assert config_flow.CONF_SETUP_METHOD not in result["data_schema"].schema
+
+
+async def test_user_manual_host_unpaired_aborts(hass: HomeAssistant) -> None:
+    """Unpaired bridge placeholder aborts manual host setup."""
+    with (
+        patch(
+            "homeassistant.components.izone.discovery.async_discover_by_host",
+            new=AsyncMock(side_effect=pizone.UnpairedBridgeError("unpaired")),
+        ),
+        patch(
+            "homeassistant.components.izone.discovery.discovery_service_active",
+            return_value=False,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.111")
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unpaired_bridge"
 
 
 async def test_homekit_without_model_aborts(
@@ -893,8 +1248,10 @@ async def test_runtime_integration_discovery_skips_during_user_select_controller
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert user_flow["type"] is FlowResultType.FORM
-    assert user_flow["step_id"] == "select_controller"
+        assert user_flow["type"] is FlowResultType.FORM
+        assert user_flow["step_id"] == "user"
+        user_flow = await _configure_user_search(hass, user_flow["flow_id"])
+        assert user_flow["step_id"] == "select_controller"
 
     new_ctrl = create_mock_controller("000000002", "192.0.2.2")
 
@@ -920,6 +1277,8 @@ async def test_runtime_integration_discovery_skips_during_user_confirm(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
 
     izone_discovery.async_note_integration_discovery(
@@ -976,12 +1335,15 @@ async def test_confirm_asserts_when_controller_data_is_missing(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "confirm"
 
     # Corrupt flow-local state that the public path always sets before confirm.
     flow = hass.config_entries.flow._progress[result["flow_id"]]
     flow._discovered_controller_ip = None
     with pytest.raises(AssertionError):
-        await flow.async_step_confirm()
+        await flow.async_step_confirm({})
 
 
 async def test_confirm_asserts_when_unique_id_is_not_string(
@@ -994,6 +1356,9 @@ async def test_confirm_asserts_when_unique_id_is_not_string(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["step_id"] == "user"
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "confirm"
 
     flow = hass.config_entries.flow._progress[result["flow_id"]]
     flow.context["unique_id"] = None

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -853,7 +853,13 @@ async def test_user_flow_returns_to_form_when_no_controllers_found(
     hass: HomeAssistant,
 ) -> None:
     """User flow loops back to the setup form when broadcast discovery finds nothing."""
-    with patch_discovered_controllers([]):
+    with (
+        patch_discovered_controllers([]),
+        patch(
+            "homeassistant.components.izone.discovery.async_stop_discovery",
+            new=AsyncMock(),
+        ) as mock_stop,
+    ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -863,6 +869,31 @@ async def test_user_flow_returns_to_form_when_no_controllers_found(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "no_devices_found"}
+    # Search must remain available after an empty scan (not host-only).
+    assert config_flow.CONF_SETUP_METHOD in result["data_schema"].schema
+    mock_stop.assert_awaited_once()
+
+
+async def test_user_flow_can_search_again_after_empty_discovery(
+    hass: HomeAssistant,
+) -> None:
+    """After an empty search, choosing Search again still runs discovery."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    with patch_discovered_controllers([]) as (mock_discover_all, _):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["errors"] == {"base": "no_devices_found"}
+
+        mock_discover_all.side_effect = None
+        mock_discover_all.return_value = {
+            controller.device_uid: endpoint_from_controller(controller)
+        }
+        result = await _configure_user_search(hass, result["flow_id"])
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
@@ -973,20 +1004,14 @@ async def test_user_manual_host_already_configured_aborts(hass: HomeAssistant) -
         version=2,
     ).add_to_hass(hass)
 
-    with (
-        patch(
-            "homeassistant.components.izone.discovery.async_discover_by_host",
-        ) as mock_discover_by_host,
-        patch(
-            "homeassistant.components.izone.discovery.discovery_service_active",
-            return_value=True,
-        ),
-    ):
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+    ) as mock_discover_by_host:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "10.0.0.90"}
+            result["flow_id"], _user_manual_host_input("10.0.0.90")
         )
 
     mock_discover_by_host.assert_not_called()
@@ -996,43 +1021,44 @@ async def test_user_manual_host_already_configured_aborts(hass: HomeAssistant) -
 
 async def test_user_manual_host_claimed_controller_aborts(hass: HomeAssistant) -> None:
     """Claim-cache collision aborts when HA has no matching host entry yet."""
-    with (
-        patch(
-            "homeassistant.components.izone.discovery.async_discover_by_host",
-            new=AsyncMock(
-                side_effect=pizone.ControllerAlreadyClaimedError(
-                    "Controller 000025841 already created"
-                )
-            ),
-        ),
-        patch(
-            "homeassistant.components.izone.discovery.discovery_service_active",
-            return_value=True,
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(
+            side_effect=pizone.ControllerAlreadyClaimedError(
+                "Controller 000025841 already created"
+            )
         ),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], {CONF_HOST: "10.0.0.90"}
+            result["flow_id"], _user_manual_host_input("10.0.0.90")
         )
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
 
-async def test_user_flow_host_only_when_discovery_active(hass: HomeAssistant) -> None:
-    """When discovery is already active, the user step asks for a host only."""
-    with patch(
-        "homeassistant.components.izone.discovery.discovery_service_active",
-        return_value=True,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_flow_host_only_when_entry_loaded(hass: HomeAssistant) -> None:
+    """When an iZone entry is already loaded, the user step asks for a host only."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={CONF_HOST: "192.0.2.1"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
 
     assert result["step_id"] == "user"
     assert config_flow.CONF_SETUP_METHOD not in result["data_schema"].schema
+    assert CONF_HOST in result["data_schema"].schema
 
 
 async def test_user_manual_host_unpaired_aborts(hass: HomeAssistant) -> None:

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -1061,6 +1061,107 @@ async def test_user_flow_host_only_when_entry_loaded(hass: HomeAssistant) -> Non
     assert CONF_HOST in result["data_schema"].schema
 
 
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_host_only_empty_host_required(hass: HomeAssistant) -> None:
+    """Host-only form requires a non-empty host."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={CONF_HOST: "192.0.2.1"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: ""}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {CONF_HOST: "required"}
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_host_only_probes_and_confirms(hass: HomeAssistant) -> None:
+    """Host-only form probes the entered address and continues to confirm."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={CONF_HOST: "192.0.2.1"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    new_controller = create_mock_controller("000000002", "192.0.2.55")
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(return_value=endpoint_from_controller(new_controller)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.0.2.55"}
+        )
+
+    assert result["step_id"] == "confirm"
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_host_only_unreachable_keeps_host_defaults(
+    hass: HomeAssistant,
+) -> None:
+    """Host-only cannot_connect redisplays the form with the entered host."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={CONF_HOST: "192.0.2.1"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(return_value=None),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: "192.0.2.99"}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+    assert config_flow.CONF_SETUP_METHOD not in result["data_schema"].schema
+
+
+async def test_user_manual_host_aborts_when_discovery_bind_fails(
+    hass: HomeAssistant,
+) -> None:
+    """Manual host aborts when discovery cannot bind the UDP socket."""
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(side_effect=OSError("bind failed")),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.55")
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "discovery_failed"
+
+
 async def test_user_manual_host_unpaired_aborts(hass: HomeAssistant) -> None:
     """Unpaired bridge placeholder aborts manual host setup."""
     with (

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -1028,6 +1028,36 @@ async def test_user_manual_host_already_configured_aborts(hass: HomeAssistant) -
     assert result["reason"] == "already_configured"
 
 
+async def test_user_manual_host_updates_address_when_uid_configured(
+    hass: HomeAssistant,
+) -> None:
+    """Entering a new host for a configured UID updates CONF_HOST and aborts."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={CONF_HOST: "192.0.2.10"},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+    moved = create_mock_controller("000000001", "192.0.2.77")
+
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(return_value=endpoint_from_controller(moved)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.77")
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_host_updated"
+    assert result["description_placeholders"] == {"host": "192.0.2.77"}
+    assert entry.data[CONF_HOST] == "192.0.2.77"
+
+
 async def test_user_manual_host_claimed_controller_aborts(hass: HomeAssistant) -> None:
     """Claim-cache collision aborts when HA has no matching host entry yet."""
     with patch(

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -49,6 +49,11 @@ async def _configure_user_search(hass: HomeAssistant, flow_id: str) -> dict[str,
     return await hass.config_entries.flow.async_configure(flow_id, _user_search_input())
 
 
+def _schema_defaults(schema: Any) -> dict[str, Any]:
+    """Return default values from a voluptuous form schema keyed by field name."""
+    return {str(k): k.default() for k in schema.schema}
+
+
 @pytest.fixture(autouse=True)
 def mock_izone_timeouts() -> Generator[None]:
     """Mock iZone idle-stop delay to speed up tests."""
@@ -940,7 +945,45 @@ async def test_user_flow_returns_to_form_when_no_controllers_found(
     assert result["errors"] == {"base": "no_devices_found"}
     # Search must remain available after an empty scan (not host-only).
     assert config_flow.CONF_SETUP_METHOD in result["data_schema"].schema
+    defaults = _schema_defaults(result["data_schema"])
+    assert (
+        defaults[config_flow.CONF_SETUP_METHOD] == config_flow.SETUP_METHOD_MANUAL_HOST
+    )
     mock_stop.assert_awaited_once()
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_empty_discover_keeps_discovery_when_entry_loaded(
+    hass: HomeAssistant,
+) -> None:
+    """Empty discover does not stop the listener while a loaded entry needs it."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="000000001",
+        data={CONF_HOST: "192.0.2.1"},
+    )
+    entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    with (
+        patch_discovered_controllers([]),
+        patch(
+            "homeassistant.components.izone.discovery.async_stop_discovery",
+            new=AsyncMock(),
+        ) as mock_stop,
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        # Host-only UI has no Search; call discover directly to hit the loaded-entry
+        # empty-scan branch (skip stop).
+        flow = hass.config_entries.flow._progress[result["flow_id"]]
+        result = await flow.async_step_discover()
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "no_devices_found"}
+    mock_stop.assert_not_called()
 
 
 async def test_user_flow_can_search_again_after_empty_discovery(
@@ -1040,6 +1083,11 @@ async def test_user_manual_host_unreachable(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
+    defaults = _schema_defaults(result["data_schema"])
+    assert (
+        defaults[config_flow.CONF_SETUP_METHOD] == config_flow.SETUP_METHOD_MANUAL_HOST
+    )
+    assert defaults[CONF_HOST] == "192.0.2.99"
 
 
 async def test_user_manual_host_probe_content_error_cannot_connect(
@@ -1240,6 +1288,8 @@ async def test_user_host_only_unreachable_keeps_host_defaults(
     assert result["step_id"] == "user"
     assert result["errors"] == {"base": "cannot_connect"}
     assert config_flow.CONF_SETUP_METHOD not in result["data_schema"].schema
+    defaults = _schema_defaults(result["data_schema"])
+    assert defaults[CONF_HOST] == "192.0.2.99"
 
 
 async def test_user_manual_host_aborts_when_discovery_bind_fails(

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -314,6 +314,44 @@ async def test_select_controller_creates_selected_uid_and_queues_others(
     assert skipped_flows[0]["context"]["unique_id"] == "000000001"
 
 
+@pytest.mark.usefixtures("mock_entry_setup")
+async def test_select_controller_skips_fan_out_for_ignored_uid(
+    hass: HomeAssistant,
+) -> None:
+    """Unselected ignored controllers stay ignored; no doomed discovery flow."""
+    new_controller = create_mock_controller("000000001", "192.0.2.1")
+    ignored_controller = create_mock_controller("000000002", "192.0.2.2")
+    ignored_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ignored_controller.device_uid,
+        source=config_entries.SOURCE_IGNORE,
+        data={},
+    )
+    ignored_entry.add_to_hass(hass)
+
+    with patch_discovered_controllers([new_controller, ignored_controller]):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "select_controller"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {config_flow.SELECTED_CONTROLLER_UID: new_controller.device_uid},
+        )
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == new_controller.device_uid
+    assert ignored_entry.source == config_entries.SOURCE_IGNORE
+    assert not [
+        p
+        for p in hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        if p["context"].get("unique_id") == ignored_controller.device_uid
+    ]
+
+
 async def test_broadcast_aborts_when_all_discovered_are_configured(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -640,18 +640,14 @@ async def test_new_user_flow_replaces_stale_user_flow(
     hass: HomeAssistant,
 ) -> None:
     """A fresh user flow replaces an earlier one left open (e.g. after refresh)."""
-    with patch(
-        "homeassistant.components.izone.discovery.discovery_service_active",
-        return_value=False,
-    ):
-        first = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        assert first["step_id"] == "user"
+    first = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert first["step_id"] == "user"
 
-        second = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
+    second = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
 
     assert second["type"] is FlowResultType.FORM
     assert second["step_id"] == "user"
@@ -900,15 +896,9 @@ async def test_user_flow_can_search_again_after_empty_discovery(
 async def test_user_manual_host_success(hass: HomeAssistant) -> None:
     """Manual host entry probes the bridge and continues to confirm."""
     controller = create_mock_controller("000000001", "192.0.2.55")
-    with (
-        patch(
-            "homeassistant.components.izone.discovery.async_discover_by_host",
-            new=AsyncMock(return_value=endpoint_from_controller(controller)),
-        ),
-        patch(
-            "homeassistant.components.izone.discovery.discovery_service_active",
-            return_value=False,
-        ),
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(return_value=endpoint_from_controller(controller)),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -930,13 +920,7 @@ async def test_user_manual_host_success(hass: HomeAssistant) -> None:
 async def test_user_blank_host_submits_search(hass: HomeAssistant) -> None:
     """Leaving the host blank triggers broadcast discovery."""
     controller = create_mock_controller("000000001", "192.0.2.1")
-    with (
-        patch_discovered_controllers(controller),
-        patch(
-            "homeassistant.components.izone.discovery.discovery_service_active",
-            return_value=False,
-        ),
-    ):
+    with patch_discovered_controllers(controller):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
@@ -955,16 +939,12 @@ async def test_user_manual_host_required_when_enter_host_selected(
     hass: HomeAssistant,
 ) -> None:
     """Enter host without an address shows a field error."""
-    with patch(
-        "homeassistant.components.izone.discovery.discovery_service_active",
-        return_value=False,
-    ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("")
-        )
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], _user_manual_host_input("")
+    )
 
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "user"
@@ -973,15 +953,9 @@ async def test_user_manual_host_required_when_enter_host_selected(
 
 async def test_user_manual_host_unreachable(hass: HomeAssistant) -> None:
     """Unreachable manual host returns to the user form with an error."""
-    with (
-        patch(
-            "homeassistant.components.izone.discovery.async_discover_by_host",
-            new=AsyncMock(return_value=None),
-        ),
-        patch(
-            "homeassistant.components.izone.discovery.discovery_service_active",
-            return_value=False,
-        ),
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(return_value=None),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
@@ -1164,15 +1138,9 @@ async def test_user_manual_host_aborts_when_discovery_bind_fails(
 
 async def test_user_manual_host_unpaired_aborts(hass: HomeAssistant) -> None:
     """Unpaired bridge placeholder aborts manual host setup."""
-    with (
-        patch(
-            "homeassistant.components.izone.discovery.async_discover_by_host",
-            new=AsyncMock(side_effect=pizone.UnpairedBridgeError("unpaired")),
-        ),
-        patch(
-            "homeassistant.components.izone.discovery.discovery_service_active",
-            return_value=False,
-        ),
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(side_effect=pizone.UnpairedBridgeError("unpaired")),
     ):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -1004,6 +1004,28 @@ async def test_user_manual_host_unreachable(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_user_manual_host_probe_content_error_cannot_connect(
+    hass: HomeAssistant,
+) -> None:
+    """Content-shaped probe failures redisplay cannot_connect instead of 500."""
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(
+            side_effect=AttributeError("'NoneType' object has no attribute 'get'")
+        ),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.50")
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
 async def test_user_manual_host_already_configured_aborts(hass: HomeAssistant) -> None:
     """Re-entering a host for an existing controller aborts before probing."""
     MockConfigEntry(

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -1,5 +1,6 @@
 """Tests for iZone config flow."""
 
+import asyncio
 from collections.abc import Generator
 from types import SimpleNamespace
 from typing import Any
@@ -949,6 +950,42 @@ async def test_user_flow_returns_to_form_when_no_controllers_found(
     assert result["step_id"] == "manual_host"
     assert result["errors"] == {"base": "no_devices_found"}
     mock_stop.assert_awaited_once()
+
+
+async def test_user_discover_progress_while_task_running(hass: HomeAssistant) -> None:
+    """Polling discover while the broadcast task is open keeps showing progress."""
+    controller = create_mock_controller("000000001", "192.0.2.1")
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _slow_discover(_hass: HomeAssistant) -> dict[str, Any]:
+        started.set()
+        await release.wait()
+        return {controller.device_uid: endpoint_from_controller(controller)}
+
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_all_endpoints",
+        new=AsyncMock(side_effect=_slow_discover),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {"next_step_id": "discover"}
+        )
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        await started.wait()
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        assert result["progress_action"] == "discover"
+
+        release.set()
+        await hass.async_block_till_done()
+        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "confirm"
 
 
 @pytest.mark.usefixtures("mock_entry_setup")

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -367,6 +367,41 @@ async def test_user_flow_offers_ignored_controller_for_setup(
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
+async def test_user_manual_host_offers_ignored_controller_for_setup(
+    hass: HomeAssistant,
+) -> None:
+    """Enter host can re-add a previously ignored controller."""
+    ignored_controller = create_mock_controller("000000001", "192.0.2.1")
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=ignored_controller.device_uid,
+        source=config_entries.SOURCE_IGNORE,
+        data={},
+    ).add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.izone.discovery.async_discover_by_host",
+        new=AsyncMock(return_value=endpoint_from_controller(ignored_controller)),
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["step_id"] == "user"
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], _user_manual_host_input("192.0.2.1")
+        )
+        assert result["step_id"] == "confirm_ignored"
+        progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+        assert progress[0]["context"].get("confirm_only") is True
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["result"].unique_id == "000000001"
+    assert result["data"] == {CONF_HOST: "192.0.2.1"}
+
+
+@pytest.mark.usefixtures("mock_entry_setup")
 async def test_confirm_uses_confirm_only(hass: HomeAssistant) -> None:
     """Confirm step is confirm-only so closing the dialog dismisses silently."""
     controller = create_mock_controller("000000001", "192.0.2.1")

--- a/tests/components/izone/test_config_flow.py
+++ b/tests/components/izone/test_config_flow.py
@@ -13,7 +13,7 @@ from homeassistant.components.izone import config_flow, discovery as izone_disco
 from homeassistant.components.izone.const import DOMAIN
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
 from homeassistant.setup import async_setup_component
 
 from .conftest import (
@@ -23,7 +23,7 @@ from .conftest import (
     patch_discovered_controllers,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, get_schema_suggested_value
 
 
 def _make_homekit_info(md: str, host: str | None = None) -> SimpleNamespace:
@@ -31,27 +31,30 @@ def _make_homekit_info(md: str, host: str | None = None) -> SimpleNamespace:
     return SimpleNamespace(properties={"md": md}, host=host)
 
 
-def _user_search_input() -> dict[str, str]:
-    """Return user-step input that triggers broadcast discovery."""
-    return {config_flow.CONF_SETUP_METHOD: config_flow.SETUP_METHOD_SEARCH}
-
-
-def _user_manual_host_input(host: str) -> dict[str, str]:
-    """Return user-step input for manual host entry."""
-    return {
-        config_flow.CONF_SETUP_METHOD: config_flow.SETUP_METHOD_MANUAL_HOST,
-        CONF_HOST: host,
-    }
-
-
 async def _configure_user_search(hass: HomeAssistant, flow_id: str) -> dict[str, Any]:
-    """Submit the user step choosing broadcast discovery."""
-    return await hass.config_entries.flow.async_configure(flow_id, _user_search_input())
+    """Submit the user menu choosing broadcast discovery and finish progress."""
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "discover"}
+    )
+    assert result["type"] is FlowResultType.SHOW_PROGRESS
+    assert result["step_id"] == "discover"
+    assert result["progress_action"] == "discover"
+    await hass.async_block_till_done()
+    return await hass.config_entries.flow.async_configure(result["flow_id"])
 
 
-def _schema_defaults(schema: Any) -> dict[str, Any]:
-    """Return default values from a voluptuous form schema keyed by field name."""
-    return {str(k): k.default() for k in schema.schema}
+async def _configure_manual_host(
+    hass: HomeAssistant, flow_id: str, host: str
+) -> dict[str, Any]:
+    """Submit the user menu choosing manual host, then the host form."""
+    result = await hass.config_entries.flow.async_configure(
+        flow_id, {"next_step_id": "manual_host"}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual_host"
+    return await hass.config_entries.flow.async_configure(
+        result["flow_id"], {CONF_HOST: host}
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -74,7 +77,7 @@ async def test_user_discovery_success(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
         result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
@@ -100,7 +103,7 @@ async def test_user_discovery_default_selects_first_and_queues_other(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
         result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "select_controller"
@@ -141,7 +144,7 @@ async def test_broadcast_skips_already_configured_controller(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
         result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
@@ -169,7 +172,7 @@ async def test_user_discovery_skips_yaml_excluded_controllers(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert result["type"] is FlowResultType.FORM
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
         result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "confirm"
@@ -197,7 +200,7 @@ async def test_broadcast_multiple_unconfigured_shows_choice(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
 
-        assert result["type"] is FlowResultType.FORM
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
         result = await _configure_user_search(hass, result["flow_id"])
         assert result["step_id"] == "select_controller"
@@ -429,10 +432,9 @@ async def test_user_manual_host_offers_ignored_controller_for_setup(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.1")
-        )
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.1")
         assert result["step_id"] == "confirm_ignored"
         progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
         assert progress[0]["context"].get("confirm_only") is True
@@ -469,7 +471,7 @@ async def test_import_aborts_when_another_izone_flow_in_progress(
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-    assert user_flow["type"] is FlowResultType.FORM
+    assert user_flow["type"] is FlowResultType.MENU
     assert user_flow["step_id"] == "user"
 
     result = await hass.config_entries.flow.async_init(
@@ -650,7 +652,7 @@ async def test_homekit_aborts_while_user_confirm_is_open(
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert user_flow["type"] is FlowResultType.FORM
+        assert user_flow["type"] is FlowResultType.MENU
         assert user_flow["step_id"] == "user"
         user_flow = await _configure_user_search(hass, user_flow["flow_id"])
         assert user_flow["step_id"] == "confirm"
@@ -685,7 +687,7 @@ async def test_user_flow_continues_when_homekit_flow_in_progress(
             context={"source": config_entries.SOURCE_USER},
         )
 
-    assert user_flow["type"] is FlowResultType.FORM
+    assert user_flow["type"] is FlowResultType.MENU
     assert user_flow["step_id"] == "user"
 
 
@@ -710,7 +712,7 @@ async def test_user_flow_continues_when_integration_discovery_in_progress(
             context={"source": config_entries.SOURCE_USER},
         )
 
-    assert user_flow["type"] is FlowResultType.FORM
+    assert user_flow["type"] is FlowResultType.MENU
     assert user_flow["step_id"] == "user"
 
 
@@ -721,13 +723,14 @@ async def test_new_user_flow_replaces_stale_user_flow(
     first = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
+    assert first["type"] is FlowResultType.MENU
     assert first["step_id"] == "user"
 
     second = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert second["type"] is FlowResultType.FORM
+    assert second["type"] is FlowResultType.MENU
     assert second["step_id"] == "user"
     assert len(hass.config_entries.flow.async_progress_by_handler(DOMAIN)) == 1
     assert (
@@ -759,6 +762,7 @@ async def test_new_user_flow_replaces_stale_confirm_after_ignore(
         replacement = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert replacement["type"] is FlowResultType.MENU
         assert replacement["step_id"] == "user"
 
         replacement = await _configure_user_search(hass, replacement["flow_id"])
@@ -926,7 +930,7 @@ async def test_homekit_aborts_when_discovery_bind_fails(hass: HomeAssistant) -> 
 async def test_user_flow_returns_to_form_when_no_controllers_found(
     hass: HomeAssistant,
 ) -> None:
-    """User flow loops back to the setup form when broadcast discovery finds nothing."""
+    """Empty broadcast discovery nudges the user to enter a host."""
     with (
         patch_discovered_controllers([]),
         patch(
@@ -937,18 +941,13 @@ async def test_user_flow_returns_to_form_when_no_controllers_found(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
         result = await _configure_user_search(hass, result["flow_id"])
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "manual_host"
     assert result["errors"] == {"base": "no_devices_found"}
-    # Search must remain available after an empty scan (not host-only).
-    assert config_flow.CONF_SETUP_METHOD in result["data_schema"].schema
-    defaults = _schema_defaults(result["data_schema"])
-    assert (
-        defaults[config_flow.CONF_SETUP_METHOD] == config_flow.SETUP_METHOD_MANUAL_HOST
-    )
     mock_stop.assert_awaited_once()
 
 
@@ -980,8 +979,14 @@ async def test_empty_discover_keeps_discovery_when_entry_loaded(
         # empty-scan branch (skip stop).
         flow = hass.config_entries.flow._progress[result["flow_id"]]
         result = await flow.async_step_discover()
+        assert result["type"] is FlowResultType.SHOW_PROGRESS
+        await hass.async_block_till_done()
+        result = await flow.async_step_discover()
+        assert result["type"] is FlowResultType.SHOW_PROGRESS_DONE
+        result = await flow.async_step_no_devices()
 
     assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual_host"
     assert result["errors"] == {"base": "no_devices_found"}
     mock_stop.assert_not_called()
 
@@ -989,19 +994,24 @@ async def test_empty_discover_keeps_discovery_when_entry_loaded(
 async def test_user_flow_can_search_again_after_empty_discovery(
     hass: HomeAssistant,
 ) -> None:
-    """After an empty search, choosing Search again still runs discovery."""
+    """After an empty search, a new Add integration can still run discovery."""
     controller = create_mock_controller("000000001", "192.0.2.1")
     with patch_discovered_controllers([]) as (mock_discover_all, _):
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
         result = await _configure_user_search(hass, result["flow_id"])
+        assert result["step_id"] == "manual_host"
         assert result["errors"] == {"base": "no_devices_found"}
 
         mock_discover_all.side_effect = None
         mock_discover_all.return_value = {
             controller.device_uid: endpoint_from_controller(controller)
         }
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": config_entries.SOURCE_USER}
+        )
+        assert result["type"] is FlowResultType.MENU
         result = await _configure_user_search(hass, result["flow_id"])
 
     assert result["type"] is FlowResultType.FORM
@@ -1019,10 +1029,9 @@ async def test_user_manual_host_success(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
+        assert result["type"] is FlowResultType.MENU
         assert result["step_id"] == "user"
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.55")
-        )
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.55")
         assert result["step_id"] == "confirm"
         progress = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
         assert progress[0]["context"].get("confirm_only") is True
@@ -1033,42 +1042,36 @@ async def test_user_manual_host_success(hass: HomeAssistant) -> None:
     assert result["data"] == {CONF_HOST: "192.0.2.55"}
 
 
-async def test_user_blank_host_submits_search(hass: HomeAssistant) -> None:
-    """Leaving the host blank triggers broadcast discovery."""
-    controller = create_mock_controller("000000001", "192.0.2.1")
-    with patch_discovered_controllers(controller):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN, context={"source": config_entries.SOURCE_USER}
-        )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            {
-                config_flow.CONF_SETUP_METHOD: config_flow.SETUP_METHOD_SEARCH,
-                CONF_HOST: "",
-            },
-        )
-
-    assert result["step_id"] == "confirm"
-
-
-async def test_user_manual_host_required_when_enter_host_selected(
-    hass: HomeAssistant,
-) -> None:
-    """Enter host without an address shows a field error."""
+async def test_user_manual_host_empty_rejected_by_schema(hass: HomeAssistant) -> None:
+    """Empty host fails schema validation before the step runs."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
     result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], _user_manual_host_input("")
+        result["flow_id"], {"next_step_id": "manual_host"}
     )
+    assert result["step_id"] == "manual_host"
+
+    with pytest.raises(InvalidData):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: ""}
+        )
+
+
+async def test_user_manual_host_whitespace_required(hass: HomeAssistant) -> None:
+    """Whitespace-only host is rejected after strip."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    result = await _configure_manual_host(hass, result["flow_id"], "   ")
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "manual_host"
     assert result["errors"] == {CONF_HOST: "required"}
 
 
 async def test_user_manual_host_unreachable(hass: HomeAssistant) -> None:
-    """Unreachable manual host returns to the user form with an error."""
+    """Unreachable manual host returns to the host form with an error."""
     with patch(
         "homeassistant.components.izone.discovery.async_discover_by_host",
         new=AsyncMock(return_value=None),
@@ -1076,18 +1079,16 @@ async def test_user_manual_host_unreachable(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.99")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.99")
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "manual_host"
     assert result["errors"] == {"base": "cannot_connect"}
-    defaults = _schema_defaults(result["data_schema"])
     assert (
-        defaults[config_flow.CONF_SETUP_METHOD] == config_flow.SETUP_METHOD_MANUAL_HOST
+        get_schema_suggested_value(result["data_schema"].schema, CONF_HOST)
+        == "192.0.2.99"
     )
-    assert defaults[CONF_HOST] == "192.0.2.99"
 
 
 async def test_user_manual_host_probe_content_error_cannot_connect(
@@ -1103,12 +1104,11 @@ async def test_user_manual_host_probe_content_error_cannot_connect(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.50")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.50")
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "manual_host"
     assert result["errors"] == {"base": "cannot_connect"}
 
 
@@ -1127,9 +1127,8 @@ async def test_user_manual_host_already_configured_aborts(hass: HomeAssistant) -
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("10.0.0.90")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "10.0.0.90")
 
     mock_discover_by_host.assert_not_called()
     assert result["type"] is FlowResultType.ABORT
@@ -1156,9 +1155,8 @@ async def test_user_manual_host_updates_address_when_uid_configured(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.77")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.77")
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured_host_updated"
@@ -1179,9 +1177,8 @@ async def test_user_manual_host_claimed_controller_aborts(hass: HomeAssistant) -
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("10.0.0.90")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "10.0.0.90")
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
@@ -1189,7 +1186,7 @@ async def test_user_manual_host_claimed_controller_aborts(hass: HomeAssistant) -
 
 @pytest.mark.usefixtures("mock_entry_setup")
 async def test_user_flow_host_only_when_entry_loaded(hass: HomeAssistant) -> None:
-    """When an iZone entry is already loaded, the user step asks for a host only."""
+    """When an iZone entry is already loaded, Add integration skips the menu."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="000000001",
@@ -1203,14 +1200,14 @@ async def test_user_flow_host_only_when_entry_loaded(hass: HomeAssistant) -> Non
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
-    assert result["step_id"] == "user"
-    assert config_flow.CONF_SETUP_METHOD not in result["data_schema"].schema
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manual_host_additional"
     assert CONF_HOST in result["data_schema"].schema
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
 async def test_user_host_only_empty_host_required(hass: HomeAssistant) -> None:
-    """Host-only form requires a non-empty host."""
+    """Host-only form rejects an empty host via schema validation."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="000000001",
@@ -1223,13 +1220,12 @@ async def test_user_host_only_empty_host_required(hass: HomeAssistant) -> None:
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], {CONF_HOST: ""}
-    )
+    assert result["step_id"] == "manual_host_additional"
 
-    assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
-    assert result["errors"] == {CONF_HOST: "required"}
+    with pytest.raises(InvalidData):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_HOST: ""}
+        )
 
 
 @pytest.mark.usefixtures("mock_entry_setup")
@@ -1285,11 +1281,12 @@ async def test_user_host_only_unreachable_keeps_host_defaults(
         )
 
     assert result["type"] is FlowResultType.FORM
-    assert result["step_id"] == "user"
+    assert result["step_id"] == "manual_host_additional"
     assert result["errors"] == {"base": "cannot_connect"}
-    assert config_flow.CONF_SETUP_METHOD not in result["data_schema"].schema
-    defaults = _schema_defaults(result["data_schema"])
-    assert defaults[CONF_HOST] == "192.0.2.99"
+    assert (
+        get_schema_suggested_value(result["data_schema"].schema, CONF_HOST)
+        == "192.0.2.99"
+    )
 
 
 async def test_user_manual_host_aborts_when_discovery_bind_fails(
@@ -1303,9 +1300,8 @@ async def test_user_manual_host_aborts_when_discovery_bind_fails(
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.55")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.55")
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "discovery_failed"
@@ -1320,9 +1316,8 @@ async def test_user_manual_host_unpaired_aborts(hass: HomeAssistant) -> None:
         result = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"], _user_manual_host_input("192.0.2.111")
-        )
+        assert result["type"] is FlowResultType.MENU
+        result = await _configure_manual_host(hass, result["flow_id"], "192.0.2.111")
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unpaired_bridge"
@@ -1518,7 +1513,7 @@ async def test_runtime_integration_discovery_skips_during_user_select_controller
         user_flow = await hass.config_entries.flow.async_init(
             DOMAIN, context={"source": config_entries.SOURCE_USER}
         )
-        assert user_flow["type"] is FlowResultType.FORM
+        assert user_flow["type"] is FlowResultType.MENU
         assert user_flow["step_id"] == "user"
         user_flow = await _configure_user_search(hass, user_flow["flow_id"])
         assert user_flow["step_id"] == "select_controller"

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -75,6 +75,20 @@ async def test_ensure_discovery_starts_and_stops_on_homeassistant_stop(
     assert not izone_discovery.discovery_service_active(hass)
 
 
+async def test_discovery_service_active_while_starting(hass: HomeAssistant) -> None:
+    """discovery_service_active is true while create_discovery is in flight."""
+    starting: asyncio.Future[DiscoveryService] = hass.loop.create_future()
+    hass.data[DATA_DISCOVERY_SERVICE] = izone_discovery.DiscoveryServiceState(
+        starting=starting
+    )
+
+    assert izone_discovery.discovery_service_active(hass)
+
+    starting.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await starting
+
+
 async def test_ensure_discovery_recreates_after_stop(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -55,9 +55,12 @@ async def test_ensure_discovery_starts_and_stops_on_homeassistant_stop(
     """Ensure starts discovery with an initial scan and closes on HA stop."""
     mock_create, mock_service = mock_pizone_create_discovery
 
+    assert not izone_discovery.discovery_service_active(hass)
+
     service = await izone_discovery.async_ensure_discovery(hass)
 
     assert service is mock_service
+    assert izone_discovery.discovery_service_active(hass)
     mock_create.assert_awaited_once()
     mock_service.scan.assert_awaited_once()
 
@@ -69,6 +72,7 @@ async def test_ensure_discovery_starts_and_stops_on_homeassistant_stop(
     await hass.async_block_till_done()
 
     mock_service.close.assert_awaited_once()
+    assert not izone_discovery.discovery_service_active(hass)
 
 
 async def test_ensure_discovery_recreates_after_stop(

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -55,12 +55,9 @@ async def test_ensure_discovery_starts_and_stops_on_homeassistant_stop(
     """Ensure starts discovery with an initial scan and closes on HA stop."""
     mock_create, mock_service = mock_pizone_create_discovery
 
-    assert not izone_discovery.discovery_service_active(hass)
-
     service = await izone_discovery.async_ensure_discovery(hass)
 
     assert service is mock_service
-    assert izone_discovery.discovery_service_active(hass)
     mock_create.assert_awaited_once()
     mock_service.scan.assert_awaited_once()
 
@@ -72,21 +69,6 @@ async def test_ensure_discovery_starts_and_stops_on_homeassistant_stop(
     await hass.async_block_till_done()
 
     mock_service.close.assert_awaited_once()
-    assert not izone_discovery.discovery_service_active(hass)
-
-
-async def test_discovery_service_active_while_starting(hass: HomeAssistant) -> None:
-    """discovery_service_active is true while create_discovery is in flight."""
-    starting: asyncio.Future[DiscoveryService] = hass.loop.create_future()
-    hass.data[DATA_DISCOVERY_SERVICE] = izone_discovery.DiscoveryServiceState(
-        starting=starting
-    )
-
-    assert izone_discovery.discovery_service_active(hass)
-
-    starting.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await starting
 
 
 async def test_ensure_discovery_recreates_after_stop(

--- a/tests/components/izone/test_discovery.py
+++ b/tests/components/izone/test_discovery.py
@@ -532,3 +532,18 @@ async def test_discover_endpoint_by_uid(
 
     assert result == endpoint
     mock_service.discover_by_uid.assert_awaited_once_with("000000001")
+
+
+async def test_discover_by_host(
+    hass: HomeAssistant,
+    mock_pizone_create_discovery: tuple[AsyncMock, Mock],
+) -> None:
+    """Manual-host probe returns a single endpoint from discover_by_host."""
+    _, mock_service = mock_pizone_create_discovery
+    endpoint = create_mock_endpoint("000000001", "192.0.2.55")
+    mock_service.discover_by_host = AsyncMock(return_value=endpoint)
+
+    result = await izone_discovery.async_discover_by_host(hass, "192.0.2.55")
+
+    assert result == endpoint
+    mock_service.discover_by_host.assert_awaited_once_with("192.0.2.55")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to the iZone runtime rewrite (#176751). Adds **manual host entry** to the iZone user config flow so you can set up a controller by IP/hostname when broadcast discovery is unavailable or fails. This is essential when the UDP discovery messages are blocked, and there's no other way of reaching the bridge.

The Add integration flow now lets you enter a controller address; Home Assistant HTTP-probes that host and continues to confirm when a controller is found. Related UX for that path:

- Setup method selector (**Search for devices** / **Enter host**) with optional host field when no iZone entry is loaded yet
- Empty LAN search returns to the same form with a nudge to enter a host (no abort)
- Host-only form when an iZone entry is already loaded as the discovery service is already running and has found any valid bridges already (probe → confirm)
- Ignored controllers can be offered again from user search so they can be re-added

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176751
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47026
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Manual smoke testing

Devenv: one iZone bridge zeroconf off (user **Search** still works).

### User-flow cases

- [x] No loaded entry · radio **Search** → devices found → picker or confirm → CREATE_ENTRY
- [x] No loaded entry · radio **Search** → none found (UDP blocked by FW) → back to form, default **Enter host**, error nudge, no abort
- [x] No loaded entry · radio **Search** + blank host → treated as search
- [x] No loaded entry · **Enter host** + IP → probe → confirm
- [x] No loaded entry · **Enter host**, empty host → form error on host
- [x] **Loaded** iZone entry · **Add integration** → host-only form (no Search radio)
- [x] Re-enter host / IP of configured controller → `already_configured`
- [x] **Enter host** + IP of unpaired bridge → abort / unpaired bridge message
- [x] **Enter host** + incorrect IP → unable to contact controller at this address

### Two-bridge hardware

Not exercised on this devenv — only one unit in the house (although I do have a spare bridge). Covered by unit tests where applicable; will rely on user reports to field validate.

- [ ] Ignore second UID → **Search** again → ignored UID offered; confirm replaces `SOURCE_IGNORE`
- [ ] Two unconfigured UIDs → `select_controller` picker
- [ ] One configured + one new → straight to **confirm** (not picker)

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


