### PR TITLE
Unsubscribe earn_e_p1 sensor setup listener once all sensors are added

### DIFF
--- a/homeassistant/components/earn_e_p1/sensor.py
+++ b/homeassistant/components/earn_e_p1/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.const import (
     UnitOfPower,
     UnitOfVolume,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
@@ -119,23 +119,34 @@ async def async_setup_entry(
 ) -> None:
     """Set up EARN-E P1 sensor entities."""
     coordinator = entry.runtime_data
-    added_keys: set[str] = set()
+    pending_keys = {description.key for description in SENSOR_DESCRIPTIONS}
+    remove_listener: CALLBACK_TYPE | None = None
+
+    @callback
+    def _async_remove_listener() -> None:
+        nonlocal remove_listener
+        if remove_listener is not None:
+            remove_listener()
+            remove_listener = None
 
     @callback
     def _async_add_sensors() -> None:
         if coordinator.data is None:
             return
-        new_entities = [
-            EarnEP1Sensor(coordinator, description)
-            for description in SENSOR_DESCRIPTIONS
-            if description.key in coordinator.data and description.key not in added_keys
-        ]
-        if new_entities:
-            added_keys.update(entity.entity_description.key for entity in new_entities)
-            async_add_entities(new_entities)
+        if new_keys := pending_keys & coordinator.data.keys():
+            pending_keys.difference_update(new_keys)
+            async_add_entities(
+                EarnEP1Sensor(coordinator, description)
+                for description in SENSOR_DESCRIPTIONS
+                if description.key in new_keys
+            )
+        if not pending_keys:
+            _async_remove_listener()
 
-    entry.async_on_unload(coordinator.async_add_listener(_async_add_sensors))
     _async_add_sensors()
+    if pending_keys:
+        remove_listener = coordinator.async_add_listener(_async_add_sensors)
+        entry.async_on_unload(_async_remove_listener)
 
 
 class EarnEP1Sensor(EarnEP1Entity, SensorEntity):

--- a/tests/components/earn_e_p1/test_sensor.py
+++ b/tests/components/earn_e_p1/test_sensor.py
@@ -101,6 +101,25 @@ async def test_sensors_added_when_key_appears_in_later_packet(
     assert gas.state == "1234.567"
 
 
+async def test_unload_after_all_sensors_added(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_listener: MagicMock,
+) -> None:
+    """Test unloading after every sensor has been added.
+
+    Once all described keys have been seen, the setup listener unsubscribes
+    itself; unloading afterwards must not attempt a second unsubscribe.
+    """
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    trigger_callback(mock_listener)
+    await hass.async_block_till_done()
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+
+
 async def test_wifi_rssi_disabled_by_default(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Follow-up to #177027. Unsubscribes the sensor setup listener once every described sensor has been added, so the callback no longer runs on every coordinator update for the lifetime of the entry.

Implements the approach @Swamp-Ig suggested in review (https://github.com/home-assistant/core/pull/177027#discussion_r3651947001): start with the full key set, discard keys as their sensors are added, unsubscribe when the set is empty. The unsubscribe is guarded so the `entry.async_on_unload` cleanup stays a no-op after early removal — removing a coordinator listener twice raises `KeyError`. Adds a test that unloads the entry after all sensors were added.

Why this is a follow-up instead of part of #177027 — the change was written during review but landed on the wrong branch (all times 2026-07-26 UTC):

- 06:46 — @Swamp-Ig suggested the refinement in #177027 review.
- 08:50 — Implemented as `637182fbb52`, accidentally committed to the branch of #176551 instead of the PR branch.
- 10:24 — #177027 was squash-merged without it.
- 11:05 — Mistake noticed; the change was cherry-picked to the PR branch as `bbcd4395837`, but the merge had already happened, so it never landed.

This PR carries that same commit on top of current dev.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
