### PR TITLE
Make _LOGGER public in venstar

### DIFF
--- a/homeassistant/components/venstar/climate.py
+++ b/homeassistant/components/venstar/climate.py
@@ -40,13 +40,13 @@ from homeassistant.helpers.entity_platform import (
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from .const import (
-    _LOGGER,
     ATTR_FAN_STATE,
     ATTR_HVAC_STATE,
     CONF_HUMIDIFIER,
     DEFAULT_SSL,
     DOMAIN,
     HOLD_MODE_TEMPERATURE,
+    LOGGER,
 )
 from .coordinator import VenstarConfigEntry, VenstarDataUpdateCoordinator
 from .entity import VenstarEntity
@@ -95,7 +95,7 @@ async def async_setup_platform(
     configuration.yaml, the import flow will attempt to import it and create
     a config entry.
     """
-    _LOGGER.warning(
+    LOGGER.warning(
         "Loading venstar via platform config is deprecated; The configuration"
         " has been migrated to a config entry and can be safely removed"
     )
@@ -266,7 +266,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
             success = self._client.set_mode(self._client.MODE_OFF)
 
         if not success:
-            _LOGGER.error("Failed to change the operation mode")
+            LOGGER.error("Failed to change the operation mode")
         return success
 
     @override
@@ -295,7 +295,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
                 success = self._client.set_setpoints(temp_low, temp_high)
             else:
                 success = False
-                _LOGGER.error(
+                LOGGER.error(
                     (
                         "The thermostat is currently not in a mode "
                         "that supports target temperature: %s"
@@ -304,7 +304,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
                 )
 
             if not success:
-                _LOGGER.error("Failed to change the temperature")
+                LOGGER.error("Failed to change the temperature")
         self.schedule_update_ha_state()
 
     @override
@@ -316,7 +316,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
             success = self._client.set_fan(self._client.FAN_AUTO)
 
         if not success:
-            _LOGGER.error("Failed to change the fan mode")
+            LOGGER.error("Failed to change the fan mode")
         self.schedule_update_ha_state()
 
     @override
@@ -331,7 +331,7 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
         success = self._client.set_hum_setpoint(humidity)
 
         if not success:
-            _LOGGER.error("Failed to change the target humidity level")
+            LOGGER.error("Failed to change the target humidity level")
         self.schedule_update_ha_state()
 
     @override
@@ -346,9 +346,9 @@ class VenstarThermostat(VenstarEntity, ClimateEntity):
             success = self._client.set_away(self._client.AWAY_HOME)
             success = success and self._client.set_schedule(1)
         else:
-            _LOGGER.error("Unknown hold mode: %s", preset_mode)
+            LOGGER.error("Unknown hold mode: %s", preset_mode)
             success = False
 
         if not success:
-            _LOGGER.error("Failed to change the schedule/hold state")
+            LOGGER.error("Failed to change the schedule/hold state")
         self.schedule_update_ha_state()

--- a/homeassistant/components/venstar/config_flow.py
+++ b/homeassistant/components/venstar/config_flow.py
@@ -16,7 +16,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 
-from .const import _LOGGER, DOMAIN, VENSTAR_TIMEOUT
+from .const import DOMAIN, LOGGER, VENSTAR_TIMEOUT
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> str:
@@ -66,7 +66,7 @@ class VenstarConfigFlow(ConfigFlow, domain=DOMAIN):
             except CannotConnect:
                 errors["base"] = "cannot_connect"
             except Exception:  # noqa: BLE001
-                _LOGGER.exception("Unexpected exception")
+                LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
             else:
                 return self.async_create_entry(title=title, data=user_input)

--- a/homeassistant/components/venstar/const.py
+++ b/homeassistant/components/venstar/const.py
@@ -17,4 +17,4 @@ HOLD_MODE_TEMPERATURE = "temperature"
 VENSTAR_TIMEOUT = 5
 VENSTAR_SLEEP = 1.0
 
-_LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger(__name__)

--- a/homeassistant/components/venstar/coordinator.py
+++ b/homeassistant/components/venstar/coordinator.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import update_coordinator
 
-from .const import _LOGGER, DOMAIN, VENSTAR_SLEEP
+from .const import DOMAIN, LOGGER, VENSTAR_SLEEP
 
 type VenstarConfigEntry = ConfigEntry[VenstarDataUpdateCoordinator]
 
@@ -30,7 +30,7 @@ class VenstarDataUpdateCoordinator(update_coordinator.DataUpdateCoordinator[None
         """Initialize global Venstar data updater."""
         super().__init__(
             hass,
-            _LOGGER,
+            LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
             update_interval=timedelta(seconds=60),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename the exported `_LOGGER` constant in the `venstar` integration to `LOGGER`. Since the constant is exported from `const.py` and imported by other modules, it should be public, as tracked in epic home-assistant/epics#115. The logger name itself is unchanged, only the constant name changes. The import and all usages in `config_flow.py`, `coordinator.py` and `climate.py` are updated accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#177319
- This PR is related to issue: home-assistant/epics#115
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
