### PR TITLE
Make _LOGGER public in refoss

### DIFF
--- a/homeassistant/components/refoss/bridge.py
+++ b/homeassistant/components/refoss/bridge.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import _LOGGER, DISPATCH_DEVICE_DISCOVERED
+from .const import DISPATCH_DEVICE_DISCOVERED, LOGGER
 from .coordinator import RefossDataUpdateCoordinator
 
 type RefossConfigEntry = ConfigEntry[DiscoveryService]
@@ -40,7 +40,7 @@ class DiscoveryService(Listener):
         self.coordinators.append(coordo)
         await coordo.async_refresh()
 
-        _LOGGER.debug(
+        LOGGER.debug(
             "Discover new device: %s, ip: %s",
             device_info.dev_name,
             device_info.inner_ip,
@@ -51,7 +51,7 @@ class DiscoveryService(Listener):
         """Handle updates in device information, update if ip has changed."""
         for coordinator in self.coordinators:
             if coordinator.device.device_info.mac == device_info.mac:
-                _LOGGER.debug(
+                LOGGER.debug(
                     "Update device %s ip to %s",
                     device_info.dev_name,
                     device_info.inner_ip,

--- a/homeassistant/components/refoss/config_flow.py
+++ b/homeassistant/components/refoss/config_flow.py
@@ -3,7 +3,7 @@
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow
 
-from .const import _LOGGER, DISCOVERY_TIMEOUT, DOMAIN
+from .const import DISCOVERY_TIMEOUT, DOMAIN, LOGGER
 from .util import refoss_discovery_server
 
 
@@ -12,7 +12,7 @@ async def _async_has_devices(hass: HomeAssistant) -> bool:
 
     refoss_discovery = await refoss_discovery_server(hass)
     devices = await refoss_discovery.broadcast_msg(wait_for=DISCOVERY_TIMEOUT)
-    _LOGGER.debug(
+    LOGGER.debug(
         "Discovered devices: [%s]", ", ".join([info.dev_name for info in devices])
     )
     return len(devices) > 0

--- a/homeassistant/components/refoss/const.py
+++ b/homeassistant/components/refoss/const.py
@@ -2,7 +2,7 @@
 
 from logging import Logger, getLogger
 
-_LOGGER: Logger = getLogger(__package__)
+LOGGER: Logger = getLogger(__package__)
 
 COORDINATORS = "coordinators"
 

--- a/homeassistant/components/refoss/coordinator.py
+++ b/homeassistant/components/refoss/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
-from .const import _LOGGER, DOMAIN, MAX_ERRORS
+from .const import DOMAIN, LOGGER, MAX_ERRORS
 
 
 class RefossDataUpdateCoordinator(DataUpdateCoordinator[None]):
@@ -24,7 +24,7 @@ class RefossDataUpdateCoordinator(DataUpdateCoordinator[None]):
         """Initialize the data update coordinator."""
         super().__init__(
             hass,
-            _LOGGER,
+            LOGGER,
             config_entry=config_entry,
             name=f"{DOMAIN}-{device.device_info.dev_name}",
             update_interval=timedelta(seconds=15),
@@ -40,7 +40,7 @@ class RefossDataUpdateCoordinator(DataUpdateCoordinator[None]):
             self.last_update_success = True
             self._error_count = 0
         except DeviceTimeoutError:
-            _LOGGER.debug(
+            LOGGER.debug(
                 "Update device %s status timeout,ip: %s",
                 self.device.dev_name,
                 self.device.inner_ip,

--- a/homeassistant/components/refoss/sensor.py
+++ b/homeassistant/components/refoss/sensor.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
 from .bridge import RefossConfigEntry, RefossDataUpdateCoordinator
-from .const import _LOGGER, CHANNEL_DISPLAY_NAME, DISPATCH_DEVICE_DISCOVERED, SENSOR_EM
+from .const import CHANNEL_DISPLAY_NAME, DISPATCH_DEVICE_DISCOVERED, LOGGER, SENSOR_EM
 from .entity import RefossEntity
 
 
@@ -135,7 +135,7 @@ async def async_setup_entry(
             for channel in device.channels
             for description in descriptions
         )
-        _LOGGER.debug("Device %s add sensor entity success", device.dev_name)
+        LOGGER.debug("Device %s add sensor entity success", device.dev_name)
 
     for coordinator in config_entry.runtime_data.coordinators:
         init_device(coordinator)

--- a/homeassistant/components/refoss/switch.py
+++ b/homeassistant/components/refoss/switch.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .bridge import RefossConfigEntry, RefossDataUpdateCoordinator
-from .const import _LOGGER, DISPATCH_DEVICE_DISCOVERED
+from .const import DISPATCH_DEVICE_DISCOVERED, LOGGER
 from .entity import RefossEntity
 
 
@@ -34,7 +34,7 @@ async def async_setup_entry(
             new_entities.append(entity)
 
         async_add_entities(new_entities)
-        _LOGGER.debug("Device %s add switch entity success", device.dev_name)
+        LOGGER.debug("Device %s add switch entity success", device.dev_name)
 
     for coordinator in config_entry.runtime_data.coordinators:
         init_device(coordinator)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Rename the exported `_LOGGER` constant in the `refoss` integration to `LOGGER`. Since the constant is exported from `const.py` and imported by other modules, it should be public, as tracked in epic home-assistant/epics#115. The logger name itself is unchanged, only the constant name changes. The import and all usages in `bridge.py`, `switch.py`, `config_flow.py`, `sensor.py` and `coordinator.py` are updated accordingly.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#177316
- This PR is related to issue: home-assistant/epics#115
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
