### PR TITLE
Fix Nintendo parental-controls PIN service authorization

### DIFF
--- a/homeassistant/components/nintendo_parental_controls/services.py
+++ b/homeassistant/components/nintendo_parental_controls/services.py
@@ -9,7 +9,11 @@ import voluptuous as vol
 from homeassistant.const import ATTR_DEVICE_ID, CONF_PIN
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    service,
+)
 
 from .const import ATTR_BONUS_TIME, DOMAIN
 from .coordinator import NintendoParentalControlsConfigEntry
@@ -40,11 +44,12 @@ def async_setup_services(
             }
         ),
     )
-    hass.services.async_register(
-        domain=DOMAIN,
-        service=NintendoParentalServices.UPDATE_PIN_CODE,
-        service_func=async_update_pin_code,
-        schema=vol.Schema(
+    service.async_register_admin_service(
+        hass,
+        DOMAIN,
+        NintendoParentalServices.UPDATE_PIN_CODE,
+        async_update_pin_code,
+        vol.Schema(
             {
                 vol.Required(ATTR_DEVICE_ID): cv.string,
                 vol.Required(CONF_PIN): cv.string,

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -175,7 +175,9 @@ async def test_update_pin_code_requires_admin(
 ) -> None:
     """Test updating the PIN code requires administrator access."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "testdevid")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "testdevid"), mock_config_entry.entry_id
+    )
     assert device_entry
     with pytest.raises(Unauthorized):
         await hass.services.async_call(

--- a/tests/components/nintendo_parental_controls/test_services.py
+++ b/tests/components/nintendo_parental_controls/test_services.py
@@ -13,13 +13,13 @@ from homeassistant.components.nintendo_parental_controls.services import (
     NintendoParentalServices,
 )
 from homeassistant.const import ATTR_DEVICE_ID, CONF_PIN
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import ServiceValidationError, Unauthorized
 from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockUser
 
 
 async def test_add_bonus_time(
@@ -163,3 +163,29 @@ async def test_update_pin_code(
         blocking=True,
     )
     assert len(mock_nintendo_device.set_new_pin.mock_calls) == 1
+
+
+async def test_update_pin_code_requires_admin(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    hass_read_only_user: MockUser,
+    mock_config_entry: MockConfigEntry,
+    mock_nintendo_client: AsyncMock,
+    mock_nintendo_device: AsyncMock,
+) -> None:
+    """Test updating the PIN code requires administrator access."""
+    await setup_integration(hass, mock_config_entry)
+    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "testdevid")})
+    assert device_entry
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            NintendoParentalServices.UPDATE_PIN_CODE,
+            {
+                ATTR_DEVICE_ID: device_entry.id,
+                CONF_PIN: "1234",
+            },
+            blocking=True,
+            context=Context(user_id=hass_read_only_user.id),
+        )
+    mock_nintendo_device.set_new_pin.assert_not_called()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The `nintendo_parental_controls.update_pin_code` service was exposed as a normal service, allowing any authenticated non-admin user to reset a device PIN. This PR registers the PIN-update service as admin-only and adds a regression test confirming that a read-only user receives `Unauthorized` without invoking the Nintendo client.

Testing:
- `.venv/bin/python -m pytest -q tests/components/nintendo_parental_controls/test_services.py` (`11 passed`)
- Ruff check and format checks on the changed files

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Codex task: https://chatgpt.com/codex/cloud/tasks/task_e_6a60d15268548322a1f85a41debf7467

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr