### PR TITLE
Make _LOGGER public in starline

### DIFF
--- a/homeassistant/components/starline/account.py
+++ b/homeassistant/components/starline/account.py
@@ -13,7 +13,6 @@ from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .const import (
-    _LOGGER,
     DATA_EXPIRES,
     DATA_SLID_TOKEN,
     DATA_SLNET_TOKEN,
@@ -21,6 +20,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DEFAULT_SCAN_OBD_INTERVAL,
     DOMAIN,
+    LOGGER,
 )
 
 
@@ -73,7 +73,7 @@ class StarlineAccount:
                 },
             )
         except Exception as err:  # noqa: BLE001
-            _LOGGER.error("Error updating SLNet token: %s", err)
+            LOGGER.error("Error updating SLNet token: %s", err)
 
     @callback
     def _save_slnet_token(self, data) -> None:
@@ -107,7 +107,7 @@ class StarlineAccount:
 
     def set_update_interval(self, interval: int) -> None:
         """Set StarLine API update interval."""
-        _LOGGER.debug("Setting update interval: %ds", interval)
+        LOGGER.debug("Setting update interval: %ds", interval)
         self._update_interval = interval
         if self._unsubscribe_auto_updater is not None:
             self._unsubscribe_auto_updater()
@@ -119,7 +119,7 @@ class StarlineAccount:
 
     def set_update_obd_interval(self, interval: int) -> None:
         """Set StarLine API OBD update interval."""
-        _LOGGER.debug("Setting OBD update interval: %ds", interval)
+        LOGGER.debug("Setting OBD update interval: %ds", interval)
         self._update_obd_interval = interval
         if self._unsubscribe_auto_obd_updater is not None:
             self._unsubscribe_auto_obd_updater()
@@ -131,7 +131,7 @@ class StarlineAccount:
 
     def unload(self):
         """Unload StarLine API."""
-        _LOGGER.debug("Unloading StarLine API")
+        LOGGER.debug("Unloading StarLine API")
         if self._unsubscribe_auto_updater is not None:
             self._unsubscribe_auto_updater()
             self._unsubscribe_auto_updater = None

--- a/homeassistant/components/starline/config_flow.py
+++ b/homeassistant/components/starline/config_flow.py
@@ -10,7 +10,6 @@ from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import callback
 
 from .const import (
-    _LOGGER,
     CONF_APP_ID,
     CONF_APP_SECRET,
     CONF_CAPTCHA_CODE,
@@ -23,6 +22,7 @@ from .const import (
     ERROR_AUTH_APP,
     ERROR_AUTH_MFA,
     ERROR_AUTH_USER,
+    LOGGER,
 )
 
 
@@ -206,7 +206,7 @@ class StarlineFlowHandler(ConfigFlow, domain=DOMAIN):
             self._app_token = await self.hass.async_add_executor_job(_get_app_token)
             return self._async_form_auth_user(error)
         except Exception as err:  # noqa: BLE001
-            _LOGGER.error("Error auth StarLine: %s", err)
+            LOGGER.error("Error auth StarLine: %s", err)
             return self._async_form_auth_app(ERROR_AUTH_APP)
 
     async def _async_authenticate_user(
@@ -241,7 +241,7 @@ class StarlineFlowHandler(ConfigFlow, domain=DOMAIN):
 
             raise Exception(data)  # noqa: TRY002, TRY301
         except Exception as err:  # noqa: BLE001
-            _LOGGER.error("Error auth user: %s", err)
+            LOGGER.error("Error auth user: %s", err)
             return self._async_form_auth_user(ERROR_AUTH_USER)
 
     async def _async_get_entry(self) -> ConfigFlowResult:

--- a/homeassistant/components/starline/const.py
+++ b/homeassistant/components/starline/const.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.const import Platform
 
-_LOGGER = logging.getLogger(__package__)
+LOGGER = logging.getLogger(__package__)
 
 DOMAIN = "starline"
 PLATFORMS = [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename the exported `_LOGGER` constant in the `starline` integration to `LOGGER`. Since the constant is exported from `const.py` and imported by other modules, it should be public, as tracked in epic home-assistant/epics#115. The logger name itself is unchanged, only the constant name changes. The import and all usages in `config_flow.py` and `account.py` are updated accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#177317
- This PR is related to issue: home-assistant/epics#115
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
