### PR TITLE
Report unknown iZone fan/mode without breaking climate updates

### DIFF
--- a/homeassistant/components/izone/climate.py
+++ b/homeassistant/components/izone/climate.py
@@ -1,6 +1,7 @@
 """Support for the iZone HVAC."""
 
 from collections.abc import Mapping
+import logging
 from typing import Any, override
 
 from pizone import Controller, Zone
@@ -34,6 +35,8 @@ from homeassistant.helpers.typing import VolDictType
 from .const import DOMAIN
 from .coordinator import IZoneConfigEntry, IZoneCoordinator
 from .entity import IZoneCoordinatorEntity
+
+_LOGGER = logging.getLogger(__name__)
 
 _IZONE_FAN_TO_HA = {
     Controller.Fan.LOW: FAN_LOW,
@@ -91,6 +94,8 @@ class ControllerDevice(IZoneCoordinatorEntity, ClimateEntity):
         """Initialise ControllerDevice."""
         super().__init__(coordinator)
         controller = coordinator.controller
+        self._unknown_fan_logged = False
+        self._unknown_mode_logged = False
 
         self._attr_supported_features = (
             ClimateEntityFeature.FAN_MODE
@@ -177,11 +182,25 @@ class ControllerDevice(IZoneCoordinatorEntity, ClimateEntity):
 
     @property
     @override
-    def hvac_mode(self) -> HVACMode:
+    def hvac_mode(self) -> HVACMode | None:
         """Return current operation ie. heat, cool, idle."""
         if not self.controller.is_on:
             return HVACMode.OFF
-        if (mode := self.controller.mode) is Controller.Mode.FREE_AIR:
+        try:
+            mode = self.controller.mode
+        except ValueError as err:
+            if not self._unknown_mode_logged:
+                _LOGGER.warning(
+                    "Unknown SysMode from iZone controller %s (%s); "
+                    "HVAC mode unavailable. Please open an issue at "
+                    "https://github.com/home-assistant/core/issues "
+                    "and attach diagnostics",
+                    self.controller.device_uid,
+                    err,
+                )
+                self._unknown_mode_logged = True
+            return None
+        if mode is Controller.Mode.FREE_AIR:
             return HVACMode.FAN_ONLY
         for key, value in self._state_to_pizone.items():
             if value is mode:
@@ -214,7 +233,7 @@ class ControllerDevice(IZoneCoordinatorEntity, ClimateEntity):
     @override
     def current_temperature(self) -> float | None:
         """Return the current temperature."""
-        if self.controller.mode is Controller.Mode.FREE_AIR:
+        if self.controller.free_air:
             return self.controller.temp_supply
         return self.controller.temp_return
 
@@ -266,7 +285,21 @@ class ControllerDevice(IZoneCoordinatorEntity, ClimateEntity):
     @override
     def fan_mode(self) -> str | None:
         """Return the fan setting."""
-        return _IZONE_FAN_TO_HA[self.controller.fan]
+        try:
+            return _IZONE_FAN_TO_HA[self.controller.fan]
+        except ValueError as err:
+            if not self._unknown_fan_logged:
+                _LOGGER.warning(
+                    "Unknown SysFan from iZone controller %s (%s); "
+                    "reporting fan_mode unknown. Please open an issue at "
+                    "https://github.com/home-assistant/core/issues "
+                    "and attach diagnostics",
+                    self.controller.device_uid,
+                    err,
+                )
+                self._unknown_fan_logged = True
+            # Display-only; omit from fan_modes so it cannot be selected.
+            return "unknown"
 
     @property
     @override

--- a/tests/components/izone/test_climate.py
+++ b/tests/components/izone/test_climate.py
@@ -1,7 +1,7 @@
 """Tests for iZone climate platform."""
 
 import logging
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, PropertyMock
 
 from freezegun.api import FrozenDateTimeFactory
 from pizone import Controller, ControllerCommandError, Zone
@@ -9,7 +9,9 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
     ATTR_FAN_MODE,
+    ATTR_FAN_MODES,
     ATTR_HVAC_MODE,
     ATTR_TEMPERATURE,
     DOMAIN as CLIMATE_DOMAIN,
@@ -21,7 +23,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.izone.const import DOMAIN
 from homeassistant.components.izone.coordinator import UPDATE_INTERVAL
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 import homeassistant.helpers.entity_registry as er
@@ -33,6 +35,18 @@ from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_plat
 
 CONTROLLER_ENTITY = "climate.izone_controller_000000001"
 ZONE_ENTITY = "climate.living_room"
+
+
+def _raise_on_controller_property(
+    mock_controller: Mock, name: str, message: str
+) -> None:
+    """Make a controller property raise ValueError without affecting other mocks."""
+    # Unique type so PropertyMock does not affect other Mock instances.
+    raising_type = type(
+        f"Raising{name.title()}Controller_{id(mock_controller)}", (Mock,), {}
+    )
+    mock_controller.__class__ = raising_type
+    setattr(type(mock_controller), name, PropertyMock(side_effect=ValueError(message)))
 
 
 @pytest.mark.usefixtures("init_integration")
@@ -97,6 +111,55 @@ async def test_set_controller_hvac_and_fan(
         blocking=True,
     )
     mock_controller.set_fan.assert_awaited_once_with(Controller.Fan.HIGH)
+
+
+async def test_unknown_fan_mode_reports_unknown(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_create_discovery: AsyncMock,
+    mock_controller: Mock,
+    mock_zones: list[Mock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown SysFan from the library surfaces as display-only fan_mode unknown."""
+    mock_controller.zones = mock_zones
+    _raise_on_controller_property(mock_controller, "fan", "quiet")
+
+    with caplog.at_level(logging.WARNING):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(CONTROLLER_ENTITY)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes[ATTR_FAN_MODE] == "unknown"
+    assert "unknown" not in (state.attributes.get(ATTR_FAN_MODES) or [])
+    assert "Unknown SysFan from iZone controller" in caplog.text
+    assert "quiet" in caplog.text
+    assert "attach diagnostics" in caplog.text
+
+
+async def test_unknown_mode_keeps_entity_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_create_discovery: AsyncMock,
+    mock_controller: Mock,
+    mock_zones: list[Mock],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown SysMode leaves HVAC state unknown without marking unavailable."""
+    mock_controller.zones = mock_zones
+    _raise_on_controller_property(mock_controller, "mode", "turbo")
+
+    with caplog.at_level(logging.WARNING):
+        await setup_integration(hass, mock_config_entry)
+
+    state = hass.states.get(CONTROLLER_ENTITY)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_CURRENT_TEMPERATURE] == mock_controller.temp_return
+    assert "Unknown SysMode from iZone controller" in caplog.text
+    assert "turbo" in caplog.text
+    assert "attach diagnostics" in caplog.text
 
 
 @pytest.mark.usefixtures("init_integration")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When `python-izone` raises `ValueError` for an unrecognized `SysFan` / `SysMode` (from 1.3.9), keep the iZone climate entity available instead of breaking state updates.

- `fan_mode` reports display-only `"unknown"` (not added to `fan_modes`, so it cannot be selected)
- `hvac_mode` returns `None` (entity state unknown) for unrecognized `SysMode`
- `current_temperature` uses `free_air` to choose supply vs return temperature
- Logs a one-shot warning with the exception detail and asks reporters to open an issue with diagnostics

Requires `python-izone` 1.3.9 behavior already on `dev` via #177251.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #160350 [this comment specifically](#160350#issuecomment-3943604261)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
