### PR TITLE
Change gardena_bluetooth valve activation_reason sensor to enum

### DIFF
--- a/homeassistant/components/gardena_bluetooth/sensor.py
+++ b/homeassistant/components/gardena_bluetooth/sensor.py
@@ -77,10 +77,14 @@ DESCRIPTIONS = (
     GardenaBluetoothSensorEntityDescription(
         key=Valve.activation_reason.unique_id,
         translation_key="activation_reason",
-        state_class=SensorStateClass.MEASUREMENT,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
+        device_class=SensorDeviceClass.ENUM,
         char=Valve.activation_reason,
+        get=lambda x: (
+            x.name.lower() if isinstance(x, Valve.activation_reason.enum) else None
+        ),
+        options=[member.name.lower() for member in Valve.activation_reason.enum],
     ),
     GardenaBluetoothSensorEntityDescription(
         key=Battery.battery_level.unique_id,

--- a/homeassistant/components/gardena_bluetooth/strings.json
+++ b/homeassistant/components/gardena_bluetooth/strings.json
@@ -102,7 +102,14 @@
     },
     "sensor": {
       "activation_reason": {
-        "name": "Activation reason"
+        "name": "Activation reason",
+        "state": {
+          "external": "External",
+          "manual": "Manual",
+          "none": "Inactive",
+          "schedule": "Schedule",
+          "setup": "Setup"
+        }
       },
       "aqua_contour_error": {
         "name": "Error",

--- a/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
+++ b/tests/components/gardena_bluetooth/snapshots/test_sensor.ambr
@@ -603,6 +603,72 @@
     'state': '21',
   })
 # ---
+# name: test_sensors[timer][sensor.mock_title_activation_reason-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.mock_title_activation_reason',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Activation reason',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
+    'original_icon': None,
+    'original_name': 'Activation reason',
+    'platform': 'gardena_bluetooth',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'activation_reason',
+    'unique_id': '00000000-0000-0000-0000-000000000001-98bd0f15-0b0e-421a-84e5-ddbf75dc6de4',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[timer][sensor.mock_title_activation_reason-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Title Activation reason',
+      <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'none',
+        'manual',
+        'schedule',
+        'external',
+        'setup',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_title_activation_reason',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'schedule',
+  })
+# ---
 # name: test_sensors[timer][sensor.mock_title_battery-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/gardena_bluetooth/test_sensor.py
+++ b/tests/components/gardena_bluetooth/test_sensor.py
@@ -15,7 +15,7 @@ from gardena_bluetooth.const import (
     Spray,
     Valve,
 )
-from gardena_bluetooth.parse import ErrorData
+from gardena_bluetooth.parse import ActivationReason, ErrorData
 from habluetooth import BluetoothServiceInfo
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -88,6 +88,9 @@ async def test_setup(
             {
                 Battery.battery_level.uuid: Battery.battery_level.encode(100),
                 Valve.remaining_open_time.uuid: Valve.remaining_open_time.encode(10),
+                Valve.activation_reason.uuid: Valve.activation_reason.encode(
+                    ActivationReason.SCHEDULE
+                ),
             },
             id="timer",
         ),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

The activation reason sensor is changed from a numeric value to an actual understandable string. Update any automations to handle this change.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Report the decoded reason (schedule, manual, external, setup, none) as an enum sensor instead of the raw numeric measurement.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
