### PR TITLE
Restore KNX cover state and mark uninitialized covers as assumed

### DIFF
--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -135,8 +135,8 @@ class _KnxCover(CoverEntity, RestoreEntity):
     def assumed_state(self) -> bool:
         """Return True if unable to access real state of the entity."""
         # Without a known position or movement value, the position is only
-        # calculated from the configured travel time, so the state is assumed.
-        # This avoids presenting a restored position as if it were confirmed.
+        # read from the restored state in the travelcalculator. This prevents
+        # out-of-sync positions from disabling controls in the UI.
         return (
             self._device.position_current.value is None
             and self._device.position_target.value is None

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -86,9 +86,6 @@ class _KnxCover(CoverEntity, RestoreEntity):
 
     def init_base(self) -> None:
         """Initialize common attributes - may be based on xknx device instance."""
-        # When the position can't be read from the bus it is only calculated
-        # from the configured travel time, so the state has to be assumed.
-        self._attr_assumed_state = not self._device.position_current.readable
         self._attr_supported_features = (
             CoverEntityFeature.CLOSE | CoverEntityFeature.OPEN
         )
@@ -132,6 +129,19 @@ class _KnxCover(CoverEntity, RestoreEntity):
             tilt_position := last_state.attributes.get(ATTR_CURRENT_TILT_POSITION)
         ) is not None:
             self._device.angle.value = 100 - tilt_position
+
+    @property
+    @override
+    def assumed_state(self) -> bool:
+        """Return True if unable to access real state of the entity."""
+        # Without a known position or movement value, the position is only
+        # calculated from the configured travel time, so the state is assumed.
+        # This avoids presenting a restored position as if it were confirmed.
+        return (
+            self._device.position_current.value is None
+            and self._device.position_target.value is None
+            and self._device.updown.value is None
+        )
 
     @property
     @override

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -7,6 +7,8 @@ from xknx.devices import Cover as XknxCover
 
 from homeassistant import config_entries
 from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     CoverDeviceClass,
@@ -17,6 +19,8 @@ from homeassistant.const import (
     CONF_DEVICE_CLASS,
     CONF_ENTITY_CATEGORY,
     CONF_NAME,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -24,6 +28,7 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     async_get_current_platform,
 )
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_SYNC_STATE, DOMAIN, KNX_MODULE_KEY, CoverConf
@@ -74,20 +79,23 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
-class _KnxCover(CoverEntity):
+class _KnxCover(CoverEntity, RestoreEntity):
     """Representation of a KNX cover."""
 
     _device: XknxCover
 
     def init_base(self) -> None:
         """Initialize common attributes - may be based on xknx device instance."""
-        _supports_tilt = False
+        # When the position can't be read from the bus it is only calculated
+        # from the configured travel time, so the state has to be assumed.
+        self._attr_assumed_state = not self._device.position_current.readable
         self._attr_supported_features = (
             CoverEntityFeature.CLOSE | CoverEntityFeature.OPEN
         )
         if self._device.supports_position or self._device.supports_stop:
             # when stop is supported, xknx travelcalculator can set position
             self._attr_supported_features |= CoverEntityFeature.SET_POSITION
+        _supports_tilt = False
         if self._device.step.writable:
             _supports_tilt = True
             self._attr_supported_features |= (
@@ -104,6 +112,26 @@ class _KnxCover(CoverEntity):
                 self._attr_supported_features |= CoverEntityFeature.STOP_TILT
 
         self._attr_device_class = CoverDeviceClass.BLIND if _supports_tilt else None
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore last known position and tilt.
+
+        For readable group addresses this bridges the gap until the bus read
+        response arrives; for non-readable ones it is the only source of state.
+        """
+        await super().async_added_to_hass()
+        if (last_state := await self.async_get_last_state()) is None or (
+            last_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
+        ):
+            return
+        if (position := last_state.attributes.get(ATTR_CURRENT_POSITION)) is not None:
+            # In KNX 0 is open, 100 is closed.
+            self._device.travelcalculator.set_position(100 - position)
+        if (
+            tilt_position := last_state.attributes.get(ATTR_CURRENT_TILT_POSITION)
+        ) is not None:
+            self._device.angle.value = 100 - tilt_position
 
     @property
     @override

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -4,15 +4,20 @@ from typing import Any
 
 import pytest
 
-from homeassistant.components.cover import CoverEntityFeature, CoverState
+from homeassistant.components.cover import (
+    ATTR_CURRENT_POSITION,
+    ATTR_CURRENT_TILT_POSITION,
+    CoverEntityFeature,
+    CoverState,
+)
 from homeassistant.components.knx.schema import CoverSchema
-from homeassistant.const import CONF_NAME, STATE_UNKNOWN, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant, State
 
 from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
-from tests.common import async_capture_events
+from tests.common import async_capture_events, mock_restore_cache
 
 
 async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -80,6 +85,7 @@ async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
     knx.assert_state(
         "cover.test",
         CoverState.CLOSING,
+        assumed_state=None,
     )
 
     assert len(events) == 1
@@ -169,8 +175,106 @@ async def test_cover_tilt_move_short(hass: HomeAssistant, knx: KNXTestKit) -> No
     await knx.assert_write("1/0/1", 0)
 
 
+async def test_cover_restore_assumed_state(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test a cover without position feedback restores its state and is assumed."""
+    mock_restore_cache(
+        hass,
+        (
+            State(
+                "cover.test",
+                CoverState.OPEN,
+                {ATTR_CURRENT_POSITION: 40, ATTR_CURRENT_TILT_POSITION: 60},
+            ),
+        ),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_STOP_ADDRESS: "1/0/1",
+                CoverSchema.CONF_ANGLE_ADDRESS: "1/0/2",
+            }
+        }
+    )
+    # position and tilt can't be read from the bus - no telegrams are sent
+    await knx.assert_no_telegram()
+    knx.assert_state(
+        "cover.test",
+        CoverState.OPEN,
+        current_position=40,
+        current_tilt_position=60,
+        assumed_state=True,
+    )
+
+
 @pytest.mark.parametrize(
-    ("knx_data", "read_responses", "initial_state", "supported_features"),
+    "restored_state",
+    [STATE_UNKNOWN, STATE_UNAVAILABLE],
+)
+async def test_cover_restore_unknown_state(
+    hass: HomeAssistant, knx: KNXTestKit, restored_state: str
+) -> None:
+    """Test a cover doesn't restore a non-numeric position."""
+    mock_restore_cache(
+        hass,
+        (State("cover.test", restored_state, {ATTR_CURRENT_POSITION: 40}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_STOP_ADDRESS: "1/0/1",
+            }
+        }
+    )
+    await knx.assert_no_telegram()
+    knx.assert_state(
+        "cover.test",
+        STATE_UNKNOWN,
+        current_position=None,
+        assumed_state=True,
+    )
+
+
+async def test_cover_restore_readable(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test a readable cover shows the restored state until the bus read completes."""
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.CLOSED, {ATTR_CURRENT_POSITION: 0}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverSchema.CONF_POSITION_ADDRESS: "1/0/3",
+            }
+        }
+    )
+    # restored value bridges the gap until the bus read completes - not assumed
+    knx.assert_state(
+        "cover.test",
+        CoverState.CLOSED,
+        current_position=0,
+        assumed_state=None,
+    )
+    # bus reports a different position - the real value overwrites the restored one
+    await knx.assert_read("1/0/2", response=(0x00,))
+    knx.assert_state(
+        "cover.test",
+        CoverState.OPEN,
+        current_position=100,
+        assumed_state=None,
+    )
+
+
+@pytest.mark.parametrize(
+    ("knx_data", "read_responses", "initial_state", "supported_features", "assumed"),
     [
         (
             {
@@ -180,6 +284,7 @@ async def test_cover_tilt_move_short(hass: HomeAssistant, knx: KNXTestKit) -> No
             {},
             STATE_UNKNOWN,
             CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE,
+            True,
         ),
         (
             {
@@ -192,6 +297,7 @@ async def test_cover_tilt_move_short(hass: HomeAssistant, knx: KNXTestKit) -> No
             CoverEntityFeature.OPEN
             | CoverEntityFeature.CLOSE
             | CoverEntityFeature.SET_POSITION,
+            None,
         ),
         (
             {
@@ -213,6 +319,7 @@ async def test_cover_tilt_move_short(hass: HomeAssistant, knx: KNXTestKit) -> No
             | CoverEntityFeature.SET_TILT_POSITION
             | CoverEntityFeature.STOP
             | CoverEntityFeature.STOP_TILT,
+            None,
         ),
     ],
 )
@@ -223,6 +330,7 @@ async def test_cover_ui_create(
     read_responses: dict[str, int | tuple[int]],
     initial_state: str,
     supported_features: int,
+    assumed: bool | None,
 ) -> None:
     """Test creating a cover."""
     await knx.setup_integration()
@@ -234,7 +342,12 @@ async def test_cover_ui_create(
     # created entity sends read-request to KNX bus
     for ga, value in read_responses.items():
         await knx.assert_read(ga, response=value, ignore_order=True)
-    knx.assert_state("cover.test", initial_state, supported_features=supported_features)
+    knx.assert_state(
+        "cover.test",
+        initial_state,
+        supported_features=supported_features,
+        assumed_state=assumed,
+    )
 
 
 async def test_cover_ui_load(knx: KNXTestKit) -> None:
@@ -249,6 +362,7 @@ async def test_cover_ui_load(knx: KNXTestKit) -> None:
         "cover.minimal",
         STATE_UNKNOWN,
         supported_features=CoverEntityFeature.CLOSE | CoverEntityFeature.OPEN,
+        assumed_state=True,
     )
     knx.assert_state(
         "cover.position_only",

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -256,14 +256,16 @@ async def test_cover_restore_readable(hass: HomeAssistant, knx: KNXTestKit) -> N
             }
         }
     )
-    # restored value bridges the gap until the bus read completes - not assumed
+    # restored value bridges the gap until the bus read completes - it is
+    # assumed as long as it hasn't been confirmed by the bus
     knx.assert_state(
         "cover.test",
         CoverState.CLOSED,
         current_position=0,
-        assumed_state=None,
+        assumed_state=True,
     )
-    # bus reports a different position - the real value overwrites the restored one
+    # bus reports a different position - the confirmed value overwrites the
+    # restored one and the state is no longer assumed
     await knx.assert_read("1/0/2", response=(0x00,))
     knx.assert_state(
         "cover.test",


### PR DESCRIPTION
## Breaking change


## Proposed change

KNX covers previously started as `unknown` after a Home Assistant restart. For covers configured without a position state group address this was permanent — the position can never be read back from the bus, so the entity stayed `unknown` until the cover was moved.

This PR:

- Makes the cover entity a `RestoreEntity` and restores the last known position and tilt on startup. For readable group addresses this bridges the gap until the bus read response arrives; for non-readable ones it is the only source of state. The restored value is cleanly overwritten once a real state read response is received.
- Reports `assumed_state` while Home Assistant has no confirmed value for the cover — that is, `position_current`, `position_target`, and `updown` are all unset. A restored position is therefore treated as assumed until it is confirmed by the bus or the cover is moved. Covers with a position state address leave the assumed state once the bus reports their position; covers without one leave it the first time they are moved. This prevents an out-of-sync restored state from disabling the move buttons in the UI as if the position were known.

Tests were added for the assumed/non-readable restore case, the readable bridge case, and unknown/unavailable restore states. Existing state-asserting tests now also assert `assumed_state`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
  - https://github.com/orgs/home-assistant/discussions/4342
  - https://github.com/home-assistant/core/pull/176413
  - https://github.com/home-assistant/core/pull/176352
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47032
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
