### PR TITLE
Add KNX notify entity UI configuration

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -200,6 +200,7 @@ SUPPORTED_PLATFORMS_UI: Final = {
     Platform.FAN,
     Platform.DATETIME,
     Platform.LIGHT,
+    Platform.NOTIFY,
     Platform.NUMBER,
     Platform.SCENE,
     Platform.SENSOR,

--- a/homeassistant/components/knx/notify.py
+++ b/homeassistant/components/knx/notify.py
@@ -2,19 +2,23 @@
 
 from typing import override
 
-from xknx import XKNX
 from xknx.devices import Notification as XknxNotification
 
 from homeassistant import config_entries
 from homeassistant.components.notify import NotifyEntity
 from homeassistant.const import CONF_ENTITY_CATEGORY, CONF_NAME, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    async_get_current_platform,
+)
 from homeassistant.helpers.typing import ConfigType
 
-from .const import KNX_ADDRESS, KNX_MODULE_KEY
-from .entity import KnxYamlEntity
+from .const import DOMAIN, KNX_ADDRESS, KNX_MODULE_KEY
+from .entity import KnxUiEntity, KnxUiEntityPlatformController, KnxYamlEntity
 from .knx_module import KNXModule
+from .storage.const import CONF_ENTITY, CONF_GA_SEND
+from .storage.util import ConfigExtractor
 
 
 async def async_setup_entry(
@@ -24,29 +28,55 @@ async def async_setup_entry(
 ) -> None:
     """Set up notify(s) for KNX platform."""
     knx_module = hass.data[KNX_MODULE_KEY]
-    config: list[ConfigType] = knx_module.config_yaml[Platform.NOTIFY]
-
-    async_add_entities(KNXNotify(knx_module, entity_config) for entity_config in config)
-
-
-def _create_notification_instance(xknx: XKNX, config: ConfigType) -> XknxNotification:
-    """Return a KNX Notification to be used within XKNX."""
-    return XknxNotification(
-        xknx,
-        name=config[CONF_NAME],
-        group_address=config[KNX_ADDRESS],
-        value_type=config[CONF_TYPE],
+    platform = async_get_current_platform()
+    knx_module.config_store.add_platform(
+        platform=Platform.NOTIFY,
+        controller=KnxUiEntityPlatformController(
+            knx_module=knx_module,
+            entity_platform=platform,
+            entity_class=KnxUiNotify,
+        ),
     )
 
+    entities: list[KnxYamlEntity | KnxUiEntity] = []
+    if yaml_platform_config := knx_module.config_yaml.get(Platform.NOTIFY):
+        entities.extend(
+            KnxYamlNotify(knx_module, entity_config)
+            for entity_config in yaml_platform_config
+        )
+    if ui_config := knx_module.config_store.data["entities"].get(Platform.NOTIFY):
+        entities.extend(
+            KnxUiNotify(knx_module, unique_id, config)
+            for unique_id, config in ui_config.items()
+        )
+    if entities:
+        async_add_entities(entities)
 
-class KNXNotify(KnxYamlEntity, NotifyEntity):
+
+class _KnxNotify(NotifyEntity):
     """Representation of a KNX notification entity."""
+
+    _device: XknxNotification
+
+    @override
+    async def async_send_message(self, message: str, title: str | None = None) -> None:
+        """Send a notification to knx bus."""
+        await self._device.set(message)
+
+
+class KnxYamlNotify(_KnxNotify, KnxYamlEntity):
+    """Representation of a KNX notification entity configured from YAML."""
 
     _device: XknxNotification
 
     def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
         """Initialize a KNX notification."""
-        self._device = _create_notification_instance(knx_module.xknx, config)
+        self._device = XknxNotification(
+            knx_module.xknx,
+            name=config[CONF_NAME],
+            group_address=config[KNX_ADDRESS],
+            value_type=config[CONF_TYPE],
+        )
         super().__init__(
             knx_module=knx_module,
             unique_id=str(self._device.remote_value.group_address),
@@ -54,7 +84,25 @@ class KNXNotify(KnxYamlEntity, NotifyEntity):
             entity_category=config.get(CONF_ENTITY_CATEGORY),
         )
 
-    @override
-    async def async_send_message(self, message: str, title: str | None = None) -> None:
-        """Send a notification to knx bus."""
-        await self._device.set(message)
+
+class KnxUiNotify(_KnxNotify, KnxUiEntity):
+    """Representation of a KNX notification entity configured from UI."""
+
+    _device: XknxNotification
+
+    def __init__(
+        self, knx_module: KNXModule, unique_id: str, config: ConfigType
+    ) -> None:
+        """Initialize a KNX notification."""
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=unique_id,
+            entity_config=config[CONF_ENTITY],
+        )
+        knx_conf = ConfigExtractor(config[DOMAIN])
+        self._device = XknxNotification(
+            knx_module.xknx,
+            name=config[CONF_ENTITY][CONF_NAME],
+            group_address=knx_conf.get_write(CONF_GA_SEND),
+            value_type=knx_conf.get_dpt(CONF_GA_SEND),
+        )

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -485,6 +485,15 @@ LIGHT_KNX_SCHEMA = AllSerializeFirst(
 )
 
 
+NOTIFY_KNX_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_GA_SEND): GASelector(
+            state=False, passive=False, write_required=True, dpt=["string"]
+        ),
+    }
+)
+
+
 def _number_limit_sub_validator(config: dict) -> dict:
     """Validate min, max, and step values for a number entity."""
     dpt = config[CONF_GA_SENSOR][CONF_DPT]
@@ -802,6 +811,7 @@ KNX_SCHEMA_FOR_PLATFORM = {
     Platform.DATETIME: DATETIME_KNX_SCHEMA,
     Platform.FAN: FAN_KNX_SCHEMA,
     Platform.LIGHT: LIGHT_KNX_SCHEMA,
+    Platform.NOTIFY: NOTIFY_KNX_SCHEMA,
     Platform.NUMBER: NUMBER_KNX_SCHEMA,
     Platform.SCENE: SCENE_KNX_SCHEMA,
     Platform.SENSOR: SENSOR_KNX_SCHEMA,

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -860,6 +860,15 @@
             }
           }
         },
+        "notify": {
+          "description": "The KNX notify platform allows you to send text messages to the KNX bus.",
+          "knx": {
+            "ga_send": {
+              "description": "The group address messages are sent to.",
+              "label": "Address"
+            }
+          }
+        },
         "number": {
           "description": "Entity for numeric datapoints. Temperature, percent, etc.",
           "knx": {

--- a/tests/components/knx/fixtures/config_store_notify.json
+++ b/tests/components/knx/fixtures/config_store_notify.json
@@ -1,0 +1,27 @@
+{
+  "version": 2,
+  "minor_version": 4,
+  "key": "knx/config_store.json",
+  "data": {
+    "entities": {
+      "notify": {
+        "knx_es_01KCXYT0WEJEQQ13SGCY1NHCYX": {
+          "entity": {
+            "name": "test",
+            "device_info": null,
+            "entity_category": null
+          },
+          "knx": {
+            "ga_send": {
+              "write": "1/0/0",
+              "dpt": "16.001",
+              "passive": []
+            }
+          }
+        }
+      }
+    },
+    "expose": {},
+    "time_server": {}
+  }
+}

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -1649,6 +1649,30 @@
     'type': 'result',
   })
 # ---
+# name: test_knx_get_schema[notify]
+  dict({
+    'id': 1,
+    'result': list([
+      dict({
+        'name': 'ga_send',
+        'options': dict({
+          'dptClasses': list([
+            'string',
+          ]),
+          'passive': False,
+          'state': False,
+          'write': dict({
+            'required': True,
+          }),
+        }),
+        'required': True,
+        'type': 'knx_group_address',
+      }),
+    ]),
+    'success': True,
+    'type': 'result',
+  })
+# ---
 # name: test_knx_get_schema[number]
   dict({
     'id': 1,

--- a/tests/components/knx/test_notify.py
+++ b/tests/components/knx/test_notify.py
@@ -3,9 +3,10 @@
 from homeassistant.components import notify
 from homeassistant.components.knx.const import KNX_ADDRESS
 from homeassistant.components.knx.schema import NotifySchema
-from homeassistant.const import CONF_NAME, CONF_TYPE
+from homeassistant.const import CONF_NAME, CONF_TYPE, Platform
 from homeassistant.core import HomeAssistant
 
+from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
 
@@ -95,4 +96,49 @@ async def test_notify_multiple_sends_with_different_encodings(
     await knx.assert_write(
         "1/0/1",
         (71, 228, 110, 115, 101, 102, 252, 223, 99, 104, 101, 110, 0, 0),
+    )
+
+
+async def test_notify_ui_create(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test creating a notify entity from the UI."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.NOTIFY,
+        entity_data={"name": "test"},
+        knx_data={"ga_send": {"write": "1/0/0", "dpt": "16.000"}},
+    )
+    await hass.services.async_call(
+        notify.DOMAIN,
+        notify.SERVICE_SEND_MESSAGE,
+        {"entity_id": "notify.test", notify.ATTR_MESSAGE: "Home Assistant"},
+        blocking=True,
+    )
+    await knx.assert_write(
+        "1/0/0",
+        (72, 111, 109, 101, 32, 65, 115, 115, 105, 115, 116, 97, 110, 116),
+    )
+
+
+async def test_notify_ui_load(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+) -> None:
+    """Test loading a notify entity from storage."""
+    await knx.setup_integration(config_store_fixture="config_store_notify.json")
+
+    assert hass.states.get("notify.test")
+
+    await hass.services.async_call(
+        notify.DOMAIN,
+        notify.SERVICE_SEND_MESSAGE,
+        {"entity_id": "notify.test", notify.ATTR_MESSAGE: "Home Assistant"},
+        blocking=True,
+    )
+    await knx.assert_write(
+        "1/0/0",
+        (72, 111, 109, 101, 32, 65, 115, 115, 105, 115, 116, 97, 110, 116),
     )


### PR DESCRIPTION
## Breaking change


## Proposed change

Add UI configuration support for the KNX `notify` platform. Until now notify entities could only be configured via YAML; this adds a config store schema so they can be created and edited from the KNX config panel, matching the other UI-capable platforms.

Details:
- `notify` is added to `SUPPORTED_PLATFORMS_UI`.
- A `NOTIFY_KNX_SCHEMA` with a single required, write-only, string group address selector is added. It reuses the shared `ga_send` address key (same as the `button` platform) rather than introducing a new constant.
- `notify.py` is refactored into a shared `_KnxNotify` base with `KnxYamlNotify` and `KnxUiNotify` subclasses, and registers a `KnxUiEntityPlatformController`. YAML behavior is unchanged.
- Strings, the generated schema websocket snapshot, a config store fixture and tests (UI create and UI load) are added.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47039
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
