### PR TITLE
homee: Add more logging

### DIFF
--- a/homeassistant/components/homee/entity.py
+++ b/homeassistant/components/homee/entity.py
@@ -1,5 +1,6 @@
 """Base Entities for Homee integration."""
 
+import logging
 from typing import override
 
 from pyHomee.const import AttributeType, NodeProfile, NodeState
@@ -13,6 +14,8 @@ from homeassistant.helpers.entity import Entity
 from . import HomeeConfigEntry
 from .const import DOMAIN
 from .helpers import get_name_for_enum
+
+_LOGGER = logging.getLogger(__name__)
 
 FIRST_UNAVAILABLE_ATTRIBUTE_STATE = 5
 
@@ -74,6 +77,7 @@ class HomeeEntity(Entity):
     async def async_set_homee_value(self, value: float) -> None:
         """Set an attribute value on the homee node."""
         homee = self._entry.runtime_data
+        _LOGGER.debug("Setting attribute %s to %s", self._attribute.id, value)
         try:
             await homee.set_value(self._attribute.node_id, self._attribute.id, value)
         except ConnectionClosed as exception:
@@ -88,6 +92,7 @@ class HomeeEntity(Entity):
         await homee.update_attribute(self._attribute.node_id, self._attribute.id)
 
     def _on_node_updated(self, attribute: HomeeAttribute) -> None:
+        _LOGGER.debug("Update for attribute %s received", attribute.id)
         self.schedule_update_ha_state()
 
     async def _on_connection_changed(self, connected: bool) -> None:
@@ -168,6 +173,7 @@ class HomeeNodeEntity(Entity):
     ) -> None:
         """Set an attribute value on the homee node."""
         homee = self._entry.runtime_data
+        _LOGGER.debug("Setting attribute %s to %s", attribute.id, value)
         try:
             await homee.set_value(attribute.node_id, attribute.id, value)
         except ConnectionClosed as exception:
@@ -177,6 +183,7 @@ class HomeeNodeEntity(Entity):
             ) from exception
 
     def _on_node_updated(self, node: HomeeNode) -> None:
+        _LOGGER.debug("Update for node %s with id %s received", node.name, node.id)
         self.schedule_update_ha_state()
 
     async def _on_connection_changed(self, connected: bool) -> None:

--- a/homeassistant/components/homee/manifest.json
+++ b/homeassistant/components/homee/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://www.home-assistant.io/integrations/homee",
   "integration_type": "hub",
   "iot_class": "local_push",
-  "loggers": ["homee"],
+  "loggers": ["homee", "pyHomee"],
   "quality_scale": "silver",
   "requirements": ["pyHomee==1.4.2"],
   "zeroconf": [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This adds the backend pyHomee to the loggers to easier retrieve debug logs for this and also some more log-lines to see what Ha does in relateion to the backend.

Would be nice to still get this in 2026.8, since there are upcoming bigger changes to homee Firmware, that might make this necessary quite soon.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
