### PR TITLE
bosch_shc: add diagnostics.py

### DIFF
--- a/homeassistant/components/bosch_shc/diagnostics.py
+++ b/homeassistant/components/bosch_shc/diagnostics.py
@@ -1,0 +1,71 @@
+"""Diagnostics support for the Bosch SHC integration."""
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from . import BoschConfigEntry
+from .const import CONF_SSL_CERTIFICATE, CONF_SSL_KEY
+
+# async_redact_data matches by key name recursively, so both the config-entry
+# keys and the device-level keys below are covered by one set. Device *names*
+# are deliberately not redacted -- needed to correlate a report, not secret.
+TO_REDACT = {
+    CONF_HOST,
+    CONF_SSL_CERTIFICATE,
+    CONF_SSL_KEY,
+    "macAddress",
+    "shcIpAddress",
+    "root_device_id",
+    "serial",
+    # device.id embeds a hardware address for Zigbee devices, e.g.
+    # "hdm:ZigBee:5c0272fffe462481" -- same class of identifying data as
+    # macAddress/serial/root_device_id above. Named "device_id" (not "id")
+    # so this doesn't also redact service.id (e.g. "PowerSwitch"), which is
+    # not identifying and is needed to read the dump.
+    "device_id",
+}
+
+
+def _device_dump(device: Any) -> dict[str, Any]:
+    """One device + the raw state of each of its services."""
+    return {
+        "device_id": device.id,
+        "root_device_id": device.root_device_id,
+        "device_model": device.device_model,
+        "manufacturer": device.manufacturer,
+        "name": device.name,
+        "room_id": device.room_id,
+        "serial": device.serial,
+        "services": [
+            {"id": service.id, "state": service.state}
+            for service in device.device_services
+        ],
+    }
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: BoschConfigEntry
+) -> dict[str, Any]:
+    """Return redacted diagnostics for a Bosch SHC config entry."""
+    session = entry.runtime_data
+    info = session.information
+
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+        "shc": async_redact_data(
+            {
+                "version": info.version,
+                "update_state": info.updateState.name,
+                "macAddress": info.macAddress,
+                "shcIpAddress": info.shcIpAddress,
+            },
+            TO_REDACT,
+        ),
+        "devices": [
+            async_redact_data(_device_dump(device), TO_REDACT)
+            for device in session.devices
+        ],
+    }

--- a/homeassistant/components/bosch_shc/diagnostics.py
+++ b/homeassistant/components/bosch_shc/diagnostics.py
@@ -3,17 +3,19 @@
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 
 from . import BoschConfigEntry
-from .const import CONF_SSL_CERTIFICATE, CONF_SSL_KEY
+from .const import CONF_HOSTNAME, CONF_SSL_CERTIFICATE, CONF_SSL_KEY
 
 # async_redact_data matches by key name recursively, so both the config-entry
 # keys and the device-level keys below are covered by one set. Device *names*
 # are deliberately not redacted -- needed to correlate a report, not secret.
 TO_REDACT = {
     CONF_HOST,
+    CONF_HOSTNAME,
+    CONF_TOKEN,
     CONF_SSL_CERTIFICATE,
     CONF_SSL_KEY,
     "macAddress",
@@ -52,13 +54,22 @@ async def async_get_config_entry_diagnostics(
     """Return redacted diagnostics for a Bosch SHC config entry."""
     session = entry.runtime_data
     info = session.information
+    # The sync SHCInformation exposes an updateState enum; the async session
+    # (#177379) replaces it with a plain update_state string. Support both so
+    # this doesn't crash regardless of which of the two PRs merges first.
+    update_state_enum = getattr(info, "updateState", None)
+    update_state = (
+        update_state_enum.name
+        if update_state_enum is not None
+        else getattr(info, "update_state", None)
+    )
 
     return {
         "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
         "shc": async_redact_data(
             {
                 "version": info.version,
-                "update_state": info.updateState.name,
+                "update_state": update_state,
                 "macAddress": info.macAddress,
                 "shcIpAddress": info.shcIpAddress,
             },

--- a/homeassistant/components/bosch_shc/diagnostics.py
+++ b/homeassistant/components/bosch_shc/diagnostics.py
@@ -32,7 +32,12 @@ TO_REDACT = {
 
 
 def _device_dump(device: Any) -> dict[str, Any]:
-    """One device + the raw state of each of its services."""
+    """One device + the state of each of its known services.
+
+    boschshcpy only builds device_services for service IDs it recognizes
+    (SUPPORTED_DEVICE_SERVICE_IDS); an unknown/unmapped service on a device
+    won't appear here.
+    """
     return {
         "device_id": device.id,
         "root_device_id": device.root_device_id,
@@ -54,9 +59,9 @@ async def async_get_config_entry_diagnostics(
     """Return redacted diagnostics for a Bosch SHC config entry."""
     session = entry.runtime_data
     info = session.information
-    # The sync SHCInformation exposes an updateState enum; the async session
-    # (#177379) replaces it with a plain update_state string. Support both so
-    # this doesn't crash regardless of which of the two PRs merges first.
+    # SHCInformation exposes an updateState enum; the async
+    # _AsyncSHCInformation counterpart exposes a plain update_state string
+    # instead. Support both shapes since either can be the runtime type here.
     update_state_enum = getattr(info, "updateState", None)
     update_state = (
         update_state_enum.name

--- a/tests/components/bosch_shc/test_diagnostics.py
+++ b/tests/components/bosch_shc/test_diagnostics.py
@@ -1,0 +1,96 @@
+"""Test the Bosch SHC diagnostics."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from homeassistant.components.bosch_shc.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+ENTRY_DATA = {
+    "host": "192.168.1.10",
+    "ssl_certificate": "/config/bosch_shc/abc/bosch_shc-cert.pem",
+    "ssl_key": "/config/bosch_shc/abc/bosch_shc-key.pem",
+    "token": "0123456789abcdef:hostname-part",
+    "hostname": "hostname-part",
+}
+
+
+def _make_device(device_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=device_id,
+        root_device_id="64-da-a0-00-00-00",
+        device_model="SWD",
+        manufacturer="BOSCH",
+        name="Front door",
+        room_id="hz_1",
+        serial="123456789",
+        device_services=[SimpleNamespace(id="ShutterContact", state={"value": "OPEN"})],
+    )
+
+
+async def _get_diagnostics(hass: HomeAssistant) -> dict:
+    entry = MockConfigEntry(domain="bosch_shc", data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock(
+        information=SimpleNamespace(
+            version="1.2.3",
+            updateState=SimpleNamespace(name="NO_UPDATE_AVAILABLE"),
+            macAddress="64-da-a0-00-00-00",
+            shcIpAddress="192.168.1.10",
+        ),
+        devices=[
+            _make_device("hdm:ZigBee:5c0272fffe462481"),
+            _make_device("swd-1"),
+        ],
+    )
+    return await async_get_config_entry_diagnostics(hass, entry)
+
+
+async def test_diagnostics_redacts_credentials_and_identifiers(
+    hass: HomeAssistant,
+) -> None:
+    """Credentials and network identifiers must never appear unredacted."""
+    diag = await _get_diagnostics(hass)
+
+    entry_data = diag["entry_data"]
+    assert entry_data["host"] == REDACTED
+    assert entry_data["ssl_certificate"] == REDACTED
+    assert entry_data["ssl_key"] == REDACTED
+    assert entry_data["token"] == REDACTED
+    assert entry_data["hostname"] == REDACTED
+
+    shc = diag["shc"]
+    assert shc["macAddress"] == REDACTED
+    assert shc["shcIpAddress"] == REDACTED
+    assert shc["version"] == "1.2.3"
+    assert shc["update_state"] == "NO_UPDATE_AVAILABLE"
+
+    for device in diag["devices"]:
+        assert device["device_id"] == REDACTED
+        assert device["root_device_id"] == REDACTED
+        assert device["serial"] == REDACTED
+        # names are not secret and must survive redaction
+        assert device["name"] == "Front door"
+
+
+async def test_diagnostics_update_state_string_fallback(hass: HomeAssistant) -> None:
+    """Support the async session's update_state string, not just updateState."""
+    entry = MockConfigEntry(domain="bosch_shc", data=ENTRY_DATA)
+    entry.add_to_hass(hass)
+    entry.runtime_data = MagicMock(
+        information=SimpleNamespace(
+            version="1.2.3",
+            update_state="NO_UPDATE_AVAILABLE",
+            macAddress="64-da-a0-00-00-00",
+            shcIpAddress="192.168.1.10",
+        ),
+        devices=[],
+    )
+    diag = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diag["shc"]["update_state"] == "NO_UPDATE_AVAILABLE"

--- a/tests/components/bosch_shc/test_diagnostics.py
+++ b/tests/components/bosch_shc/test_diagnostics.py
@@ -76,6 +76,11 @@ async def test_diagnostics_redacts_credentials_and_identifiers(
         assert device["serial"] == REDACTED
         # names are not secret and must survive redaction
         assert device["name"] == "Front door"
+        # raw service state is the whole point of this diagnostics dump --
+        # must survive intact, not just the device metadata around it
+        assert device["services"] == [
+            {"id": "ShutterContact", "state": {"value": "OPEN"}}
+        ]
 
 
 async def test_diagnostics_update_state_string_fallback(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

Adds `diagnostics.py` to `bosch_shc` — currently entirely missing (Gold quality-scale rule), part of the same follow-up series as #177379 (async-dependency) and #177389 (parallel-updates).

Returns a redacted snapshot of the controller's public information and every paired device's raw service state — the "rawscan"-equivalent that makes a device/state bug report actionable without asking the reporter to manually run anything. Credentials (`ssl_certificate`/`ssl_key` config-entry data) and network-identifying fields (`host`, MAC address, device serials, and the Zigbee hardware address embedded in some `device.id` values) are redacted via `homeassistant.components.diagnostics.async_redact_data`, which walks the structure recursively by key name. Device *names* are deliberately left in — needed to correlate a report, not secret.

Mirrors the pattern already shipped in the HACS sibling integration (`tschamm/boschshc-hass`), adapted to `bosch_shc`'s actual `runtime_data` shape here (`entry.runtime_data` is the `SHCSession` directly, no wrapper dataclass) and its smaller platform surface (no rawscan service / custom actions in ha-core).

Independent of #177379/#177389 — this branch is off current `dev`, not stacked on either.

Local gate (`ruff check`, `ruff format`, `mypy`, `pylint`, `hassfest`, `pytest`) all green.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: tschamm/boschshc-hass#341 (ha-core platform sync roadmap)
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
