### PR TITLE
Add KNX weather entity UI configuration

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -213,6 +213,7 @@ SUPPORTED_PLATFORMS_UI: Final = {
     Platform.SWITCH,
     Platform.TEXT,
     Platform.TIME,
+    Platform.WEATHER,
 }
 
 # Map KNX controller modes to HA modes. This list might not be complete.

--- a/homeassistant/components/knx/storage/const.py
+++ b/homeassistant/components/knx/storage/const.py
@@ -83,3 +83,19 @@ CONF_ALWAYS_CALLBACK: Final = "always_callback"
 
 # Text
 CONF_GA_TEXT: Final = "ga_text"
+
+# Weather
+CONF_GA_TEMPERATURE: Final = "ga_temperature"
+CONF_GA_BRIGHTNESS_SOUTH: Final = "ga_brightness_south"
+CONF_GA_BRIGHTNESS_NORTH: Final = "ga_brightness_north"
+CONF_GA_BRIGHTNESS_WEST: Final = "ga_brightness_west"
+CONF_GA_BRIGHTNESS_EAST: Final = "ga_brightness_east"
+CONF_GA_WIND_SPEED: Final = "ga_wind_speed"
+CONF_GA_WIND_BEARING: Final = "ga_wind_bearing"
+CONF_GA_RAIN_ALARM: Final = "ga_rain_alarm"
+CONF_GA_FROST_ALARM: Final = "ga_frost_alarm"
+CONF_GA_WIND_ALARM: Final = "ga_wind_alarm"
+CONF_GA_DAY_NIGHT: Final = "ga_day_night"
+CONF_INVERT_DAY_NIGHT: Final = "invert_day_night"
+CONF_GA_AIR_PRESSURE: Final = "ga_air_pressure"
+CONF_GA_HUMIDITY: Final = "ga_humidity"

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -64,23 +64,31 @@ from .const import (
     CONF_DPT,
     CONF_ENTITY,
     CONF_GA_ACTIVE,
+    CONF_GA_AIR_PRESSURE,
     CONF_GA_ANGLE,
     CONF_GA_BLUE_BRIGHTNESS,
     CONF_GA_BLUE_SWITCH,
     CONF_GA_BRIGHTNESS,
+    CONF_GA_BRIGHTNESS_EAST,
+    CONF_GA_BRIGHTNESS_NORTH,
+    CONF_GA_BRIGHTNESS_SOUTH,
+    CONF_GA_BRIGHTNESS_WEST,
     CONF_GA_COLOR,
     CONF_GA_COLOR_TEMP,
     CONF_GA_CONTROLLER_MODE,
     CONF_GA_CONTROLLER_STATUS,
     CONF_GA_DATE,
     CONF_GA_DATETIME,
+    CONF_GA_DAY_NIGHT,
     CONF_GA_FAN_SPEED,
     CONF_GA_FAN_SWING,
     CONF_GA_FAN_SWING_HORIZONTAL,
+    CONF_GA_FROST_ALARM,
     CONF_GA_GREEN_BRIGHTNESS,
     CONF_GA_GREEN_SWITCH,
     CONF_GA_HEAT_COOL,
     CONF_GA_HUE,
+    CONF_GA_HUMIDITY,
     CONF_GA_HUMIDITY_CURRENT,
     CONF_GA_ON_OFF,
     CONF_GA_OP_MODE_COMFORT,
@@ -91,6 +99,7 @@ from .const import (
     CONF_GA_OSCILLATION,
     CONF_GA_POSITION_SET,
     CONF_GA_POSITION_STATE,
+    CONF_GA_RAIN_ALARM,
     CONF_GA_RED_BRIGHTNESS,
     CONF_GA_RED_SWITCH,
     CONF_GA_SATURATION,
@@ -102,6 +111,7 @@ from .const import (
     CONF_GA_STEP,
     CONF_GA_STOP,
     CONF_GA_SWITCH,
+    CONF_GA_TEMPERATURE,
     CONF_GA_TEMPERATURE_CURRENT,
     CONF_GA_TEMPERATURE_TARGET,
     CONF_GA_TEXT,
@@ -110,7 +120,11 @@ from .const import (
     CONF_GA_VALVE,
     CONF_GA_WHITE_BRIGHTNESS,
     CONF_GA_WHITE_SWITCH,
+    CONF_GA_WIND_ALARM,
+    CONF_GA_WIND_BEARING,
+    CONF_GA_WIND_SPEED,
     CONF_IGNORE_AUTO_MODE,
+    CONF_INVERT_DAY_NIGHT,
     CONF_SPEED,
     CONF_TARGET_TEMPERATURE,
 )
@@ -802,6 +816,41 @@ SENSOR_KNX_SCHEMA = AllSerializeFirst(
     _sensor_attribute_sub_validator,
 )
 
+WEATHER_KNX_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_GA_TEMPERATURE): GASelector(
+            write=False, state_required=True, valid_dpt="9.001"
+        ),
+        vol.Optional(CONF_GA_HUMIDITY): GASelector(write=False, valid_dpt="9.007"),
+        vol.Optional(CONF_GA_AIR_PRESSURE): GASelector(
+            write=False, valid_dpt=["9.006", "14.058"]
+        ),
+        vol.Optional(CONF_GA_WIND_SPEED): GASelector(write=False, valid_dpt="9.005"),
+        vol.Optional(CONF_GA_WIND_BEARING): GASelector(write=False, valid_dpt="5.003"),
+        "section_brightness": KNXSectionFlat(collapsible=True),
+        vol.Optional(CONF_GA_BRIGHTNESS_EAST): GASelector(
+            write=False, valid_dpt="9.004"
+        ),
+        vol.Optional(CONF_GA_BRIGHTNESS_SOUTH): GASelector(
+            write=False, valid_dpt="9.004"
+        ),
+        vol.Optional(CONF_GA_BRIGHTNESS_WEST): GASelector(
+            write=False, valid_dpt="9.004"
+        ),
+        vol.Optional(CONF_GA_BRIGHTNESS_NORTH): GASelector(
+            write=False, valid_dpt="9.004"
+        ),
+        "section_day_night": KNXSectionFlat(collapsible=True),
+        vol.Optional(CONF_GA_DAY_NIGHT): GASelector(write=False, valid_dpt="1.024"),
+        vol.Optional(CONF_INVERT_DAY_NIGHT, default=False): selector.BooleanSelector(),
+        "section_alarms": KNXSectionFlat(collapsible=True),
+        vol.Optional(CONF_GA_RAIN_ALARM): GASelector(write=False, valid_dpt="1"),
+        vol.Optional(CONF_GA_FROST_ALARM): GASelector(write=False, valid_dpt="1"),
+        vol.Optional(CONF_GA_WIND_ALARM): GASelector(write=False, valid_dpt="1"),
+        vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+    }
+)
+
 KNX_SCHEMA_FOR_PLATFORM = {
     Platform.BINARY_SENSOR: BINARY_SENSOR_KNX_SCHEMA,
     Platform.BUTTON: BUTTON_KNX_SCHEMA,
@@ -818,6 +867,7 @@ KNX_SCHEMA_FOR_PLATFORM = {
     Platform.SWITCH: SWITCH_KNX_SCHEMA,
     Platform.TEXT: TEXT_KNX_SCHEMA,
     Platform.TIME: TIME_KNX_SCHEMA,
+    Platform.WEATHER: WEATHER_KNX_SCHEMA,
 }
 
 ENTITY_STORE_DATA_SCHEMA: VolSchemaType = vol.All(

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -996,6 +996,79 @@
         "type_selection": {
           "header": "Select entity type"
         },
+        "weather": {
+          "description": "The KNX weather platform is used as an interface to KNX weather stations.",
+          "knx": {
+            "ga_air_pressure": {
+              "description": "Group address for reading the current air pressure.",
+              "label": "Air pressure"
+            },
+            "ga_brightness_east": {
+              "description": "Group address for reading the current brightness to the east.",
+              "label": "Brightness east"
+            },
+            "ga_brightness_north": {
+              "description": "Group address for reading the current brightness to the north.",
+              "label": "Brightness north"
+            },
+            "ga_brightness_south": {
+              "description": "Group address for reading the current brightness to the south.",
+              "label": "Brightness south"
+            },
+            "ga_brightness_west": {
+              "description": "Group address for reading the current brightness to the west.",
+              "label": "Brightness west"
+            },
+            "ga_day_night": {
+              "description": "Group address for reading whether it is day or night.",
+              "label": "Day/Night"
+            },
+            "ga_frost_alarm": {
+              "description": "Group address for reading whether the frost alarm is active.",
+              "label": "Frost alarm"
+            },
+            "ga_humidity": {
+              "description": "Group address for reading the current humidity.",
+              "label": "Humidity"
+            },
+            "ga_rain_alarm": {
+              "description": "Group address for reading whether the rain alarm is active.",
+              "label": "Rain alarm"
+            },
+            "ga_temperature": {
+              "description": "Group address for reading the current outside temperature.",
+              "label": "Temperature"
+            },
+            "ga_wind_alarm": {
+              "description": "Group address for reading whether the wind alarm is active.",
+              "label": "Wind alarm"
+            },
+            "ga_wind_bearing": {
+              "description": "Group address for reading the current wind bearing.",
+              "label": "Wind bearing"
+            },
+            "ga_wind_speed": {
+              "description": "Group address for reading the current wind speed.",
+              "label": "Wind speed"
+            },
+            "invert_day_night": {
+              "description": "By default `0` is interpreted as day and `1` as night (DPT 1.024). Enable to invert this.",
+              "label": "Invert day/night"
+            },
+            "section_alarms": {
+              "description": "Binary states used to determine the weather condition.",
+              "title": "Alarms"
+            },
+            "section_brightness": {
+              "description": "Brightness readings used to determine the weather condition.",
+              "title": "Brightness"
+            },
+            "section_day_night": {
+              "description": "Day and night state used to determine the weather condition.",
+              "title": "Day/Night"
+            }
+          }
+        },
         "yaml": {
           "mode_hint": "This is an internal representation of the entity configuration and may change in future Home Assistant versions. YAML mode is intended for debugging, and for sharing or copying configurations — prefer the visual editor for everyday use.",
           "yaml_error": "There are YAML errors and it cannot be parsed. Switching to the visual editor may cause pending changes to be lost."

--- a/homeassistant/components/knx/weather.py
+++ b/homeassistant/components/knx/weather.py
@@ -2,7 +2,6 @@
 
 from typing import override
 
-from xknx import XKNX
 from xknx.devices import Weather as XknxWeather
 
 from homeassistant import config_entries
@@ -15,13 +14,39 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    async_get_current_platform,
+)
 from homeassistant.helpers.typing import ConfigType
 
-from .const import KNX_MODULE_KEY
-from .entity import KnxYamlEntity, build_yaml_unique_id
+from .const import CONF_SYNC_STATE, DOMAIN, KNX_MODULE_KEY
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .schema import WeatherSchema
+from .storage.const import (
+    CONF_ENTITY,
+    CONF_GA_AIR_PRESSURE,
+    CONF_GA_BRIGHTNESS_EAST,
+    CONF_GA_BRIGHTNESS_NORTH,
+    CONF_GA_BRIGHTNESS_SOUTH,
+    CONF_GA_BRIGHTNESS_WEST,
+    CONF_GA_DAY_NIGHT,
+    CONF_GA_FROST_ALARM,
+    CONF_GA_HUMIDITY,
+    CONF_GA_RAIN_ALARM,
+    CONF_GA_TEMPERATURE,
+    CONF_GA_WIND_ALARM,
+    CONF_GA_WIND_BEARING,
+    CONF_GA_WIND_SPEED,
+    CONF_INVERT_DAY_NIGHT,
+)
+from .storage.util import ConfigExtractor
 
 
 async def async_setup_entry(
@@ -29,69 +54,40 @@ async def async_setup_entry(
     config_entry: config_entries.ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up switch(es) for KNX platform."""
+    """Set up weather entities for KNX platform."""
     knx_module = hass.data[KNX_MODULE_KEY]
-    config: list[ConfigType] = knx_module.config_yaml[Platform.WEATHER]
-
-    async_add_entities(
-        KNXWeather(knx_module, entity_config) for entity_config in config
+    platform = async_get_current_platform()
+    knx_module.config_store.add_platform(
+        platform=Platform.WEATHER,
+        controller=KnxUiEntityPlatformController(
+            knx_module=knx_module,
+            entity_platform=platform,
+            entity_class=KnxUiWeather,
+        ),
     )
 
-
-def _create_weather(xknx: XKNX, config: ConfigType) -> XknxWeather:
-    """Return a KNX weather device to be used within XKNX."""
-    return XknxWeather(
-        xknx,
-        name=config[CONF_NAME],
-        sync_state=config[WeatherSchema.CONF_SYNC_STATE],
-        group_address_temperature=config[WeatherSchema.CONF_KNX_TEMPERATURE_ADDRESS],
-        group_address_brightness_south=config.get(
-            WeatherSchema.CONF_KNX_BRIGHTNESS_SOUTH_ADDRESS
-        ),
-        group_address_brightness_east=config.get(
-            WeatherSchema.CONF_KNX_BRIGHTNESS_EAST_ADDRESS
-        ),
-        group_address_brightness_west=config.get(
-            WeatherSchema.CONF_KNX_BRIGHTNESS_WEST_ADDRESS
-        ),
-        group_address_brightness_north=config.get(
-            WeatherSchema.CONF_KNX_BRIGHTNESS_NORTH_ADDRESS
-        ),
-        group_address_wind_speed=config.get(WeatherSchema.CONF_KNX_WIND_SPEED_ADDRESS),
-        group_address_wind_bearing=config.get(
-            WeatherSchema.CONF_KNX_WIND_BEARING_ADDRESS
-        ),
-        group_address_rain_alarm=config.get(WeatherSchema.CONF_KNX_RAIN_ALARM_ADDRESS),
-        group_address_frost_alarm=config.get(
-            WeatherSchema.CONF_KNX_FROST_ALARM_ADDRESS
-        ),
-        group_address_wind_alarm=config.get(WeatherSchema.CONF_KNX_WIND_ALARM_ADDRESS),
-        group_address_day_night=config.get(WeatherSchema.CONF_KNX_DAY_NIGHT_ADDRESS),
-        group_address_air_pressure=config.get(
-            WeatherSchema.CONF_KNX_AIR_PRESSURE_ADDRESS
-        ),
-        group_address_humidity=config.get(WeatherSchema.CONF_KNX_HUMIDITY_ADDRESS),
-    )
+    entities: list[KnxYamlEntity | KnxUiEntity] = []
+    if yaml_platform_config := knx_module.config_yaml.get(Platform.WEATHER):
+        entities.extend(
+            KnxYamlWeather(knx_module, entity_config)
+            for entity_config in yaml_platform_config
+        )
+    if ui_config := knx_module.config_store.data["entities"].get(Platform.WEATHER):
+        entities.extend(
+            KnxUiWeather(knx_module, unique_id, config)
+            for unique_id, config in ui_config.items()
+        )
+    if entities:
+        async_add_entities(entities)
 
 
-class KNXWeather(KnxYamlEntity, WeatherEntity):
+class _KnxWeather(WeatherEntity):
     """Representation of a KNX weather device."""
 
     _device: XknxWeather
     _attr_native_pressure_unit = UnitOfPressure.PA
     _attr_native_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_native_wind_speed_unit = UnitOfSpeed.METERS_PER_SECOND
-
-    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
-        """Initialize of a KNX sensor."""
-        self._device = _create_weather(knx_module.xknx, config)
-        super().__init__(
-            knx_module=knx_module,
-            unique_id=build_yaml_unique_id(
-                self._device._temperature.group_address_state  # noqa: SLF001
-            ),
-            entity_config=config,
-        )
 
     @property
     @override
@@ -128,3 +124,115 @@ class KNXWeather(KnxYamlEntity, WeatherEntity):
     def native_wind_speed(self) -> float | None:
         """Return current wind speed in m/s."""
         return self._device.wind_speed
+
+
+class KnxYamlWeather(_KnxWeather, KnxYamlEntity):
+    """Representation of a KNX weather device configured from YAML."""
+
+    _device: XknxWeather
+
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
+        """Initialize of a KNX weather device."""
+        self._device = XknxWeather(
+            knx_module.xknx,
+            name=config[CONF_NAME],
+            sync_state=config[WeatherSchema.CONF_SYNC_STATE],
+            group_address_temperature=config[
+                WeatherSchema.CONF_KNX_TEMPERATURE_ADDRESS
+            ],
+            group_address_brightness_south=config.get(
+                WeatherSchema.CONF_KNX_BRIGHTNESS_SOUTH_ADDRESS
+            ),
+            group_address_brightness_east=config.get(
+                WeatherSchema.CONF_KNX_BRIGHTNESS_EAST_ADDRESS
+            ),
+            group_address_brightness_west=config.get(
+                WeatherSchema.CONF_KNX_BRIGHTNESS_WEST_ADDRESS
+            ),
+            group_address_brightness_north=config.get(
+                WeatherSchema.CONF_KNX_BRIGHTNESS_NORTH_ADDRESS
+            ),
+            group_address_wind_speed=config.get(
+                WeatherSchema.CONF_KNX_WIND_SPEED_ADDRESS
+            ),
+            group_address_wind_bearing=config.get(
+                WeatherSchema.CONF_KNX_WIND_BEARING_ADDRESS
+            ),
+            group_address_rain_alarm=config.get(
+                WeatherSchema.CONF_KNX_RAIN_ALARM_ADDRESS
+            ),
+            group_address_frost_alarm=config.get(
+                WeatherSchema.CONF_KNX_FROST_ALARM_ADDRESS
+            ),
+            group_address_wind_alarm=config.get(
+                WeatherSchema.CONF_KNX_WIND_ALARM_ADDRESS
+            ),
+            group_address_day_night=config.get(
+                WeatherSchema.CONF_KNX_DAY_NIGHT_ADDRESS
+            ),
+            group_address_air_pressure=config.get(
+                WeatherSchema.CONF_KNX_AIR_PRESSURE_ADDRESS
+            ),
+            group_address_humidity=config.get(WeatherSchema.CONF_KNX_HUMIDITY_ADDRESS),
+        )
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=build_yaml_unique_id(
+                self._device._temperature.group_address_state  # noqa: SLF001
+            ),
+            entity_config=config,
+        )
+
+
+class KnxUiWeather(_KnxWeather, KnxUiEntity):
+    """Representation of a KNX weather device configured from UI."""
+
+    _device: XknxWeather
+
+    def __init__(
+        self, knx_module: KNXModule, unique_id: str, config: ConfigType
+    ) -> None:
+        """Initialize of a KNX weather device."""
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=unique_id,
+            entity_config=config[CONF_ENTITY],
+        )
+        knx_conf = ConfigExtractor(config[DOMAIN])
+        self._device = XknxWeather(
+            knx_module.xknx,
+            name=config[CONF_ENTITY][CONF_NAME],
+            sync_state=knx_conf.get(CONF_SYNC_STATE),
+            group_address_temperature=knx_conf.get_state_and_passive(
+                CONF_GA_TEMPERATURE
+            ),
+            group_address_brightness_south=knx_conf.get_state_and_passive(
+                CONF_GA_BRIGHTNESS_SOUTH
+            ),
+            group_address_brightness_east=knx_conf.get_state_and_passive(
+                CONF_GA_BRIGHTNESS_EAST
+            ),
+            group_address_brightness_west=knx_conf.get_state_and_passive(
+                CONF_GA_BRIGHTNESS_WEST
+            ),
+            group_address_brightness_north=knx_conf.get_state_and_passive(
+                CONF_GA_BRIGHTNESS_NORTH
+            ),
+            group_address_wind_speed=knx_conf.get_state_and_passive(CONF_GA_WIND_SPEED),
+            group_address_wind_bearing=knx_conf.get_state_and_passive(
+                CONF_GA_WIND_BEARING
+            ),
+            group_address_rain_alarm=knx_conf.get_state_and_passive(CONF_GA_RAIN_ALARM),
+            group_address_frost_alarm=knx_conf.get_state_and_passive(
+                CONF_GA_FROST_ALARM
+            ),
+            group_address_wind_alarm=knx_conf.get_state_and_passive(CONF_GA_WIND_ALARM),
+            group_address_day_night=knx_conf.get_state_and_passive(CONF_GA_DAY_NIGHT),
+            group_address_air_pressure=knx_conf.get_state_and_passive(
+                CONF_GA_AIR_PRESSURE
+            ),
+            group_address_humidity=knx_conf.get_state_and_passive(CONF_GA_HUMIDITY),
+            # xknx treats a raw `1` as day, so its default is inverted compared to
+            # DPT 1.024 (0 = day, 1 = night) which the UI flag represents.
+            invert_day_night=not knx_conf.get(CONF_INVERT_DAY_NIGHT),
+        )

--- a/tests/components/knx/fixtures/config_store_weather.json
+++ b/tests/components/knx/fixtures/config_store_weather.json
@@ -1,0 +1,89 @@
+{
+  "version": 2,
+  "minor_version": 4,
+  "key": "knx/config_store.json",
+  "data": {
+    "entities": {
+      "weather": {
+        "knx_es_01KCXYT0WEJEQQ13SGCY1NHCYW": {
+          "entity": {
+            "name": "test",
+            "device_info": null,
+            "entity_category": null
+          },
+          "knx": {
+            "ga_temperature": {
+              "write": null,
+              "state": "1/1/11",
+              "passive": []
+            },
+            "ga_humidity": {
+              "write": null,
+              "state": "1/1/4",
+              "passive": []
+            },
+            "ga_air_pressure": {
+              "write": null,
+              "state": "1/1/13",
+              "passive": []
+            },
+            "ga_wind_speed": {
+              "write": null,
+              "state": "1/1/9",
+              "passive": []
+            },
+            "ga_wind_bearing": {
+              "write": null,
+              "state": "1/1/10",
+              "passive": []
+            },
+            "ga_brightness_east": {
+              "write": null,
+              "state": "1/1/5",
+              "passive": []
+            },
+            "ga_brightness_south": {
+              "write": null,
+              "state": "1/1/6",
+              "passive": []
+            },
+            "ga_brightness_west": {
+              "write": null,
+              "state": "1/1/7",
+              "passive": []
+            },
+            "ga_brightness_north": {
+              "write": null,
+              "state": "1/1/8",
+              "passive": []
+            },
+            "ga_rain_alarm": {
+              "write": null,
+              "state": "1/1/2",
+              "passive": []
+            },
+            "ga_frost_alarm": {
+              "write": null,
+              "state": "1/1/3",
+              "passive": []
+            },
+            "ga_wind_alarm": {
+              "write": null,
+              "state": "1/1/1",
+              "passive": []
+            },
+            "ga_day_night": {
+              "write": null,
+              "state": "1/1/12",
+              "passive": []
+            },
+            "invert_day_night": false,
+            "sync_state": true
+          }
+        }
+      }
+    },
+    "expose": {},
+    "time_server": {}
+  }
+}

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -2608,3 +2608,299 @@
     'type': 'result',
   })
 # ---
+# name: test_knx_get_schema[weather]
+  dict({
+    'id': 1,
+    'result': list([
+      dict({
+        'name': 'ga_temperature',
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': True,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 1,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': True,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_humidity',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 7,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_air_pressure',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 6,
+            }),
+            dict({
+              'main': 14,
+              'sub': 58,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_wind_speed',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 5,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_wind_bearing',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 5,
+              'sub': 3,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'collapsible': True,
+        'name': 'section_brightness',
+        'required': False,
+        'type': 'knx_section_flat',
+      }),
+      dict({
+        'name': 'ga_brightness_east',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 4,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_brightness_south',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 4,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_brightness_west',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 4,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_brightness_north',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 9,
+              'sub': 4,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'collapsible': True,
+        'name': 'section_day_night',
+        'required': False,
+        'type': 'knx_section_flat',
+      }),
+      dict({
+        'name': 'ga_day_night',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': 24,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'default': False,
+        'name': 'invert_day_night',
+        'optional': True,
+        'required': False,
+        'selector': dict({
+          'boolean': dict({
+          }),
+        }),
+        'type': 'ha_selector',
+      }),
+      dict({
+        'collapsible': True,
+        'name': 'section_alarms',
+        'required': False,
+        'type': 'knx_section_flat',
+      }),
+      dict({
+        'name': 'ga_rain_alarm',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_frost_alarm',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'name': 'ga_wind_alarm',
+        'optional': True,
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'validDPTs': list([
+            dict({
+              'main': 1,
+              'sub': None,
+            }),
+          ]),
+          'write': False,
+        }),
+        'required': False,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'allow_false': False,
+        'default': True,
+        'name': 'sync_state',
+        'optional': True,
+        'required': False,
+        'type': 'knx_sync_state',
+      }),
+    ]),
+    'success': True,
+    'type': 'result',
+  })
+# ---

--- a/tests/components/knx/test_weather.py
+++ b/tests/components/knx/test_weather.py
@@ -1,15 +1,19 @@
 """Test KNX weather."""
 
+import pytest
+
 from homeassistant.components.knx.schema import WeatherSchema
 from homeassistant.components.weather import (
+    ATTR_CONDITION_CLEAR_NIGHT,
     ATTR_CONDITION_EXCEPTIONAL,
     ATTR_CONDITION_RAINY,
     ATTR_CONDITION_SUNNY,
     ATTR_CONDITION_WINDY,
 )
-from homeassistant.const import CONF_NAME
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 
+from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
 
@@ -99,3 +103,112 @@ async def test_weather(hass: HomeAssistant, knx: KNXTestKit) -> None:
     await knx.receive_write("1/1/1", True)
     state = hass.states.get("weather.test")
     assert state.state is ATTR_CONDITION_WINDY
+
+
+async def test_weather_ui_create(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test creating a weather station from UI."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.WEATHER,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_temperature": {"state": "1/1/11"},
+            "ga_rain_alarm": {"state": "1/1/2"},
+            "ga_wind_alarm": {"state": "1/1/1"},
+            "sync_state": True,
+        },
+    )
+    state = hass.states.get("weather.test")
+    assert state.state is ATTR_CONDITION_EXCEPTIONAL
+
+    await knx.assert_read("1/1/11")
+    await knx.receive_response("1/1/11", (0, 40))
+
+    await knx.assert_read("1/1/2")
+    await knx.receive_response("1/1/2", True)
+    await knx.assert_read("1/1/1")
+    await knx.receive_response("1/1/1", False)
+
+    state = hass.states.get("weather.test")
+    assert state.attributes["temperature"] == 0.4
+    assert state.state is ATTR_CONDITION_RAINY
+
+
+@pytest.mark.parametrize(
+    ("invert_day_night", "day_night_payload"),
+    [
+        # DPT 1.024: `1` is night - yields a clear-night condition
+        pytest.param(False, True, id="dpt_1_024"),
+        # inverted: `0` is night
+        pytest.param(True, False, id="inverted"),
+    ],
+)
+async def test_weather_ui_invert_day_night(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+    invert_day_night: bool,
+    day_night_payload: bool,
+) -> None:
+    """Test UI weather day/night follows DPT 1.024 and can be inverted."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.WEATHER,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_temperature": {"state": "1/1/11"},
+            "ga_day_night": {"state": "1/1/12"},
+            "invert_day_night": invert_day_night,
+            "sync_state": True,
+        },
+    )
+    await knx.assert_read("1/1/11", response=(0, 40))
+    await knx.assert_read("1/1/12", response=day_night_payload)
+    knx.assert_state("weather.test", ATTR_CONDITION_CLEAR_NIGHT)
+
+
+async def test_weather_ui_load(knx: KNXTestKit) -> None:
+    """Test loading a weather station from storage."""
+    await knx.setup_integration(config_store_fixture="config_store_weather.json")
+
+    await knx.assert_read("1/1/11", response=(0, 40))
+
+    # brightness
+    await knx.assert_read("1/1/6")
+    await knx.assert_read("1/1/8")
+    await knx.receive_response("1/1/6", (0x7C, 0x5E))
+    await knx.receive_response("1/1/8", (0x7C, 0x5E))
+    await knx.assert_read("1/1/5")
+    await knx.assert_read("1/1/7")
+    await knx.receive_response("1/1/7", (0x7C, 0x5E))
+    await knx.receive_response("1/1/5", (0x7C, 0x5E))
+
+    # wind speed
+    await knx.assert_read("1/1/9", response=(0, 40))
+    # wind bearing
+    await knx.assert_read("1/1/10", response=(0xBF,))
+
+    # alarms
+    await knx.assert_read("1/1/2", response=False)
+    await knx.assert_read("1/1/1")
+    await knx.assert_read("1/1/3")
+    await knx.receive_response("1/1/1", False)
+    await knx.receive_response("1/1/3", False)
+
+    # day night
+    await knx.assert_read("1/1/12", response=False)
+    # air pressure
+    await knx.assert_read("1/1/13", response=(0x6C, 0xAD))
+    # humidity
+    await knx.assert_read("1/1/4", response=(0, 40))
+
+    knx.assert_state(
+        "weather.test",
+        ATTR_CONDITION_SUNNY,
+        temperature=0.4,
+        wind_bearing=270,
+    )


### PR DESCRIPTION
## Breaking change


## Proposed change

Add UI configuration support for the KNX `weather` platform. Until now weather stations could only be configured via YAML; this adds a config store schema so they can be created and edited from the KNX config panel, matching the other UI-capable platforms.

Details:
- `weather` is added to `SUPPORTED_PLATFORMS_UI`.
- A `WEATHER_KNX_SCHEMA` with group address selectors is added for temperature (required), humidity, air pressure, wind speed, wind bearing, the four brightness directions, the rain/frost/wind alarms and the day/night state. `validDPTs` are set per address to filter the frontend group address dropdowns.
- The day/night address filters on **DPT 1.024** (`0` = day, `1` = night). xknx's `Weather` device treats a raw `1` as day, i.e. it is inverted relative to DPT 1.024. To keep the UI aligned with the proper DPT, the UI exposes an `invert_day_night` flag that defaults to off, and the entity class re-inverts it before passing it to xknx (`invert_day_night=not <ui flag>`).
- `weather.py` is refactored into a shared `_KnxWeather` base with `KnxYamlWeather` and `KnxUiWeather` subclasses, and registers a `KnxUiEntityPlatformController`. YAML behavior is unchanged.
- Strings, the generated schema websocket snapshot, a config store fixture and tests (UI create, UI load, and a parametrized day/night inversion test) are added.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47022
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
