### PR TITLE
Suggest area device name

### DIFF
--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1297,12 +1297,8 @@ def suggest_device_area(
 ) -> DeviceAreaSuggestion | None:
     """Suggest a cleaned device name and area from a known area label.
 
-    When the device already has an area, only that area's label is stripped, so
-    an assigned area is never overridden. Otherwise the area with the longest
-    matching name or alias wins and is suggested along with the cleaned name.
-
-    A match that strips the whole name (name equals the label) is a no-op, with
-    no fallback to a shorter label. Returns None when nothing should change.
+    An already assigned area is never overridden, only stripped from the name.
+    Returns None when nothing should change.
     """
     if not (name := (name or "").strip()):
         return None
@@ -1699,6 +1695,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         )
 
         is_new = False
+        is_restored = False
 
         if device is None:
             is_new = True
@@ -1741,6 +1738,7 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 )
 
             else:
+                is_restored = True
                 self.deleted_devices.pop(deleted_device.id)
                 device = deleted_device.to_device_entry(
                     config_entry,
@@ -1815,15 +1813,11 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 "merge_identifiers": identifiers or UNDEFINED,
             }
 
-        # On creation, strip a known area label from the device name into
-        # name_by_user and, when the device has no area, assign the matching area.
-        # Storing the cleaned name as name_by_user leaves the integration's raw name
-        # in name and lets the cleaned name survive re-registration untouched, so
-        # this only runs for new devices. A device restored with a user-set name is
-        # left alone.
+        # The cleaned name goes in name_by_user so the integration's raw name in name
+        # is left alone and re-registration can't overwrite the cleaned name.
         device_area_id: str | None | UndefinedType = UNDEFINED
         device_name_by_user: str | UndefinedType = UNDEFINED
-        if is_new and name is not UNDEFINED and name and device.name_by_user is None:
+        if is_new and not is_restored and name is not UNDEFINED and name:
             from . import area_registry as ar  # noqa: PLC0415  # Circular dependency
 
             if suggestion := suggest_device_area(

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1276,17 +1276,24 @@ class DeviceAreaSuggestion(NamedTuple):
     area_id: str | None = None
 
 
-def _match_area(name: str, area: AreaEntry) -> tuple[str, int] | None:
+class _AreaMatch(NamedTuple):
+    """A device name with an area label stripped, and the length of that label."""
+
+    name: str
+    label_length: int
+
+
+def _match_area(name: str, area: AreaEntry) -> _AreaMatch | None:
     """Return the stripped name and length of the area's longest matching label."""
-    best: tuple[str, int] | None = None
+    best: _AreaMatch | None = None
     for label in (area.name, *area.aliases):
         if not label:
             continue
         stripped = strip_boundary_label(name, label)
         if stripped is None:
             continue
-        if best is None or len(label) > best[1]:
-            best = (stripped, len(label))
+        if best is None or len(label) > best.label_length:
+            best = _AreaMatch(stripped, len(label))
     return best
 
 
@@ -1298,26 +1305,33 @@ def suggest_device_area(
     """Suggest a cleaned device name and area from a known area label.
 
     An already assigned area is never overridden, only stripped from the name.
-    Returns None when nothing should change.
+    Labels are not unique across areas, so an equally long match from another
+    area is ambiguous. Returns None when nothing should change.
     """
     if not (name := (name or "").strip()):
         return None
 
     if current_area_id:
         area = next((area for area in areas if area.id == current_area_id), None)
-        if area and (match := _match_area(name, area)) and match[0]:
-            return DeviceAreaSuggestion(name=match[0])
+        if area and (match := _match_area(name, area)) and match.name:
+            return DeviceAreaSuggestion(name=match.name)
         return None
 
-    best: tuple[str, str] | None = None
-    best_length = 0
+    best: _AreaMatch | None = None
+    best_area_id: str | None = None
+    is_ambiguous = False
     for area in areas:
-        if (match := _match_area(name, area)) and match[1] > best_length:
-            best = (area.id, match[0])
-            best_length = match[1]
-    if best and best[1]:
-        return DeviceAreaSuggestion(name=best[1], area_id=best[0])
-    return None
+        if not (match := _match_area(name, area)):
+            continue
+        if best is None or match.label_length > best.label_length:
+            best = match
+            best_area_id = area.id
+            is_ambiguous = False
+        elif match.label_length == best.label_length:
+            is_ambiguous = True
+    if is_ambiguous or best is None or not best.name:
+        return None
+    return DeviceAreaSuggestion(name=best.name, area_id=best_area_id)
 
 
 class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -12,7 +12,7 @@ import logging
 import os
 import shutil
 import time
-from typing import TYPE_CHECKING, Any, Literal, TypedDict, Unpack, override
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, Unpack, override
 
 import attr
 from yarl import URL
@@ -27,7 +27,7 @@ from homeassistant.core import (
 )
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.loader import async_suggest_report_issue
-from homeassistant.util import uuid as uuid_util
+from homeassistant.util import strip_boundary_label, uuid as uuid_util
 from homeassistant.util.dt import utc_from_timestamp, utcnow
 from homeassistant.util.event_type import EventType
 from homeassistant.util.hass_dict import HassKey
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
     from homeassistant.config_entries import ConfigEntry
 
     from . import entity_registry
+    from .area_registry import AreaEntry
 else:
     from propcache.api import under_cached_property
 
@@ -1268,6 +1269,61 @@ class DeletedDeviceRegistryItems(DeviceRegistryItems[DeletedDeviceEntry]):
         return None
 
 
+class DeviceAreaSuggestion(NamedTuple):
+    """A cleaned device name and an optional area to assign."""
+
+    name: str
+    area_id: str | None = None
+
+
+def _match_area(name: str, area: AreaEntry) -> tuple[str, int] | None:
+    """Return the stripped name and length of the area's longest matching label."""
+    best: tuple[str, int] | None = None
+    for label in (area.name, *area.aliases):
+        if not label:
+            continue
+        stripped = strip_boundary_label(name, label)
+        if stripped is None:
+            continue
+        if best is None or len(label) > best[1]:
+            best = (stripped, len(label))
+    return best
+
+
+def suggest_device_area(
+    name: str | None,
+    current_area_id: str | None,
+    areas: Iterable[AreaEntry],
+) -> DeviceAreaSuggestion | None:
+    """Suggest a cleaned device name and area from a known area label.
+
+    When the device already has an area, only that area's label is stripped, so
+    an assigned area is never overridden. Otherwise the area with the longest
+    matching name or alias wins and is suggested along with the cleaned name.
+
+    A match that strips the whole name (name equals the label) is a no-op, with
+    no fallback to a shorter label. Returns None when nothing should change.
+    """
+    if not (name := (name or "").strip()):
+        return None
+
+    if current_area_id:
+        area = next((area for area in areas if area.id == current_area_id), None)
+        if area and (match := _match_area(name, area)) and match[0]:
+            return DeviceAreaSuggestion(name=match[0])
+        return None
+
+    best: tuple[str, str] | None = None
+    best_length = 0
+    for area in areas:
+        if (match := _match_area(name, area)) and match[1] > best_length:
+            best = (area.id, match[0])
+            best_length = match[1]
+    if best and best[1]:
+        return DeviceAreaSuggestion(name=best[1], area_id=best[0])
+    return None
+
+
 class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
     """Class to hold a registry of devices."""
 
@@ -1759,13 +1815,33 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
                 "merge_identifiers": identifiers or UNDEFINED,
             }
 
+        # On creation, strip a known area label from the device name into
+        # name_by_user and, when the device has no area, assign the matching area.
+        # Storing the cleaned name as name_by_user leaves the integration's raw name
+        # in name and lets the cleaned name survive re-registration untouched, so
+        # this only runs for new devices. A device restored with a user-set name is
+        # left alone.
+        device_area_id: str | None | UndefinedType = UNDEFINED
+        device_name_by_user: str | UndefinedType = UNDEFINED
+        if is_new and name is not UNDEFINED and name and device.name_by_user is None:
+            from . import area_registry as ar  # noqa: PLC0415  # Circular dependency
+
+            if suggestion := suggest_device_area(
+                name, device.area_id, ar.async_get(self.hass).async_list_areas()
+            ):
+                device_name_by_user = suggestion.name
+                if suggestion.area_id is not None:
+                    device_area_id = suggestion.area_id
+
         device = self._async_update_device(
             device.id,
             allow_collisions=True,
+            area_id=device_area_id,
             disabled_by=disabled_by,
             entry_type=entry_type,
             is_new=is_new,
             name=name,
+            name_by_user=device_name_by_user,
             has_composite_identifiers=has_composite_identifiers,
             # Move the device if the integration re-registers it under a different
             # subentry; UNDEFINED leaves the subentry unchanged. Also validates an

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -120,12 +120,11 @@ _ENDS_WITH_SEPARATOR = re.compile(rf"[{_SEPARATOR_CLASS}]$")
 def strip_boundary_label(text: str, label: str) -> str | None:
     """Strip label from the start or end of text on a word boundary.
 
-    Matching is case-insensitive and only made on a separator boundary (any of
-    whitespace, ``-``, ``_`` or ``.``), so "Kitchen" is not stripped from
-    "Kitchenette". Surrounding separators are trimmed from the remainder.
+    Matching is case-insensitive and requires a separator boundary (whitespace,
+    ``-``, ``_`` or ``.``), so "Kitchen" is not stripped from "Kitchenette".
 
-    Returns an empty string when text equals label, the trimmed remainder for a
-    prefix or suffix match, or None when label is neither.
+    Returns the trimmed remainder, an empty string when text equals label, or
+    None when label is neither a prefix nor a suffix.
     """
     lower_text = text.lower()
     lower_label = label.lower()

--- a/homeassistant/util/__init__.py
+++ b/homeassistant/util/__init__.py
@@ -110,6 +110,42 @@ def snakecase(text: str) -> str:
     return text.lower()
 
 
+_SEPARATOR_CLASS = r"\s\-_."
+_LEADING_SEPARATORS = re.compile(rf"^[{_SEPARATOR_CLASS}]+")
+_TRAILING_SEPARATORS = re.compile(rf"[{_SEPARATOR_CLASS}]+$")
+_STARTS_WITH_SEPARATOR = re.compile(rf"^[{_SEPARATOR_CLASS}]")
+_ENDS_WITH_SEPARATOR = re.compile(rf"[{_SEPARATOR_CLASS}]$")
+
+
+def strip_boundary_label(text: str, label: str) -> str | None:
+    """Strip label from the start or end of text on a word boundary.
+
+    Matching is case-insensitive and only made on a separator boundary (any of
+    whitespace, ``-``, ``_`` or ``.``), so "Kitchen" is not stripped from
+    "Kitchenette". Surrounding separators are trimmed from the remainder.
+
+    Returns an empty string when text equals label, the trimmed remainder for a
+    prefix or suffix match, or None when label is neither.
+    """
+    lower_text = text.lower()
+    lower_label = label.lower()
+
+    if lower_text == lower_label:
+        return ""
+
+    if lower_text.startswith(lower_label):
+        rest = text[len(label) :]
+        if _STARTS_WITH_SEPARATOR.match(rest):
+            return _LEADING_SEPARATORS.sub("", rest).strip()
+
+    if lower_text.endswith(lower_label):
+        rest = text[: len(text) - len(label)]
+        if _ENDS_WITH_SEPARATOR.search(rest):
+            return _TRAILING_SEPARATORS.sub("", rest).strip()
+
+    return None
+
+
 class Throttle:
     """A class for throttling the execution of tasks.
 

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -8112,6 +8112,27 @@ async def test_dict_repr_dual_writes_deprecated_keys(
             id="name-equals-area-no-fallback",
         ),
         pytest.param(
+            [("Hall", ["Downstairs"]), ("Cellar", ["Downstairs"])],
+            "Downstairs Light",
+            None,
+            None,
+            id="ambiguous-shared-alias",
+        ),
+        pytest.param(
+            [("Kitchen", []), ("Cookhouse", ["Kitchen"])],
+            "Kitchen Sensor",
+            None,
+            None,
+            id="ambiguous-alias-matches-other-area-name",
+        ),
+        pytest.param(
+            [("Master", []), ("Spare", ["Master"]), ("Master Bedroom", [])],
+            "Master Bedroom Lamp",
+            None,
+            dr.DeviceAreaSuggestion("Lamp", "master_bedroom"),
+            id="longest-label-beats-shorter-ambiguity",
+        ),
+        pytest.param(
             [("Kitchen", [])],
             "Kitchenette Sensor",
             None,

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -8163,7 +8163,6 @@ async def test_dict_repr_dual_writes_deprecated_keys(
     ],
 )
 async def test_suggest_device_area(
-    hass: HomeAssistant,
     area_registry: ar.AreaRegistry,
     areas: list[tuple[str, list[str]]],
     name: str,
@@ -8181,7 +8180,6 @@ async def test_suggest_device_area(
 
 
 async def test_get_or_create_strips_area_from_name(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     area_registry: ar.AreaRegistry,
     mock_config_entry: MockConfigEntry,
@@ -8195,12 +8193,10 @@ async def test_get_or_create_strips_area_from_name(
         name="Living Room Thermostat",
     )
 
-    # The integration's raw name is kept, the cleaned name is stored as name_by_user.
     assert device.name == "Living Room Thermostat"
     assert device.name_by_user == "Thermostat"
     assert device.area_id == living_room.id
 
-    # Re-registering with the original name keeps the cleaned name and area.
     device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("bla", "123")},
@@ -8213,7 +8209,6 @@ async def test_get_or_create_strips_area_from_name(
 
 
 async def test_get_or_create_strips_suggested_area_from_name(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     area_registry: ar.AreaRegistry,
     mock_config_entry: MockConfigEntry,
@@ -8234,7 +8229,6 @@ async def test_get_or_create_strips_suggested_area_from_name(
 
 
 async def test_get_or_create_keeps_name_when_it_matches_another_area(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     area_registry: ar.AreaRegistry,
     mock_config_entry: MockConfigEntry,
@@ -8256,21 +8250,42 @@ async def test_get_or_create_keeps_name_when_it_matches_another_area(
     assert device.area_id == kitchen.id
 
 
-async def test_get_or_create_does_not_reclean_restored_device(
+@pytest.mark.parametrize(
+    ("updates", "expected_name_by_user", "expected_area_id"),
+    [
+        pytest.param(
+            {"name_by_user": "My Thermostat"},
+            "My Thermostat",
+            "living_room",
+            id="user-renamed",
+        ),
+        pytest.param({"name_by_user": None}, None, "living_room", id="never-renamed"),
+        pytest.param(
+            {"name_by_user": None, "area_id": None},
+            None,
+            None,
+            id="area-cleared",
+        ),
+    ],
+)
+async def test_get_or_create_does_not_clean_restored_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     area_registry: ar.AreaRegistry,
     mock_config_entry: MockConfigEntry,
+    updates: dict[str, str | None],
+    expected_name_by_user: str | None,
+    expected_area_id: str | None,
 ) -> None:
-    """Test a restored device keeps its user name instead of being re-cleaned."""
-    living_room = area_registry.async_create("Living Room")
+    """Test a restored device keeps the name and area the user left it with."""
+    area_registry.async_create("Living Room")
 
     device = device_registry.async_get_or_create(
         config_entry_id=mock_config_entry.entry_id,
         identifiers={("bla", "123")},
         name="Living Room Thermostat",
     )
-    device_registry.async_update_device(device.id, name_by_user="My Thermostat")
+    device_registry.async_update_device(device.id, **updates)
 
     # Removing the config entry orphans the device so re-registering restores it.
     device_registry.async_clear_config_entry(mock_config_entry.entry_id)
@@ -8284,5 +8299,35 @@ async def test_get_or_create_does_not_reclean_restored_device(
     )
 
     assert restored.id == device.id
-    assert restored.name_by_user == "My Thermostat"
-    assert restored.area_id == living_room.id
+    assert restored.name_by_user == expected_name_by_user
+    assert restored.area_id == expected_area_id
+
+
+async def test_get_or_create_cleaned_name_entity_naming(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test how the cleaned device name is reflected in entity naming."""
+    area_registry.async_create("Living Room")
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Living Room Thermostat",
+    )
+    entity = entity_registry.async_get_or_create(
+        "climate",
+        "test",
+        "unique",
+        device_id=device.id,
+        has_entity_name=True,
+        original_name=None,
+    )
+
+    assert device.name_by_user == "Thermostat"
+    # The entity id prefixes the area, the full entity name does not.
+    assert entity.entity_id == "climate.living_room_thermostat"
+    assert er.async_get_full_entity_name(hass, entity) == "Thermostat"

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -8286,8 +8286,6 @@ async def test_get_or_create_does_not_clean_restored_device(
         name="Living Room Thermostat",
     )
     device_registry.async_update_device(device.id, **updates)
-
-    # Removing the config entry orphans the device so re-registering restores it.
     device_registry.async_clear_config_entry(mock_config_entry.entry_id)
 
     new_entry = MockConfigEntry()
@@ -8328,6 +8326,5 @@ async def test_get_or_create_cleaned_name_entity_naming(
     )
 
     assert device.name_by_user == "Thermostat"
-    # The entity id prefixes the area, the full entity name does not.
     assert entity.entity_id == "climate.living_room_thermostat"
     assert er.async_get_full_entity_name(hass, entity) == "Thermostat"

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -8078,3 +8078,211 @@ async def test_dict_repr_dual_writes_deprecated_keys(
     assert "composite_primary_config_entry" not in repr_
     assert "split_at" not in repr_
     assert "has_composite_identifiers" not in repr_
+
+
+@pytest.mark.parametrize(
+    ("areas", "name", "current_area_id", "expected"),
+    [
+        pytest.param(
+            [("Living Room", [])],
+            "Living Room Thermostat",
+            None,
+            dr.DeviceAreaSuggestion("Thermostat", "living_room"),
+            id="prefix",
+        ),
+        pytest.param(
+            [("Living Room", [])],
+            "Thermostat Living Room",
+            None,
+            dr.DeviceAreaSuggestion("Thermostat", "living_room"),
+            id="suffix",
+        ),
+        pytest.param(
+            [("Master", []), ("Master Bedroom", [])],
+            "Master Bedroom Lamp",
+            None,
+            dr.DeviceAreaSuggestion("Lamp", "master_bedroom"),
+            id="longest-label-wins",
+        ),
+        pytest.param(
+            [("Master", []), ("Master Bedroom", [])],
+            "Master Bedroom",
+            None,
+            None,
+            id="name-equals-area-no-fallback",
+        ),
+        pytest.param(
+            [("Kitchen", [])],
+            "Kitchenette Sensor",
+            None,
+            None,
+            id="word-boundary",
+        ),
+        pytest.param(
+            [("Living Room", ["Lounge"])],
+            "Lounge TV",
+            None,
+            dr.DeviceAreaSuggestion("TV", "living_room"),
+            id="alias-match",
+        ),
+        pytest.param(
+            [("Living Room", [])],
+            "living room thermostat",
+            None,
+            dr.DeviceAreaSuggestion("thermostat", "living_room"),
+            id="case-insensitive",
+        ),
+        pytest.param(
+            [("Living Room", [])],
+            "Thermostat",
+            None,
+            None,
+            id="no-match",
+        ),
+        pytest.param(
+            [("Kitchen", [])],
+            "Kitchen Sensor",
+            "kitchen",
+            dr.DeviceAreaSuggestion("Sensor"),
+            id="current-area-cleans-name-only",
+        ),
+        pytest.param(
+            [("Kitchen", []), ("Living Room", [])],
+            "Living Room Sensor",
+            "kitchen",
+            None,
+            id="current-area-never-overridden",
+        ),
+        pytest.param(
+            [("Kitchen", [])],
+            "   ",
+            None,
+            None,
+            id="blank-name",
+        ),
+    ],
+)
+async def test_suggest_device_area(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    areas: list[tuple[str, list[str]]],
+    name: str,
+    current_area_id: str | None,
+    expected: dr.DeviceAreaSuggestion | None,
+) -> None:
+    """Test suggesting a cleaned device name and area from a known area label."""
+    for area_name, aliases in areas:
+        area_registry.async_create(area_name, aliases=set(aliases))
+
+    assert (
+        dr.suggest_device_area(name, current_area_id, area_registry.async_list_areas())
+        == expected
+    )
+
+
+async def test_get_or_create_strips_area_from_name(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a new device is assigned the area in its name and gets a cleaned name."""
+    living_room = area_registry.async_create("Living Room")
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Living Room Thermostat",
+    )
+
+    # The integration's raw name is kept, the cleaned name is stored as name_by_user.
+    assert device.name == "Living Room Thermostat"
+    assert device.name_by_user == "Thermostat"
+    assert device.area_id == living_room.id
+
+    # Re-registering with the original name keeps the cleaned name and area.
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Living Room Thermostat",
+    )
+
+    assert device.name == "Living Room Thermostat"
+    assert device.name_by_user == "Thermostat"
+    assert device.area_id == living_room.id
+
+
+async def test_get_or_create_strips_suggested_area_from_name(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the suggested area is stripped from the name without being overridden."""
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Kitchen Sensor",
+        suggested_area="Kitchen",
+    )
+
+    kitchen = area_registry.async_get_area_by_name("Kitchen")
+    assert kitchen is not None
+    assert device.name == "Kitchen Sensor"
+    assert device.name_by_user == "Sensor"
+    assert device.area_id == kitchen.id
+
+
+async def test_get_or_create_keeps_name_when_it_matches_another_area(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a name matching an area other than the device's own is left untouched."""
+    area_registry.async_create("Living Room")
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Living Room Sensor",
+        suggested_area="Kitchen",
+    )
+
+    kitchen = area_registry.async_get_area_by_name("Kitchen")
+    assert kitchen is not None
+    assert device.name == "Living Room Sensor"
+    assert device.name_by_user is None
+    assert device.area_id == kitchen.id
+
+
+async def test_get_or_create_does_not_reclean_restored_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    area_registry: ar.AreaRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a restored device keeps its user name instead of being re-cleaned."""
+    living_room = area_registry.async_create("Living Room")
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Living Room Thermostat",
+    )
+    device_registry.async_update_device(device.id, name_by_user="My Thermostat")
+
+    # Removing the config entry orphans the device so re-registering restores it.
+    device_registry.async_clear_config_entry(mock_config_entry.entry_id)
+
+    new_entry = MockConfigEntry()
+    new_entry.add_to_hass(hass)
+    restored = device_registry.async_get_or_create(
+        config_entry_id=new_entry.entry_id,
+        identifiers={("bla", "123")},
+        name="Living Room Thermostat",
+    )
+
+    assert restored.id == device.id
+    assert restored.name_by_user == "My Thermostat"
+    assert restored.area_id == living_room.id

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -261,3 +261,28 @@ async def test_throttle_async() -> None:
 def test_snakecase(input, expected) -> None:
     """Test snake casing a string."""
     assert util.snakecase(input) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "label", "expected"),
+    [
+        ("Living Room Thermostat", "Living Room", "Thermostat"),
+        ("Thermostat Living Room", "Living Room", "Thermostat"),
+        ("Living Room", "Living Room", ""),
+        ("living room thermostat", "Living Room", "thermostat"),
+        ("LIVING ROOM Thermostat", "living room", "Thermostat"),
+        ("Kitchen-Sensor", "Kitchen", "Sensor"),
+        ("Kitchen_Sensor", "Kitchen", "Sensor"),
+        ("Kitchen.Sensor", "Kitchen", "Sensor"),
+        ("Sensor-Kitchen", "Kitchen", "Sensor"),
+        ("Kitchen   Sensor", "Kitchen", "Sensor"),
+        ("Kitchenette Sensor", "Kitchen", None),
+        ("My Kitchen Sensor", "Kitchen", None),
+        ("Thermostat", "Living Room", None),
+        ("Kitchen -", "Kitchen", ""),
+        ("- Kitchen", "Kitchen", ""),
+    ],
+)
+def test_strip_boundary_label(text: str, label: str, expected: str | None) -> None:
+    """Test stripping a label from the boundary of a string."""
+    assert util.strip_boundary_label(text, label) == expected


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
When a device is added and its name starts or ends with the name or alias of an existing area, the device is placed in that area and the area is removed from the name shown in the UI. A device an integration reports as "Living Room Thermostat" lands in the Living Room area and is shown as "Thermostat".

This applies to every newly registered device, including ones discovered at runtime by an already configured integration, not only to devices added through a config flow. The cleaned name is stored as the user name, so it stays editable and the name the integration reports is kept. Devices already in the registry, devices restored after their config entry was removed, and devices the user has renamed are left alone.

Two side effects worth noting: generated entity IDs stop repeating the area (`climate.living_room_living_room_thermostat` becomes `climate.living_room_thermostat`), and entity names follow the shortened device name, so that entity is named "Thermostat" instead of "Living Room Thermostat".

Core side of https://github.com/home-assistant/frontend/pull/53270.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/pull/53270
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

