### PR TITLE
Add configurable HomeKit types for valve entities

### DIFF
--- a/homeassistant/components/homekit/type_switches.py
+++ b/homeassistant/components/homekit/type_switches.py
@@ -504,13 +504,28 @@ class ValveSwitch(ValveBase):
 class Valve(ValveBase):
     """Generate a Valve accessory from a HomeAssistant valve."""
 
-    def __init__(self, *args: Any) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        driver: HomeDriver,
+        name: str,
+        entity_id: str,
+        aid: int,
+        config: dict[str, Any],
+        *args: Any,
+    ) -> None:
         """Initialize a Valve accessory object."""
         super().__init__(
-            TYPE_VALVE,
+            config.get(CONF_TYPE, TYPE_VALVE),
             VALVE_OPEN_STATES,
             SERVICE_OPEN_VALVE,
             SERVICE_CLOSE_VALVE,
+            hass,
+            driver,
+            name,
+            entity_id,
+            aid,
+            config,
             *args,
         )
 

--- a/homeassistant/components/homekit/util.py
+++ b/homeassistant/components/homekit/util.py
@@ -296,6 +296,10 @@ SENSOR_SCHEMA = BASIC_INFO_SCHEMA.extend(
 
 VALVE_SCHEMA = BASIC_INFO_SCHEMA.extend(
     {
+        vol.Optional(CONF_TYPE): vol.All(
+            cv.string,
+            vol.In((TYPE_FAUCET, TYPE_SHOWER, TYPE_SPRINKLER, TYPE_VALVE)),
+        ),
         vol.Optional(CONF_LINKED_VALVE_DURATION): cv.entity_domain(INPUT_NUMBER_DOMAIN),
         vol.Optional(CONF_LINKED_VALVE_END_TIME): cv.entity_domain(SENSOR_DOMAIN),
     }

--- a/tests/components/homekit/test_type_switches.py
+++ b/tests/components/homekit/test_type_switches.py
@@ -244,7 +244,7 @@ async def test_valve_set_state(
     hass.states.async_set(entity_id, None)
     await hass.async_block_till_done()
 
-    acc = Valve(hass, hk_driver, "Valve", entity_id, 5, {CONF_TYPE: TYPE_VALVE})
+    acc = Valve(hass, hk_driver, "Valve", entity_id, 5, {})
     acc.run()
     await hass.async_block_till_done()
 
@@ -284,6 +284,39 @@ async def test_valve_set_state(
     assert call_turn_off[0].data[ATTR_ENTITY_ID] == entity_id
     assert len(events) == 2
     assert events[-1].data[ATTR_VALUE] is None
+
+
+@pytest.mark.parametrize(
+    ("valve_type", "category", "homekit_valve_type"),
+    [
+        pytest.param(TYPE_FAUCET, 29, 3, id="faucet"),
+        pytest.param(TYPE_SHOWER, 30, 2, id="shower"),
+        pytest.param(TYPE_SPRINKLER, 28, 1, id="sprinkler"),
+        pytest.param(TYPE_VALVE, 29, 0, id="generic"),
+    ],
+)
+async def test_valve_type(
+    hass: HomeAssistant,
+    hk_driver: HomeDriver,
+    valve_type: str,
+    category: int,
+    homekit_valve_type: int,
+) -> None:
+    """Test native valve HomeKit type configuration."""
+    entity_id = f"valve.{valve_type}"
+    hass.states.async_set(entity_id, STATE_CLOSED)
+
+    acc = Valve(
+        hass,
+        hk_driver,
+        "Valve",
+        entity_id,
+        5,
+        {CONF_TYPE: valve_type},
+    )
+
+    assert acc.category == category
+    assert acc.char_valve_type.value == homekit_valve_type
 
 
 async def test_vacuum_set_state_with_returnhome_and_start_support(

--- a/tests/components/homekit/test_util.py
+++ b/tests/components/homekit/test_util.py
@@ -151,11 +151,7 @@ def test_validate_entity_config() -> None:
                 CONF_LINKED_VALVE_DURATION: "number.valve_duration",
             }
         },
-        {
-            "valve.test": {
-                CONF_TYPE: "sprinkler",  # Extra keys not allowed
-            }
-        },
+        {"valve.test": {CONF_TYPE: "invalid_type"}},
     ]
 
     for conf in configs:
@@ -291,11 +287,13 @@ def test_validate_entity_config() -> None:
         }
     }
     config = {
+        CONF_TYPE: TYPE_SPRINKLER,
         CONF_LINKED_VALVE_DURATION: "input_number.valve_duration",
         CONF_LINKED_VALVE_END_TIME: "sensor.valve_end_time",
     }
     assert vec({"valve.demo": config}) == {
         "valve.demo": {
+            CONF_TYPE: TYPE_SPRINKLER,
             CONF_LINKED_VALVE_DURATION: "input_number.valve_duration",
             CONF_LINKED_VALVE_END_TIME: "sensor.valve_end_time",
             CONF_LOW_BATTERY_THRESHOLD: DEFAULT_LOW_BATTERY_THRESHOLD,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Native Home Assistant `valve` entities are currently always exposed as generic HomeKit valves, while valve accessories created from `switch` entities can be configured as faucets, shower heads, sprinklers, or generic valves.

This change adds the same `type` configuration support to native `valve` entities. Supported values are `faucet`, `shower`, `sprinkler`, and `valve`.

When `type` is omitted, native valve entities continue to be exposed as generic valves. Tests cover every supported type, invalid configuration, and the existing default behavior.

Existing `linked_valve_duration` and `linked_valve_end_time` configuration remains supported and unchanged for native valve entities.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47080
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
