### PR TITLE
Use Matter semantic tags to name multi-endpoint entities

### DIFF
--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable, Coroutine
 from dataclasses import dataclass
+from enum import IntEnum
 import functools
 import logging
 from typing import TYPE_CHECKING, Any, Concatenate, cast, override
@@ -60,6 +61,62 @@ VENDOR_LABELING_LIST: dict[int, dict[int, list[str] | None]] = {
 }
 
 
+class _SwitchesNamespaceTag(IntEnum):
+    """Tag values of the Matter "Switches" semantic tag namespace (0x43)."""
+
+    ON = 0x00
+    OFF = 0x01
+    TOGGLE = 0x02
+    UP = 0x03
+    DOWN = 0x04
+    NEXT = 0x05
+    PREVIOUS = 0x06
+    ENTER_OK_SELECT = 0x07
+    CUSTOM = 0x08  # textual description provided in the Label field
+    OPEN = 0x09
+    CLOSE = 0x0A
+    STOP = 0x0B
+
+
+class _CommonPositionNamespaceTag(IntEnum):
+    """Tag values of the Matter "Common Position" semantic tag namespace (0x08)."""
+
+    LEFT = 0x00
+    RIGHT = 0x01
+    TOP = 0x02
+    BOTTOM = 0x03
+    MIDDLE = 0x04
+
+
+# Translation key suffix (see strings.json) for each standard Switches tag,
+# except CUSTOM which carries a free-text vendor label instead.
+_SWITCHES_TAG_TRANSLATION_KEYS: dict[int, str] = {
+    _SwitchesNamespaceTag.ON: "on",
+    _SwitchesNamespaceTag.OFF: "off",
+    _SwitchesNamespaceTag.TOGGLE: "toggle",
+    _SwitchesNamespaceTag.UP: "up",
+    _SwitchesNamespaceTag.DOWN: "down",
+    _SwitchesNamespaceTag.NEXT: "next",
+    _SwitchesNamespaceTag.PREVIOUS: "previous",
+    _SwitchesNamespaceTag.ENTER_OK_SELECT: "enter_ok_select",
+    _SwitchesNamespaceTag.OPEN: "open",
+    _SwitchesNamespaceTag.CLOSE: "close",
+    _SwitchesNamespaceTag.STOP: "stop",
+}
+
+# Order matters: when a device combines two of these tags (e.g. Top + Right
+# for a corner position), they are read out in this canonical order so the
+# result reads naturally ("Top Right", not "Right Top"), regardless of the
+# order the device lists them in.
+_COMMON_POSITION_TAG_TRANSLATION_KEYS: dict[int, str] = {
+    _CommonPositionNamespaceTag.TOP: "top",
+    _CommonPositionNamespaceTag.BOTTOM: "bottom",
+    _CommonPositionNamespaceTag.MIDDLE: "middle",
+    _CommonPositionNamespaceTag.LEFT: "left",
+    _CommonPositionNamespaceTag.RIGHT: "right",
+}
+
+
 def catch_matter_error[_R, **P](
     func: Callable[Concatenate[MatterEntity, P], Coroutine[Any, Any, _R]],
 ) -> Callable[Concatenate[MatterEntity, P], Coroutine[Any, Any, _R]]:
@@ -93,6 +150,7 @@ class MatterEntity(Entity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _name_postfix: str | None = None
+    _name_postfix_needs_translation = False
     _platform_translation_key: str | None = None
 
     def __init__(
@@ -143,9 +201,18 @@ class MatterEntity(Entity):
             if not self._name_postfix:
                 self._attr_name = None
 
-        # Matter labels can be used to modify the entity name
-        # by appending the text.
+        # Matter labels or semantic tags (Descriptor TagList) can be used to
+        # modify the entity name by appending the text. Structured semantic
+        # tags (position/action) are preferred over a Custom tag's free-text
+        # label, which often just repeats the entity's own generic name
+        # (e.g. a "button 1" label on an entity already named "Button").
         if name_modifier := self._get_name_modifier():
+            self._name_postfix = name_modifier
+        elif self._has_translatable_semantic_tag_name_modifier():
+            # the translated word is only known once platform translations
+            # are available, so defer the lookup to `name`
+            self._name_postfix_needs_translation = True
+        elif name_modifier := self._find_untranslated_semantic_tag_name_modifier():
             self._name_postfix = name_modifier
 
         # make sure to update the attributes once
@@ -183,6 +250,107 @@ class MatterEntity(Entity):
         if found_labels := self._find_matching_labels():
             return found_labels[0]
         return None
+
+    def _get_semantic_tags(self) -> list[clusters.Globals.Structs.semtag]:
+        """Get the semantic tags (Descriptor TagList) for the endpoint."""
+        return (
+            self.get_matter_attribute_value(clusters.Descriptor.Attributes.TagList)
+            or []
+        )
+
+    def _has_translatable_semantic_tag_name_modifier(self) -> bool:
+        """Return whether the endpoint has a semantic tag that needs translation.
+
+        Used to decide, at __init__ time, whether the (higher-priority)
+        translated tier applies, without yet resolving the actual translated
+        word, which requires platform translations that are not available
+        until the entity has been added to hass (see `name`).
+        """
+        namespace = clusters.Globals.Enums.namespace
+        return any(
+            (
+                tag.namespaceID == namespace.kCommonPosition
+                and tag.tag in _COMMON_POSITION_TAG_TRANSLATION_KEYS
+            )
+            or (
+                tag.namespaceID == namespace.kSwitches
+                and tag.tag in _SWITCHES_TAG_TRANSLATION_KEYS
+            )
+            for tag in self._get_semantic_tags()
+        )
+
+    def _find_untranslated_semantic_tag_name_modifier(self) -> str | None:
+        """Find a name modifier from the endpoint's semantic tags.
+
+        Only used as a fallback when no structured, translatable tag
+        (Common Position or Switches action) is present. Handles the tags
+        that need no translation: a Common Number tag (whose value is a
+        plain, language-independent digit) or, as a last resort, an explicit
+        vendor-supplied Custom tag label.
+        """
+        namespace = clusters.Globals.Enums.namespace
+        tags = self._get_semantic_tags()
+        for tag in tags:
+            if tag.namespaceID == namespace.kCommonNumber:
+                return str(tag.tag)
+        for tag in tags:
+            if (
+                tag.namespaceID == namespace.kSwitches
+                and tag.tag == _SwitchesNamespaceTag.CUSTOM
+                and isinstance(tag.label, str)
+            ):
+                return tag.label
+        return None
+
+    def _find_translated_semantic_tag_name_modifier(self) -> str | None:
+        """Find a translated name modifier from the endpoint's semantic tags.
+
+        Handles the tags whose meaning is a word that needs translation
+        (a position or an action), so it can only run once platform
+        translations are available (see `_name_postfix_needs_translation`).
+        A namespace can carry multiple tags at once (e.g. Top + Right for a
+        corner position), in which case all of them are combined.
+        """
+        namespace = clusters.Globals.Enums.namespace
+        tags = self._get_semantic_tags()
+        if words := self._translate_semantic_tags(
+            tags, namespace.kCommonPosition, _COMMON_POSITION_TAG_TRANSLATION_KEYS
+        ):
+            return " ".join(words)
+        if words := self._translate_semantic_tags(
+            tags, namespace.kSwitches, _SWITCHES_TAG_TRANSLATION_KEYS
+        ):
+            return " ".join(words)
+        return None
+
+    def _translate_semantic_tags(
+        self,
+        tags: list[clusters.Globals.Structs.semtag],
+        namespace_id: int,
+        translation_keys: dict[int, str],
+    ) -> list[str]:
+        """Translate all semantic tags of a given namespace present on the endpoint.
+
+        Words are combined in the canonical order of `translation_keys`,
+        regardless of the order the device lists the tags in.
+        """
+        device_tags = {tag.tag for tag in tags if tag.namespaceID == namespace_id}
+        words = []
+        for tag_id, translation_key in translation_keys.items():
+            if tag_id not in device_tags:
+                continue
+            if translated := self._translate_semantic_tag(translation_key):
+                words.append(translated)
+        return words
+
+    def _translate_semantic_tag(self, translation_key: str) -> str | None:
+        """Look up the translated word for a semantic tag."""
+        platform_data = self.platform_data
+        full_key = (
+            f"component.{platform_data.platform_name}.entity.{platform_data.domain}"
+            f".matter_semantic_tag_{translation_key}.name"
+        )
+        return platform_data.platform_translations.get(full_key)
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -274,8 +442,13 @@ class MatterEntity(Entity):
             # an explicit entity name was defined, we use that
             return self._attr_name
         name = super().name
-        if name and self._name_postfix:
-            name = f"{name} ({self._name_postfix})"
+        postfix = self._name_postfix
+        if self._name_postfix_needs_translation and (
+            translated := self._find_translated_semantic_tag_name_modifier()
+        ):
+            postfix = translated
+        if name and postfix:
+            name = f"{name} ({postfix})"
         return name
 
     @cached_property

--- a/homeassistant/components/matter/strings.json
+++ b/homeassistant/components/matter/strings.json
@@ -196,6 +196,54 @@
             }
           }
         }
+      },
+      "matter_semantic_tag_bottom": {
+        "name": "Bottom"
+      },
+      "matter_semantic_tag_close": {
+        "name": "[%key:common::action::close%]"
+      },
+      "matter_semantic_tag_down": {
+        "name": "Down"
+      },
+      "matter_semantic_tag_enter_ok_select": {
+        "name": "Enter/OK"
+      },
+      "matter_semantic_tag_left": {
+        "name": "Left"
+      },
+      "matter_semantic_tag_middle": {
+        "name": "Middle"
+      },
+      "matter_semantic_tag_next": {
+        "name": "Next"
+      },
+      "matter_semantic_tag_off": {
+        "name": "[%key:common::state::off%]"
+      },
+      "matter_semantic_tag_on": {
+        "name": "[%key:common::state::on%]"
+      },
+      "matter_semantic_tag_open": {
+        "name": "[%key:common::action::open%]"
+      },
+      "matter_semantic_tag_previous": {
+        "name": "Previous"
+      },
+      "matter_semantic_tag_right": {
+        "name": "Right"
+      },
+      "matter_semantic_tag_stop": {
+        "name": "[%key:common::action::stop%]"
+      },
+      "matter_semantic_tag_toggle": {
+        "name": "[%key:common::action::toggle%]"
+      },
+      "matter_semantic_tag_top": {
+        "name": "Top"
+      },
+      "matter_semantic_tag_up": {
+        "name": "Up"
       }
     },
     "fan": {
@@ -531,6 +579,54 @@
       },
       "hepa_filter_condition": {
         "name": "HEPA filter condition"
+      },
+      "matter_semantic_tag_bottom": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_bottom::name%]"
+      },
+      "matter_semantic_tag_close": {
+        "name": "[%key:common::action::close%]"
+      },
+      "matter_semantic_tag_down": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_down::name%]"
+      },
+      "matter_semantic_tag_enter_ok_select": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_enter_ok_select::name%]"
+      },
+      "matter_semantic_tag_left": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_left::name%]"
+      },
+      "matter_semantic_tag_middle": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_middle::name%]"
+      },
+      "matter_semantic_tag_next": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_next::name%]"
+      },
+      "matter_semantic_tag_off": {
+        "name": "[%key:common::state::off%]"
+      },
+      "matter_semantic_tag_on": {
+        "name": "[%key:common::state::on%]"
+      },
+      "matter_semantic_tag_open": {
+        "name": "[%key:common::action::open%]"
+      },
+      "matter_semantic_tag_previous": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_previous::name%]"
+      },
+      "matter_semantic_tag_right": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_right::name%]"
+      },
+      "matter_semantic_tag_stop": {
+        "name": "[%key:common::action::stop%]"
+      },
+      "matter_semantic_tag_toggle": {
+        "name": "[%key:common::action::toggle%]"
+      },
+      "matter_semantic_tag_top": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_top::name%]"
+      },
+      "matter_semantic_tag_up": {
+        "name": "[%key:component::matter::entity::event::matter_semantic_tag_up::name%]"
       },
       "nitrogen_dioxide": {
         "name": "[%key:component::sensor::entity_component::nitrogen_dioxide::name%]"

--- a/tests/components/matter/snapshots/test_event.ambr
+++ b/tests/components/matter/snapshots/test_event.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_3-entry]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_bottom-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -20,7 +20,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.climate_sensor_w100_button_3',
+    'entity_id': 'event.climate_sensor_w100_button_bottom',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -28,142 +28,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (3)',
+    'object_id_base': 'Button (Bottom)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (3)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-3-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'long_press',
-        'long_release',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Button (3)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.climate_sensor_w100_button_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'long_press',
-        'long_release',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.climate_sensor_w100_button_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (4)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (4)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-4-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'long_press',
-        'long_release',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Button (4)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.climate_sensor_w100_button_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_5-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'long_press',
-        'long_release',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.climate_sensor_w100_button_5',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (5)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (5)',
+    'original_name': 'Button (Bottom)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -173,7 +43,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_5-state]
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_bottom-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -184,10 +54,140 @@
         'long_press',
         'long_release',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Button (5)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Button (Bottom)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.climate_sensor_w100_button_5',
+    'entity_id': 'event.climate_sensor_w100_button_bottom',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_middle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'long_press',
+        'long_release',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.climate_sensor_w100_button_middle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Middle)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Middle)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_middle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'long_press',
+        'long_release',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Button (Middle)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.climate_sensor_w100_button_middle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_top-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'long_press',
+        'long_release',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.climate_sensor_w100_button_top',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Top)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Top)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-3-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[aqara_sensor_w100][event.climate_sensor_w100_button_top-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'long_press',
+        'long_release',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Button (Top)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.climate_sensor_w100_button_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -584,7 +584,7 @@
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_1-entry]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_bottom-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -605,7 +605,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_dual_button_button_1',
+    'entity_id': 'event.bilresa_dual_button_button_bottom',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -613,77 +613,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (1)',
+    'object_id_base': 'Button (Bottom)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (1)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-1-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'long_press',
-        'long_release',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Button (1)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.bilresa_dual_button_button_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'long_press',
-        'long_release',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.bilresa_dual_button_button_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (2)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (2)',
+    'original_name': 'Button (Bottom)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -693,7 +628,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_2-state]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_bottom-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -704,17 +639,17 @@
         'long_press',
         'long_release',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Button (2)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Button (Bottom)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_dual_button_button_2',
+    'entity_id': 'event.bilresa_dual_button_button_bottom',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_1-entry]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_top-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -724,12 +659,8 @@
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'long_press',
+        'long_release',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -739,7 +670,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_1',
+    'entity_id': 'event.bilresa_dual_button_button_top',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -747,22 +678,22 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (1)',
+    'object_id_base': 'Button (Top)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (1)',
+    'original_name': 'Button (Top)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-1-GenericSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_1-state]
+# name: test_events[ikea_bilresa_dual_button][event.bilresa_dual_button_button_top-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -770,24 +701,20 @@
       <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
         'multi_press_1',
         'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
+        'long_press',
+        'long_release',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (1)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Button (Top)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_1',
+    'entity_id': 'event.bilresa_dual_button_button_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_2-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_down-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -812,7 +739,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_2',
+    'entity_id': 'event.bilresa_scroll_wheel_button_down',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -820,12 +747,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (2)',
+    'object_id_base': 'Button (Down)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (2)',
+    'original_name': 'Button (Down)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -835,7 +762,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_2-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_down-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -850,84 +777,17 @@
         'multi_press_7',
         'multi_press_8',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (2)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Down)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_2',
+    'entity_id': 'event.bilresa_scroll_wheel_button_down',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_3-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'long_press',
-        'long_release',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_3',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (3)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (3)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-3-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'long_press',
-        'long_release',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (3)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_4-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_down_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -952,7 +812,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_4',
+    'entity_id': 'event.bilresa_scroll_wheel_button_down_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -960,85 +820,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (4)',
+    'object_id_base': 'Button (Down)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (4)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-4-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (4)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_5-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_5',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (5)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (5)',
+    'original_name': 'Button (Down)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1048,7 +835,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_5-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_down_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -1063,84 +850,17 @@
         'multi_press_7',
         'multi_press_8',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (5)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Down)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_5',
+    'entity_id': 'event.bilresa_scroll_wheel_button_down_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_6-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'long_press',
-        'long_release',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_6',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (6)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (6)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-6-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_6-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'long_press',
-        'long_release',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (6)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_6',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_7-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_down_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1165,7 +885,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_7',
+    'entity_id': 'event.bilresa_scroll_wheel_button_down_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1173,85 +893,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (7)',
+    'object_id_base': 'Button (Down)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (7)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-7-GenericSwitch-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_7-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
-      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
-      ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (7)',
-    }),
-    'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_7',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': 'unknown',
-  })
-# ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_8-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
-        'multi_press_1',
-        'multi_press_2',
-        'multi_press_3',
-        'multi_press_4',
-        'multi_press_5',
-        'multi_press_6',
-        'multi_press_7',
-        'multi_press_8',
-      ]),
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'event',
-    'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_8',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Button (8)',
-    'options': dict({
-    }),
-    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
-    'original_icon': None,
-    'original_name': 'Button (8)',
+    'original_name': 'Button (Down)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -1261,7 +908,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_8-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_down_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -1276,17 +923,17 @@
         'multi_press_7',
         'multi_press_8',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (8)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Down)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_8',
+    'entity_id': 'event.bilresa_scroll_wheel_button_down_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_9-entry]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_toggle_next_previous-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1308,7 +955,7 @@
     'disabled_by': None,
     'domain': 'event',
     'entity_category': None,
-    'entity_id': 'event.bilresa_scroll_wheel_button_9',
+    'entity_id': 'event.bilresa_scroll_wheel_button_toggle_next_previous',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1316,22 +963,22 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Button (9)',
+    'object_id_base': 'Button (Toggle Next Previous)',
     'options': dict({
     }),
     'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
     'original_icon': None,
-    'original_name': 'Button (9)',
+    'original_name': 'Button (Toggle Next Previous)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': 'button',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-9-GenericSwitch-59-1',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-3-GenericSwitch-59-1',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_9-state]
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_toggle_next_previous-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
@@ -1343,10 +990,363 @@
         'long_press',
         'long_release',
       ]),
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (9)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Toggle Next Previous)',
     }),
     'context': <ANY>,
-    'entity_id': 'event.bilresa_scroll_wheel_button_9',
+    'entity_id': 'event.bilresa_scroll_wheel_button_toggle_next_previous',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_toggle_next_previous_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'long_press',
+        'long_release',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.bilresa_scroll_wheel_button_toggle_next_previous_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Toggle Next Previous)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Toggle Next Previous)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-6-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_toggle_next_previous_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'long_press',
+        'long_release',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Toggle Next Previous)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.bilresa_scroll_wheel_button_toggle_next_previous_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_toggle_next_previous_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'long_press',
+        'long_release',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.bilresa_scroll_wheel_button_toggle_next_previous_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Toggle Next Previous)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Toggle Next Previous)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-9-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_toggle_next_previous_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'long_press',
+        'long_release',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Toggle Next Previous)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.bilresa_scroll_wheel_button_toggle_next_previous_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_up-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'multi_press_4',
+        'multi_press_5',
+        'multi_press_6',
+        'multi_press_7',
+        'multi_press_8',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.bilresa_scroll_wheel_button_up',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Up)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Up)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_up-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'multi_press_4',
+        'multi_press_5',
+        'multi_press_6',
+        'multi_press_7',
+        'multi_press_8',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Up)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.bilresa_scroll_wheel_button_up',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_up_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'multi_press_4',
+        'multi_press_5',
+        'multi_press_6',
+        'multi_press_7',
+        'multi_press_8',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.bilresa_scroll_wheel_button_up_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Up)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Up)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-4-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_up_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'multi_press_4',
+        'multi_press_5',
+        'multi_press_6',
+        'multi_press_7',
+        'multi_press_8',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Up)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.bilresa_scroll_wheel_button_up_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_up_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'multi_press_4',
+        'multi_press_5',
+        'multi_press_6',
+        'multi_press_7',
+        'multi_press_8',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'event',
+    'entity_category': None,
+    'entity_id': 'event.bilresa_scroll_wheel_button_up_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Button (Up)',
+    'options': dict({
+    }),
+    'original_device_class': <EventDeviceClass.BUTTON: 'button'>,
+    'original_icon': None,
+    'original_name': 'Button (Up)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'button',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-7-GenericSwitch-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_events[ikea_scroll_wheel][event.bilresa_scroll_wheel_button_up_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'button',
+      <EventEntityStateAttribute.EVENT_TYPE: 'event_type'>: None,
+      <EventEntityCapabilityAttribute.EVENT_TYPES: 'event_types'>: list([
+        'multi_press_1',
+        'multi_press_2',
+        'multi_press_3',
+        'multi_press_4',
+        'multi_press_5',
+        'multi_press_6',
+        'multi_press_7',
+        'multi_press_8',
+      ]),
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Button (Up)',
+    }),
+    'context': <ANY>,
+    'entity_id': 'event.bilresa_scroll_wheel_button_up_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/matter/snapshots/test_sensor.ambr
+++ b/tests/components/matter/snapshots/test_sensor.ambr
@@ -2780,7 +2780,7 @@
     'state': 'software_reset',
   })
 # ---
-# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_3-entry]
+# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_bottom-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2796,7 +2796,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_3',
+    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_bottom',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2804,118 +2804,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current switch position (3)',
+    'object_id_base': 'Current switch position (Bottom)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current switch position (3)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-3-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Current switch position (3)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (4)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (4)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-4-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Current switch position (4)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_5-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_5',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (5)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (5)',
+    'original_name': 'Current switch position (Bottom)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -2925,14 +2819,120 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_5-state]
+# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_bottom-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Current switch position (5)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Current switch position (Bottom)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_5',
+    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_bottom',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_middle-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_middle',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Middle)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Middle)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-4-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_middle-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Current switch position (Middle)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_middle',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_top-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_top',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Top)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Top)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-000000000000004B-MatterNodeDevice-3-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[aqara_sensor_w100][sensor.climate_sensor_w100_current_switch_position_top-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Climate Sensor W100 Current switch position (Top)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.climate_sensor_w100_current_switch_position_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -12994,7 +12994,7 @@
     'state': '2.82',
   })
 # ---
-# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_1-entry]
+# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_bottom-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13010,7 +13010,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_1',
+    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_bottom',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -13018,65 +13018,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current switch position (1)',
+    'object_id_base': 'Current switch position (Bottom)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current switch position (1)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-1-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Current switch position (1)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (2)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (2)',
+    'original_name': 'Current switch position (Bottom)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -13086,14 +13033,67 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_2-state]
+# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_bottom-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Current switch position (2)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Current switch position (Bottom)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_2',
+    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_bottom',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_top-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_top',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Top)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Top)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-0000000000000089-MatterNodeDevice-1-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[ikea_bilresa_dual_button][sensor.bilresa_dual_button_current_switch_position_top-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA dual button Current switch position (Top)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bilresa_dual_button_current_switch_position_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -13542,7 +13542,7 @@
     'state': '2.57',
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_1-entry]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_down-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13558,7 +13558,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_1',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_down',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -13566,65 +13566,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current switch position (1)',
+    'object_id_base': 'Current switch position (Down)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current switch position (1)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_1-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (1)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_1',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_2-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_2',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (2)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (2)',
+    'original_name': 'Current switch position (Down)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -13634,21 +13581,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_2-state]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_down-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (2)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Down)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_2',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_down',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_3-entry]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_down_2-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13664,7 +13611,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_3',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_down_2',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -13672,118 +13619,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current switch position (3)',
+    'object_id_base': 'Current switch position (Down)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current switch position (3)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-3-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_3-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (3)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_3',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (4)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (4)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-4-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_4-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (4)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_4',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_5-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_5',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (5)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (5)',
+    'original_name': 'Current switch position (Down)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -13793,21 +13634,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_5-state]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_down_2-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (5)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Down)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_5',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_down_2',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_6-entry]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_down_3-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13823,7 +13664,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_6',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_down_3',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -13831,118 +13672,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current switch position (6)',
+    'object_id_base': 'Current switch position (Down)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current switch position (6)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-6-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_6-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (6)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_6',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_7-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_7',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (7)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (7)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': 'switch_current_position',
-    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-7-SwitchCurrentPosition-59-1',
-    'unit_of_measurement': None,
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_7-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (7)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_7',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '0',
-  })
-# ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_8-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_8',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Current switch position (8)',
-    'options': dict({
-    }),
-    'original_device_class': None,
-    'original_icon': None,
-    'original_name': 'Current switch position (8)',
+    'original_name': 'Current switch position (Down)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -13952,21 +13687,21 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_8-state]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_down_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (8)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Down)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_8',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_down_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_9-entry]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13982,7 +13717,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_9',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -13990,12 +13725,118 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current switch position (9)',
+    'object_id_base': 'Current switch position (Toggle Next Previous)',
     'options': dict({
     }),
     'original_device_class': None,
     'original_icon': None,
-    'original_name': 'Current switch position (9)',
+    'original_name': 'Current switch position (Toggle Next Previous)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-3-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Toggle Next Previous)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Toggle Next Previous)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Toggle Next Previous)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-6-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Toggle Next Previous)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Toggle Next Previous)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Toggle Next Previous)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -14005,14 +13846,173 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_9-state]
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_3-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (9)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Toggle Next Previous)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_9',
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_toggle_next_previous_3',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_up-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_up',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Up)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Up)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-1-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_up-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Up)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_up',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_up_2-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_up_2',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Up)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Up)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-4-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_up_2-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Up)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_up_2',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '0',
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_up_3-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_up_3',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Current switch position (Up)',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Current switch position (Up)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'switch_current_position',
+    'unique_id': '00000000000004D2-0000000000000002-MatterNodeDevice-7-SwitchCurrentPosition-59-1',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensors[ikea_scroll_wheel][sensor.bilresa_scroll_wheel_current_switch_position_up_3-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'BILRESA scroll wheel Current switch position (Up)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.bilresa_scroll_wheel_current_switch_position_up_3',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -21815,7 +21815,7 @@
     'state': 'unspecified',
   })
 # ---
-# name: test_sensors[mock_oven][sensor.mock_oven_current_phase-entry]
+# name: test_sensors[mock_oven][sensor.mock_oven_current_phase_top-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -21835,7 +21835,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_oven_current_phase',
+    'entity_id': 'sensor.mock_oven_current_phase_top',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21843,12 +21843,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Current phase',
+    'object_id_base': 'Current phase (Top)',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'Current phase',
+    'original_name': 'Current phase (Top)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -21858,11 +21858,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[mock_oven][sensor.mock_oven_current_phase-state]
+# name: test_sensors[mock_oven][sensor.mock_oven_current_phase_top-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Current phase',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Current phase (Top)',
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'pre-heating',
         'pre-heated',
@@ -21870,14 +21870,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_oven_current_phase',
+    'entity_id': 'sensor.mock_oven_current_phase_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'pre-heating',
   })
 # ---
-# name: test_sensors[mock_oven][sensor.mock_oven_operational_state-entry]
+# name: test_sensors[mock_oven][sensor.mock_oven_operational_state_top-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -21897,7 +21897,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_oven_operational_state',
+    'entity_id': 'sensor.mock_oven_operational_state_top',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21905,12 +21905,12 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Operational state',
+    'object_id_base': 'Operational state (Top)',
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
     'original_icon': None,
-    'original_name': 'Operational state',
+    'original_name': 'Operational state (Top)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -21920,11 +21920,11 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_sensors[mock_oven][sensor.mock_oven_operational_state-state]
+# name: test_sensors[mock_oven][sensor.mock_oven_operational_state_top-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Operational state',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Operational state (Top)',
       <SensorEntityCapabilityAttribute.OPTIONS: 'options'>: list([
         'stopped',
         'running',
@@ -21932,7 +21932,7 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_oven_operational_state',
+    'entity_id': 'sensor.mock_oven_operational_state_top',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
@@ -21992,7 +21992,7 @@
     'state': '1',
   })
 # ---
-# name: test_sensors[mock_oven][sensor.mock_oven_temperature_2-entry]
+# name: test_sensors[mock_oven][sensor.mock_oven_temperature_left-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -22008,7 +22008,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.mock_oven_temperature_2',
+    'entity_id': 'sensor.mock_oven_temperature_left',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -22016,7 +22016,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Temperature (2)',
+    'object_id_base': 'Temperature (Left)',
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 1,
@@ -22024,65 +22024,7 @@
     }),
     'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
     'original_icon': None,
-    'original_name': 'Temperature (2)',
-    'platform': 'matter',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': '00000000000004D2-0000000000000029-MatterNodeDevice-2-TemperatureSensor-1026-0',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_sensors[mock_oven][sensor.mock_oven_temperature_2-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Temperature (2)',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.mock_oven_temperature_2',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '65.55',
-  })
-# ---
-# name: test_sensors[mock_oven][sensor.mock_oven_temperature_4-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': None,
-    'entity_id': 'sensor.mock_oven_temperature_4',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Temperature (4)',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'Temperature (4)',
+    'original_name': 'Temperature (Left)',
     'platform': 'matter',
     'previous_unique_id': None,
     'suggested_object_id': None,
@@ -22092,20 +22034,78 @@
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensors[mock_oven][sensor.mock_oven_temperature_4-state]
+# name: test_sensors[mock_oven][sensor.mock_oven_temperature_left-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Temperature (4)',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Temperature (Left)',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.mock_oven_temperature_4',
+    'entity_id': 'sensor.mock_oven_temperature_left',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0.0',
+  })
+# ---
+# name: test_sensors[mock_oven][sensor.mock_oven_temperature_top-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.mock_oven_temperature_top',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Temperature (Top)',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Temperature (Top)',
+    'platform': 'matter',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': '00000000000004D2-0000000000000029-MatterNodeDevice-2-TemperatureSensor-1026-0',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensors[mock_oven][sensor.mock_oven_temperature_top-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Mock Oven Temperature (Top)',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.mock_oven_temperature_top',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '65.55',
   })
 # ---
 # name: test_sensors[mock_oven][sensor.mock_oven_uptime-entry]

--- a/tests/components/matter/test_entity.py
+++ b/tests/components/matter/test_entity.py
@@ -1,5 +1,6 @@
 """Test Matter entity behavior."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from matter_server.client.models.node import MatterNode
@@ -128,6 +129,85 @@ async def test_label_modified_entity_translation_key(
     state_bottom = hass.states.get("switch.eve_energy_20ecn4101_switch_bottom")
     assert state_bottom is not None
     assert state_bottom.name == "Eve Energy 20ECN4101 Switch (bottom)"
+
+
+@pytest.mark.usefixtures("matter_node")
+@pytest.mark.parametrize("node_fixture", ["ikea_bilresa_dual_button"])
+async def test_semantic_tag_translated_tag_wins_over_custom_label(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that a structured semantic tag is preferred over a Custom tag label.
+
+    Both endpoints of this device carry a Common Position tag (Top/Bottom), a
+    Switches action tag (On/Up, Off/Down) and a Switches Custom tag with a
+    free-text label ("button 1"/"button 2"). The Custom tag label would
+    produce a redundant name (the entity is already named "Button"), so the
+    translated Common Position tag must take priority over it.
+    """
+    entry_1 = entity_registry.async_get("event.bilresa_dual_button_button_top")
+    assert entry_1 is not None
+    assert entry_1.original_name == "Button (Top)"
+
+    state_1 = hass.states.get("event.bilresa_dual_button_button_top")
+    assert state_1 is not None
+    assert state_1.name == "BILRESA dual button Button (Top)"
+
+    entry_2 = entity_registry.async_get("event.bilresa_dual_button_button_bottom")
+    assert entry_2 is not None
+    assert entry_2.original_name == "Button (Bottom)"
+
+    state_2 = hass.states.get("event.bilresa_dual_button_button_bottom")
+    assert state_2 is not None
+    assert state_2.name == "BILRESA dual button Button (Bottom)"
+
+
+@pytest.mark.parametrize(
+    ("tags", "expected_postfix"),
+    [
+        # Common Position namespace (0x08), tag 2 = Top: translated word
+        ([{"0": None, "1": 8, "2": 2}], "Top"),
+        # Common Position namespace (0x08), tags 1 + 2 = Right + Top: a
+        # namespace can carry multiple tags at once for a corner position.
+        # Sent in reverse (Right before Top) to verify the result is still
+        # combined in canonical reading order ("Top Right"), not device order.
+        (
+            [{"0": None, "1": 8, "2": 1}, {"0": None, "1": 8, "2": 2}],
+            "Top Right",
+        ),
+        # Switches namespace (0x43), tag 3 = Up: translated word, used as
+        # fallback when no Common Position tag is present
+        ([{"0": None, "1": 67, "2": 3}], "Up"),
+        # Common Number namespace (0x07), tag 5 = Five: a plain digit does
+        # not need any translation, used as fallback when no structured,
+        # translatable tag (Common Position or Switches action) is present
+        ([{"0": None, "1": 7, "2": 5}], "5"),
+        # Switches namespace (0x43), tag 8 = Custom: a free-text vendor label,
+        # used as the last-resort fallback
+        ([{"0": None, "1": 67, "2": 8, "3": "custom label"}], "custom label"),
+    ],
+)
+async def test_semantic_tag_name_modifier(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    tags: list[dict[str, Any]],
+    expected_postfix: str,
+) -> None:
+    """Test that a Descriptor TagList entry can modify the entity name postfix.
+
+    Endpoint 1 of "mock_generic_switch_multi" has no FixedLabel/UserLabel, so
+    it normally falls back to its raw endpoint id ("1") as name postfix.
+    """
+    await setup_integration_with_node_fixture(
+        hass, "mock_generic_switch_multi", matter_client, {"1/29/4": tags}
+    )
+
+    entity_id = (
+        f"event.mock_generic_switch_button_{expected_postfix.lower().replace(' ', '_')}"
+    )
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.name == f"Mock Generic Switch Button ({expected_postfix})"
 
 
 @pytest.mark.usefixtures("matter_node")


### PR DESCRIPTION
## Proposed change

When a device exposes several entities of the same kind on different
endpoints (e.g. two buttons on a remote), the entity name currently falls
back to the raw endpoint id: `Button (2)`. The Matter Descriptor cluster's
`TagList` attribute (semantic tags, see the CSA "Standard Namespace
Specification") often carries a much more meaningful, standardized
description of the endpoint, so this PR uses it to build a better name
postfix.

### Detection

`Descriptor.Attributes.TagList` is a list of `SemanticTagStruct` entries
(`namespaceID`, `tag`, optional `label`). Each entry is matched against a
small set of known, standard namespaces:

- **Switches** (`0x43`): `On`/`Off`/`Toggle`/`Up`/`Down`/`Next`/`Previous`/
  `EnterOkSelect`/`Open`/`Close`/`Stop`, plus `Custom` which carries a
  free-text vendor label instead of a fixed meaning.
- **Common Position** (`0x08`): `Left`/`Right`/`Top`/`Bottom`/`Middle`.
- **Common Number** (`0x07`): a plain enumerated digit (`Zero`..`Thirty`).

A namespace can carry more than one tag at once (e.g. `Top` + `Right` for a
corner position); when that happens the matching words are combined in a
fixed, canonical reading order (`"Top Right"`, not `"Right Top"`),
independent of the order the device reports them in.

Priority order, highest first:
1. the existing vendor-specific `FixedLabel`/`UserLabel` list (unchanged
   behavior).
2. `Common Position` / `Switches` action tags — see "Translation" below.
3. `Common Number` tag, used as-is (a digit needs no translation).
4. `Switches` `Custom` tag free-text label, as a last resort — it often
   just repeats the entity's own generic name (e.g. a `"button 1"` label on
   an entity already named `"Button"`), so structured tags are preferred
   when available.
5. unchanged fallback: the raw endpoint id.

### Translation

Tiers 3 and 4 are plain text and need no translation. Tier 2 words do need
translation, but the translated string is only known once the entity has
been added to a platform (`platform_data.platform_translations` is `None`
before that), so detection (does a translatable tag exist?) happens eagerly
in `__init__`, while the actual translated string is resolved lazily in the
`name` property.

Each word gets its own `entity.<domain>.matter_semantic_tag_<word>.name`
translation string in `strings.json` (reusing `common::` strings like
`[%key:common::state::on%]` where one already exists), resolved through the
same `platform_translations` dict Home Assistant's own `translation_key`
mechanism uses — so these postfixes are fully localized like any other
entity name, not just hardcoded English text. Verified locally with a
throwaway `fr.json`: `Button (Top)` / `Button (Bottom)` becomes
`Bouton (Haut)` / `Bouton (Bas)`.

This also fixes the "sensor W100 has a `TagList` attribute" case the closed
#151448 was about, but generalizes it: any structured tag now improves
naming instead of only `Common Number`, without leaking free-text vendor
labels that duplicate the entity's own name (raised by @Apollon77 in that
PR's review).

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #151448
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
