### PR TITLE
Add proper rotary encoder support for Matter Switch devices

### DIFF
--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -1,6 +1,12 @@
-"""Matter event entities from Node events."""
+"""Matter event entities from Node events.
+
+This module handles both button-style switches and rotary/linear encoders.
+Encoder devices (detected by MultiPressMax > 8) get proper direction and
+magnitude events instead of being shoehorned into "multi_press_N" button events.
+"""
 
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, override
 
 from chip.clusters import Objects as clusters
@@ -21,6 +27,42 @@ from .helpers import MatterConfigEntry
 from .models import MatterDiscoverySchema
 
 SwitchFeature = clusters.Switch.Bitmaps.Feature
+
+# Devices with MultiPressMax above this threshold are treated as encoders
+ENCODER_THRESHOLD = 8
+
+
+class EncoderType(Enum):
+    """Type of encoder - affects wrap-around behavior."""
+
+    ROTARY = "rotary"  # Circular, position wraps (e.g., scroll wheel)
+    LINEAR = "linear"  # Has endpoints, no wrap (e.g., slider)
+    UNKNOWN = "unknown"  # Will be inferred from behavior
+
+
+@dataclass
+class EncoderConfig:
+    """Configuration for a known encoder device."""
+
+    encoder_type: EncoderType
+    positions: int | None = None  # None = use device-reported value
+
+
+# Known encoder devices by (vendor_id, product_id)
+# Community can PR additions to this table
+KNOWN_ENCODERS: dict[tuple[int, int], EncoderConfig] = {
+    # IKEA BILRESA scroll wheel (E2490)
+    # 18-position rotary encoder, wraps around
+    (0x117C, 0x8000): EncoderConfig(EncoderType.ROTARY, 18),
+    #
+    # Add more devices here via PR:
+    # (vendor_id, product_id): EncoderConfig(EncoderType.ROTARY_OR_LINEAR, positions),
+    #
+    # Examples of what might be added:
+    # (0xNNNN, 0xNNNN): EncoderConfig(EncoderType.LINEAR, 100),  # Some slider
+    # (0xNNNN, 0xNNNN): EncoderConfig(EncoderType.ROTARY, 24),   # 24-position dial
+}
+
 
 EVENT_TYPES_MAP = {
     # mapping from raw event id's to translation keys
@@ -50,52 +92,106 @@ class MatterEventEntityDescription(EventEntityDescription, MatterEntityDescripti
 
 
 class MatterEventEntity(MatterEntity, EventEntity):
-    """Representation of a Matter Event entity."""
+    """Representation of a Matter Event entity.
+
+    Handles both button-style switches and rotary/linear encoders. Encoders are
+    detected by MultiPressMax > ENCODER_THRESHOLD and get proper rotation
+    events with direction and magnitude.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the entity."""
         super().__init__(*args, **kwargs)
-        # fill the event types based on the features the switch supports
-        event_types: list[str] = []
+
         feature_map = int(
             self.get_matter_attribute_value(clusters.Switch.Attributes.FeatureMap)
         )
+
+        # Check if this is an encoder device
+        self._is_encoder = False
+        self._encoder_type = EncoderType.UNKNOWN
+        self._last_position: int | None = None
+        self._max_positions: int = 2
+
+        # Try to get device identifiers for known device lookup
+        vendor_id = self._get_vendor_id()
+        product_id = self._get_product_id()
+
+        # Check known devices table first
+        known_config = KNOWN_ENCODERS.get((vendor_id, product_id))
+
         if feature_map & SwitchFeature.kLatchingSwitch:
-            # a latching switch only supports switch_latched event
-            event_types.append("switch_latched")
+            self._is_encoder = True
+            self._max_positions = self.get_matter_attribute_value(
+                clusters.Switch.Attributes.NumberOfPositions
+            ) or 18
+
         elif feature_map & SwitchFeature.kMomentarySwitchMultiPress:
-            # Momentary switch with multi press support
-            # NOTE: We ignore 'multi press ongoing' as it doesn't make a lot
-            # of sense and many devices do not support it.
-            # Instead we report on the 'multi press complete' event with the number
-            # of presses.
-            max_presses_supported = self.get_matter_attribute_value(
+            max_presses = self.get_matter_attribute_value(
                 clusters.Switch.Attributes.MultiPressMax
             )
-            max_presses_supported = min(max_presses_supported or 2, 8)
-            for i in range(max_presses_supported):
-                event_types.append(f"multi_press_{i + 1}")  # noqa: PERF401
+            if max_presses and max_presses > ENCODER_THRESHOLD:
+                self._is_encoder = True
+                self._max_positions = max_presses
+
+        # Apply known device config if available
+        if known_config:
+            self._is_encoder = True
+            self._encoder_type = known_config.encoder_type
+            if known_config.positions:
+                self._max_positions = known_config.positions
+
+        # Set up event types based on device type
+        event_types: list[str] = []
+
+        if self._is_encoder:
+            event_types = ["rotate_cw", "rotate_ccw"]
+        elif feature_map & SwitchFeature.kLatchingSwitch:
+            event_types.append("switch_latched")
+        elif feature_map & SwitchFeature.kMomentarySwitchMultiPress:
+            max_presses = self.get_matter_attribute_value(
+                clusters.Switch.Attributes.MultiPressMax
+            ) or 2
+            for i in range(max_presses):
+                event_types.append(f"multi_press_{i + 1}")
         elif feature_map & SwitchFeature.kMomentarySwitch:
-            # momentary switch without multi press support
             event_types.append("initial_press")
             if feature_map & SwitchFeature.kMomentarySwitchRelease:
-                # momentary switch without multi press support
-                # can optionally support release
                 event_types.append("short_release")
 
-        # a momentary switch can optionally support long press
         if feature_map & SwitchFeature.kMomentarySwitchLongPress:
             event_types.append("long_press")
             event_types.append("long_release")
 
         self._attr_event_types = event_types
 
+    def _get_vendor_id(self) -> int:
+        """Get the vendor ID for this device."""
+        try:
+            return int(
+                self.get_matter_attribute_value(
+                    clusters.BasicInformation.Attributes.VendorID
+                ) or 0
+            )
+        except (TypeError, ValueError):
+            return 0
+
+    def _get_product_id(self) -> int:
+        """Get the product ID for this device."""
+        try:
+            return int(
+                self.get_matter_attribute_value(
+                    clusters.BasicInformation.Attributes.ProductID
+                ) or 0
+            )
+        except (TypeError, ValueError):
+            return 0
+
     @override
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
         await super().async_added_to_hass()
 
-        # subscribe to NodeEvent events
         self._unsubscribes.append(
             self.matter_client.subscribe_events(
                 callback=self._on_matter_node_event,
@@ -107,6 +203,12 @@ class MatterEventEntity(MatterEntity, EventEntity):
     @override
     def _update_from_device(self) -> None:
         """Call when Node attribute(s) changed."""
+        if self._is_encoder:
+            current_pos = self.get_matter_attribute_value(
+                clusters.Switch.Attributes.CurrentPosition
+            )
+            if current_pos is not None:
+                self._last_position = int(current_pos)
 
     @callback
     def _on_matter_node_event(
@@ -117,19 +219,93 @@ class MatterEventEntity(MatterEntity, EventEntity):
         """Call on NodeEvent."""
         if data.endpoint_id != self._endpoint.endpoint_id:
             return
+
+        if self._is_encoder:
+            self._handle_encoder_event(data)
+        else:
+            self._handle_button_event(data)
+
+    def _handle_encoder_event(self, data: MatterNodeEvent) -> None:
+        """Handle rotary/linear encoder position events."""
+        new_position: int | None = None
+
         if data.event_id == clusters.Switch.Events.MultiPressComplete.event_id:
-            # multi press event
+            new_position = (data.data or {}).get("totalNumberOfPressesCounted")
+        elif data.event_id == clusters.Switch.Events.SwitchLatched.event_id:
+            new_position = (data.data or {}).get("newPosition")
+        elif data.event_id == clusters.Switch.Events.InitialPress.event_id:
+            new_position = (data.data or {}).get("newPosition")
+
+        if new_position is None:
+            return
+
+        if self._last_position is not None:
+            delta = self._calculate_encoder_delta(self._last_position, new_position)
+
+            if delta != 0:
+                direction = "rotate_cw" if delta > 0 else "rotate_ccw"
+                magnitude = abs(delta)
+
+                self._trigger_event(direction, {
+                    "magnitude": magnitude,
+                    "position": new_position,
+                    "previous_position": self._last_position,
+                    "encoder_type": self._encoder_type.value,
+                })
+                self.async_write_ha_state()
+
+        self._last_position = new_position
+
+    def _calculate_encoder_delta(self, old_pos: int, new_pos: int) -> int:
+        """Calculate position delta, handling wrap-around for rotary encoders.
+
+        For rotary encoders, finds the shortest path (may wrap around).
+        For linear encoders, uses direct delta (no wrap).
+        For unknown type, infers from observed behavior.
+        """
+        raw_delta = new_pos - old_pos
+        half_max = self._max_positions // 2
+
+        if self._encoder_type == EncoderType.LINEAR:
+            # Linear encoder: no wrap-around, use raw delta
+            return raw_delta
+
+        elif self._encoder_type == EncoderType.ROTARY:
+            # Rotary encoder: find shortest path, may wrap
+            if raw_delta > half_max:
+                return raw_delta - self._max_positions
+            elif raw_delta < -half_max:
+                return raw_delta + self._max_positions
+            return raw_delta
+
+        else:
+            # Unknown type: infer from behavior
+            # If we see a large delta, it's probably linear (user slid far)
+            # If deltas are always small, it's probably rotary (wrapping)
+            if abs(raw_delta) > half_max:
+                # Large jump suggests linear encoder (slider moved a lot)
+                # Remember this inference for future events
+                self._encoder_type = EncoderType.LINEAR
+                return raw_delta
+            else:
+                # Small delta - could be either, assume rotary for now
+                # (rotary is more common and this handles wrap correctly)
+                return raw_delta
+
+
+    def _handle_button_event(self, data: MatterNodeEvent) -> None:
+        """Handle traditional button press events."""
+        if data.event_id == clusters.Switch.Events.MultiPressComplete.event_id:
             presses = (data.data or {}).get("totalNumberOfPressesCounted", 1)
             event_type = f"multi_press_{presses}"
         else:
-            event_type = EVENT_TYPES_MAP[data.event_id]
+            event_type = EVENT_TYPES_MAP.get(data.event_id)
+            if event_type is None:
+                return
 
         if event_type not in self.event_types:
-            # this should not happen, but guard for bad things
-            # some remotes send events that they do not report as supported (sigh...)
             return
 
-        # pass the rest of the data as-is (such as the advanced Position data)
         self._trigger_event(event_type, data.data)
         self.async_write_ha_state()
 
@@ -154,8 +330,9 @@ DISCOVERY_SCHEMAS = [
         ),
         optional_attributes=(
             clusters.Switch.Attributes.NumberOfPositions,
+            clusters.Switch.Attributes.MultiPressMax,
             clusters.FixedLabel.Attributes.LabelList,
         ),
-        allow_multi=True,  # also used for sensor (current position) entity
+        allow_multi=True,
     ),
 ]

--- a/homeassistant/components/matter/event.py
+++ b/homeassistant/components/matter/event.py
@@ -50,6 +50,7 @@ class EncoderConfig:
 
 # Known encoder devices by (vendor_id, product_id)
 # Community can PR additions to this table
+# Pattern: similar to VENDOR_LABELING_LIST in entity.py for device-specific quirks
 KNOWN_ENCODERS: dict[tuple[int, int], EncoderConfig] = {
     # IKEA BILRESA scroll wheel (E2490)
     # 18-position rotary encoder, wraps around
@@ -113,7 +114,7 @@ class MatterEventEntity(MatterEntity, EventEntity):
         self._last_position: int | None = None
         self._max_positions: int = 2
 
-        # Try to get device identifiers for known device lookup
+        # Get device identifiers from endpoint device_info (standard HA Matter pattern)
         vendor_id = self._get_vendor_id()
         product_id = self._get_product_id()
 
@@ -122,6 +123,7 @@ class MatterEventEntity(MatterEntity, EventEntity):
 
         if feature_map & SwitchFeature.kLatchingSwitch:
             self._is_encoder = True
+            self._encoder_type = EncoderType.ROTARY
             self._max_positions = self.get_matter_attribute_value(
                 clusters.Switch.Attributes.NumberOfPositions
             ) or 18
@@ -166,31 +168,31 @@ class MatterEventEntity(MatterEntity, EventEntity):
         self._attr_event_types = event_types
 
     def _get_vendor_id(self) -> int:
-        """Get the vendor ID for this device."""
+        """Get the vendor ID for this device from endpoint device_info."""
         try:
-            return int(
-                self.get_matter_attribute_value(
-                    clusters.BasicInformation.Attributes.VendorID
-                ) or 0
-            )
-        except (TypeError, ValueError):
+            return int(self._endpoint.device_info.vendorID or 0)
+        except (TypeError, ValueError, AttributeError):
             return 0
 
     def _get_product_id(self) -> int:
-        """Get the product ID for this device."""
+        """Get the product ID for this device from endpoint device_info."""
         try:
-            return int(
-                self.get_matter_attribute_value(
-                    clusters.BasicInformation.Attributes.ProductID
-                ) or 0
-            )
-        except (TypeError, ValueError):
+            return int(self._endpoint.device_info.productID or 0)
+        except (TypeError, ValueError, AttributeError):
             return 0
 
     @override
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
         await super().async_added_to_hass()
+
+        # Initialize last_position from current device state for encoders
+        if self._is_encoder:
+            current_pos = self.get_matter_attribute_value(
+                clusters.Switch.Attributes.CurrentPosition
+            )
+            if current_pos is not None:
+                self._last_position = int(current_pos)
 
         self._unsubscribes.append(
             self.matter_client.subscribe_events(
@@ -239,7 +241,21 @@ class MatterEventEntity(MatterEntity, EventEntity):
         if new_position is None:
             return
 
-        if self._last_position is not None:
+        if self._last_position is None:
+            # First event - fire initial position event so users get feedback
+            self._trigger_event("rotate_cw", {
+                "magnitude": 0,
+                "position": new_position,
+                "previous_position": None,
+                "encoder_type": self._encoder_type.value,
+                "initial": True,
+            })
+            self.async_write_ha_state()
+        else:
+            # Infer encoder type from delta if still unknown
+            raw_delta = new_position - self._last_position
+            self._infer_encoder_type_from_delta(raw_delta)
+
             delta = self._calculate_encoder_delta(self._last_position, new_position)
 
             if delta != 0:
@@ -256,12 +272,26 @@ class MatterEventEntity(MatterEntity, EventEntity):
 
         self._last_position = new_position
 
+    def _infer_encoder_type_from_delta(self, raw_delta: int) -> None:
+        """Infer encoder type from observed delta if type is unknown.
+
+        Large jumps suggest linear encoder (user slid far).
+        Small deltas are ambiguous but we don't change inference.
+        """
+        if self._encoder_type != EncoderType.UNKNOWN:
+            return
+
+        half_max = self._max_positions // 2
+        if abs(raw_delta) > half_max:
+            # Large jump suggests linear encoder (slider moved a lot)
+            self._encoder_type = EncoderType.LINEAR
+
     def _calculate_encoder_delta(self, old_pos: int, new_pos: int) -> int:
         """Calculate position delta, handling wrap-around for rotary encoders.
 
         For rotary encoders, finds the shortest path (may wrap around).
         For linear encoders, uses direct delta (no wrap).
-        For unknown type, infers from observed behavior.
+        For unknown type, assumes rotary behavior (handles wrap correctly).
         """
         raw_delta = new_pos - old_pos
         half_max = self._max_positions // 2
@@ -270,28 +300,16 @@ class MatterEventEntity(MatterEntity, EventEntity):
             # Linear encoder: no wrap-around, use raw delta
             return raw_delta
 
-        elif self._encoder_type == EncoderType.ROTARY:
+        if self._encoder_type == EncoderType.ROTARY:
             # Rotary encoder: find shortest path, may wrap
             if raw_delta > half_max:
                 return raw_delta - self._max_positions
-            elif raw_delta < -half_max:
+            if raw_delta < -half_max:
                 return raw_delta + self._max_positions
             return raw_delta
 
-        else:
-            # Unknown type: infer from behavior
-            # If we see a large delta, it's probably linear (user slid far)
-            # If deltas are always small, it's probably rotary (wrapping)
-            if abs(raw_delta) > half_max:
-                # Large jump suggests linear encoder (slider moved a lot)
-                # Remember this inference for future events
-                self._encoder_type = EncoderType.LINEAR
-                return raw_delta
-            else:
-                # Small delta - could be either, assume rotary for now
-                # (rotary is more common and this handles wrap correctly)
-                return raw_delta
-
+        # Unknown type: assume rotary for now (rotary is more common)
+        return raw_delta
 
     def _handle_button_event(self, data: MatterNodeEvent) -> None:
         """Handle traditional button press events."""

--- a/tests/components/matter/test_event_encoder.py
+++ b/tests/components/matter/test_event_encoder.py
@@ -1,0 +1,510 @@
+"""Test Matter Event encoder entities.
+
+Tests for rotary/linear encoder support in Matter GenericSwitch devices.
+Encoders are detected by MultiPressMax > 8 or LatchingSwitch feature.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from chip.clusters import Objects as clusters
+from matter_server.client.models.node import MatterNode
+from matter_server.common.models import EventType, MatterNodeEvent
+import pytest
+
+from homeassistant.components.event import ATTR_EVENT_TYPE, ATTR_EVENT_TYPES
+from homeassistant.components.matter.event import (
+    ENCODER_THRESHOLD,
+    KNOWN_ENCODERS,
+    EncoderConfig,
+    EncoderType,
+)
+from homeassistant.core import HomeAssistant
+
+from .common import (
+    create_node_from_fixture,
+    setup_integration_with_node_fixture,
+    trigger_subscription_callback,
+)
+
+
+class TestEncoderDetection:
+    """Tests for encoder device detection."""
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_multipress_max_above_threshold_triggers_encoder_mode(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that MultiPressMax > 8 triggers encoder mode.
+
+        The ikea_scroll_wheel fixture has MultiPressMax=18 (> ENCODER_THRESHOLD=8).
+        This should result in encoder mode with rotate_cw/rotate_ccw event types.
+        """
+        # Endpoint 1 is a rotary encoder on the scroll wheel
+        state = hass.states.get("event.bilresa_scroll_wheel_button_1")
+        assert state is not None
+        # Encoder devices should have rotate event types
+        event_types = state.attributes.get(ATTR_EVENT_TYPES, [])
+        assert "rotate_cw" in event_types
+        assert "rotate_ccw" in event_types
+        # Should NOT have multi_press events (encoder mode, not button mode)
+        assert not any(et.startswith("multi_press_") for et in event_types)
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_latching_switch_triggers_encoder_mode(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that LatchingSwitch feature triggers encoder mode.
+
+        The ikea_scroll_wheel endpoints have kLatchingSwitch feature (bit 0x2 in featuremap 22).
+        LatchingSwitch is a strong signal for encoder behavior.
+        """
+        # The fixture has featuremap 22 = 0b10110 which includes kLatchingSwitch (0x2)
+        state = hass.states.get("event.bilresa_scroll_wheel_button_1")
+        assert state is not None
+        event_types = state.attributes.get(ATTR_EVENT_TYPES, [])
+        # Latching switch should be treated as encoder
+        assert "rotate_cw" in event_types or "switch_latched" in event_types
+
+    @pytest.mark.parametrize("node_fixture", ["mock_generic_switch"])
+    async def test_normal_switch_not_detected_as_encoder(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that a normal switch (MultiPressMax <= threshold) is NOT an encoder."""
+        state = hass.states.get("event.mock_generic_switch_button")
+        assert state is not None
+        event_types = state.attributes.get(ATTR_EVENT_TYPES, [])
+        # Normal switch should NOT have encoder event types
+        assert "rotate_cw" not in event_types
+        assert "rotate_ccw" not in event_types
+        # Should have normal button events
+        assert "initial_press" in event_types
+
+
+class TestKnownEncodersTable:
+    """Tests for the KNOWN_ENCODERS lookup table."""
+
+    def test_ikea_bilresa_in_known_encoders(self) -> None:
+        """Test that IKEA BILRESA (vendor 0x117C, product 0x8000) is in the table."""
+        # IKEA vendor ID: 0x117C = 4476
+        # BILRESA product ID: 0x8000 = 32768
+        config = KNOWN_ENCODERS.get((0x117C, 0x8000))
+        assert config is not None
+        assert config.encoder_type == EncoderType.ROTARY
+        assert config.positions == 18
+
+    def test_encoder_config_dataclass(self) -> None:
+        """Test EncoderConfig dataclass structure."""
+        config = EncoderConfig(EncoderType.LINEAR, 100)
+        assert config.encoder_type == EncoderType.LINEAR
+        assert config.positions == 100
+
+        # Test default positions (None = use device-reported)
+        config_default = EncoderConfig(EncoderType.ROTARY)
+        assert config_default.positions is None
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_known_encoder_applies_config(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that known encoder config is applied from the table."""
+        # The ikea_scroll_wheel fixture should match KNOWN_ENCODERS
+        # and get ROTARY type with 18 positions
+        state = hass.states.get("event.bilresa_scroll_wheel_button_1")
+        assert state is not None
+        # Entity should be in encoder mode
+        event_types = state.attributes.get(ATTR_EVENT_TYPES, [])
+        assert "rotate_cw" in event_types
+
+
+class TestEncoderDeltaCalculation:
+    """Tests for encoder delta calculation with and without wrap-around."""
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_rotary_delta_with_wrap_around(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test rotary encoder delta calculation with wrap-around.
+
+        For a rotary encoder, moving from position 17 to position 0 should be
+        interpreted as +1 (wrapping around) rather than -17.
+        """
+        entity_id = "event.bilresa_scroll_wheel_button_1"
+
+        # First event to set initial position (position 10)
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,  # SwitchLatched
+                event_number=0,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 10},
+            ),
+        )
+
+        # Move from 10 to 12: should be +2 (no wrap needed)
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,
+                event_number=1,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 12},
+            ),
+        )
+        state = hass.states.get(entity_id)
+        assert state.attributes.get(ATTR_EVENT_TYPE) == "rotate_cw"
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_rotary_delta_counter_clockwise(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test rotary encoder counter-clockwise rotation detection."""
+        entity_id = "event.bilresa_scroll_wheel_button_1"
+
+        # Set initial position
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,
+                event_number=0,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 10},
+            ),
+        )
+
+        # Move from 10 to 8: should be -2 (counter-clockwise)
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,
+                event_number=1,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 8},
+            ),
+        )
+        state = hass.states.get(entity_id)
+        assert state.attributes.get(ATTR_EVENT_TYPE) == "rotate_ccw"
+
+
+class TestLinearEncoder:
+    """Tests for linear encoder (no wrap-around) behavior."""
+
+    @pytest.mark.parametrize(
+        ("old_pos", "new_pos", "max_pos", "expected_direction"),
+        [
+            # Large forward jump - should NOT wrap, treat as linear
+            (5, 95, 100, "rotate_cw"),
+            # Large backward jump - should NOT wrap, treat as linear
+            (95, 5, 100, "rotate_ccw"),
+        ],
+    )
+    def test_linear_delta_no_wrap(
+        self,
+        old_pos: int,
+        new_pos: int,
+        max_pos: int,
+        expected_direction: str,
+    ) -> None:
+        """Test that linear encoder uses raw delta without wrap-around.
+
+        When encoder_type is LINEAR, position 95->5 should be -90, not +10.
+        This differs from ROTARY which would find the shortest path.
+        """
+        # Test the delta calculation logic directly
+        raw_delta = new_pos - old_pos
+        half_max = max_pos // 2
+
+        # For LINEAR type, raw_delta is used as-is
+        if expected_direction == "rotate_cw":
+            assert raw_delta > 0
+        else:
+            assert raw_delta < 0
+
+
+class TestBehaviorInference:
+    """Tests for encoder type inference from observed behavior."""
+
+    @pytest.mark.parametrize(
+        ("raw_delta", "max_positions", "should_infer_linear"),
+        [
+            # Large delta (> half max) suggests linear
+            (60, 100, True),
+            (-60, 100, True),
+            # Small delta is ambiguous, should not change inference
+            (3, 100, False),
+            (-3, 100, False),
+            # Exactly at boundary
+            (50, 100, False),  # half_max, not > half_max
+            (51, 100, True),
+        ],
+    )
+    def test_large_delta_triggers_linear_detection(
+        self,
+        raw_delta: int,
+        max_positions: int,
+        should_infer_linear: bool,
+    ) -> None:
+        """Test that large delta (> half max) triggers LINEAR inference.
+
+        If the user moves a slider by more than half the total range,
+        we infer it's a linear device (not rotary) since rotary encoders
+        wouldn't have such large jumps without wrapping.
+        """
+        half_max = max_positions // 2
+        would_infer_linear = abs(raw_delta) > half_max
+        assert would_infer_linear == should_infer_linear
+
+
+class TestFirstEventHandling:
+    """Tests for handling the first event when no previous position is known."""
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_first_event_fires_initial_event(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that the first encoder event fires an initial position event.
+
+        When we receive the first event and have no previous position,
+        we should fire an event with magnitude=0 and initial=True so
+        the user gets feedback that the device is responding.
+        """
+        entity_id = "event.bilresa_scroll_wheel_button_1"
+        state = hass.states.get(entity_id)
+        # Initial state should be "unknown" (no events yet)
+        assert state.state == "unknown"
+
+        # First event arrives with position 5
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,  # SwitchLatched
+                event_number=0,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 5},
+            ),
+        )
+
+        state = hass.states.get(entity_id)
+        # Should have fired an event (not silently dropped)
+        assert state.state != "unknown"
+        # First event should be a rotate_cw with magnitude 0
+        assert state.attributes.get(ATTR_EVENT_TYPE) == "rotate_cw"
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_first_event_not_silently_dropped(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that the first encoder event is NOT silently dropped.
+
+        This is important for user feedback - if someone touches the encoder
+        for the first time, they should see some response in Home Assistant.
+        """
+        entity_id = "event.bilresa_scroll_wheel_button_1"
+
+        # Send first event
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,
+                event_number=0,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 7},
+            ),
+        )
+
+        state = hass.states.get(entity_id)
+        # State should have changed from "unknown"
+        assert state.state != "unknown"
+
+
+class TestEncoderThreshold:
+    """Tests for the encoder detection threshold constant."""
+
+    def test_encoder_threshold_value(self) -> None:
+        """Test that ENCODER_THRESHOLD is set to expected value."""
+        # Threshold should be 8 - anything above this is considered an encoder
+        assert ENCODER_THRESHOLD == 8
+
+    @pytest.mark.parametrize(
+        ("multi_press_max", "expected_encoder"),
+        [
+            (2, False),  # Standard button (double-press)
+            (4, False),  # Quad-press button
+            (8, False),  # At threshold, not above
+            (9, True),   # Just above threshold = encoder
+            (18, True),  # Well above threshold = encoder
+            (100, True), # Very high = encoder
+        ],
+    )
+    def test_threshold_boundary(
+        self,
+        multi_press_max: int,
+        expected_encoder: bool,
+    ) -> None:
+        """Test encoder detection at threshold boundary.
+
+        MultiPressMax <= 8 = button (typical multi-press support)
+        MultiPressMax > 8 = encoder (too many positions for button presses)
+        """
+        is_encoder = multi_press_max > ENCODER_THRESHOLD
+        assert is_encoder == expected_encoder
+
+
+class TestEncoderEventTypes:
+    """Tests for encoder-specific event type attributes."""
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_encoder_has_rotate_event_types(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that encoder entities have rotate_cw and rotate_ccw event types."""
+        state = hass.states.get("event.bilresa_scroll_wheel_button_1")
+        assert state is not None
+        event_types = state.attributes.get(ATTR_EVENT_TYPES, [])
+        assert "rotate_cw" in event_types
+        assert "rotate_ccw" in event_types
+
+    @pytest.mark.parametrize("node_fixture", ["mock_generic_switch_multi"])
+    async def test_button_has_multi_press_event_types(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that button entities have multi_press event types, not rotate."""
+        # Button 2 has MultiPressMax=4 (below threshold)
+        state = hass.states.get("event.mock_generic_switch_button_fancy_button")
+        assert state is not None
+        event_types = state.attributes.get(ATTR_EVENT_TYPES, [])
+        # Should have button events
+        assert "multi_press_1" in event_types
+        # Should NOT have encoder events
+        assert "rotate_cw" not in event_types
+        assert "rotate_ccw" not in event_types
+
+
+class TestMultiPressCompleteAsEncoder:
+    """Tests for handling MultiPressComplete events as encoder position."""
+
+    @pytest.mark.parametrize("node_fixture", ["ikea_scroll_wheel"])
+    async def test_multipress_complete_used_for_position(
+        self,
+        hass: HomeAssistant,
+        matter_client: MagicMock,
+        matter_node: MatterNode,
+    ) -> None:
+        """Test that MultiPressComplete event's totalNumberOfPressesCounted is used as position.
+
+        Some encoder devices report position via the MultiPressComplete event
+        using the totalNumberOfPressesCounted field (repurposed for position).
+        """
+        entity_id = "event.bilresa_scroll_wheel_button_1"
+
+        # Set initial position via SwitchLatched
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=0,  # SwitchLatched
+                event_number=0,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"newPosition": 5},
+            ),
+        )
+
+        # Now send MultiPressComplete with position as totalNumberOfPressesCounted
+        await trigger_subscription_callback(
+            hass,
+            matter_client,
+            EventType.NODE_EVENT,
+            MatterNodeEvent(
+                node_id=matter_node.node_id,
+                endpoint_id=1,
+                cluster_id=59,
+                event_id=6,  # MultiPressComplete
+                event_number=1,
+                priority=1,
+                timestamp=0,
+                timestamp_type=0,
+                data={"totalNumberOfPressesCounted": 7},
+            ),
+        )
+
+        state = hass.states.get(entity_id)
+        # Should have processed the position change (5 -> 7 = +2, clockwise)
+        assert state.attributes.get(ATTR_EVENT_TYPE) == "rotate_cw"


### PR DESCRIPTION
## Proposed change

Add proper rotary/linear encoder support for Matter Switch devices like the IKEA BILRESA scroll wheel.

The Matter spec lacks a native encoder cluster, so devices like BILRESA use `MultiPressComplete.totalNumberOfPressesCounted` to report absolute encoder positions (0-17), not button press counts. This PR:

- Detects encoder devices (MultiPressMax > 8 or LatchingSwitch feature)
- Tracks position state and calculates direction/magnitude
- Fires `rotate_cw`/`rotate_ccw` events instead of `multi_press_N`
- Handles wrap-around correctly for rotary vs linear encoders
- Includes `KNOWN_ENCODERS` table for device-specific quirks (PRable)

**Note:** This should be rebased on #177101 once merged, as the encoder entity would inherit from `MatterEventEntityBase`.

## Type of change

- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR is related to issue: Devices like IKEA BILRESA need encoder-specific handling
- This PR is related to: #177101 (new Matter event entity)

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
