### PR TITLE
Add silence-alarm button to ToGrill

### DIFF
--- a/homeassistant/components/togrill/__init__.py
+++ b/homeassistant/components/togrill/__init__.py
@@ -7,6 +7,7 @@ from homeassistant.exceptions import ConfigEntryNotReady
 from .coordinator import DeviceNotFound, ToGrillConfigEntry, ToGrillCoordinator
 
 _PLATFORMS: list[Platform] = [
+    Platform.BUTTON,
     Platform.EVENT,
     Platform.NUMBER,
     Platform.SELECT,

--- a/homeassistant/components/togrill/button.py
+++ b/homeassistant/components/togrill/button.py
@@ -1,0 +1,57 @@
+"""Support for button entities."""
+
+from typing import override
+
+from togrill_bluetooth.packets import PacketA5Write
+
+from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from . import ToGrillConfigEntry
+from .coordinator import ToGrillCoordinator
+from .entity import ToGrillEntity
+
+PARALLEL_UPDATES = 0
+
+ENTITY_DESCRIPTIONS = (
+    ButtonEntityDescription(
+        key="silence",
+        translation_key="silence",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ToGrillConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up button based on a config entry."""
+
+    coordinator = entry.runtime_data
+
+    async_add_entities(
+        ToGrillButton(coordinator, entity_description)
+        for entity_description in ENTITY_DESCRIPTIONS
+    )
+
+
+class ToGrillButton(ToGrillEntity, ButtonEntity):
+    """Representation of a button."""
+
+    def __init__(
+        self,
+        coordinator: ToGrillCoordinator,
+        entity_description: ButtonEntityDescription,
+    ) -> None:
+        """Initialize."""
+
+        super().__init__(coordinator)
+        self.entity_description = entity_description
+        self._attr_unique_id = f"{coordinator.address}_{entity_description.key}"
+
+    @override
+    async def async_press(self) -> None:
+        """Silence any active alarm on the device."""
+        await self._write_packet(PacketA5Write())

--- a/homeassistant/components/togrill/icons.json
+++ b/homeassistant/components/togrill/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "button": {
+      "silence": {
+        "default": "mdi:alarm-off"
+      }
+    },
     "select": {
       "grill_type": {
         "default": "mdi:grill",

--- a/homeassistant/components/togrill/manifest.json
+++ b/homeassistant/components/togrill/manifest.json
@@ -16,5 +16,5 @@
   "iot_class": "local_push",
   "loggers": ["togrill_bluetooth"],
   "quality_scale": "bronze",
-  "requirements": ["togrill-bluetooth==0.8.1"]
+  "requirements": ["togrill-bluetooth==0.9.0"]
 }

--- a/homeassistant/components/togrill/strings.json
+++ b/homeassistant/components/togrill/strings.json
@@ -28,6 +28,11 @@
     }
   },
   "entity": {
+    "button": {
+      "silence": {
+        "name": "Silence alarm"
+      }
+    },
     "event": {
       "event": {
         "name": "Event",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3208,7 +3208,7 @@ tmb==0.0.4
 todoist-api-python==3.1.0
 
 # homeassistant.components.togrill
-togrill-bluetooth==0.8.1
+togrill-bluetooth==0.9.0
 
 # homeassistant.components.tolo
 tololib==1.2.2

--- a/tests/components/togrill/snapshots/test_button.ambr
+++ b/tests/components/togrill/snapshots/test_button.ambr
@@ -1,0 +1,51 @@
+# serializer version: 1
+# name: test_setup[button.pro_05_silence_alarm-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'button',
+    'entity_category': None,
+    'entity_id': 'button.pro_05_silence_alarm',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Silence alarm',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Silence alarm',
+    'platform': 'togrill',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'silence',
+    'unique_id': '00000000-0000-0000-0000-000000000001_silence',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_setup[button.pro_05_silence_alarm-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Pro-05 Silence alarm',
+    }),
+    'context': <ANY>,
+    'entity_id': 'button.pro_05_silence_alarm',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/togrill/test_button.py
+++ b/tests/components/togrill/test_button.py
@@ -1,0 +1,81 @@
+"""Test buttons for ToGrill integration."""
+
+from unittest.mock import Mock
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from togrill_bluetooth.packets import PacketA5Write
+
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN, SERVICE_PRESS
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from . import TOGRILL_SERVICE_INFO, setup_entry
+
+from tests.common import MockConfigEntry, snapshot_platform
+from tests.components.bluetooth import inject_bluetooth_service_info
+
+
+async def test_setup(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+) -> None:
+    """Test the buttons."""
+
+    inject_bluetooth_service_info(hass, TOGRILL_SERVICE_INFO)
+
+    await setup_entry(hass, mock_entry, [Platform.BUTTON])
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_entry.entry_id)
+
+
+async def test_press(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+) -> None:
+    """Test pressing the silence button."""
+
+    inject_bluetooth_service_info(hass, TOGRILL_SERVICE_INFO)
+
+    await setup_entry(hass, mock_entry, [Platform.BUTTON])
+
+    await hass.services.async_call(
+        BUTTON_DOMAIN,
+        SERVICE_PRESS,
+        target={
+            ATTR_ENTITY_ID: "button.pro_05_silence_alarm",
+        },
+        blocking=True,
+    )
+
+    mock_client.write.assert_any_call(PacketA5Write())
+
+
+async def test_press_disconnected(
+    hass: HomeAssistant,
+    mock_entry: MockConfigEntry,
+    mock_client: Mock,
+) -> None:
+    """Test pressing the button while disconnected raises."""
+
+    inject_bluetooth_service_info(hass, TOGRILL_SERVICE_INFO)
+
+    await setup_entry(hass, mock_entry, [Platform.BUTTON])
+
+    mock_client.is_connected = False
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            BUTTON_DOMAIN,
+            SERVICE_PRESS,
+            target={
+                ATTR_ENTITY_ID: "button.pro_05_silence_alarm",
+            },
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a **Silence alarm** button to the ToGrill integration. Pressing it sends the `A5` acknowledge/silence command, which stops a ringing buzzer for both temperature and timer alarms. Adds the `button` platform to the integration.

Update library to 0.9.0 https://github.com/elupus/togrill-bluetooth/releases/tag/0.9.0
Changes: https://github.com/elupus/togrill-bluetooth/compare/0.8.1...0.9.0

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47211
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

