### PR TITLE
Add sensor for Verisure arm readiness

### DIFF
--- a/homeassistant/components/verisure/const.py
+++ b/homeassistant/components/verisure/const.py
@@ -19,6 +19,11 @@ DEFAULT_LOCK_CODE_DIGITS = 4
 # vsure cookies are valid for ~15 minutes; refresh before expiry.
 COOKIE_REFRESH_INTERVAL = timedelta(minutes=10)
 
+# Force-arm readiness is primarily rechecked when a door/window state changes.
+# This is the fallback interval for violation types not reflected there, for
+# example an offline or otherwise faulted device.
+DRY_RUN_FALLBACK_INTERVAL = timedelta(minutes=30)
+
 # Exponential backoff when Verisure returns AUT_00021 / rate limits.
 RATE_LIMIT_BACKOFF = (
     timedelta(minutes=5),

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -260,7 +260,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         while result is None:
             if attempts == 30:
                 break
-            if attempts > 1:
+            if attempts > 0:
                 await asyncio.sleep(0.5)
             attempts += 1
             try:

--- a/homeassistant/components/verisure/coordinator.py
+++ b/homeassistant/components/verisure/coordinator.py
@@ -1,5 +1,6 @@
 """DataUpdateCoordinator for the Verisure integration."""
 
+import asyncio
 from datetime import datetime, timedelta
 from time import sleep
 from typing import override
@@ -28,6 +29,7 @@ from .const import (
     COOKIE_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    DRY_RUN_FALLBACK_INTERVAL,
     LOGGER,
     RATE_LIMIT_BACKOFF,
 )
@@ -44,6 +46,21 @@ def _requires_mfa_reauth(exc: VerisureLoginError) -> bool:
     return _MFA_REQUIRED_MESSAGE in str(exc)
 
 
+def _safe_nested_get(data: object, *keys: str) -> object:
+    """Traverse nested dict keys, tolerating a missing or null value at any level.
+
+    A plain chain of dict.get(key, {}) calls only falls back to {} when a key
+    is absent; a GraphQL error response can return an explicit null instead
+    (for example data itself, on an HTTP-200 error payload), which a chained
+    .get() then raises AttributeError on.
+    """
+    for key in keys:
+        if not isinstance(data, dict):
+            return None
+        data = data.get(key)
+    return data
+
+
 class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
     """A Verisure Data Update Coordinator."""
 
@@ -55,6 +72,11 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
         self._overview: list[dict] = []
         self._rate_limit_backoff_level = 0
         self._last_successful_cookie_refresh: datetime | None = None
+        self._last_dry_run_check: datetime | None = None
+        self._last_door_window_fingerprint: frozenset[tuple[str, str]] | None = None
+        self._force_arm_required: bool | None = None
+        self._dry_run_retry_after: datetime | None = None
+        self._dry_run_backoff_level = 0
 
         self.verisure = Verisure(
             username=entry.data[CONF_EMAIL],
@@ -172,6 +194,138 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
 
         self._last_successful_cookie_refresh = dt_util.utcnow()
 
+    async def _async_check_force_arm_required(self, door_window: dict) -> None:
+        """Check via an arm state dry run whether arming currently requires force.
+
+        Runs when a door/window state changes, readiness is not currently
+        known, or otherwise at most once per DRY_RUN_FALLBACK_INTERVAL as a
+        safety net for violation types not reflected in door/window state,
+        for example an offline or otherwise faulted device. Checking on
+        unknown readiness (rather than only a fingerprint change or the
+        fallback interval) matters because the fingerprint is only stored on
+        success: if a check fails and the door/window state then reverts to
+        a value already seen before that failure, the fingerprint alone
+        would look unchanged and silently skip the retry a failure is
+        supposed to get on the next cycle. Failures are logged and do not
+        fail the overall coordinator update; readiness stays unknown until a
+        check succeeds (or after the rate limit backoff, if rate limited).
+        """
+        fingerprint = frozenset(
+            (label, device.get("state")) for label, device in door_window.items()
+        )
+        fingerprint_changed = fingerprint != self._last_door_window_fingerprint
+        due_for_fallback_check = (
+            self._last_dry_run_check is None
+            or dt_util.utcnow() - self._last_dry_run_check >= DRY_RUN_FALLBACK_INTERVAL
+        )
+        if (
+            not fingerprint_changed
+            and not due_for_fallback_check
+            and self._force_arm_required is not None
+        ):
+            return
+        if (
+            self._dry_run_retry_after is not None
+            and dt_util.utcnow() < self._dry_run_retry_after
+        ):
+            return
+
+        # A due check is about to run; any failure below now leaves readiness
+        # as unknown instead of holding onto a value that may no longer be
+        # accurate, for example after a door/window change.
+        self._force_arm_required = None
+
+        try:
+            dry_run = await self.hass.async_add_executor_job(
+                self.verisure.request, self.verisure.arm_state_dry_run()
+            )
+        except VerisureRateLimitError as ex:
+            self._defer_dry_run_retry(f"rate limited starting the dry run, {ex}")
+            return
+        except VerisureError as ex:
+            LOGGER.debug("Could not start arm state dry run, %s", ex)
+            return
+
+        if not isinstance(dry_run, dict):
+            return
+        data = dry_run.get("data")
+        if not isinstance(data, dict):
+            return
+        transaction_id = data.get("armStateDryRun")
+        if not transaction_id:
+            return
+
+        result = None
+        attempts = 0
+        while result is None:
+            if attempts == 30:
+                break
+            if attempts > 1:
+                await asyncio.sleep(0.5)
+            attempts += 1
+            try:
+                status = await self.hass.async_add_executor_job(
+                    self.verisure.request,
+                    self.verisure.arm_state_dry_run_status(transaction_id),
+                )
+            except VerisureRateLimitError as ex:
+                self._defer_dry_run_retry(f"rate limited polling the dry run, {ex}")
+                return
+            except VerisureError as ex:
+                LOGGER.debug("Could not poll arm state dry run, %s", ex)
+                return
+            if not isinstance(status, dict):
+                return
+            dry_run_status = _safe_nested_get(
+                status, "data", "installation", "armState", "dryRunStatus"
+            )
+            if not isinstance(dry_run_status, dict):
+                return
+            if _safe_nested_get(dry_run_status, "status", "status") != "DONE":
+                continue
+            result = dry_run_status.get("result")
+            if not isinstance(result, dict) or not isinstance(
+                result.get("deviceViolations"), list
+            ):
+                LOGGER.debug("Arm state dry run completed without a violations list")
+                return
+
+        if result is None:
+            self._defer_dry_run_retry(
+                f"exhausted {attempts} poll attempts without a DONE status"
+            )
+            return
+
+        self._force_arm_required = bool(result["deviceViolations"])
+        self._last_dry_run_check = dt_util.utcnow()
+        self._last_door_window_fingerprint = fingerprint
+        self._dry_run_retry_after = None
+        self._dry_run_backoff_level = 0
+
+    def _defer_dry_run_retry(self, reason: str) -> None:
+        """Back off the next dry run attempt on its own schedule.
+
+        Used both for rate limits and for a transaction that never reaches a
+        DONE status: either way, retrying right away risks piling more load
+        onto a backend that is already struggling. Uses a dedicated counter
+        and deadline rather than the coordinator's shared rate-limit backoff:
+        that level is reset whenever the overall update succeeds, which
+        happens right after this check runs on every cycle, so it can never
+        actually defer a retry here. A dedicated deadline is also checked
+        unconditionally, so it still defers a changed-fingerprint recheck,
+        which would otherwise see the fingerprint as still changed (it is
+        only stored on success) and retry every cycle.
+        """
+        level = min(self._dry_run_backoff_level, len(RATE_LIMIT_BACKOFF) - 1)
+        self._dry_run_retry_after = dt_util.utcnow() + RATE_LIMIT_BACKOFF[level]
+        if self._dry_run_backoff_level < len(RATE_LIMIT_BACKOFF) - 1:
+            self._dry_run_backoff_level += 1
+        LOGGER.debug(
+            "Deferring next arm state dry run check until %s, %s",
+            self._dry_run_retry_after,
+            reason,
+        )
+
     async def async_login(self) -> bool:
         """Login to Verisure."""
         try:
@@ -242,6 +396,12 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
             )
             return unpacked or []
 
+        door_window = {
+            device["device"]["deviceLabel"]: device
+            for device in unpack(overview, "doorWindows")
+        }
+        await self._async_check_force_arm_required(door_window)
+
         # Store data in a way Home Assistant can easily consume it
         self._overview = overview
         self._rate_limit_backoff_level = 0
@@ -256,10 +416,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
                 device["device"]["deviceLabel"]: device
                 for device in unpack(overview, "climates")
             },
-            "door_window": {
-                device["device"]["deviceLabel"]: device
-                for device in unpack(overview, "doorWindows")
-            },
+            "door_window": door_window,
             "locks": {
                 device["device"]["deviceLabel"]: device
                 for device in unpack(overview, "smartLocks")
@@ -268,6 +425,7 @@ class VerisureDataUpdateCoordinator(DataUpdateCoordinator):
                 device["device"]["deviceLabel"]: device
                 for device in unpack(overview, "smartplugs")
             },
+            "force_arm_required": self._force_arm_required,
         }
 
     @Throttle(timedelta(seconds=60))

--- a/homeassistant/components/verisure/icons.json
+++ b/homeassistant/components/verisure/icons.json
@@ -1,4 +1,15 @@
 {
+  "entity": {
+    "sensor": {
+      "arm_status": {
+        "default": "mdi:shield-off-outline",
+        "state": {
+          "bypass_needed": "mdi:shield-alert",
+          "ready": "mdi:shield-check"
+        }
+      }
+    }
+  },
   "services": {
     "capture_smartcam": {
       "service": "mdi:camera"

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -38,6 +38,8 @@ async def async_setup_entry(
         for serial_number, values in coordinator.data["climate"].items()
         if values.get("humidityEnabled")
     )
+
+    sensors.append(VerisureArmStatus(coordinator))
 
     async_add_entities(sensors)
 
@@ -139,3 +141,44 @@ class VerisureHygrometer(
             and self.serial_number in self.coordinator.data["climate"]
             and "humidityValue" in self.coordinator.data["climate"][self.serial_number]
         )
+
+
+class VerisureArmStatus(CoordinatorEntity[VerisureDataUpdateCoordinator], SensorEntity):
+    """Whether Verisure currently requires force to arm.
+
+    Backed by an arm-state dry run, run when a door/window state changes or
+    otherwise at least once per DRY_RUN_FALLBACK_INTERVAL.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+    _attr_options = ["ready", "bypass_needed"]
+    _attr_translation_key = "arm_status"
+
+    @property
+    @override
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        return f"{self.coordinator.config_entry.data[CONF_GIID]}_arm_status"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this entity."""
+        return DeviceInfo(
+            name="Verisure Alarm",
+            manufacturer="Verisure",
+            model="VBox",
+            identifiers={(DOMAIN, self.coordinator.config_entry.data[CONF_GIID])},
+            configuration_url="https://mypages.verisure.com",
+        )
+
+    @property
+    @override
+    def native_value(self) -> str | None:
+        """Return whether arming currently requires force."""
+        force_arm_required = self.coordinator.data["force_arm_required"]
+        if force_arm_required is None:
+            return None
+        return "bypass_needed" if force_arm_required else "ready"

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -7,7 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, UnitOfTemperature
+from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
@@ -37,6 +37,8 @@ async def async_setup_entry(
         for serial_number, values in coordinator.data["climate"].items()
         if values.get("humidityEnabled")
     )
+
+    sensors.append(VerisureArmStatus(coordinator))
 
     async_add_entities(sensors)
 
@@ -144,3 +146,44 @@ class VerisureHygrometer(
             and self.serial_number in self.coordinator.data["climate"]
             and "humidityValue" in self.coordinator.data["climate"][self.serial_number]
         )
+
+
+class VerisureArmStatus(CoordinatorEntity[VerisureDataUpdateCoordinator], SensorEntity):
+    """Whether Verisure currently requires force to arm.
+
+    Backed by an arm-state dry run, run when a door/window state changes or
+    otherwise at least once per DRY_RUN_FALLBACK_INTERVAL.
+    """
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+    _attr_options = ["ready", "bypass_needed"]
+    _attr_translation_key = "arm_status"
+
+    @property
+    @override
+    def unique_id(self) -> str:
+        """Return the unique ID for this entity."""
+        return f"{self.coordinator.config_entry.data[CONF_GIID]}_arm_status"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device information about this entity."""
+        return DeviceInfo(
+            name="Verisure Alarm",
+            manufacturer="Verisure",
+            model="VBox",
+            identifiers={(DOMAIN, self.coordinator.config_entry.data[CONF_GIID])},
+            configuration_url="https://mypages.verisure.com",
+        )
+
+    @property
+    @override
+    def native_value(self) -> str | None:
+        """Return whether arming currently requires force."""
+        force_arm_required = self.coordinator.data["force_arm_required"]
+        if force_arm_required is None:
+            return None
+        return "bypass_needed" if force_arm_required else "ready"

--- a/homeassistant/components/verisure/strings.json
+++ b/homeassistant/components/verisure/strings.json
@@ -50,6 +50,15 @@
       "ethernet": {
         "name": "Ethernet status"
       }
+    },
+    "sensor": {
+      "arm_status": {
+        "name": "Arm status",
+        "state": {
+          "bypass_needed": "Bypass needed",
+          "ready": "Ready"
+        }
+      }
     }
   },
   "exceptions": {

--- a/tests/components/verisure/test_init.py
+++ b/tests/components/verisure/test_init.py
@@ -20,6 +20,7 @@ from homeassistant.components.verisure.const import (
     COOKIE_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    DRY_RUN_FALLBACK_INTERVAL,
     RATE_LIMIT_BACKOFF,
 )
 from homeassistant.config_entries import ConfigEntryState
@@ -571,3 +572,471 @@ async def test_update_session_refresh_transient(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get(ALARM_ENTITY_ID).state == STATE_UNAVAILABLE
+
+
+def _overview(door_window_state: str = "CLOSED") -> list:
+    """Build a minimal overview payload with a controllable door/window state."""
+    return [
+        {
+            "data": {
+                "installation": {
+                    "armState": {"status": "DISARMED", "statusType": "DISARMED"},
+                    "doorWindows": [
+                        {
+                            "device": {"deviceLabel": "door-1"},
+                            "state": door_window_state,
+                        }
+                    ],
+                }
+            }
+        }
+    ]
+
+
+DRY_RUN_TRANSACTION = {"data": {"armStateDryRun": "dry-run-txn"}}
+DRY_RUN_STATUS_CLEAN = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {"deviceViolations": []},
+                }
+            }
+        }
+    }
+}
+DRY_RUN_STATUS_VIOLATION = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {
+                        "deviceViolations": [
+                            {
+                                "deviceLabel": "door-1",
+                                "violation": "DOOR_WINDOW_OPEN",
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_checked_on_first_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """The dry run runs on the first update, since there is no prior fingerprint."""
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_not_rechecked_when_unchanged(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The dry run does not rerun when the door/window state has not changed.
+
+    The mock only provides one overview response for the second update, with no
+    dry-run-shaped responses after it; if the coordinator incorrectly reran the
+    dry run, the mock would be consumed out of order and this test would fail.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+        _overview("CLOSED"),
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is True
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_rechecked_when_changed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The dry run reruns as soon as the door/window state changes."""
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("OPEN"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_rechecked_after_fallback_interval(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The dry run reruns after the fallback interval even if nothing changed.
+
+    This is the safety net for violation types not reflected in door/window
+    state, for example an offline or otherwise faulted device.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is True
+
+    freezer.tick(DRY_RUN_FALLBACK_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is False
+
+
+DRY_RUN_STATUS_INCOMPLETE = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {},
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_rate_limit_defers_next_check(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A rate limit during the periodic fallback check defers the next attempt.
+
+    The door/window state never changes here, so a rechecked dry run only
+    happens because the fallback interval elapsed. The mock only provides one
+    overview response for the third update, with no dry-run-shaped responses
+    after it; if the coordinator retried the dry run right away instead of
+    backing off, the mock would be consumed out of order and this test would
+    fail. The rate limit also clears the previously known readiness, since a
+    failed recheck no longer confirms the earlier answer still holds.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("CLOSED"),
+        RateLimitError("AUT_00021"),
+        _overview("CLOSED"),
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DRY_RUN_FALLBACK_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.data["force_arm_required"] is None
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is None
+
+
+async def test_force_arm_required_rate_limit_defers_changed_fingerprint_recheck(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A rate limit also defers a recheck triggered by a changed fingerprint.
+
+    The fingerprint is only stored on success, so after the rate limit the
+    door/window state still looks "changed" on the next cycle too. The mock
+    only provides an overview response for that cycle, with no dry-run-shaped
+    responses after it; if the coordinator retried just because the
+    fingerprint still looked changed, instead of honoring the backoff
+    deadline, the mock would be consumed out of order and this test would
+    fail.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("OPEN"),
+        RateLimitError("AUT_00021"),
+        _overview("OPEN"),
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.data["force_arm_required"] is None
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_STATUS_PENDING = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "PENDING"},
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_defers_after_exhausting_poll_attempts(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A dry run that never reaches DONE backs off instead of retrying immediately.
+
+    Without a deferred retry, a transaction that never completes would start
+    a brand new one on every one-minute cycle, indefinitely. The mock only
+    provides one overview response for the second update, with no
+    dry-run-shaped responses after it; if the coordinator started another
+    dry run right away instead of backing off, the mock would be consumed
+    out of order and this test would fail.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        *([DRY_RUN_STATUS_PENDING] * 30),
+        _overview("CLOSED"),
+    ]
+    with patch("homeassistant.components.verisure.coordinator.asyncio.sleep"):
+        await _async_setup(hass, mock_config_entry)
+        coordinator = mock_config_entry.runtime_data
+        assert coordinator.data["force_arm_required"] is None
+
+        freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is None
+
+
+async def test_force_arm_required_ignores_incomplete_dry_run_result(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A DONE dry run without a violations list is not treated as ready.
+
+    The result dict is missing "deviceViolations" entirely; treating that as
+    an empty list would incorrectly report the alarm as ready to arm.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_INCOMPLETE,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_STATUS_NULL_VIOLATIONS = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {"deviceViolations": None},
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_ignores_null_device_violations(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A DONE dry run with deviceViolations set to null is not treated as ready.
+
+    The key is present but its value is not a list; bool(None) is False,
+    which would incorrectly report the alarm as ready to arm.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_NULL_VIOLATIONS,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_START_NULL_DATA = {"data": None}
+
+
+async def test_force_arm_required_ignores_null_data_starting_dry_run(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A GraphQL error response with data set to null does not crash setup.
+
+    vsure.request() can return an HTTP-200 GraphQL error payload with "data"
+    explicitly null rather than missing. dict.get("data", {}) only falls
+    back to {} when the key is absent, not when its value is null, so a
+    naive chained .get() would raise AttributeError instead of leaving
+    readiness unknown.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_START_NULL_DATA,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_STATUS_NULL_DRY_RUN_STATUS = {
+    "data": {"installation": {"armState": {"dryRunStatus": None}}}
+}
+
+
+async def test_force_arm_required_ignores_null_dry_run_status(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A poll response with dryRunStatus set to null does not crash setup."""
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_NULL_DRY_RUN_STATUS,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+async def test_force_arm_required_failure_retried_next_cycle(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A failed dry run does not break the update and is retried next cycle.
+
+    The door/window state is unchanged between cycles; the retry happens
+    because a failed attempt does not update the stored fingerprint.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        RequestError("offline"),
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+    assert hass.states.get(ALARM_ENTITY_ID).state == "disarmed"
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_retries_after_failure_even_if_fingerprint_reverts(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A retry is still due if the door/window state reverts after a failure.
+
+    The fingerprint is only stored on success, so once the door closes again
+    it matches the earlier CLOSED baseline from before the failed OPEN check.
+    Without also gating on the last known readiness, that coincidental match
+    would look like nothing changed and silently skip the promised retry.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("OPEN"),
+        RequestError("offline"),
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.data["force_arm_required"] is None
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True

--- a/tests/components/verisure/test_init.py
+++ b/tests/components/verisure/test_init.py
@@ -19,6 +19,7 @@ from homeassistant.components.verisure.const import (
     COOKIE_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
+    DRY_RUN_FALLBACK_INTERVAL,
     RATE_LIMIT_BACKOFF,
 )
 from homeassistant.config_entries import ConfigEntryState
@@ -546,3 +547,471 @@ async def test_update_session_refresh_transient(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert hass.states.get(ALARM_ENTITY_ID).state == STATE_UNAVAILABLE
+
+
+def _overview(door_window_state: str = "CLOSED") -> list:
+    """Build a minimal overview payload with a controllable door/window state."""
+    return [
+        {
+            "data": {
+                "installation": {
+                    "armState": {"status": "DISARMED", "statusType": "DISARMED"},
+                    "doorWindows": [
+                        {
+                            "device": {"deviceLabel": "door-1"},
+                            "state": door_window_state,
+                        }
+                    ],
+                }
+            }
+        }
+    ]
+
+
+DRY_RUN_TRANSACTION = {"data": {"armStateDryRun": "dry-run-txn"}}
+DRY_RUN_STATUS_CLEAN = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {"deviceViolations": []},
+                }
+            }
+        }
+    }
+}
+DRY_RUN_STATUS_VIOLATION = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {
+                        "deviceViolations": [
+                            {
+                                "deviceLabel": "door-1",
+                                "violation": "DOOR_WINDOW_OPEN",
+                            }
+                        ]
+                    },
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_checked_on_first_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """The dry run runs on the first update, since there is no prior fingerprint."""
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_not_rechecked_when_unchanged(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The dry run does not rerun when the door/window state has not changed.
+
+    The mock only provides one overview response for the second update, with no
+    dry-run-shaped responses after it; if the coordinator incorrectly reran the
+    dry run, the mock would be consumed out of order and this test would fail.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+        _overview("CLOSED"),
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is True
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_rechecked_when_changed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The dry run reruns as soon as the door/window state changes."""
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("OPEN"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_rechecked_after_fallback_interval(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """The dry run reruns after the fallback interval even if nothing changed.
+
+    This is the safety net for violation types not reflected in door/window
+    state, for example an offline or otherwise faulted device.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is True
+
+    freezer.tick(DRY_RUN_FALLBACK_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is False
+
+
+DRY_RUN_STATUS_INCOMPLETE = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {},
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_rate_limit_defers_next_check(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A rate limit during the periodic fallback check defers the next attempt.
+
+    The door/window state never changes here, so a rechecked dry run only
+    happens because the fallback interval elapsed. The mock only provides one
+    overview response for the third update, with no dry-run-shaped responses
+    after it; if the coordinator retried the dry run right away instead of
+    backing off, the mock would be consumed out of order and this test would
+    fail. The rate limit also clears the previously known readiness, since a
+    failed recheck no longer confirms the earlier answer still holds.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("CLOSED"),
+        RateLimitError("AUT_00021"),
+        _overview("CLOSED"),
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DRY_RUN_FALLBACK_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.data["force_arm_required"] is None
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is None
+
+
+async def test_force_arm_required_rate_limit_defers_changed_fingerprint_recheck(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A rate limit also defers a recheck triggered by a changed fingerprint.
+
+    The fingerprint is only stored on success, so after the rate limit the
+    door/window state still looks "changed" on the next cycle too. The mock
+    only provides an overview response for that cycle, with no dry-run-shaped
+    responses after it; if the coordinator retried just because the
+    fingerprint still looked changed, instead of honoring the backoff
+    deadline, the mock would be consumed out of order and this test would
+    fail.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("OPEN"),
+        RateLimitError("AUT_00021"),
+        _overview("OPEN"),
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.data["force_arm_required"] is None
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_STATUS_PENDING = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "PENDING"},
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_defers_after_exhausting_poll_attempts(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A dry run that never reaches DONE backs off instead of retrying immediately.
+
+    Without a deferred retry, a transaction that never completes would start
+    a brand new one on every one-minute cycle, indefinitely. The mock only
+    provides one overview response for the second update, with no
+    dry-run-shaped responses after it; if the coordinator started another
+    dry run right away instead of backing off, the mock would be consumed
+    out of order and this test would fail.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        *([DRY_RUN_STATUS_PENDING] * 30),
+        _overview("CLOSED"),
+    ]
+    with patch("homeassistant.components.verisure.coordinator.asyncio.sleep"):
+        await _async_setup(hass, mock_config_entry)
+        coordinator = mock_config_entry.runtime_data
+        assert coordinator.data["force_arm_required"] is None
+
+        freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is None
+
+
+async def test_force_arm_required_ignores_incomplete_dry_run_result(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A DONE dry run without a violations list is not treated as ready.
+
+    The result dict is missing "deviceViolations" entirely; treating that as
+    an empty list would incorrectly report the alarm as ready to arm.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_INCOMPLETE,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_STATUS_NULL_VIOLATIONS = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {"deviceViolations": None},
+                }
+            }
+        }
+    }
+}
+
+
+async def test_force_arm_required_ignores_null_device_violations(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A DONE dry run with deviceViolations set to null is not treated as ready.
+
+    The key is present but its value is not a list; bool(None) is False,
+    which would incorrectly report the alarm as ready to arm.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_NULL_VIOLATIONS,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_START_NULL_DATA = {"data": None}
+
+
+async def test_force_arm_required_ignores_null_data_starting_dry_run(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A GraphQL error response with data set to null does not crash setup.
+
+    vsure.request() can return an HTTP-200 GraphQL error payload with "data"
+    explicitly null rather than missing. dict.get("data", {}) only falls
+    back to {} when the key is absent, not when its value is null, so a
+    naive chained .get() would raise AttributeError instead of leaving
+    readiness unknown.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_START_NULL_DATA,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+DRY_RUN_STATUS_NULL_DRY_RUN_STATUS = {
+    "data": {"installation": {"armState": {"dryRunStatus": None}}}
+}
+
+
+async def test_force_arm_required_ignores_null_dry_run_status(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """A poll response with dryRunStatus set to null does not crash setup."""
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_NULL_DRY_RUN_STATUS,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+
+
+async def test_force_arm_required_failure_retried_next_cycle(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A failed dry run does not break the update and is retried next cycle.
+
+    The door/window state is unchanged between cycles; the retry happens
+    because a failed attempt does not update the stored fingerprint.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        RequestError("offline"),
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is None
+    assert hass.states.get(ALARM_ENTITY_ID).state == "disarmed"
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True
+
+
+async def test_force_arm_required_retries_after_failure_even_if_fingerprint_reverts(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A retry is still due if the door/window state reverts after a failure.
+
+    The fingerprint is only stored on success, so once the door closes again
+    it matches the earlier CLOSED baseline from before the failed OPEN check.
+    Without also gating on the last known readiness, that coincidental match
+    would look like nothing changed and silently skip the promised retry.
+    """
+    mock_verisure.request.side_effect = [
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+        _overview("OPEN"),
+        RequestError("offline"),
+        _overview("CLOSED"),
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+    coordinator = mock_config_entry.runtime_data
+    assert coordinator.data["force_arm_required"] is False
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+    assert coordinator.data["force_arm_required"] is None
+
+    freezer.tick(DEFAULT_SCAN_INTERVAL + timedelta(seconds=10))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert coordinator.data["force_arm_required"] is True

--- a/tests/components/verisure/test_sensor.py
+++ b/tests/components/verisure/test_sensor.py
@@ -1,0 +1,82 @@
+"""Tests for the Verisure sensor platform."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+from .conftest import OVERVIEW
+
+from tests.common import MockConfigEntry
+
+ARM_STATUS_ENTITY_ID = "sensor.verisure_alarm_arm_status"
+
+DRY_RUN_TRANSACTION = {"data": {"armStateDryRun": "dry-run-txn"}}
+DRY_RUN_STATUS_VIOLATION = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {
+                        "deviceViolations": [
+                            {"deviceLabel": "door-1", "violation": "DOOR_WINDOW_OPEN"}
+                        ]
+                    },
+                }
+            }
+        }
+    }
+}
+DRY_RUN_STATUS_CLEAN = {
+    "data": {
+        "installation": {
+            "armState": {
+                "dryRunStatus": {
+                    "status": {"status": "DONE"},
+                    "result": {"deviceViolations": []},
+                }
+            }
+        }
+    }
+}
+
+
+async def _async_setup(hass: HomeAssistant, mock_config_entry: MockConfigEntry) -> None:
+    """Set up the Verisure integration with the sensor platform."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.verisure.PLATFORMS", [Platform.SENSOR]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+async def test_arm_status_bypass_needed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """The sensor reports bypass_needed when the dry run finds a violation."""
+    mock_verisure.request.side_effect = [
+        OVERVIEW,
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_VIOLATION,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    assert hass.states.get(ARM_STATUS_ENTITY_ID).state == "bypass_needed"
+
+
+async def test_arm_status_ready(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+) -> None:
+    """The sensor reports ready when the dry run finds no violations."""
+    mock_verisure.request.side_effect = [
+        OVERVIEW,
+        DRY_RUN_TRANSACTION,
+        DRY_RUN_STATUS_CLEAN,
+    ]
+    await _async_setup(hass, mock_config_entry)
+
+    assert hass.states.get(ARM_STATUS_ENTITY_ID).state == "ready"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a sensor reporting whether arming the Verisure alarm currently requires force (a device is out of place). It's backed by an arm-state dry run (`arm_state_dry_run` / `arm_state_dry_run_status`, added to vsure in #176206), run when a door/window state changes, or otherwise at least once every 30 minutes as a fallback for violation types not reflected in door/window state (for example an offline device).

Modeled as a `sensor` with `device_class: enum` (values `ready` / `bypass_needed`) rather than a binary sensor, since neither On/Off nor any existing binary_sensor device class's canned text reads naturally against a name like "Arm status".

Related to #175045, which adds the actual force-arm behavior; this sensor is independent and useful on its own for automations, but the two are intentionally split into separate PRs.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #175045
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47041
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr