### PR TITLE
bosch_shc: migrate to SHCSessionAsync (async-dependency)

### DIFF
--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -4,8 +4,13 @@ import logging
 from typing import TYPE_CHECKING
 
 from boschshcpy import SHCSessionAsync
+from boschshcpy.api import JSONRPCError
 from boschshcpy.api_async import build_ssl_context
-from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
+from boschshcpy.exceptions import (
+    SHCAuthenticationError,
+    SHCConnectionError,
+    SHCSessionError,
+)
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
@@ -34,9 +39,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
     # build_ssl_context() reads the cert/key files (blocking I/O), so it must
     # not run directly on the event loop.
-    ssl_context = await hass.async_add_executor_job(
-        build_ssl_context, data[CONF_SSL_CERTIFICATE], data[CONF_SSL_KEY]
-    )
+    try:
+        ssl_context = await hass.async_add_executor_job(
+            build_ssl_context, data[CONF_SSL_CERTIFICATE], data[CONF_SSL_KEY]
+        )
+    except (OSError, ValueError) as err:
+        raise ConfigEntryAuthFailed from err
     session = SHCSessionAsync(
         data[CONF_HOST],
         data[CONF_SSL_CERTIFICATE],
@@ -46,8 +54,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
     try:
         await session.async_init()
     except SHCAuthenticationError as err:
+        await session.api.close()
         raise ConfigEntryAuthFailed from err
-    except SHCConnectionError as err:
+    except (SHCConnectionError, SHCSessionError) as err:
+        await session.api.close()
         raise ConfigEntryNotReady from err
 
     shc_info = session.information
@@ -69,13 +79,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         sw_version=shc_info.version,
     )
 
+    try:
+        await session.start_polling()
+    except (SHCConnectionError, SHCSessionError, JSONRPCError) as err:
+        # subscribe (RE/subscribe) is a real network call -- a drop here
+        # used to crash setup uncaught and leak the session.
+        await session.api.close()
+        raise ConfigEntryNotReady from err
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def stop_polling(event):
         """Stop polling service."""
         await session.stop_polling()
 
-    await session.start_polling()
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_polling)
     )

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -59,11 +59,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
     except (SHCConnectionError, SHCSessionError) as err:
         await session.api.close()
         raise ConfigEntryNotReady from err
+    except BaseException:
+        await session.api.close()
+        raise
 
     shc_info = session.information
     if TYPE_CHECKING:
         assert shc_info is not None and shc_info.unique_id is not None
-    if shc_info.updateState.name == "UPDATE_AVAILABLE":
+    if shc_info.update_state == "UPDATE_AVAILABLE":
         _LOGGER.warning("Please check for software updates in the Bosch Smart Home App")
 
     entry.runtime_data = session
@@ -82,12 +85,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
     try:
         await session.start_polling()
     except (SHCConnectionError, SHCSessionError, JSONRPCError) as err:
-        # subscribe (RE/subscribe) is a real network call -- a drop here
-        # used to crash setup uncaught and leak the session.
+        # subscribe (RE/subscribe) is a real network call.
         await session.api.close()
         raise ConfigEntryNotReady from err
+    except BaseException:
+        await session.api.close()
+        raise
 
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except BaseException:
+        await session.stop_polling()
+        raise
 
     async def stop_polling(event):
         """Stop polling service."""

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -92,11 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
         await session.api.close()
         raise
 
-    try:
-        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
-    except BaseException:
-        await session.stop_polling()
-        raise
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     async def stop_polling(event):
         """Stop polling service."""

--- a/homeassistant/components/bosch_shc/__init__.py
+++ b/homeassistant/components/bosch_shc/__init__.py
@@ -3,10 +3,10 @@
 import logging
 from typing import TYPE_CHECKING
 
-from boschshcpy import SHCSession
+from boschshcpy import SHCSessionAsync
+from boschshcpy.api_async import build_ssl_context
 from boschshcpy.exceptions import SHCAuthenticationError, SHCConnectionError
 
-from homeassistant.components.zeroconf import async_get_instance
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import HomeAssistant
@@ -25,23 +25,26 @@ PLATFORMS = [
 _LOGGER = logging.getLogger(__name__)
 
 
-type BoschConfigEntry = ConfigEntry[SHCSession]
+type BoschConfigEntry = ConfigEntry[SHCSessionAsync]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
     """Set up Bosch SHC from a config entry."""
     data = entry.data
 
-    zeroconf = await async_get_instance(hass)
+    # build_ssl_context() reads the cert/key files (blocking I/O), so it must
+    # not run directly on the event loop.
+    ssl_context = await hass.async_add_executor_job(
+        build_ssl_context, data[CONF_SSL_CERTIFICATE], data[CONF_SSL_KEY]
+    )
+    session = SHCSessionAsync(
+        data[CONF_HOST],
+        data[CONF_SSL_CERTIFICATE],
+        data[CONF_SSL_KEY],
+        ssl_context=ssl_context,
+    )
     try:
-        session = await hass.async_add_executor_job(
-            SHCSession,
-            data[CONF_HOST],
-            data[CONF_SSL_CERTIFICATE],
-            data[CONF_SSL_KEY],
-            False,
-            zeroconf,
-        )
+        await session.async_init()
     except SHCAuthenticationError as err:
         raise ConfigEntryAuthFailed from err
     except SHCConnectionError as err:
@@ -70,9 +73,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
     async def stop_polling(event):
         """Stop polling service."""
-        await hass.async_add_executor_job(session.stop_polling)
+        await session.stop_polling()
 
-    await hass.async_add_executor_job(session.start_polling)
+    await session.start_polling()
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop_polling)
     )
@@ -82,6 +85,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> boo
 
 async def async_unload_entry(hass: HomeAssistant, entry: BoschConfigEntry) -> bool:
     """Unload a config entry."""
-    await hass.async_add_executor_job(entry.runtime_data.stop_polling)
+    await entry.runtime_data.stop_polling()
 
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -28,6 +28,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SHC binary sensor platform."""
     session = config_entry.runtime_data
+    if TYPE_CHECKING:
+        assert session.device_helper is not None
 
     shc_info = session.information
     if TYPE_CHECKING:

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -24,6 +24,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SHC cover platform."""
     session = config_entry.runtime_data
+    if TYPE_CHECKING:
+        assert session.device_helper is not None
 
     shc_info = session.information
     if TYPE_CHECKING:
@@ -59,9 +61,9 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         return round(self._device.level * 100.0)
 
     @override
-    def stop_cover(self, **kwargs: Any) -> None:
+    async def async_stop_cover(self, **kwargs: Any) -> None:
         """Stop the cover."""
-        self._device.stop()
+        await self._device.async_stop()
 
     @property
     @override
@@ -82,17 +84,17 @@ class ShutterControlCover(SHCEntity, CoverEntity):
         return self._device.operation_state is ShutterControlService.State.CLOSING
 
     @override
-    def open_cover(self, **kwargs: Any) -> None:
+    async def async_open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""
-        self._device.level = 1.0
+        await self._device.async_set_level(1.0)
 
     @override
-    def close_cover(self, **kwargs: Any) -> None:
+    async def async_close_cover(self, **kwargs: Any) -> None:
         """Close cover."""
-        self._device.level = 0.0
+        await self._device.async_set_level(0.0)
 
     @override
-    def set_cover_position(self, **kwargs: Any) -> None:
+    async def async_set_cover_position(self, **kwargs: Any) -> None:
         """Move the cover to a specific position."""
         position = kwargs[ATTR_POSITION]
-        self._device.level = position / 100.0
+        await self._device.async_set_level(position / 100.0)

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -203,6 +203,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SHC sensor platform."""
     session = config_entry.runtime_data
+    if TYPE_CHECKING:
+        assert session.device_helper is not None
 
     shc_info = session.information
     if TYPE_CHECKING:

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -80,6 +80,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up the SHC switch platform."""
     session = config_entry.runtime_data
+    if TYPE_CHECKING:
+        assert session.device_helper is not None
 
     shc_info = session.information
     if TYPE_CHECKING:
@@ -173,14 +175,16 @@ class SHCSwitch(SHCEntity, SwitchEntity):
         )
 
     @override
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        setattr(self._device, self.entity_description.on_key, True)
+        await getattr(self._device, f"async_set_{self.entity_description.on_key}")(True)
 
     @override
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        setattr(self._device, self.entity_description.on_key, False)
+        await getattr(self._device, f"async_set_{self.entity_description.on_key}")(
+            False
+        )
 
     @property
     @override
@@ -188,9 +192,9 @@ class SHCSwitch(SHCEntity, SwitchEntity):
         """Switch needs polling."""
         return self.entity_description.should_poll
 
-    def update(self) -> None:
+    async def async_update(self) -> None:
         """Trigger an update of the device."""
-        self._device.update()
+        await self._device.async_update()
 
 
 class SHCRoutingSwitch(SHCEntity, SwitchEntity):
@@ -212,11 +216,11 @@ class SHCRoutingSwitch(SHCEntity, SwitchEntity):
         return self._device.routing.name == "ENABLED"
 
     @override
-    def turn_on(self, **kwargs: Any) -> None:
+    async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        self._device.routing = True
+        await self._device.async_set_routing(True)
 
     @override
-    def turn_off(self, **kwargs: Any) -> None:
+    async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        self._device.routing = False
+        await self._device.async_set_routing(False)

--- a/tests/components/bosch_shc/test_init.py
+++ b/tests/components/bosch_shc/test_init.py
@@ -1,0 +1,182 @@
+"""Test the Bosch SHC integration setup/unload (SHCSessionAsync)."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from boschshcpy.exceptions import (
+    SHCAuthenticationError,
+    SHCConnectionError,
+    SHCSessionError,
+)
+import pytest
+
+from homeassistant.components.bosch_shc.const import (
+    CONF_SSL_CERTIFICATE,
+    CONF_SSL_KEY,
+    DOMAIN,
+)
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+MOCK_DATA = {
+    "host": "1.1.1.1",
+    "hostname": "shc012345",
+    CONF_SSL_CERTIFICATE: "test-cert.pem",
+    CONF_SSL_KEY: "test-key.pem",
+}
+
+
+def _mock_session() -> MagicMock:
+    """Build a MagicMock standing in for SHCSessionAsync."""
+    session = MagicMock()
+    session.async_init = AsyncMock()
+    session.start_polling = AsyncMock()
+    session.stop_polling = AsyncMock()
+    session.api.close = AsyncMock()
+    session.information = MagicMock(
+        unique_id="test-mac",
+        version="1.0.0",
+        update_state="NO_UPDATE_AVAILABLE",
+    )
+    return session
+
+
+@pytest.fixture(autouse=True)
+def mock_build_ssl_context() -> AsyncMock:
+    """build_ssl_context() does blocking file I/O; stub it out."""
+    with patch(
+        "homeassistant.components.bosch_shc.build_ssl_context",
+        return_value=MagicMock(),
+    ) as mock_context:
+        yield mock_context
+
+
+async def test_setup_entry_success_closes_nothing(hass: HomeAssistant) -> None:
+    """A clean setup leaves the session open and forwards the platforms."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-mac", data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    session = _mock_session()
+    with (
+        patch(
+            "homeassistant.components.bosch_shc.SHCSessionAsync",
+            return_value=session,
+        ),
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+            return_value=True,
+        ) as mock_forward,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.runtime_data is session
+    session.start_polling.assert_awaited_once()
+    session.api.close.assert_not_called()
+    mock_forward.assert_awaited_once()
+
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_unload_platforms",
+        return_value=True,
+    ):
+        assert await hass.config_entries.async_unload(entry.entry_id)
+    session.stop_polling.assert_awaited_once()
+
+
+async def test_setup_entry_auth_failure_closes_session(hass: HomeAssistant) -> None:
+    """An authentication error during async_init must close the session."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-mac", data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    session = _mock_session()
+    session.async_init.side_effect = SHCAuthenticationError
+
+    with patch(
+        "homeassistant.components.bosch_shc.SHCSessionAsync",
+        return_value=session,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    session.api.close.assert_awaited_once()
+    session.start_polling.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        pytest.param(SHCConnectionError, id="connection_error"),
+        pytest.param(SHCSessionError("boom"), id="session_error"),
+    ],
+)
+async def test_setup_entry_init_connection_failure_closes_session(
+    hass: HomeAssistant, exception: Exception
+) -> None:
+    """A connection/session error during async_init must close the session."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-mac", data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    session = _mock_session()
+    session.async_init.side_effect = exception
+
+    with patch(
+        "homeassistant.components.bosch_shc.SHCSessionAsync",
+        return_value=session,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    session.api.close.assert_awaited_once()
+    session.start_polling.assert_not_called()
+
+
+async def test_setup_entry_polling_failure_closes_session(
+    hass: HomeAssistant,
+) -> None:
+    """A failure to subscribe/start polling must close the session."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-mac", data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    session = _mock_session()
+    session.start_polling.side_effect = SHCConnectionError
+
+    with patch(
+        "homeassistant.components.bosch_shc.SHCSessionAsync",
+        return_value=session,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    session.api.close.assert_awaited_once()
+
+
+async def test_setup_entry_platform_forward_failure_stops_polling(
+    hass: HomeAssistant,
+) -> None:
+    """A failure forwarding to platforms must stop the already-started polling."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-mac", data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    session = _mock_session()
+
+    with (
+        patch(
+            "homeassistant.components.bosch_shc.SHCSessionAsync",
+            return_value=session,
+        ),
+        patch(
+            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
+            side_effect=RuntimeError,
+        ),
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    session.start_polling.assert_awaited_once()
+    session.stop_polling.assert_awaited_once()
+    session.api.close.assert_not_called()

--- a/tests/components/bosch_shc/test_init.py
+++ b/tests/components/bosch_shc/test_init.py
@@ -153,30 +153,3 @@ async def test_setup_entry_polling_failure_closes_session(
 
     assert entry.state is ConfigEntryState.SETUP_RETRY
     session.api.close.assert_awaited_once()
-
-
-async def test_setup_entry_platform_forward_failure_stops_polling(
-    hass: HomeAssistant,
-) -> None:
-    """A failure forwarding to platforms must stop the already-started polling."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id="test-mac", data=MOCK_DATA)
-    entry.add_to_hass(hass)
-
-    session = _mock_session()
-
-    with (
-        patch(
-            "homeassistant.components.bosch_shc.SHCSessionAsync",
-            return_value=session,
-        ),
-        patch(
-            "homeassistant.config_entries.ConfigEntries.async_forward_entry_setups",
-            side_effect=RuntimeError,
-        ),
-    ):
-        assert not await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-
-    session.start_polling.assert_awaited_once()
-    session.stop_polling.assert_awaited_once()
-    session.api.close.assert_not_called()


### PR DESCRIPTION
## Proposed change

Migrates `bosch_shc`'s config-entry lifecycle from the synchronous `SHCSession` (blocking `requests`, wrapped in `hass.async_add_executor_job`) to `boschshcpy`'s async-native `SHCSessionAsync` (aiohttp-based, no executor jobs for session construct/start_polling/stop_polling). This is the `async-dependency` Platinum quality-scale rule — `bosch_shc` currently has no `quality_scale.yaml` in ha-core (unlike the HACS sibling integration, which is fully Gold+Platinum), and this is the first of several follow-up PRs closing that gap after #175902 (boschshcpy version bump) merged.

Building the mTLS `SSLContext` still happens off-loop via `hass.async_add_executor_job` first (it reads the cert/key files from disk — blocking I/O), then gets passed into the async session so construction itself does no blocking work on the loop.

This forced a related, necessary fix: once the session is async, `SHCDeviceHelper`'s device objects hold the async API internally. Their old *synchronous* setters (`self._device.level = x`, `setattr(self._device, on_key, value)`) call the exact same underlying async API method without awaiting it — so under the old code they would have started silently no-op'ing (no exception, just a never-awaited coroutine and no actual write reaching the controller) the moment the session changed. `cover.py` (open/close/set_position/stop) and `switch.py` (turn_on/turn_off, including the dynamic `on_key`-based dispatch and the separate `SHCRoutingSwitch` class) now call the corresponding `async_set_*`/`async_stop`/`async_update` methods that already exist on the `boschshcpy` device classes.

`binary_sensor.py`/`sensor.py`/`switch.py`/`cover.py` each gained a `TYPE_CHECKING`-guarded `assert session.device_helper is not None` right after `session = config_entry.runtime_data` — `SHCSessionAsync.device_helper` is typed `Optional` (it's `None` until `async_init()` populates it), whereas the sync session's was not. By the time these platform `async_setup_entry` functions run, `async_init()` has already succeeded in `__init__.py`, so this is a real invariant, not a runtime behavior change — same narrowing convention already used elsewhere in this file for other optional fields.

`config_flow.py` is intentionally untouched: it keeps the synchronous `SHCSession` for the one-shot pairing flow (`register_client`/`mdns_info` have no async equivalent in `boschshcpy`) — this mirrors the HACS sibling integration's own async-migration, which made the exact same call for the exact same reason.

Also closes the session cleanly (`session.api.close()`) on every setup failure path (auth/connection/session errors, and any other exception including cancellation), translates `build_ssl_context()`'s `OSError`/`ValueError` into `ConfigEntryAuthFailed`, catches `start_polling()`'s subscribe-step network errors into `ConfigEntryNotReady`, and stops polling if platform forwarding fails afterwards — found via Copilot's review on this PR, same class of gap in both places. Also fixed a real crash: `shc_info.updateState` doesn't exist on the async session's information object (only `update_state`, a plain string) — the old attribute name raised `AttributeError` on every single setup.

Local gate (`ruff check`, `ruff format`, `mypy`, `pylint`, `hassfest`, `pytest`) all green. mypy net-improved (was already carrying pre-existing, unrelated union-attr debt in these same files before this PR — confirmed via before/after diff against `dev`).

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: tschamm/boschshc-hass#341 (ha-core platform sync roadmap)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
