### PR TITLE
Add repair issue for device_tracker.see service action

### DIFF
--- a/homeassistant/components/device_tracker/legacy.py
+++ b/homeassistant/components/device_tracker/legacy.py
@@ -36,7 +36,11 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.entity_platform import (
     async_create_platform_config_not_supported_issue,
 )
@@ -226,6 +230,21 @@ async def async_setup_integration(
                 SERVICE_SEE,
             )
             warned_called_see = True
+        # Recreate the issue on every call so it reappears if the user
+        # confirmed (deleted) it while still using the deprecated action.
+        docs_url = "https://www.home-assistant.io/integrations/template/#device-tracker"
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            "deprecated_see_action",
+            breaks_in_ha_version="2027.5.0",
+            is_fixable=True,
+            is_persistent=True,
+            learn_more_url=docs_url,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key="deprecated_see_action",
+            translation_placeholders={"docs_url": docs_url},
+        )
         # Temp workaround for iOS, introduced in 0.65
         data = dict(call.data)
         data.pop("hostname", None)

--- a/homeassistant/components/device_tracker/strings.json
+++ b/homeassistant/components/device_tracker/strings.json
@@ -55,6 +55,17 @@
     "associated_zone_missing": {
       "description": "The scanner entity `{entity_id}` is associated with the zone `{zone}`, but that zone has been removed.\n\nTo fix this, reconfigure the scanner to use a different zone or recreate the missing zone.",
       "title": "Scanner is associated with a removed zone"
+    },
+    "deprecated_see_action": {
+      "fix_flow": {
+        "step": {
+          "confirm": {
+            "description": "The `device_tracker.see` action is deprecated and will be removed in Home Assistant Core 2027.5.\n\nUse a [template device tracker]({docs_url}) instead, then remove any use of this action from your automations and scripts and select **Submit** to close this issue.",
+            "title": "Detected use of deprecated action device_tracker.see"
+          }
+        }
+      },
+      "title": "Detected use of deprecated action device_tracker.see"
     }
   },
   "services": {

--- a/tests/components/device_tracker/test_legacy.py
+++ b/tests/components/device_tracker/test_legacy.py
@@ -8,12 +8,16 @@ from homeassistant.components import device_tracker
 from homeassistant.components.device_tracker import legacy
 from homeassistant.const import CONF_PLATFORM
 from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.setup import async_setup_component
 from homeassistant.util.yaml import dump
 
 from .common import MockScanner, mock_legacy_device_tracker_setup
 
 from tests.common import assert_setup_component, patch_yaml_files
+from tests.components.repairs import process_repair_fix_flow, start_repair_fix_flow
+from tests.typing import ClientSessionGenerator
 
 TEST_PLATFORM = {device_tracker.DOMAIN: {CONF_PLATFORM: "test"}}
 
@@ -58,6 +62,7 @@ def test_remove_device_from_config(hass: HomeAssistant) -> None:
 async def test_see_service_deprecation_warning(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,
+    issue_registry: ir.IssueRegistry,
 ) -> None:
     """Test deprecation warning when calling device_tracker.see."""
     mock_legacy_device_tracker_setup(hass, MockScanner())
@@ -77,6 +82,14 @@ async def test_see_service_deprecation_warning(
         "Home Assistant Core 2027.5"
     ) in caplog.text
 
+    issue = issue_registry.async_get_issue(
+        device_tracker.DOMAIN, "deprecated_see_action"
+    )
+    assert issue is not None
+    assert issue.is_fixable is True
+    assert issue.is_persistent is True
+    assert issue.breaks_in_ha_version == "2027.5.0"
+
     caplog.clear()
 
     # Second call should not produce another warning
@@ -88,6 +101,59 @@ async def test_see_service_deprecation_warning(
     )
 
     assert "deprecated" not in caplog.text
+
+
+async def test_see_service_repair_flow(
+    hass: HomeAssistant,
+    issue_registry: ir.IssueRegistry,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test confirming the repair issue removes it from the issue registry."""
+    mock_legacy_device_tracker_setup(hass, MockScanner())
+    with assert_setup_component(1, device_tracker.DOMAIN):
+        assert await async_setup_component(hass, device_tracker.DOMAIN, TEST_PLATFORM)
+        await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        device_tracker.DOMAIN,
+        legacy.SERVICE_SEE,
+        {"dev_id": "test_device", "location_name": "Work"},
+        blocking=True,
+    )
+
+    assert issue_registry.async_get_issue(
+        device_tracker.DOMAIN, "deprecated_see_action"
+    )
+
+    assert await async_setup_component(hass, "repairs", {})
+    client = await hass_client()
+
+    result = await start_repair_fix_flow(
+        client, device_tracker.DOMAIN, "deprecated_see_action"
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "confirm"
+
+    result = await process_repair_fix_flow(client, result["flow_id"], {})
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert (
+        issue_registry.async_get_issue(device_tracker.DOMAIN, "deprecated_see_action")
+        is None
+    )
+
+    # Calling the action again after confirming recreates the issue.
+    await hass.services.async_call(
+        device_tracker.DOMAIN,
+        legacy.SERVICE_SEE,
+        {"dev_id": "test_device", "location_name": "Work"},
+        blocking=True,
+    )
+
+    assert issue_registry.async_get_issue(
+        device_tracker.DOMAIN, "deprecated_see_action"
+    )
 
 
 async def test_legacy_platform_setup_deprecation_warning(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- We deprecated the `device_tracker.see` service action in 2026.5. At the time we didn't have a good alternative for users creating virtual device trackers via this service action. After that the template device tracker was added exactly for this purpose.
- Now that there's a good alternative we can create a repair issue when the device_tracker.see service action is called, asking users to migrate to the template device tracker.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [x] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177121
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
