### PR TITLE
Add connorgallopo as insteon codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -886,8 +886,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/input_select/ @home-assistant/core
 /homeassistant/components/input_text/ @home-assistant/core
 /tests/components/input_text/ @home-assistant/core
-/homeassistant/components/insteon/ @teharris1 @ssyrell
-/tests/components/insteon/ @teharris1 @ssyrell
+/homeassistant/components/insteon/ @teharris1 @ssyrell @connorgallopo
+/tests/components/insteon/ @teharris1 @ssyrell @connorgallopo
 /homeassistant/components/integration/ @dgomes
 /tests/components/integration/ @dgomes
 /homeassistant/components/intelliclima/ @dvdinth

--- a/homeassistant/components/insteon/manifest.json
+++ b/homeassistant/components/insteon/manifest.json
@@ -2,7 +2,7 @@
   "domain": "insteon",
   "name": "Insteon",
   "after_dependencies": ["panel_custom"],
-  "codeowners": ["@teharris1", "@ssyrell"],
+  "codeowners": ["@teharris1", "@ssyrell", "@connorgallopo"],
   "config_flow": true,
   "dependencies": ["http", "usb", "websocket_api"],
   "dhcp": [


### PR DESCRIPTION
## Proposed change

Add myself as a codeowner for the insteon integration, alongside the existing codeowners.

I run a 35-device Insteon network on Home Assistant and have been actively working on the integration and its dependency stack:

- home-assistant/core#177190: extend `insteon/device/get` with device identity fields (open, CI green)
- pyinsteon/pyinsteon#446, #447, #448: an i3 ALDB read fix, maintenance backoff for unresponsive devices, and transport tuning (open, CI green)
- Frontend work on the insteon-panel repository targeting its `dev` branch

The integration needs more review and triage capacity than it currently has. Issue disposition for `integration: insteon` shows the trend: from 2021 through 2023 the label averaged about 24 resolved issues per year with few stale closures; in 2025 one issue was resolved while 17 were closed as stale, and 2026 so far is 5 resolved (mostly core-team maintenance such as the `runtime_data` migration) against 7 stale. Recent stale closures include real defects, for example #160622 (ALDB cannot be read), #162946 (leak sensor heartbeat, for which a fix has been waiting in pyinsteon/pyinsteon#442 since April), and #148891 (the panel's Add Device screen showing no actionable buttons).

Being a codeowner gets me pinged on new issues and PRs so they get triage and review instead of the stale bot. The existing codeowners are unchanged and I am coordinating with the upstream pyinsteon project on the library side.

I am a very active open-source developer, and have been a software engineer for over 10 years. I personally have been able to greatly improve my Insteon device performance and reliability and want to see this integration grow. 

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
