### PR TITLE
Yolink ys5018 water temperature

### DIFF
--- a/homeassistant/components/yolink/sensor.py
+++ b/homeassistant/components/yolink/sensor.py
@@ -72,6 +72,8 @@ from .const import (
     DEV_MODEL_TH_SENSOR_YS8014_UC,
     DEV_MODEL_TH_SENSOR_YS8017_EC,
     DEV_MODEL_TH_SENSOR_YS8017_UC,
+    DEV_MODEL_WATER_METER_YS5018_EC,
+    DEV_MODEL_WATER_METER_YS5018_UC,
 )
 from .coordinator import YoLinkConfigEntry, YoLinkCoordinator
 from .entity import YoLinkEntity
@@ -249,6 +251,14 @@ SENSOR_TYPES: tuple[YoLinkSensorEntityDescription, ...] = (
                 ATTR_DEVICE_MULTI_CAPS_LEAK_SENSOR,
                 ATTR_DEVICE_MULTI_FUNCTIONAL_SENSOR,
             ]
+            or (
+                device.device_type == ATTR_DEVICE_WATER_METER_CONTROLLER
+                and device.device_model_name
+                in [
+                    DEV_MODEL_WATER_METER_YS5018_EC,
+                    DEV_MODEL_WATER_METER_YS5018_UC,
+                ]
+            )
         ),
         value=parse_data_temperature,
     ),

--- a/homeassistant/components/yolink/sensor.py
+++ b/homeassistant/components/yolink/sensor.py
@@ -260,6 +260,7 @@ SENSOR_TYPES: tuple[YoLinkSensorEntityDescription, ...] = (
                 ]
             )
         ),
+        should_update_entity=lambda value: value is not None,
         value=parse_data_temperature,
     ),
     # mcu temperature

--- a/homeassistant/components/yolink/sensor.py
+++ b/homeassistant/components/yolink/sensor.py
@@ -251,14 +251,21 @@ SENSOR_TYPES: tuple[YoLinkSensorEntityDescription, ...] = (
                 ATTR_DEVICE_MULTI_CAPS_LEAK_SENSOR,
                 ATTR_DEVICE_MULTI_FUNCTIONAL_SENSOR,
             ]
-            or (
-                device.device_type == ATTR_DEVICE_WATER_METER_CONTROLLER
-                and device.device_model_name
-                in [
-                    DEV_MODEL_WATER_METER_YS5018_EC,
-                    DEV_MODEL_WATER_METER_YS5018_UC,
-                ]
-            )
+        ),
+        value=parse_data_temperature,
+    ),
+    YoLinkSensorEntityDescription(
+        key="temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        exists_fn=lambda device: (
+            device.device_type == ATTR_DEVICE_WATER_METER_CONTROLLER
+            and device.device_model_name
+            in [
+                DEV_MODEL_WATER_METER_YS5018_EC,
+                DEV_MODEL_WATER_METER_YS5018_UC,
+            ]
         ),
         should_update_entity=lambda value: value is not None,
         value=parse_data_temperature,

--- a/tests/components/yolink/conftest.py
+++ b/tests/components/yolink/conftest.py
@@ -1,6 +1,7 @@
 """Provide common fixtures for the YoLink integration tests."""
 
 from collections.abc import Generator
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -15,11 +16,17 @@ from homeassistant.components.yolink.api import ConfigEntryAuth
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, load_json_object_fixture
 
 CLIENT_ID = "12345"
 CLIENT_SECRET = "6789"
 DOMAIN = "yolink"
+
+
+@pytest.fixture
+def water_meter_report() -> dict[str, Any]:
+    """Return a redacted YS5018 water meter report."""
+    return load_json_object_fixture("ys5018_report.json", DOMAIN)
 
 
 @pytest.fixture

--- a/tests/components/yolink/fixtures/ys5018_report.json
+++ b/tests/components/yolink/fixtures/ys5018_report.json
@@ -1,0 +1,63 @@
+{
+  "event": "WaterMeterController.Report",
+  "method": "Report",
+  "data": {
+    "state": {
+      "valve": "open",
+      "meter": 2443649,
+      "waterFlowing": true,
+      "meterVersion": "010073",
+      "pipeDiameter": 20
+    },
+    "alarm": {
+      "openReminder": false,
+      "leak": false,
+      "amountOverrun": false,
+      "durationOverrun": false,
+      "highTemp": false,
+      "reminder": false,
+      "lowTemp": false
+    },
+    "battery": 4,
+    "powerSupply": "battery",
+    "valveDelay": {
+      "ch": 1,
+      "off": 0
+    },
+    "attributes": {
+      "openReminder": 0,
+      "screenMeterUnit": 0,
+      "meterUnit": 3,
+      "alertInterval": 0,
+      "meterStepFactor": 10,
+      "leakLimit": 38,
+      "autoCloseValve": false,
+      "overrunAmountACV": true,
+      "overrunDurationACV": true,
+      "leakPlan": "on",
+      "overrunAmount": 0,
+      "overrunDuration": 0,
+      "tempLimit": {
+        "min": -873.9,
+        "max": -873.9
+      }
+    },
+    "version": "180a",
+    "tz": -4,
+    "recentUsage": {
+      "amount": 168,
+      "duration": 1
+    },
+    "temperature": 17.7,
+    "dailyUsage": 11098,
+    "loraP2PHash": 0,
+    "loraInfo": {
+      "netId": "010202",
+      "devNetType": "A",
+      "signal": -62,
+      "gatewayId": "REDACTED",
+      "gateways": 1
+    }
+  },
+  "deviceId": "REDACTED"
+}

--- a/tests/components/yolink/test_sensor.py
+++ b/tests/components/yolink/test_sensor.py
@@ -254,9 +254,18 @@ async def test_water_meter_temperature_retained_on_partial_report(
         }
     }
     resolve_sub_message(device, partial_report, "Report")
-    YoLinkHomeMessageListener(hass, mock_config_entry).on_message(
-        device, partial_report
+    setup_call = mock_yolink_home.return_value.async_setup.await_args
+    assert setup_call is not None
+    registered_listener = next(
+        (
+            argument
+            for argument in (*setup_call.args, *setup_call.kwargs.values())
+            if isinstance(argument, YoLinkHomeMessageListener)
+        ),
+        None,
     )
+    assert isinstance(registered_listener, YoLinkHomeMessageListener)
+    registered_listener.on_message(device, partial_report)
     await hass.async_block_till_done()
 
     _assert_temperature_state(hass, entity_id, 17.7)

--- a/tests/components/yolink/test_sensor.py
+++ b/tests/components/yolink/test_sensor.py
@@ -1,0 +1,262 @@
+"""Tests for YoLink sensors."""
+
+from copy import deepcopy
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from yolink.client import YoLinkClient
+from yolink.const import (
+    ATTR_DEVICE_MULTI_CAPS_LEAK_SENSOR,
+    ATTR_DEVICE_MULTI_FUNCTIONAL_SENSOR,
+    ATTR_DEVICE_SOIL_TH_SENSOR,
+    ATTR_DEVICE_TH_SENSOR,
+    ATTR_DEVICE_WATER_METER_CONTROLLER,
+)
+from yolink.device import YoLinkDevice, YoLinkDeviceMode
+from yolink.message_resolver import resolve_sub_message
+from yolink.model import BRDP
+
+from homeassistant.components.sensor import (
+    ATTR_STATE_CLASS,
+    DOMAIN as SENSOR_DOMAIN,
+    SensorDeviceClass,
+    SensorStateClass,
+)
+from homeassistant.components.yolink import DOMAIN, YoLinkHomeMessageListener
+from homeassistant.components.yolink.const import (
+    DEV_MODEL_WATER_METER_YS5018_EC,
+    DEV_MODEL_WATER_METER_YS5018_UC,
+)
+from homeassistant.const import (
+    ATTR_DEVICE_CLASS,
+    ATTR_UNIT_OF_MEASUREMENT,
+    UnitOfTemperature,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from tests.common import MockConfigEntry
+
+
+def _mock_device(
+    *,
+    device_id: str,
+    device_name: str,
+    device_type: str,
+    device_model: str,
+    state: dict[str, Any],
+) -> YoLinkDevice:
+    """Create a YoLink device with a mocked API response."""
+    client = MagicMock(spec=YoLinkClient)
+    client.execute = AsyncMock(
+        return_value=BRDP(
+            code="000000",
+            desc="Success",
+            data={"state": deepcopy(state)},
+        )
+    )
+    return YoLinkDevice(
+        YoLinkDeviceMode(
+            deviceId=device_id,
+            name=device_name,
+            token="REDACTED",
+            type=device_type,
+            modelName=device_model,
+        ),
+        client,
+    )
+
+
+async def _async_setup_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: MagicMock,
+    devices: list[YoLinkDevice],
+) -> None:
+    """Set up YoLink with the supplied devices."""
+    mock_yolink_home.return_value.get_devices.return_value = devices
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+def _assert_temperature_state(
+    hass: HomeAssistant,
+    entity_id: str,
+    expected_temperature: float,
+) -> None:
+    """Assert a temperature sensor's public state and attributes."""
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == str(expected_temperature)
+    assert state.attributes[ATTR_UNIT_OF_MEASUREMENT] == UnitOfTemperature.CELSIUS
+    assert state.attributes[ATTR_DEVICE_CLASS] == SensorDeviceClass.TEMPERATURE
+    assert state.attributes[ATTR_STATE_CLASS] == SensorStateClass.MEASUREMENT
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_auth_manager")
+@pytest.mark.parametrize(
+    ("device_model", "device_id", "device_name"),
+    [
+        pytest.param(
+            DEV_MODEL_WATER_METER_YS5018_UC,
+            "water-meter-uc",
+            "FlowSmart Water Meter UC",
+            id="ys5018-uc",
+        ),
+        pytest.param(
+            DEV_MODEL_WATER_METER_YS5018_EC,
+            "water-meter-ec",
+            "FlowSmart Water Meter EC",
+            id="ys5018-ec",
+        ),
+    ],
+)
+async def test_water_meter_temperature(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: MagicMock,
+    water_meter_report: dict[str, Any],
+    device_model: str,
+    device_id: str,
+    device_name: str,
+) -> None:
+    """Test YS5018 water meters expose top-level water temperature."""
+    device = _mock_device(
+        device_id=device_id,
+        device_name=device_name,
+        device_type=ATTR_DEVICE_WATER_METER_CONTROLLER,
+        device_model=device_model,
+        state=water_meter_report["data"],
+    )
+
+    await _async_setup_devices(hass, mock_config_entry, mock_yolink_home, [device])
+
+    entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{device_id} temperature"
+    )
+    assert entity_id is not None
+    _assert_temperature_state(hass, entity_id, 17.7)
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_auth_manager")
+async def test_other_water_meter_has_no_temperature_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: MagicMock,
+    water_meter_report: dict[str, Any],
+) -> None:
+    """Test another water meter model does not expose temperature."""
+    device = _mock_device(
+        device_id="other-water-meter",
+        device_name="Other Water Meter",
+        device_type=ATTR_DEVICE_WATER_METER_CONTROLLER,
+        device_model="YS5008-UC",
+        state=water_meter_report["data"],
+    )
+
+    await _async_setup_devices(hass, mock_config_entry, mock_yolink_home, [device])
+
+    assert (
+        entity_registry.async_get_entity_id(
+            SENSOR_DOMAIN, DOMAIN, "other-water-meter temperature"
+        )
+        is None
+    )
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_auth_manager")
+@pytest.mark.parametrize(
+    ("device_type", "state", "expected_temperature"),
+    [
+        pytest.param(
+            ATTR_DEVICE_TH_SENSOR,
+            {"temperature": 20.1},
+            20.1,
+            id="th-sensor",
+        ),
+        pytest.param(
+            ATTR_DEVICE_SOIL_TH_SENSOR,
+            {"state": {"temperature": 20.2}},
+            20.2,
+            id="soil-th-sensor",
+        ),
+        pytest.param(
+            ATTR_DEVICE_MULTI_CAPS_LEAK_SENSOR,
+            {"state": {"temperature": 20.3}},
+            20.3,
+            id="multi-caps-leak-sensor",
+        ),
+        pytest.param(
+            ATTR_DEVICE_MULTI_FUNCTIONAL_SENSOR,
+            {"state": {"temperature": 20.4}},
+            20.4,
+            id="multi-functional-sensor",
+        ),
+    ],
+)
+async def test_existing_temperature_devices(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: MagicMock,
+    device_type: str,
+    state: dict[str, Any],
+    expected_temperature: float,
+) -> None:
+    """Test existing temperature-capable device types remain supported."""
+    device = _mock_device(
+        device_id="temperature-device",
+        device_name="Temperature Device",
+        device_type=device_type,
+        device_model="YS9999-UC",
+        state=state,
+    )
+
+    await _async_setup_devices(hass, mock_config_entry, mock_yolink_home, [device])
+
+    entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, "temperature-device temperature"
+    )
+    assert entity_id is not None
+    _assert_temperature_state(hass, entity_id, expected_temperature)
+
+
+@pytest.mark.usefixtures("setup_credentials", "mock_auth_manager")
+async def test_water_meter_temperature_retained_on_partial_report(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_yolink_home: MagicMock,
+    water_meter_report: dict[str, Any],
+) -> None:
+    """Test a partial report does not clear the last water temperature."""
+    device = _mock_device(
+        device_id="water-meter-uc",
+        device_name="FlowSmart Water Meter UC",
+        device_type=ATTR_DEVICE_WATER_METER_CONTROLLER,
+        device_model=DEV_MODEL_WATER_METER_YS5018_UC,
+        state=water_meter_report["data"],
+    )
+    await _async_setup_devices(hass, mock_config_entry, mock_yolink_home, [device])
+    entity_id = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, "water-meter-uc temperature"
+    )
+    assert entity_id is not None
+    _assert_temperature_state(hass, entity_id, 17.7)
+
+    partial_report = {
+        "state": {
+            "valve": "closed",
+            "waterFlowing": False,
+        }
+    }
+    resolve_sub_message(device, partial_report, "Report")
+    YoLinkHomeMessageListener(hass, mock_config_entry).on_message(
+        device, partial_report
+    )
+    await hass.async_block_till_done()
+
+    _assert_temperature_state(hass, entity_id, 17.7)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Expose the water temperature reported by the YoLink YS5018 FlowSmart as a temperature sensor.

The YoLink API reports this value in the top-level `temperature` field. The integration already parses this field, but the temperature entity was not enabled for YS5018 water meter controllers.

This change enables the existing temperature sensor for YS5018-UC and YS5018-EC devices.

The temperature entity also retains its previous valid reading when a partial YoLink report omits the `temperature` field. This follows the existing handling used for other YoLink entities that receive partial reports.

Tests were added using a redacted payload captured from an actual YS5018-UC. They verify:

- Temperature entities are created for both YS5018-UC and YS5018-EC.
- A reported temperature of 17.7 °C is exposed correctly.
- The entity uses the temperature device class and measurement state class.
- Other water-meter models do not receive the entity.
- Existing supported YoLink temperature-device behavior remains unchanged.
- A partial report without `temperature` does not clear the previous valid reading.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Related feature request discussion: https://github.com/orgs/home-assistant/discussions/2467
- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

### Files changed

- `homeassistant/components/yolink/sensor.py`
- `tests/components/yolink/conftest.py`
- `tests/components/yolink/fixtures/ys5018_report.json`
- `tests/components/yolink/test_sensor.py`

### Validation

- Focused YoLink sensor tests: 8 passed
- Full YoLink integration test suite: 18 passed
- YoLink integration coverage: 72%
- Ruff formatting: passed
- Ruff checks: passed
- Hassfest: passed with 1,482 integrations and 0 invalid integrations

Commands run:

```text
pytest ./tests/components/yolink/test_sensor.py -vv
ruff format homeassistant/components/yolink/sensor.py tests/components/yolink
ruff check homeassistant/components/yolink/sensor.py tests/components/yolink
pytest ./tests/components/yolink/ --cov=homeassistant.components.yolink --cov-report term-missing -vv
python3 -m script.hassfest
```

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr