### PR TITLE
Centralize MELCloud entity setup in base entities

### DIFF
--- a/homeassistant/components/melcloud/binary_sensor.py
+++ b/homeassistant/components/melcloud/binary_sensor.py
@@ -15,8 +15,8 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
-from .entity import MelCloudEntity
+from .coordinator import MelCloudConfigEntry
+from .entity import MelCloudDescriptionEntity
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -149,23 +149,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MelDeviceBinarySensor(MelCloudEntity, BinarySensorEntity):
+class MelDeviceBinarySensor(MelCloudDescriptionEntity, BinarySensorEntity):
     """Representation of a Binary Sensor."""
 
     entity_description: MelcloudBinarySensorEntityDescription
-
-    def __init__(
-        self,
-        coordinator: MelCloudDeviceUpdateCoordinator,
-        description: MelcloudBinarySensorEntityDescription,
-    ) -> None:
-        """Initialize the binary sensor."""
-        super().__init__(coordinator)
-        self.entity_description = description
-        self._attr_unique_id = (
-            f"{coordinator.device.serial}-{coordinator.device.mac}-{description.key}"
-        )
-        self._attr_device_info = coordinator.device_info
 
     @property
     @override

--- a/homeassistant/components/melcloud/entity.py
+++ b/homeassistant/components/melcloud/entity.py
@@ -4,6 +4,7 @@ from typing import override
 
 from pymelcloud.atw_device import Zone
 
+from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import MelCloudDeviceUpdateCoordinator
@@ -19,6 +20,23 @@ class MelCloudEntity(CoordinatorEntity[MelCloudDeviceUpdateCoordinator]):
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.coordinator.device_available
+
+
+class MelCloudDescriptionEntity(MelCloudEntity):
+    """Base class for description-driven MELCloud device entities."""
+
+    def __init__(
+        self,
+        coordinator: MelCloudDeviceUpdateCoordinator,
+        description: EntityDescription,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator)
+        self.entity_description = description
+        self._attr_unique_id = (
+            f"{coordinator.device.serial}-{coordinator.device.mac}-{description.key}"
+        )
+        self._attr_device_info = coordinator.device_info
 
 
 class AtwZoneEntity(MelCloudEntity):

--- a/homeassistant/components/melcloud/entity.py
+++ b/homeassistant/components/melcloud/entity.py
@@ -2,6 +2,8 @@
 
 from typing import override
 
+from pymelcloud.atw_device import Zone
+
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import MelCloudDeviceUpdateCoordinator
@@ -17,3 +19,15 @@ class MelCloudEntity(CoordinatorEntity[MelCloudDeviceUpdateCoordinator]):
     def available(self) -> bool:
         """Return True if entity is available."""
         return super().available and self.coordinator.device_available
+
+
+class AtwZoneEntity(MelCloudEntity):
+    """Base class for Air-to-Water zone entities."""
+
+    def __init__(
+        self, coordinator: MelCloudDeviceUpdateCoordinator, zone: Zone
+    ) -> None:
+        """Initialize the zone entity."""
+        super().__init__(coordinator)
+        self._zone = zone
+        self._attr_device_info = coordinator.zone_device_info(zone)

--- a/homeassistant/components/melcloud/number.py
+++ b/homeassistant/components/melcloud/number.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
-from .entity import MelCloudEntity
+from .entity import AtwZoneEntity
 
 FLOW_MODES = {ZONE_OPERATION_MODE_HEAT_FLOW, ZONE_OPERATION_MODE_COOL_FLOW}
 
@@ -74,7 +74,7 @@ async def async_setup_entry(
     )
 
 
-class AtwZoneNumber(MelCloudEntity, NumberEntity):
+class AtwZoneNumber(AtwZoneEntity, NumberEntity):
     """Number entity for an Air-to-Water zone."""
 
     entity_description: MelcloudNumberEntityDescription
@@ -86,13 +86,11 @@ class AtwZoneNumber(MelCloudEntity, NumberEntity):
         description: MelcloudNumberEntityDescription,
     ) -> None:
         """Initialize the number."""
-        super().__init__(coordinator)
-        self._zone = zone
+        super().__init__(coordinator, zone)
         self.entity_description = description
         self._attr_unique_id = (
             f"{coordinator.device.serial}-{zone.zone_index}-{description.key}"
         )
-        self._attr_device_info = coordinator.zone_device_info(zone)
         self._attr_native_step = coordinator.device.temperature_increment
 
     @property

--- a/homeassistant/components/melcloud/select.py
+++ b/homeassistant/components/melcloud/select.py
@@ -17,7 +17,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
-from .entity import MelCloudEntity
+from .entity import AtwZoneEntity
 
 OPTION_ROOM = "room"
 OPTION_FLOW = "flow"
@@ -59,7 +59,7 @@ async def async_setup_entry(
     )
 
 
-class AtwZoneOperationModeSelect(MelCloudEntity, SelectEntity):
+class AtwZoneOperationModeSelect(AtwZoneEntity, SelectEntity):
     """Select for the temperature control method of an Air-to-Water zone."""
 
     _attr_translation_key = "operation_mode"
@@ -70,12 +70,10 @@ class AtwZoneOperationModeSelect(MelCloudEntity, SelectEntity):
         zone: Zone,
     ) -> None:
         """Initialize the operation mode select."""
-        super().__init__(coordinator)
-        self._zone = zone
+        super().__init__(coordinator, zone)
         self._attr_unique_id = (
             f"{coordinator.device.serial}-{zone.zone_index}-operation_mode"
         )
-        self._attr_device_info = coordinator.zone_device_info(zone)
         available = {
             MODE_TO_OPTION[mode]
             for mode in zone.operation_modes

--- a/homeassistant/components/melcloud/sensor.py
+++ b/homeassistant/components/melcloud/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import MelCloudConfigEntry, MelCloudDeviceUpdateCoordinator
-from .entity import MelCloudEntity
+from .entity import MelCloudDescriptionEntity
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -307,24 +307,10 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class MelDeviceSensor(MelCloudEntity, SensorEntity):
+class MelDeviceSensor(MelCloudDescriptionEntity, SensorEntity):
     """Representation of a Sensor."""
 
     entity_description: MelcloudSensorEntityDescription
-
-    def __init__(
-        self,
-        coordinator: MelCloudDeviceUpdateCoordinator,
-        description: MelcloudSensorEntityDescription,
-    ) -> None:
-        """Initialize the sensor."""
-        super().__init__(coordinator)
-        self.entity_description = description
-
-        self._attr_unique_id = (
-            f"{coordinator.device.serial}-{coordinator.device.mac}-{description.key}"
-        )
-        self._attr_device_info = coordinator.device_info
 
     @property
     @override


### PR DESCRIPTION
## Proposed change
Introduces an `AtwZoneEntity` base class holding the zone and device-info setup that the MELCloud Air-to-Water `select` and `number` platforms both duplicate, and has them inherit from it. Pure refactor — no functional change (existing tests and snapshots are unchanged).

Follow-up to a review comment on #177378.

The `climate` platform is not converted: its zone entity extends `MelCloudClimate` (shared with the air-to-air climate), which is device-level and can't adopt the zone base without a larger restructure.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
