### PR TITLE
Require admin for Z-Wave lock credential services

### DIFF
--- a/homeassistant/components/zwave_js/services.py
+++ b/homeassistant/components/zwave_js/services.py
@@ -83,6 +83,7 @@ def _async_register_credential_services(hass: HomeAssistant) -> None:
         hass,
         const.DOMAIN,
         "set_user",
+        admin_only=True,
         entity_domain=LOCK_DOMAIN,
         schema={
             vol.Optional(const.ATTR_USER_ID): uint16_id,
@@ -106,6 +107,7 @@ def _async_register_credential_services(hass: HomeAssistant) -> None:
         hass,
         const.DOMAIN,
         "delete_user",
+        admin_only=True,
         entity_domain=LOCK_DOMAIN,
         schema={vol.Required(const.ATTR_USER_ID): uint16_id},
         func="async_delete_user",
@@ -115,6 +117,7 @@ def _async_register_credential_services(hass: HomeAssistant) -> None:
         hass,
         const.DOMAIN,
         "delete_all_users",
+        admin_only=True,
         entity_domain=LOCK_DOMAIN,
         schema={},
         func="async_delete_all_users",
@@ -144,6 +147,7 @@ def _async_register_credential_services(hass: HomeAssistant) -> None:
         hass,
         const.DOMAIN,
         "set_credential",
+        admin_only=True,
         entity_domain=LOCK_DOMAIN,
         schema={
             vol.Required(const.ATTR_USER_ID): uint16_id,
@@ -161,6 +165,7 @@ def _async_register_credential_services(hass: HomeAssistant) -> None:
         hass,
         const.DOMAIN,
         "delete_credential",
+        admin_only=True,
         entity_domain=LOCK_DOMAIN,
         schema={
             vol.Required(const.ATTR_USER_ID): uint16_id,
@@ -176,6 +181,7 @@ def _async_register_credential_services(hass: HomeAssistant) -> None:
         hass,
         const.DOMAIN,
         "delete_all_credentials",
+        admin_only=True,
         entity_domain=LOCK_DOMAIN,
         schema={vol.Required(const.ATTR_USER_ID): uint16_id},
         func="async_delete_all_credentials",

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1270,7 +1270,7 @@ def async_register_platform_entity_service(
 
     service_func: str | HassJob[..., Any]
     service_func = func if isinstance(func, str) else HassJob(func)
-    service_handler = partial(
+    entity_handler = partial(
         entity_service_call,
         hass,
         partial(_get_platform_entities, hass, entity_domain, service_domain),
@@ -1278,12 +1278,16 @@ def async_register_platform_entity_service(
         entity_device_classes=entity_device_classes,
         required_features=required_features,
     )
-    if admin_only:
-        service_handler = partial(
+
+    service_handler = (
+        partial(
             _async_admin_handler,
             hass,
-            HassJob(service_handler, f"admin service {service_domain}.{service_name}"),
+            HassJob(entity_handler, f"admin service {service_domain}.{service_name}"),
         )
+        if admin_only
+        else entity_handler
+    )
 
     hass.services.async_register(
         service_domain,

--- a/homeassistant/helpers/service.py
+++ b/homeassistant/helpers/service.py
@@ -1256,6 +1256,7 @@ def async_register_platform_entity_service(
     service_domain: str,
     service_name: str,
     *,
+    admin_only: bool = False,
     description_placeholders: Mapping[str, str] | None = None,
     entity_device_classes: Iterable[str | None] | None = None,
     entity_domain: str,
@@ -1269,18 +1270,25 @@ def async_register_platform_entity_service(
 
     service_func: str | HassJob[..., Any]
     service_func = func if isinstance(func, str) else HassJob(func)
+    service_handler = partial(
+        entity_service_call,
+        hass,
+        partial(_get_platform_entities, hass, entity_domain, service_domain),
+        service_func,
+        entity_device_classes=entity_device_classes,
+        required_features=required_features,
+    )
+    if admin_only:
+        service_handler = partial(
+            _async_admin_handler,
+            hass,
+            HassJob(service_handler, f"admin service {service_domain}.{service_name}"),
+        )
 
     hass.services.async_register(
         service_domain,
         service_name,
-        partial(
-            entity_service_call,
-            hass,
-            partial(_get_platform_entities, hass, entity_domain, service_domain),
-            service_func,
-            entity_device_classes=entity_device_classes,
-            required_features=required_features,
-        ),
+        service_handler,
         schema,
         supports_response,
         job_type=HassJobType.Coroutinefunction,

--- a/tests/components/zwave_js/test_credential_services.py
+++ b/tests/components/zwave_js/test_credential_services.py
@@ -24,11 +24,11 @@ from zwave_js_server.model.node import Node
 from homeassistant.components.zwave_js.const import DOMAIN
 from homeassistant.components.zwave_js.helpers import get_device_id
 from homeassistant.const import ATTR_ENTITY_ID
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, Unauthorized
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, MockUser
 
 
 def _mock_access_control(
@@ -1794,3 +1794,59 @@ async def test_service_access_control_not_supported(
     # The guard runs before anything else, so no capability query is issued.
     api.is_supported.assert_called_once_with()
     api.get_user_capabilities_cached.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("service", "service_data", "returns_response"),
+    [
+        pytest.param("set_user", {}, True, id="set_user"),
+        pytest.param("delete_user", {"user_id": 1}, False, id="delete_user"),
+        pytest.param("delete_all_users", {}, False, id="delete_all_users"),
+        pytest.param(
+            "set_credential",
+            {"user_id": 1, "credential_type": "pin_code", "credential_data": "1234"},
+            True,
+            id="set_credential",
+        ),
+        pytest.param(
+            "delete_credential",
+            {"user_id": 1, "credential_type": "pin_code", "credential_slot": 1},
+            False,
+            id="delete_credential",
+        ),
+        pytest.param(
+            "delete_all_credentials", {"user_id": 1}, False, id="delete_all_credentials"
+        ),
+    ],
+)
+async def test_service_requires_admin(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    client: MagicMock,
+    lock_schlage_be469: Node,
+    integration: MockConfigEntry,
+    hass_read_only_user: MockUser,
+    service: str,
+    service_data: dict[str, int | str],
+    returns_response: bool,
+) -> None:
+    """Every mutating user/credential service rejects non-admin users."""
+    # Grant control of all entities, so the call is only rejected for not being admin
+    hass_read_only_user.mock_policy({"entities": {"all": {"control": True}}})
+    api = _mock_access_control(lock_schlage_be469)
+    entity_id = _lock_entity_id(
+        entity_registry, device_registry, client, lock_schlage_be469
+    )
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: entity_id, **service_data},
+            blocking=True,
+            return_response=returns_response,
+            context=Context(user_id=hass_read_only_user.id),
+        )
+
+    api.is_supported.assert_not_called()

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1895,7 +1895,7 @@ async def test_register_admin_service(
     hass: HomeAssistant, hass_read_only_user: MockUser, hass_admin_user: MockUser
 ) -> None:
     """Test the register admin service."""
-    calls: list[MockEntity] = []
+    calls: list[ServiceCall] = []
 
     async def mock_service(call):
         calls.append(call)
@@ -2863,6 +2863,8 @@ async def test_register_platform_entity_service_admin_only(
     hass_read_only_user: MockUser,
 ) -> None:
     """Test an admin-only platform entity service."""
+    # Grant control of all entities, so the call is only rejected for not being admin
+    hass_read_only_user.mock_policy({"entities": {"all": {"control": True}}})
     calls: list[MockEntity] = []
 
     @callback

--- a/tests/helpers/test_service.py
+++ b/tests/helpers/test_service.py
@@ -1895,7 +1895,7 @@ async def test_register_admin_service(
     hass: HomeAssistant, hass_read_only_user: MockUser, hass_admin_user: MockUser
 ) -> None:
     """Test the register admin service."""
-    calls = []
+    calls: list[MockEntity] = []
 
     async def mock_service(call):
         calls.append(call)
@@ -2855,6 +2855,54 @@ async def test_register_platform_entity_service_response_data(
     assert response_data == {
         "mock_integration.entity": {"response-key": "response-value"}
     }
+
+
+async def test_register_platform_entity_service_admin_only(
+    hass: HomeAssistant,
+    hass_admin_user: MockUser,
+    hass_read_only_user: MockUser,
+) -> None:
+    """Test an admin-only platform entity service."""
+    calls: list[MockEntity] = []
+
+    @callback
+    def handle_service(entity: MockEntity, *_: Any) -> None:
+        calls.append(entity)
+
+    service.async_register_platform_entity_service(
+        hass,
+        "mock_platform",
+        "hello",
+        admin_only=True,
+        entity_domain="mock_integration",
+        schema={},
+        func=handle_service,
+    )
+
+    entity_platform = MockEntityPlatform(
+        hass, domain="mock_integration", platform_name="mock_platform", platform=None
+    )
+    entity = MockEntity(entity_id="mock_integration.entity")
+    await entity_platform.async_add_entities([entity])
+
+    with pytest.raises(exceptions.Unauthorized):
+        await hass.services.async_call(
+            "mock_platform",
+            "hello",
+            {"entity_id": entity.entity_id},
+            blocking=True,
+            context=Context(user_id=hass_read_only_user.id),
+        )
+    assert calls == []
+
+    await hass.services.async_call(
+        "mock_platform",
+        "hello",
+        {"entity_id": entity.entity_id},
+        blocking=True,
+        context=Context(user_id=hass_admin_user.id),
+    )
+    assert calls == [entity]
 
 
 async def test_register_platform_entity_service_response_data_multiple_matches(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The Z-Wave actions `set_user`, `delete_user`, `delete_all_users`, `set_credential`, `delete_credential`, and `delete_all_credentials` now require an admin user.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Prevent non-admin Home Assistant users with `POLICY_CONTROL` access to a lock entity from creating, modifying, or deleting persistent Z-Wave lock users and credentials.

This adds an `admin_only` option to `async_register_platform_entity_service` and uses it for the Z-Wave JS `set_user`, `delete_user`, `delete_all_users`, `set_credential`, `delete_credential`, and `delete_all_credentials` services. A regression test verifies that a non-admin user is rejected while an admin user is allowed.

Testing:
- Compiled the modified Python files successfully with `python -m py_compile homeassistant/helpers/service.py homeassistant/components/zwave_js/services.py tests/helpers/test_service.py`.
- `script/setup`, `uv run prek run --all-files`, and the targeted pytest command could not complete because dependencies could not be fetched over the network.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Codex task: https://chatgpt.com/codex/cloud/tasks/task_e_6a558466d1808322a109f0037352dafd

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr