### PR TITLE
Make _LOGGER public in nina

### DIFF
--- a/homeassistant/components/nina/__init__.py
+++ b/homeassistant/components/nina/__init__.py
@@ -8,13 +8,13 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
-    _LOGGER,
     ALL_MATCH_REGEX,
     CONF_AREA_FILTER,
     CONF_FILTER_CORONA,
     CONF_FILTERS,
     CONF_HEADLINE_FILTER,
     DOMAIN,
+    LOGGER,
     NO_MATCH_REGEX,
 )
 from .coordinator import NinaConfigEntry, NINADataUpdateCoordinator
@@ -54,7 +54,7 @@ async def async_migrate_entry(hass: HomeAssistant, entry: NinaConfigEntry) -> bo
     version = entry.version
     minor_version = entry.minor_version
 
-    _LOGGER.debug("Migrating from version %s.%s", version, minor_version)
+    LOGGER.debug("Migrating from version %s.%s", version, minor_version)
 
     new_data: dict[str, Any] = {**entry.data, CONF_FILTERS: {}}
 

--- a/homeassistant/components/nina/config_flow.py
+++ b/homeassistant/components/nina/config_flow.py
@@ -18,7 +18,6 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import VolDictType
 
 from .const import (
-    _LOGGER,
     ALL_MATCH_REGEX,
     CONF_AREA_FILTER,
     CONF_FILTERS,
@@ -28,6 +27,7 @@ from .const import (
     CONST_REGION_MAPPING,
     CONST_REGIONS,
     DOMAIN,
+    LOGGER,
     NO_MATCH_REGEX,
     SENSOR_SUFFIXES,
 )
@@ -146,7 +146,7 @@ class NinaConfigFlow(ConfigFlow, domain=DOMAIN):
             except ApiError:
                 return self.async_abort(reason="no_fetch")
             except Exception:  # noqa: BLE001
-                _LOGGER.exception("Unexpected exception")
+                LOGGER.exception("Unexpected exception")
                 return self.async_abort(reason="unknown")
 
             self.regions = split_regions(self._all_region_codes_sorted, self.regions)
@@ -227,7 +227,7 @@ class OptionsFlowHandler(OptionsFlowWithReload):
             except ApiError:
                 return self.async_abort(reason="no_fetch")
             except Exception:  # noqa: BLE001
-                _LOGGER.exception("Unexpected exception")
+                LOGGER.exception("Unexpected exception")
                 return self.async_abort(reason="unknown")
 
             self.regions = split_regions(self._all_region_codes_sorted, self.regions)

--- a/homeassistant/components/nina/const.py
+++ b/homeassistant/components/nina/const.py
@@ -4,7 +4,7 @@ from datetime import timedelta
 from logging import Logger, getLogger
 from typing import Final
 
-_LOGGER: Logger = getLogger(__package__)
+LOGGER: Logger = getLogger(__package__)
 
 SCAN_INTERVAL: timedelta = timedelta(minutes=5)
 

--- a/homeassistant/components/nina/coordinator.py
+++ b/homeassistant/components/nina/coordinator.py
@@ -14,12 +14,12 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    _LOGGER,
     CONF_AREA_FILTER,
     CONF_FILTERS,
     CONF_HEADLINE_FILTER,
     CONF_REGIONS,
     DOMAIN,
+    LOGGER,
     SCAN_INTERVAL,
 )
 
@@ -70,7 +70,7 @@ class NINADataUpdateCoordinator(
 
         super().__init__(
             hass,
-            _LOGGER,
+            LOGGER,
             config_entry=config_entry,
             name=DOMAIN,
             update_interval=SCAN_INTERVAL,
@@ -123,7 +123,7 @@ class NINADataUpdateCoordinator(
                 if re.search(
                     self.headline_filter, raw_warn.headline, flags=re.IGNORECASE
                 ):
-                    _LOGGER.debug(
+                    LOGGER.debug(
                         "Ignore warning (%s) by headline filter (%s) with headline: %s",
                         raw_warn.id,
                         self.headline_filter,
@@ -138,7 +138,7 @@ class NINADataUpdateCoordinator(
                 if not re.search(
                     self.area_filter, affected_areas_string, flags=re.IGNORECASE
                 ):
-                    _LOGGER.debug(
+                    LOGGER.debug(
                         "Ignore warning (%s) by area filter (%s) with area: %s",
                         raw_warn.id,
                         self.area_filter,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename the exported `_LOGGER` constant in the `nina` integration to `LOGGER`. Since the constant is exported from `const.py` and imported by other modules, it should be public, as tracked in epic home-assistant/epics#115. The logger name itself is unchanged, only the constant name changes. The import and all usages in `__init__.py`, `config_flow.py` and `coordinator.py` are updated accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#177315
- This PR is related to issue: home-assistant/epics#115
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
