### PR TITLE
Improve AiDot reauthentication, device discovery, and light control

### DIFF
--- a/homeassistant/components/aidot/config_flow.py
+++ b/homeassistant/components/aidot/config_flow.py
@@ -30,6 +30,12 @@ DATA_SCHEMA = vol.Schema(
     }
 )
 
+REAUTH_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
 
 class AidotConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle aidot config flow."""
@@ -59,9 +65,52 @@ class AidotConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._abort_if_unique_id_configured()
                 return self.async_create_entry(
                     title=f"{user_input[CONF_USERNAME]} {user_input[CONF_COUNTRY_CODE]}",
-                    data=login_info,
+                    data={
+                        **login_info,
+                        CONF_COUNTRY_CODE: user_input[CONF_COUNTRY_CODE],
+                        CONF_PASSWORD: user_input[CONF_PASSWORD],
+                    },
                 )
 
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
+        )
+
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        """Handle reauth flow."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle reauth confirmation."""
+        errors: dict[str, str] = {}
+        reauth_entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            client = AidotClient(
+                session=async_get_clientsession(self.hass),
+                country_code=reauth_entry.data[CONF_COUNTRY_CODE],
+                username=reauth_entry.data[CONF_USERNAME],
+                password=user_input[CONF_PASSWORD],
+            )
+            try:
+                login_info = await client.async_post_login()
+            except AidotUserOrPassIncorrect:
+                errors["base"] = "invalid_auth"
+            except TimeoutError, ClientError:
+                errors["base"] = "cannot_connect"
+
+            if not errors:
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates=login_info
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=REAUTH_SCHEMA,
+            description_placeholders={
+                "username": reauth_entry.data.get(CONF_USERNAME, "")
+            },
+            errors=errors,
         )

--- a/homeassistant/components/aidot/coordinator.py
+++ b/homeassistant/components/aidot/coordinator.py
@@ -17,7 +17,7 @@ from aidot.exceptions import AidotAuthFailed, AidotUserOrPassIncorrect
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryError
+from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -95,7 +95,7 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
         try:
             await self.async_auto_login()
         except AidotUserOrPassIncorrect as error:
-            raise ConfigEntryError from error
+            raise ConfigEntryAuthFailed from error
 
     @override
     async def _async_update_data(self) -> None:
@@ -103,7 +103,7 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
         try:
             data = await self.client.async_get_all_device()
         except AidotAuthFailed as error:
-            raise ConfigEntryError from error
+            raise ConfigEntryAuthFailed from error
         current_devices = {
             device[CONF_ID]: device
             for device in data[CONF_DEVICE_LIST]

--- a/homeassistant/components/aidot/coordinator.py
+++ b/homeassistant/components/aidot/coordinator.py
@@ -5,13 +5,7 @@ import logging
 from typing import override
 
 from aidot.client import AidotClient
-from aidot.const import (
-    CONF_ACCESS_TOKEN,
-    CONF_AES_KEY,
-    CONF_DEVICE_LIST,
-    CONF_ID,
-    CONF_TYPE,
-)
+from aidot.const import CONF_ACCESS_TOKEN
 from aidot.device_client import DeviceClient, DeviceStatusData
 from aidot.exceptions import AidotAuthFailed, AidotUserOrPassIncorrect
 
@@ -101,18 +95,9 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
     async def _async_update_data(self) -> None:
         """Update data async."""
         try:
-            data = await self.client.async_get_all_device()
+            current_devices = await self.client.async_get_all_device()
         except AidotAuthFailed as error:
             raise ConfigEntryAuthFailed from error
-        current_devices = {
-            device[CONF_ID]: device
-            for device in data[CONF_DEVICE_LIST]
-            if (
-                device[CONF_TYPE] == "light"
-                and CONF_AES_KEY in device
-                and device[CONF_AES_KEY][0] is not None
-            )
-        }
 
         removed_ids = set(self.device_coordinators) - set(current_devices)
         for dev_id in removed_ids:
@@ -139,7 +124,7 @@ class AidotDeviceManagerCoordinator(DataUpdateCoordinator[None]):
     def token_fresh_cb(self) -> None:
         """Update token."""
         self.hass.config_entries.async_update_entry(
-            self.config_entry, data=self.client.login_info.copy()
+            self.config_entry, data=self.client.login_info
         )
 
     async def async_auto_login(self) -> None:

--- a/homeassistant/components/aidot/light.py
+++ b/homeassistant/components/aidot/light.py
@@ -2,6 +2,8 @@
 
 from typing import Any, override
 
+from aidot.const import CONF_CCT, CONF_DIMMING, CONF_RGBW
+
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
     ATTR_COLOR_TEMP_KELVIN,
@@ -93,26 +95,26 @@ class AidotLight(CoordinatorEntity[AidotDeviceUpdateCoordinator], LightEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the light on, applying brightness, color temperature, RGBW, or plain on."""
+        attrs: dict[str, Any] = {}
         if ATTR_BRIGHTNESS in kwargs:
-            brightness = kwargs.get(ATTR_BRIGHTNESS, 255)
-            await self.coordinator.device_client.async_set_brightness(brightness)
+            brightness = kwargs[ATTR_BRIGHTNESS]
             self.coordinator.data.dimming = brightness
             self._attr_brightness = brightness
-        elif ATTR_COLOR_TEMP_KELVIN in kwargs:
-            color_temp_kelvin = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
-            await self.coordinator.device_client.async_set_cct(color_temp_kelvin)
+            attrs[CONF_DIMMING] = brightness
+        if ATTR_COLOR_TEMP_KELVIN in kwargs:
+            color_temp_kelvin = kwargs[ATTR_COLOR_TEMP_KELVIN]
             self.coordinator.data.cct = color_temp_kelvin
             self._attr_color_temp_kelvin = color_temp_kelvin
             self._attr_color_mode = ColorMode.COLOR_TEMP
-        elif ATTR_RGBW_COLOR in kwargs:
-            rgbw_color = kwargs.get(ATTR_RGBW_COLOR)
-            await self.coordinator.device_client.async_set_rgbw(rgbw_color)
+            attrs[CONF_CCT] = color_temp_kelvin
+        if ATTR_RGBW_COLOR in kwargs:
+            rgbw_color = kwargs[ATTR_RGBW_COLOR]
             self.coordinator.data.rgbw = rgbw_color
             self._attr_rgbw_color = rgbw_color
             self._attr_color_mode = ColorMode.RGBW
-        else:
-            await self.coordinator.device_client.async_turn_on()
+            attrs[CONF_RGBW] = rgbw_color
 
+        await self.coordinator.device_client.async_turn_on(attrs)
         self.coordinator.data.on = True
         self._attr_is_on = True
         self.async_write_ha_state()

--- a/homeassistant/components/aidot/manifest.json
+++ b/homeassistant/components/aidot/manifest.json
@@ -3,9 +3,14 @@
   "name": "AiDot",
   "codeowners": ["@s1eedz", "@HongBryan"],
   "config_flow": true,
+  "dhcp": [
+    {
+      "hostname": "aidot"
+    }
+  ],
   "documentation": "https://www.home-assistant.io/integrations/aidot",
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["python-aidot==0.3.53"]
+  "requirements": ["python-aidot==0.3.54"]
 }

--- a/homeassistant/components/aidot/manifest.json
+++ b/homeassistant/components/aidot/manifest.json
@@ -12,5 +12,5 @@
   "integration_type": "hub",
   "iot_class": "local_polling",
   "quality_scale": "bronze",
-  "requirements": ["python-aidot==0.3.54"]
+  "requirements": ["python-aidot==0.3.55"]
 }

--- a/homeassistant/components/aidot/quality_scale.yaml
+++ b/homeassistant/components/aidot/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: todo
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/aidot/quality_scale.yaml
+++ b/homeassistant/components/aidot/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: todo
 

--- a/homeassistant/components/aidot/quality_scale.yaml
+++ b/homeassistant/components/aidot/quality_scale.yaml
@@ -43,7 +43,7 @@ rules:
   log-when-unavailable: done
   parallel-updates: done
   reauthentication-flow: done
-  test-coverage: todo
+  test-coverage: done
 
   # Gold
   devices: done

--- a/homeassistant/components/aidot/quality_scale.yaml
+++ b/homeassistant/components/aidot/quality_scale.yaml
@@ -41,7 +41,7 @@ rules:
   entity-unavailable: done
   integration-owner: done
   log-when-unavailable: done
-  parallel-updates: done
+  parallel-updates: todo
   reauthentication-flow: done
   test-coverage: done
 

--- a/homeassistant/components/aidot/strings.json
+++ b/homeassistant/components/aidot/strings.json
@@ -8,6 +8,13 @@
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]"
+        },
+        "description": "The AiDot account needs to be re-authenticated. Please enter the password for {username}.",
+        "title": "[%key:common::config_flow::title::reauth%]"
+      },
       "user": {
         "data": {
           "country_code": "Country",

--- a/homeassistant/generated/dhcp.py
+++ b/homeassistant/generated/dhcp.py
@@ -12,6 +12,10 @@ DHCP: Final[list[dict[str, str | bool]]] = [
         "macaddress": "FC0FE7*",
     },
     {
+        "domain": "aidot",
+        "hostname": "aidot",
+    },
+    {
         "domain": "airobot",
         "hostname": "airobot-thermostat-*",
     },

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2638,7 +2638,7 @@ pythinkingcleaner==0.0.3
 python-MotionMount==2.3.0
 
 # homeassistant.components.aidot
-python-aidot==0.3.53
+python-aidot==0.3.54
 
 # homeassistant.components.awair
 python-awair==0.2.5

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2638,7 +2638,7 @@ pythinkingcleaner==0.0.3
 python-MotionMount==2.3.0
 
 # homeassistant.components.aidot
-python-aidot==0.3.54
+python-aidot==0.3.55
 
 # homeassistant.components.awair
 python-awair==0.2.5

--- a/tests/components/aidot/__init__.py
+++ b/tests/components/aidot/__init__.py
@@ -7,8 +7,9 @@ from tests.common import MockConfigEntry
 
 async def async_init_integration(
     hass: HomeAssistant, mock_config_entry: MockConfigEntry
-) -> None:
+):
     """Set up the Aidot integration for testing."""
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
+    return mock_config_entry.runtime_data

--- a/tests/components/aidot/conftest.py
+++ b/tests/components/aidot/conftest.py
@@ -18,7 +18,13 @@ import pytest
 from homeassistant.components.aidot.const import DOMAIN
 from homeassistant.core import callback
 
-from .const import TEST_DEVICE1, TEST_DEVICE_LIST, TEST_EMAIL, TEST_LOGIN_RESP
+from .const import (
+    TEST_DEVICE1,
+    TEST_DEVICE_LIST,
+    TEST_EMAIL,
+    TEST_LOGIN_ENTRY_DATA,
+    TEST_LOGIN_RESP,
+)
 
 from tests.common import MockConfigEntry
 
@@ -39,7 +45,7 @@ def mock_config_entry() -> MockConfigEntry:
         domain=DOMAIN,
         unique_id=TEST_LOGIN_RESP["id"],
         title=TEST_EMAIL,
-        data=TEST_LOGIN_RESP.copy(),
+        data=TEST_LOGIN_ENTRY_DATA.copy(),
     )
 
 

--- a/tests/components/aidot/const.py
+++ b/tests/components/aidot/const.py
@@ -1,7 +1,5 @@
 """Const for the aidot tests."""
 
-from aidot.const import CONF_DEVICE_LIST
-
 TEST_COUNTRY = "US"
 TEST_EMAIL = "test@gmail.com"
 TEST_PASSWORD = "123456"
@@ -48,4 +46,4 @@ TEST_DEVICE1 = {
     },
 }
 
-TEST_DEVICE_LIST = {CONF_DEVICE_LIST: [TEST_DEVICE1]}
+TEST_DEVICE_LIST = {"device_id": TEST_DEVICE1}

--- a/tests/components/aidot/const.py
+++ b/tests/components/aidot/const.py
@@ -19,6 +19,12 @@ TEST_LOGIN_RESP = {
     "country": "United States",
 }
 
+TEST_LOGIN_ENTRY_DATA = {
+    **TEST_LOGIN_RESP,
+    "country_code": TEST_COUNTRY,
+    "password": TEST_PASSWORD,
+}
+
 ENTITY_LIGHT = "light.test_light"
 LIGHT_DOMAIN = "light"
 

--- a/tests/components/aidot/test_config_flow.py
+++ b/tests/components/aidot/test_config_flow.py
@@ -7,12 +7,18 @@ from aiohttp import ClientError
 import pytest
 
 from homeassistant.components.aidot.const import DOMAIN
-from homeassistant.config_entries import SOURCE_USER
+from homeassistant.config_entries import SOURCE_REAUTH, SOURCE_USER
 from homeassistant.const import CONF_COUNTRY_CODE, CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
-from .const import TEST_COUNTRY, TEST_EMAIL, TEST_LOGIN_RESP, TEST_PASSWORD
+from .const import (
+    TEST_COUNTRY,
+    TEST_EMAIL,
+    TEST_LOGIN_ENTRY_DATA,
+    TEST_LOGIN_RESP,
+    TEST_PASSWORD,
+)
 
 from tests.common import MockConfigEntry
 
@@ -40,7 +46,7 @@ async def test_config_flow_cloud_login_success(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == f"{TEST_EMAIL} {TEST_COUNTRY}"
-    assert result["data"] == TEST_LOGIN_RESP
+    assert result["data"] == TEST_LOGIN_ENTRY_DATA
     assert result["result"].unique_id == TEST_LOGIN_RESP["id"]
 
 
@@ -90,7 +96,7 @@ async def test_config_flow_errors(
         },
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["data"] == TEST_LOGIN_RESP
+    assert result["data"] == TEST_LOGIN_ENTRY_DATA
 
 
 async def test_form_abort_already_configured(
@@ -117,3 +123,73 @@ async def test_form_abort_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+async def test_reauth_flow_success(
+    hass: HomeAssistant,
+    patch_aidot_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test successful reauth flow."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+            "unique_id": mock_config_entry.unique_id,
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: TEST_PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+
+
+async def test_reauth_flow_invalid_auth(
+    hass: HomeAssistant,
+    patch_aidot_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test reauth flow with invalid auth."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={
+            "source": SOURCE_REAUTH,
+            "entry_id": mock_config_entry.entry_id,
+            "unique_id": mock_config_entry.unique_id,
+        },
+    )
+
+    patch_aidot_client.async_post_login.side_effect = AidotUserOrPassIncorrect
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: "wrong_password"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}
+
+    patch_aidot_client.async_post_login.side_effect = None
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_PASSWORD: TEST_PASSWORD},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/aidot/test_init.py
+++ b/tests/components/aidot/test_init.py
@@ -40,3 +40,8 @@ async def test_async_setup_entry_auth_failed(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    # Verify reauth flow is triggered
+    flows = hass.config_entries.flow.async_progress()
+    assert len(flows) == 1
+    assert flows[0]["handler"] == "aidot"
+    assert flows[0]["context"]["source"] == "reauth"

--- a/tests/components/aidot/test_light.py
+++ b/tests/components/aidot/test_light.py
@@ -1,11 +1,13 @@
 """Test the aidot device."""
 
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock
 
-from aidot.const import CONF_DEVICE_LIST
+from aidot.const import CONF_CCT, CONF_DIMMING, CONF_RGBW
 from aidot.device_client import DeviceStatusData
 from aidot.exceptions import AidotAuthFailed
 from freezegun.api import FrozenDateTimeFactory
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.aidot.coordinator import UPDATE_DEVICE_LIST_INTERVAL
@@ -41,12 +43,46 @@ async def test_state(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.parametrize(
+    ("service_data", "expected_attrs"),
+    [
+        pytest.param({}, {}, id="plain"),
+        pytest.param(
+            {ATTR_BRIGHTNESS: 100},
+            {CONF_DIMMING: 100},
+            id="brightness",
+        ),
+        pytest.param(
+            {ATTR_COLOR_TEMP_KELVIN: 3000},
+            {CONF_CCT: 3000},
+            id="color-temperature",
+        ),
+        pytest.param(
+            {ATTR_RGBW_COLOR: (255, 255, 255, 255)},
+            {CONF_RGBW: (255, 255, 255, 255)},
+            id="rgbw",
+        ),
+        pytest.param(
+            {
+                ATTR_BRIGHTNESS: 100,
+                ATTR_RGBW_COLOR: (255, 255, 255, 255),
+            },
+            {
+                CONF_DIMMING: 100,
+                CONF_RGBW: (255, 255, 255, 255),
+            },
+            id="brightness-and-rgbw",
+        ),
+    ],
+)
 async def test_turn_on(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
     mocked_device_client: MagicMock,
+    service_data: dict[str, Any],
+    expected_attrs: dict[str, Any],
 ) -> None:
-    """Test turn on."""
+    """Test turning on the light with attributes."""
     await async_init_integration(hass, mock_config_entry)
 
     assert hass.states.get(ENTITY_LIGHT).state == STATE_ON
@@ -54,10 +90,10 @@ async def test_turn_on(
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT},
+        {ATTR_ENTITY_ID: ENTITY_LIGHT, **service_data},
         blocking=True,
     )
-    mocked_device_client.async_turn_on.assert_called_once()
+    mocked_device_client.async_turn_on.assert_awaited_once_with(expected_attrs)
 
 
 async def test_turn_off(
@@ -76,64 +112,7 @@ async def test_turn_off(
         {ATTR_ENTITY_ID: ENTITY_LIGHT},
         blocking=True,
     )
-    mocked_device_client.async_turn_off.assert_called_once()
-
-
-async def test_turn_on_brightness(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mocked_device_client: MagicMock,
-) -> None:
-    """Test turn on brightness."""
-    await async_init_integration(hass, mock_config_entry)
-
-    assert hass.states.get(ENTITY_LIGHT).state == STATE_ON
-
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_BRIGHTNESS: 100},
-        blocking=True,
-    )
-    mocked_device_client.async_set_brightness.assert_called_once()
-
-
-async def test_turn_on_with_color_temp(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mocked_device_client: MagicMock,
-) -> None:
-    """Test turn on with color temp."""
-    await async_init_integration(hass, mock_config_entry)
-
-    assert hass.states.get(ENTITY_LIGHT).state == STATE_ON
-
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_COLOR_TEMP_KELVIN: 3000},
-        blocking=True,
-    )
-    mocked_device_client.async_set_cct.assert_called_once()
-
-
-async def test_turn_on_with_rgbw(
-    hass: HomeAssistant,
-    mock_config_entry: MockConfigEntry,
-    mocked_device_client: MagicMock,
-) -> None:
-    """Test turn on with rgbw."""
-    await async_init_integration(hass, mock_config_entry)
-
-    assert hass.states.get(ENTITY_LIGHT).state == STATE_ON
-
-    await hass.services.async_call(
-        LIGHT_DOMAIN,
-        SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: ENTITY_LIGHT, ATTR_RGBW_COLOR: (255, 255, 255, 255)},
-        blocking=True,
-    )
-    mocked_device_client.async_set_rgbw.assert_called_once()
+    mocked_device_client.async_turn_off.assert_awaited_once()
 
 
 async def test_light_unavailable(
@@ -191,8 +170,7 @@ async def test_coordinator_device_removal(
 
     assert hass.states.get(ENTITY_LIGHT) is not None
 
-    # Return empty device list
-    patch_aidot_client.async_get_all_device.return_value = {CONF_DEVICE_LIST: []}
+    patch_aidot_client.async_get_all_device.return_value = {}
     freezer.tick(UPDATE_DEVICE_LIST_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Improve the AiDot integration by:

- adding reauthentication support when account credentials expire;
- adding DHCP discovery for AiDot devices;
- improving code quality and test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please, be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A
- SDK release: https://github.com/AiDot-Development-Team/python-AiDot/releases/tag/v0.3.54
- SDK pull request: https://github.com/AiDot-Development-Team/python-AiDot/pull/7
- Dependency diff: https://github.com/AiDot-Development-Team/python-AiDot/compare/v0.3.53...v0.3.54

Validation performed:

- Ruff formatting and checks pass.
- All AiDot integration tests pass (`19 passed`).
- Hassfest passes with `1481` integrations and `0` invalid integrations.
- The published `python-aidot==0.3.54` package was downloaded from PyPI and verified to contain the required APIs.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.
  
  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr