### PR TITLE
Add operation-mode select for MELCloud ATW zones

### DIFF
--- a/homeassistant/components/melcloud/__init__.py
+++ b/homeassistant/components/melcloud/__init__.py
@@ -20,6 +20,7 @@ from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.CLIMATE,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.WATER_HEATER,
 ]

--- a/homeassistant/components/melcloud/icons.json
+++ b/homeassistant/components/melcloud/icons.json
@@ -20,6 +20,11 @@
         }
       }
     },
+    "select": {
+      "operation_mode": {
+        "default": "mdi:sun-thermometer"
+      }
+    },
     "sensor": {
       "daily_cooling_energy_consumed": {
         "default": "mdi:snowflake"

--- a/homeassistant/components/melcloud/select.py
+++ b/homeassistant/components/melcloud/select.py
@@ -1,0 +1,60 @@
+"""Support for MELCloud device selects."""
+
+from typing import override
+
+from pymelcloud import DEVICE_TYPE_ATW
+from pymelcloud.atw_device import Zone
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
+from .entity import MelCloudEntity
+
+
+async def async_setup_entry(
+    _hass: HomeAssistant,
+    entry: MelCloudConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up MELCloud selects based on config_entry."""
+    coordinators = entry.runtime_data
+    async_add_entities(
+        AtwZoneOperationModeSelect(coordinator, zone)
+        for coordinator in coordinators.get(DEVICE_TYPE_ATW, [])
+        for zone in coordinator.device.zones
+    )
+
+
+class AtwZoneOperationModeSelect(MelCloudEntity, SelectEntity):
+    """Select for the operation mode of an Air-to-Water zone."""
+
+    _attr_translation_key = "operation_mode"
+
+    def __init__(
+        self,
+        coordinator: MelCloudDeviceUpdateCoordinator,
+        zone: Zone,
+    ) -> None:
+        """Initialize the operation mode select."""
+        super().__init__(coordinator)
+        self._zone = zone
+        self._attr_unique_id = (
+            f"{coordinator.device.serial}-{zone.zone_index}-operation_mode"
+        )
+        self._attr_device_info = coordinator.zone_device_info(zone)
+        self._attr_options = zone.operation_modes
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the current operation mode."""
+        option = self._zone.operation_mode
+        return option if option in self._attr_options else None
+
+    @override
+    async def async_select_option(self, option: str) -> None:
+        """Change the operation mode."""
+        await self._zone.set_operation_mode(option)
+        await self.coordinator.async_request_refresh()

--- a/homeassistant/components/melcloud/select.py
+++ b/homeassistant/components/melcloud/select.py
@@ -3,7 +3,14 @@
 from typing import override
 
 from pymelcloud import DEVICE_TYPE_ATW
-from pymelcloud.atw_device import Zone
+from pymelcloud.atw_device import (
+    ZONE_OPERATION_MODE_COOL_FLOW,
+    ZONE_OPERATION_MODE_COOL_THERMOSTAT,
+    ZONE_OPERATION_MODE_CURVE,
+    ZONE_OPERATION_MODE_HEAT_FLOW,
+    ZONE_OPERATION_MODE_HEAT_THERMOSTAT,
+    Zone,
+)
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant
@@ -11,6 +18,31 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
 from .entity import MelCloudEntity
+
+OPTION_ROOM = "room"
+OPTION_FLOW = "flow"
+OPTION_CURVE = "curve"
+
+# The device bundles the heating/cooling direction and the control method into a
+# single operation mode. The heat/cool direction is handled by the climate
+# entity, so this select only exposes the method and keeps the current direction.
+MODE_TO_OPTION = {
+    ZONE_OPERATION_MODE_HEAT_THERMOSTAT: OPTION_ROOM,
+    ZONE_OPERATION_MODE_COOL_THERMOSTAT: OPTION_ROOM,
+    ZONE_OPERATION_MODE_HEAT_FLOW: OPTION_FLOW,
+    ZONE_OPERATION_MODE_COOL_FLOW: OPTION_FLOW,
+    ZONE_OPERATION_MODE_CURVE: OPTION_CURVE,
+}
+HEATING_OPTION_TO_MODE = {
+    OPTION_ROOM: ZONE_OPERATION_MODE_HEAT_THERMOSTAT,
+    OPTION_FLOW: ZONE_OPERATION_MODE_HEAT_FLOW,
+    OPTION_CURVE: ZONE_OPERATION_MODE_CURVE,
+}
+COOLING_OPTION_TO_MODE = {
+    OPTION_ROOM: ZONE_OPERATION_MODE_COOL_THERMOSTAT,
+    OPTION_FLOW: ZONE_OPERATION_MODE_COOL_FLOW,
+}
+COOLING_MODES = {ZONE_OPERATION_MODE_COOL_THERMOSTAT, ZONE_OPERATION_MODE_COOL_FLOW}
 
 
 async def async_setup_entry(
@@ -28,7 +60,7 @@ async def async_setup_entry(
 
 
 class AtwZoneOperationModeSelect(MelCloudEntity, SelectEntity):
-    """Select for the operation mode of an Air-to-Water zone."""
+    """Select for the temperature control method of an Air-to-Water zone."""
 
     _attr_translation_key = "operation_mode"
 
@@ -44,17 +76,29 @@ class AtwZoneOperationModeSelect(MelCloudEntity, SelectEntity):
             f"{coordinator.device.serial}-{zone.zone_index}-operation_mode"
         )
         self._attr_device_info = coordinator.zone_device_info(zone)
-        self._attr_options = zone.operation_modes
+        available = {
+            MODE_TO_OPTION[mode]
+            for mode in zone.operation_modes
+            if mode in MODE_TO_OPTION
+        }
+        self._attr_options = [
+            option
+            for option in (OPTION_ROOM, OPTION_FLOW, OPTION_CURVE)
+            if option in available
+        ]
 
     @property
     @override
     def current_option(self) -> str | None:
-        """Return the current operation mode."""
-        option = self._zone.operation_mode
-        return option if option in self._attr_options else None
+        """Return the current control method."""
+        return MODE_TO_OPTION.get(self._zone.operation_mode)
 
     @override
     async def async_select_option(self, option: str) -> None:
-        """Change the operation mode."""
-        await self._zone.set_operation_mode(option)
+        """Change the control method, keeping the current heating/cooling direction."""
+        if option != OPTION_CURVE and self._zone.operation_mode in COOLING_MODES:
+            mode = COOLING_OPTION_TO_MODE[option]
+        else:
+            mode = HEATING_OPTION_TO_MODE[option]
+        await self._zone.set_operation_mode(mode)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -62,6 +62,18 @@
         "name": "Water pump {number}"
       }
     },
+    "select": {
+      "operation_mode": {
+        "name": "Operation mode",
+        "state": {
+          "cool-flow": "Flow temperature (cooling)",
+          "cool-thermostat": "Room thermostat (cooling)",
+          "curve": "Weather compensation curve",
+          "heat-flow": "Flow temperature",
+          "heat-thermostat": "Room thermostat"
+        }
+      }
+    },
     "sensor": {
       "condensing_temperature": {
         "name": "Condensing temperature"

--- a/homeassistant/components/melcloud/strings.json
+++ b/homeassistant/components/melcloud/strings.json
@@ -66,11 +66,9 @@
       "operation_mode": {
         "name": "Operation mode",
         "state": {
-          "cool-flow": "Flow temperature (cooling)",
-          "cool-thermostat": "Room thermostat (cooling)",
-          "curve": "Weather compensation curve",
-          "heat-flow": "Flow temperature",
-          "heat-thermostat": "Room thermostat"
+          "curve": "Curve",
+          "flow": "Flow",
+          "room": "Room"
         }
       }
     },

--- a/tests/components/melcloud/snapshots/test_select.ambr
+++ b/tests/components/melcloud/snapshots/test_select.ambr
@@ -1,0 +1,62 @@
+# serializer version: 1
+# name: test_all_entities[select.ecodan_zone_1_operation_mode-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'heat-thermostat',
+        'heat-flow',
+        'curve',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.ecodan_zone_1_operation_mode',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Operation mode',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Operation mode',
+    'platform': 'melcloud',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'operation_mode',
+    'unique_id': 'ABC123456-1-operation_mode',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[select.ecodan_zone_1_operation_mode-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ecodan Zone 1 Operation mode',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'heat-thermostat',
+        'heat-flow',
+        'curve',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.ecodan_zone_1_operation_mode',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'heat-flow',
+  })
+# ---

--- a/tests/components/melcloud/snapshots/test_select.ambr
+++ b/tests/components/melcloud/snapshots/test_select.ambr
@@ -7,8 +7,8 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
-        'heat-thermostat',
-        'heat-flow',
+        'room',
+        'flow',
         'curve',
       ]),
     }),
@@ -47,8 +47,8 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ecodan Zone 1 Operation mode',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
-        'heat-thermostat',
-        'heat-flow',
+        'room',
+        'flow',
         'curve',
       ]),
     }),
@@ -57,6 +57,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'heat-flow',
+    'state': 'flow',
   })
 # ---

--- a/tests/components/melcloud/test_select.py
+++ b/tests/components/melcloud/test_select.py
@@ -1,0 +1,64 @@
+"""Test the MELCloud select platform."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_platform
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+OPERATION_MODE_ENTITY = "select.ecodan_zone_1_operation_mode"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "mock_get_devices")
+async def test_all_entities(
+    hass: HomeAssistant,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test all select entities with snapshot."""
+    await setup_platform(hass, mock_config_entry, [Platform.SELECT])
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_select_option(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """Selecting an option calls the library setter."""
+    await setup_platform(hass, mock_config_entry, [Platform.SELECT])
+    await hass.services.async_call(
+        SELECT_DOMAIN,
+        SERVICE_SELECT_OPTION,
+        {ATTR_ENTITY_ID: OPERATION_MODE_ENTITY, ATTR_OPTION: "curve"},
+        blocking=True,
+    )
+    mock_atw_device.zones[0].set_operation_mode.assert_awaited_once_with("curve")
+
+
+@pytest.mark.usefixtures("mock_get_devices")
+async def test_current_option_unknown(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_atw_device: MagicMock,
+) -> None:
+    """An operation mode outside the available options reports unknown."""
+    mock_atw_device.zones[0].operation_mode = "unknown"
+    await setup_platform(hass, mock_config_entry, [Platform.SELECT])
+    state = hass.states.get(OPERATION_MODE_ENTITY)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/melcloud/test_select.py
+++ b/tests/components/melcloud/test_select.py
@@ -33,32 +33,58 @@ async def test_all_entities(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.parametrize(
+    ("current_mode", "option", "expected_mode"),
+    [
+        ("heat-flow", "room", "heat-thermostat"),
+        ("heat-flow", "flow", "heat-flow"),
+        ("heat-flow", "curve", "curve"),
+        ("cool-flow", "room", "cool-thermostat"),
+        ("cool-flow", "flow", "cool-flow"),
+        ("cool-flow", "curve", "curve"),
+    ],
+)
 @pytest.mark.usefixtures("mock_get_devices")
 async def test_select_option(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_atw_device: MagicMock,
+    current_mode: str,
+    option: str,
+    expected_mode: str,
 ) -> None:
-    """Selecting an option calls the library setter."""
+    """Selecting a method keeps the current heating/cooling direction."""
+    mock_atw_device.zones[0].operation_mode = current_mode
     await setup_platform(hass, mock_config_entry, [Platform.SELECT])
     await hass.services.async_call(
         SELECT_DOMAIN,
         SERVICE_SELECT_OPTION,
-        {ATTR_ENTITY_ID: OPERATION_MODE_ENTITY, ATTR_OPTION: "curve"},
+        {ATTR_ENTITY_ID: OPERATION_MODE_ENTITY, ATTR_OPTION: option},
         blocking=True,
     )
-    mock_atw_device.zones[0].set_operation_mode.assert_awaited_once_with("curve")
+    mock_atw_device.zones[0].set_operation_mode.assert_awaited_once_with(expected_mode)
 
 
+@pytest.mark.parametrize(
+    ("operation_mode", "expected_state"),
+    [
+        ("heat-thermostat", "room"),
+        ("cool-flow", "flow"),
+        ("curve", "curve"),
+        ("unknown", STATE_UNKNOWN),
+    ],
+)
 @pytest.mark.usefixtures("mock_get_devices")
-async def test_current_option_unknown(
+async def test_current_option(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mock_atw_device: MagicMock,
+    operation_mode: str,
+    expected_state: str,
 ) -> None:
-    """An operation mode outside the available options reports unknown."""
-    mock_atw_device.zones[0].operation_mode = "unknown"
+    """The state reflects the current control method."""
+    mock_atw_device.zones[0].operation_mode = operation_mode
     await setup_platform(hass, mock_config_entry, [Platform.SELECT])
     state = hass.states.get(OPERATION_MODE_ENTITY)
     assert state is not None
-    assert state.state == STATE_UNKNOWN
+    assert state.state == expected_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Adds a per-zone operation-mode `select` entity for MELCloud Air-to-Water (ATW / Ecodan) devices.

Each radiator zone can regulate its temperature in one of several ways, and this `select` lets the user choose it from Home Assistant:

- **Room thermostat** — the zone heats to the target room temperature on the `climate` entity.
- **Flow temperature** — the zone heats to a target flow temperature.
- **Weather compensation curve** — the zone follows the unit's weather compensation curve.

Cooling-capable zones additionally expose the room-thermostat and flow options for cooling. The available options come from `zone.operation_modes` (backed by the device's `CanHeat`/`CanCool` flags), and selecting one calls `zone.set_operation_mode()`.

This uses the existing `python-melcloud` API, so there is no dependency or manifest change, and ATA (air-to-air) devices are unaffected.

Second of the platforms split out of #177119 (one platform per PR). The on/off climate change was #177119 (merged); the flow-temperature `number` platform will follow in a separate PR, and pairs with this select (setting a zone to a flow mode is what makes the flow-temperature target take effect).


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: There has been a discussion around the lack of this feature [here](https://community.home-assistant.io/t/set-target-temperature-mode-flow-on-melcloud/239052/39)
- Link to documentation pull request:  https://github.com/home-assistant/home-assistant.io/pull/47014
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
