### PR TITLE
Expand HomeKit support for valve entities

### DIFF
--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -18,7 +18,6 @@ from homeassistant.components.input_number import (
     CONF_MAX as INPUT_NUMBER_CONF_MAX,
     CONF_MIN as INPUT_NUMBER_CONF_MIN,
     CONF_STEP as INPUT_NUMBER_CONF_STEP,
-    DOMAIN as INPUT_NUMBER_DOMAIN,
     SERVICE_SET_VALUE as INPUT_NUMBER_SERVICE_SET_VALUE,
 )
 from homeassistant.components.input_select import ATTR_OPTIONS, SERVICE_SELECT_OPTION
@@ -401,8 +400,9 @@ class ValveBase(HomeAccessory):
     def set_duration(self, value: int) -> None:
         """Set default duration for how long the valve should remain open."""
         _LOGGER.debug("%s: Set default run time to %s", self.entity_id, value)
+        assert self.linked_duration_entity
         self.async_call_service(
-            INPUT_NUMBER_DOMAIN,
+            split_entity_id(self.linked_duration_entity)[0],
             INPUT_NUMBER_SERVICE_SET_VALUE,
             {
                 ATTR_ENTITY_ID: self.linked_duration_entity,
@@ -502,13 +502,28 @@ class ValveSwitch(ValveBase):
 class Valve(ValveBase):
     """Generate a Valve accessory from a HomeAssistant valve."""
 
-    def __init__(self, *args: Any) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        driver: HomeDriver,
+        name: str,
+        entity_id: str,
+        aid: int,
+        config: dict[str, Any],
+        *args: Any,
+    ) -> None:
         """Initialize a Valve accessory object."""
         super().__init__(
-            TYPE_VALVE,
+            config.get(CONF_TYPE, TYPE_VALVE),
             VALVE_OPEN_STATES,
             SERVICE_OPEN_VALVE,
             SERVICE_CLOSE_VALVE,
+            hass,
+            driver,
+            name,
+            entity_id,
+            aid,
+            config,
             *args,
         )
 

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -17,6 +17,7 @@ from homeassistant.components import (
     binary_sensor,
     input_number,
     media_player,
+    number,
     persistent_notification,
     sensor,
 )
@@ -285,7 +286,9 @@ SWITCH_TYPE_SCHEMA = BASIC_INFO_SCHEMA.extend(
                 )
             ),
         ),
-        vol.Optional(CONF_LINKED_VALVE_DURATION): cv.entity_domain(input_number.DOMAIN),
+        vol.Optional(CONF_LINKED_VALVE_DURATION): cv.entity_domain(
+            [input_number.DOMAIN, number.DOMAIN]
+        ),
         vol.Optional(CONF_LINKED_VALVE_END_TIME): cv.entity_domain(sensor.DOMAIN),
     }
 )
@@ -299,7 +302,13 @@ SENSOR_SCHEMA = BASIC_INFO_SCHEMA.extend(
 
 VALVE_SCHEMA = BASIC_INFO_SCHEMA.extend(
     {
-        vol.Optional(CONF_LINKED_VALVE_DURATION): cv.entity_domain(input_number.DOMAIN),
+        vol.Optional(CONF_TYPE): vol.All(
+            cv.string,
+            vol.In((TYPE_FAUCET, TYPE_SHOWER, TYPE_SPRINKLER, TYPE_VALVE)),
+        ),
+        vol.Optional(CONF_LINKED_VALVE_DURATION): cv.entity_domain(
+            [input_number.DOMAIN, number.DOMAIN]
+        ),
         vol.Optional(CONF_LINKED_VALVE_END_TIME): cv.entity_domain(sensor.DOMAIN),
     }
 )

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -36,6 +36,7 @@ from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
     LawnMowerEntityFeature,
 )
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
 from homeassistant.components.select import ATTR_OPTIONS
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.components.vacuum import (
@@ -284,6 +285,39 @@ async def test_valve_set_state(
     assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] is None
+
+
+@pytest.mark.parametrize(
+    ("valve_type", "category", "homekit_valve_type"),
+    [
+        pytest.param(TYPE_FAUCET, 29, 3, id="faucet"),
+        pytest.param(TYPE_SHOWER, 30, 2, id="shower"),
+        pytest.param(TYPE_SPRINKLER, 28, 1, id="sprinkler"),
+        pytest.param(TYPE_VALVE, 29, 0, id="generic"),
+    ],
+)
+async def test_valve_type(
+    hass: HomeAssistant,
+    hk_driver: HomeDriver,
+    valve_type: str,
+    category: int,
+    homekit_valve_type: int,
+) -> None:
+    """Test native valve HomeKit type configuration."""
+    entity_id = f"valve.{valve_type}"
+    hass.states.async_set(entity_id, STATE_CLOSED)
+
+    acc = Valve(
+        hass,
+        hk_driver,
+        "Valve",
+        entity_id,
+        5,
+        {CONF_TYPE: valve_type},
+    )
+
+    assert acc.category == category
+    assert acc.char_valve_type.value == homekit_valve_type
 
 
 async def test_vacuum_set_state_with_returnhome_and_start_support(
@@ -906,15 +940,18 @@ async def test_valve_with_duration_characteristics(
     hass: HomeAssistant, hk_driver, events: list[Event]
 ) -> None:
     """Test valve with set duration and remaining duration characteristics."""
-    entity_id = "switch.sprinkler"
+    entity_id = "valve.sprinkler"
 
     # Test with duration and end time entities linked
-    hass.states.async_set(entity_id, STATE_OFF)
-    hass.states.async_set("input_number.valve_duration", "900")
+    hass.states.async_set(entity_id, STATE_CLOSED)
+    hass.states.async_set(
+        "number.valve_duration",
+        "900",
+        {"min": 60, "max": 10800, "step": 60},
+    )
     hass.states.async_set("sensor.valve_end_time", dt_util.utcnow().isoformat())
     await hass.async_block_till_done()
 
-    # Using Valve instead of ValveSwitch
     acc = Valve(
         hass,
         hk_driver,
@@ -922,12 +959,30 @@ async def test_valve_with_duration_characteristics(
         entity_id,
         5,
         {
-            "linked_valve_duration": "input_number.valve_duration",
+            "type": "sprinkler",
+            "linked_valve_duration": "number.valve_duration",
             "linked_valve_end_time": "sensor.valve_end_time",
         },
     )
     acc.run()
     await hass.async_block_till_done()
+
+    assert acc.category == 28  # Sprinkler
+    assert acc.char_valve_type.value == 1  # Irrigation
+    assert acc.char_set_duration.value == 900
+    assert acc.char_set_duration.properties["minValue"] == 60
+    assert acc.char_set_duration.properties["maxValue"] == 10800
+    assert acc.char_set_duration.properties["minStep"] == 60
+
+    call_set_value = async_mock_service(
+        hass, NUMBER_DOMAIN, INPUT_NUMBER_SERVICE_SET_VALUE
+    )
+    acc.char_set_duration.client_update_value(300)
+    await hass.async_block_till_done()
+    assert call_set_value[0].data == {
+        "entity_id": "number.valve_duration",
+        "value": 300,
+    }
 
     with freeze_time(dt_util.utcnow()):
         hass.states.async_set(

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -135,8 +135,6 @@ def test_validate_entity_config() -> None:
         {
             "switch.test": {
                 CONF_TYPE: "sprinkler",
-                # Must be input_number entity
-                CONF_LINKED_VALVE_DURATION: "number.valve_duration",
                 # Must be sensor (timestamp) entity
                 CONF_LINKED_VALVE_END_TIME: "datetime.valve_end_time",
             }
@@ -147,15 +145,9 @@ def test_validate_entity_config() -> None:
             "valve.test": {
                 # Must be sensor (timestamp) entity
                 CONF_LINKED_VALVE_END_TIME: "datetime.valve_end_time",
-                # Must be input_number
-                CONF_LINKED_VALVE_DURATION: "number.valve_duration",
             }
         },
-        {
-            "valve.test": {
-                CONF_TYPE: "sprinkler",  # Extra keys not allowed
-            }
-        },
+        {"valve.test": {CONF_TYPE: "invalid_type"}},
     ]
 
     for conf in configs:
@@ -297,6 +289,19 @@ def test_validate_entity_config() -> None:
     assert vec({"valve.demo": config}) == {
         "valve.demo": {
             CONF_LINKED_VALVE_DURATION: "input_number.valve_duration",
+            CONF_LINKED_VALVE_END_TIME: "sensor.valve_end_time",
+            CONF_LOW_BATTERY_THRESHOLD: DEFAULT_LOW_BATTERY_THRESHOLD,
+        }
+    }
+    config = {
+        CONF_TYPE: TYPE_SPRINKLER,
+        CONF_LINKED_VALVE_DURATION: "number.valve_duration",
+        CONF_LINKED_VALVE_END_TIME: "sensor.valve_end_time",
+    }
+    assert vec({"valve.sprinkler": config}) == {
+        "valve.sprinkler": {
+            CONF_TYPE: TYPE_SPRINKLER,
+            CONF_LINKED_VALVE_DURATION: "number.valve_duration",
             CONF_LINKED_VALVE_END_TIME: "sensor.valve_end_time",
             CONF_LOW_BATTERY_THRESHOLD: DEFAULT_LOW_BATTERY_THRESHOLD,
         }


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Native Home Assistant valve entities are currently always exposed as generic HomeKit valves, while switch entities can be configured as faucets, shower heads, sprinklers, or generic valves.

This change extends the same type configuration to native valve entities. It also allows integration-provided `number` entities, in addition to `input_number` helpers, to be used with `linked_valve_duration`. Duration updates are sent through the service domain of the linked entity.

Existing generic valve and `input_number` behavior remains unchanged. Linked duration values continue to use seconds.

The changes were tested with native valve entities using all four supported HomeKit valve types and with both supported linked-duration domains.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47024
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
