### PR TITLE
Derive the psi to pascal factor instead of hardcoding it

### DIFF
--- a/homeassistant/util/unit_conversion.py
+++ b/homeassistant/util/unit_conversion.py
@@ -82,6 +82,8 @@ _STONE_TO_G = _POUND_TO_G * 14  # 14 pounds to a stone
 _STANDARD_GRAVITY = 9.80665
 _MERCURY_DENSITY = 13.5951
 _INH2O_TO_PA = 249.0889083333348  # 1 inH₂O = 249.0889083333348 Pa at 4°C
+# 1 psi = 1 lbf/in², and 1 lbf = _POUND_TO_G grams under _STANDARD_GRAVITY
+_PSI_TO_PA = _POUND_TO_G / 1000 * _STANDARD_GRAVITY / _IN2_TO_M2
 
 # Volume conversion constants
 _L_TO_CUBIC_METER = 0.001  # 1 L = 0.001 m³
@@ -597,7 +599,7 @@ class PressureConverter(BaseUnitConverter):
         UnitOfPressure.INHG: 1
         / (_IN_TO_M * 1000 * _STANDARD_GRAVITY * _MERCURY_DENSITY),
         UnitOfPressure.INH2O: 1 / _INH2O_TO_PA,
-        UnitOfPressure.PSI: 1 / 6894.757,
+        UnitOfPressure.PSI: 1 / _PSI_TO_PA,
         UnitOfPressure.MMHG: 1
         / (_MM_TO_M * 1000 * _STANDARD_GRAVITY * _MERCURY_DENSITY),
     }


### PR DESCRIPTION
## Breaking change

<!-- Not a breaking change. -->

## Proposed change

`PressureConverter` derives every pressure unit from the module's base constants — `INHG` and `MMHG` from `_STANDARD_GRAVITY` and `_MERCURY_DENSITY`, `INH2O` from the named `_INH2O_TO_PA`. `PSI` was the one exception: a hardcoded `1 / 6894.757`.

That literal is the exact value rounded to seven significant figures. Since psi is pounds-force per square inch, and the module already defines the pound (`_POUND_TO_G`, exact by definition), standard gravity (`_STANDARD_GRAVITY`, exact by definition) and the square inch (`_IN2_TO_M2`, derived from the exact inch), the factor can simply be derived:

```python
_PSI_TO_PA = _POUND_TO_G / 1000 * _STANDARD_GRAVITY / _IN2_TO_M2
```

which is 6894.757293168361 Pa, the exact definition of the pound-force per square inch.

The numeric effect is negligible — a relative change of 4.25e-8, about 1.5e-6 psi on a 36 psi reading — so this is about consistency and exactness rather than a user-visible fix. No test expectations needed updating: the existing psi cases use `pytest.approx`, whose default tolerance is well above the change.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
