### PR TITLE
ProxmoxVE component change Hibernate button to Suspend and fix API call path

### DIFF
--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -131,10 +131,10 @@ VM_BUTTONS: tuple[ProxmoxVMButtonEntityDescription, ...] = (
         device_class=ButtonDeviceClass.RESTART,
     ),
     ProxmoxVMButtonEntityDescription(
-        key="hibernate",
-        translation_key="hibernate",
+        key="suspend",
+        translation_key="suspend",
         press_action=lambda coordinator, node, vmid: (
-            coordinator.proxmox.nodes(node).qemu(vmid).status.hibernate.post()
+            coordinator.proxmox.nodes(node).qemu(vmid).status.suspend.post()
         ),
         entity_category=EntityCategory.CONFIG,
     ),

--- a/homeassistant/components/proxmoxve/button.py
+++ b/homeassistant/components/proxmoxve/button.py
@@ -131,8 +131,8 @@ VM_BUTTONS: tuple[ProxmoxVMButtonEntityDescription, ...] = (
         device_class=ButtonDeviceClass.RESTART,
     ),
     ProxmoxVMButtonEntityDescription(
-        key="suspend",
-        translation_key="suspend",
+        key="hibernate",
+        translation_key="hibernate",
         press_action=lambda coordinator, node, vmid: (
             coordinator.proxmox.nodes(node).qemu(vmid).status.suspend.post()
         ),

--- a/homeassistant/components/proxmoxve/icons.json
+++ b/homeassistant/components/proxmoxve/icons.json
@@ -21,6 +21,9 @@
       }
     },
     "button": {
+      "hibernate": {
+        "default": "mdi:power-sleep"
+      },
       "reset": {
         "default": "mdi:restart"
       },
@@ -44,9 +47,6 @@
       },
       "stop_all": {
         "default": "mdi:stop"
-      },
-      "suspend": {
-        "default": "mdi:power-sleep"
       },
       "suspend_all": {
         "default": "mdi:pause"

--- a/homeassistant/components/proxmoxve/icons.json
+++ b/homeassistant/components/proxmoxve/icons.json
@@ -21,9 +21,6 @@
       }
     },
     "button": {
-      "hibernate": {
-        "default": "mdi:power-sleep"
-      },
       "reset": {
         "default": "mdi:restart"
       },
@@ -47,6 +44,9 @@
       },
       "stop_all": {
         "default": "mdi:stop"
+      },
+      "suspend": {
+        "default": "mdi:power-sleep"
       },
       "suspend_all": {
         "default": "mdi:pause"

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -136,6 +136,9 @@
       }
     },
     "button": {
+      "hibernate": {
+        "name": "Suspend"
+      },
       "reset": {
         "name": "Reset"
       },
@@ -159,9 +162,6 @@
       },
       "stop_all": {
         "name": "Stop all"
-      },
-      "suspend": {
-        "name": "Suspend"
       },
       "suspend_all": {
         "name": "Suspend all"

--- a/homeassistant/components/proxmoxve/strings.json
+++ b/homeassistant/components/proxmoxve/strings.json
@@ -136,9 +136,6 @@
       }
     },
     "button": {
-      "hibernate": {
-        "name": "Hibernate"
-      },
       "reset": {
         "name": "Reset"
       },
@@ -162,6 +159,9 @@
       },
       "stop_all": {
         "name": "Stop all"
+      },
+      "suspend": {
+        "name": "Suspend"
       },
       "suspend_all": {
         "name": "Suspend all"

--- a/tests/components/proxmoxve/snapshots/test_button.ambr
+++ b/tests/components/proxmoxve/snapshots/test_button.ambr
@@ -752,56 +752,6 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_button_entities[button.vm_web_hibernate-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': None,
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'button',
-    'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.vm_web_hibernate',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Hibernate',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Hibernate',
-    'platform': 'proxmoxve',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'hibernate',
-    'unique_id': '1234_100_hibernate',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_all_button_entities[button.vm_web_hibernate-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'vm-web Hibernate',
-    }),
-    'context': <ANY>,
-    'entity_id': 'button.vm_web_hibernate',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
 # name: test_all_button_entities[button.vm_web_reset-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
@@ -1047,6 +997,56 @@
     }),
     'context': <ANY>,
     'entity_id': 'button.vm_web_stop',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_button_entities[button.vm_web_suspend-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'button.vm_web_suspend',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Suspend',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Suspend',
+    'platform': 'proxmoxve',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'hibernate',
+    'unique_id': '1234_100_hibernate',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_button_entities[button.vm_web_suspend-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'vm-web Suspend',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.vm_web_suspend',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/proxmoxve/snapshots/test_button.ambr
+++ b/tests/components/proxmoxve/snapshots/test_button.ambr
@@ -752,7 +752,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_button_entities[button.vm_web_suspend-entry]
+# name: test_all_button_entities[button.vm_web_hibernate-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -766,7 +766,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.vm_web_suspend',
+    'entity_id': 'button.vm_web_hibernate',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -774,28 +774,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Suspend',
+    'object_id_base': 'Hibernate',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Suspend',
+    'original_name': 'Hibernate',
     'platform': 'proxmoxve',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'suspend',
-    'unique_id': '1234_100_suspend',
+    'translation_key': 'hibernate',
+    'unique_id': '1234_100_hibernate',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_button_entities[button.vm_web_suspend-state]
+# name: test_all_button_entities[button.vm_web_hibernate-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'vm-web Suspend',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'vm-web Hibernate',
     }),
     'context': <ANY>,
-    'entity_id': 'button.vm_web_suspend',
+    'entity_id': 'button.vm_web_hibernate',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/proxmoxve/snapshots/test_button.ambr
+++ b/tests/components/proxmoxve/snapshots/test_button.ambr
@@ -752,7 +752,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_all_button_entities[button.vm_web_hibernate-entry]
+# name: test_all_button_entities[button.vm_web_suspend-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -766,7 +766,7 @@
     'disabled_by': None,
     'domain': 'button',
     'entity_category': <EntityCategory.CONFIG: 'config'>,
-    'entity_id': 'button.vm_web_hibernate',
+    'entity_id': 'button.vm_web_suspend',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -774,28 +774,28 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Hibernate',
+    'object_id_base': 'Suspend',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Hibernate',
+    'original_name': 'Suspend',
     'platform': 'proxmoxve',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'hibernate',
-    'unique_id': '1234_100_hibernate',
+    'translation_key': 'suspend',
+    'unique_id': '1234_100_suspend',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_all_button_entities[button.vm_web_hibernate-state]
+# name: test_all_button_entities[button.vm_web_suspend-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'vm-web Hibernate',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'vm-web Suspend',
     }),
     'context': <ANY>,
-    'entity_id': 'button.vm_web_hibernate',
+    'entity_id': 'button.vm_web_suspend',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -112,7 +112,7 @@ async def test_node_all_actions_buttons(
         ("button.vm_web_start", 100, "start"),
         ("button.vm_web_stop", 100, "stop"),
         ("button.vm_web_restart", 100, "reboot"),
-        ("button.vm_web_hibernate", 100, "hibernate"),
+        ("button.vm_web_suspend", 100, "suspend"),
         ("button.vm_web_reset", 100, "reset"),
         ("button.vm_web_shut_down", 100, "shutdown"),
     ],
@@ -268,9 +268,9 @@ async def test_node_buttons_exceptions(
             SSLError("ssl error"),
         ),
         (
-            "button.vm_web_hibernate",
+            "button.vm_web_suspend",
             100,
-            "hibernate",
+            "suspend",
             ConnectTimeout("timeout"),
         ),
         (

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -112,7 +112,7 @@ async def test_node_all_actions_buttons(
         ("button.vm_web_start", 100, "start"),
         ("button.vm_web_stop", 100, "stop"),
         ("button.vm_web_restart", 100, "reboot"),
-        ("button.vm_web_hibernate", 100, "suspend"),
+        ("button.vm_web_suspend", 100, "suspend"),
         ("button.vm_web_reset", 100, "reset"),
         ("button.vm_web_shut_down", 100, "shutdown"),
     ],

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -268,7 +268,7 @@ async def test_node_buttons_exceptions(
             SSLError("ssl error"),
         ),
         (
-            "button.vm_web_hibernate",
+            "button.vm_web_suspend",
             100,
             "suspend",
             ConnectTimeout("timeout"),

--- a/tests/components/proxmoxve/test_button.py
+++ b/tests/components/proxmoxve/test_button.py
@@ -112,7 +112,7 @@ async def test_node_all_actions_buttons(
         ("button.vm_web_start", 100, "start"),
         ("button.vm_web_stop", 100, "stop"),
         ("button.vm_web_restart", 100, "reboot"),
-        ("button.vm_web_suspend", 100, "suspend"),
+        ("button.vm_web_hibernate", 100, "suspend"),
         ("button.vm_web_reset", 100, "reset"),
         ("button.vm_web_shut_down", 100, "shutdown"),
     ],
@@ -268,7 +268,7 @@ async def test_node_buttons_exceptions(
             SSLError("ssl error"),
         ),
         (
-            "button.vm_web_suspend",
+            "button.vm_web_hibernate",
             100,
             "suspend",
             ConnectTimeout("timeout"),


### PR DESCRIPTION
…

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The ProxmoxVE component has a button called Hibernate that call the Proxmox API with hibernate as part of the path. However at least the last two version Proxmox have not had an API endpoint that contains hibernate, it however does have one called suspend. This will change the button label, and API path to match the current API endpoint.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176440
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
