### PR TITLE
Use standard button event types on OpenDisplay

### DIFF
--- a/homeassistant/components/opendisplay/event.py
+++ b/homeassistant/components/opendisplay/event.py
@@ -52,7 +52,8 @@ async def async_setup_entry(
                         translation_key="button",
                         translation_placeholders={"number": str(button_number)},
                         device_class=EventDeviceClass.BUTTON,
-                        event_types=list(_EVENT_TYPE_MAP.values()),
+                        # Non-standard event types are deprecated; can be removed on 2027.1
+                        event_types=[*_EVENT_TYPE_MAP, *_EVENT_TYPE_MAP.values()],
                         byte_index=bi.button_data_byte_index,
                         button_id=button_id,
                     )
@@ -88,12 +89,15 @@ class OpenDisplayEventEntity(OpenDisplayEntity, EventEntity):
         """Fire events for button transitions reported by this coordinator update."""
         data = self.coordinator.data
         if data is not None and data is not self._last_processed_data:
+            self._last_processed_data = data
             for event in data.button_events:
                 if (
                     event.byte_index == self.entity_description.byte_index
                     and event.button_id == self.entity_description.button_id
                     and event.event_type in _EVENT_TYPE_MAP
                 ):
+                    # Non-standard event types are deprecated; can be removed on 2027.1
+                    self._trigger_event(event.event_type)
+                    self.async_write_ha_state()
                     self._trigger_event(_EVENT_TYPE_MAP[event.event_type])
-            self._last_processed_data = data
-            self.async_write_ha_state()
+                    self.async_write_ha_state()

--- a/homeassistant/components/opendisplay/event.py
+++ b/homeassistant/components/opendisplay/event.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from typing import override
 
 from homeassistant.components.event import (
+    ButtonEventType,
     EventDeviceClass,
     EventEntity,
     EventEntityDescription,
@@ -16,6 +17,11 @@ from . import OpenDisplayConfigEntry
 from .entity import OpenDisplayEntity
 
 PARALLEL_UPDATES = 0
+
+_EVENT_TYPE_MAP = {
+    "button_down": ButtonEventType.PRESS_START,
+    "button_up": ButtonEventType.PRESS_END,
+}
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -46,7 +52,7 @@ async def async_setup_entry(
                         translation_key="button",
                         translation_placeholders={"number": str(button_number)},
                         device_class=EventDeviceClass.BUTTON,
-                        event_types=["button_down", "button_up"],
+                        event_types=list(_EVENT_TYPE_MAP.values()),
                         byte_index=bi.button_data_byte_index,
                         button_id=button_id,
                     )
@@ -86,8 +92,8 @@ class OpenDisplayEventEntity(OpenDisplayEntity, EventEntity):
                 if (
                     event.byte_index == self.entity_description.byte_index
                     and event.button_id == self.entity_description.button_id
-                    and event.event_type in self.event_types
+                    and event.event_type in _EVENT_TYPE_MAP
                 ):
-                    self._trigger_event(event.event_type)
+                    self._trigger_event(_EVENT_TYPE_MAP[event.event_type])
             self._last_processed_data = data
             self.async_write_ha_state()

--- a/homeassistant/components/opendisplay/strings.json
+++ b/homeassistant/components/opendisplay/strings.json
@@ -53,15 +53,7 @@
   "entity": {
     "event": {
       "button": {
-        "name": "Button {number}",
-        "state_attributes": {
-          "event_type": {
-            "state": {
-              "button_down": "Button down",
-              "button_up": "Button up"
-            }
-          }
-        }
+        "name": "Button {number}"
       }
     },
     "sensor": {

--- a/homeassistant/components/opendisplay/strings.json
+++ b/homeassistant/components/opendisplay/strings.json
@@ -53,7 +53,15 @@
   "entity": {
     "event": {
       "button": {
-        "name": "Button {number}"
+        "name": "Button {number}",
+        "state_attributes": {
+          "event_type": {
+            "state": {
+              "button_down": "Button down",
+              "button_up": "Button up"
+            }
+          }
+        }
       }
     },
     "sensor": {

--- a/tests/components/opendisplay/test_event.py
+++ b/tests/components/opendisplay/test_event.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock
 
+from homeassistant.components.event import ButtonEventType
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -157,7 +158,7 @@ async def test_button_down_event_fired(
 
     state_after = hass.states.get(entity_id)
     assert state_after is not None
-    assert state_after.attributes.get("event_type") == "button_down"
+    assert state_after.attributes.get("event_type") == ButtonEventType.PRESS_START
     assert state_before != state_after
 
 
@@ -186,7 +187,7 @@ async def test_button_up_event_fired(
 
     state = hass.states.get(entity_id)
     assert state is not None
-    assert state.attributes.get("event_type") == "button_up"
+    assert state.attributes.get("event_type") == ButtonEventType.PRESS_END
 
 
 async def test_no_event_for_wrong_button_id(

--- a/tests/components/opendisplay/test_event.py
+++ b/tests/components/opendisplay/test_event.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 from homeassistant.components.event import ButtonEventType
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_state_change_event
 
 from . import (
     TEST_ADDRESS,
@@ -152,9 +153,20 @@ async def test_button_down_event_fired(
     assert entity_id is not None
     state_before = hass.states.get(entity_id)
 
+    event_types: list[str] = []
+    async_track_state_change_event(
+        hass,
+        entity_id,
+        lambda event: event_types.append(
+            event.data["new_state"].attributes.get("event_type")
+        ),
+    )
+
     # Second advertisement — byte 0: pressed=True, button_id=0 → raw=0x80
     inject_bluetooth_service_info(hass, make_v1_service_info(b"\x80" + b"\x00" * 10))
     await hass.async_block_till_done()
+
+    assert event_types == ["button_down", ButtonEventType.PRESS_START]
 
     state_after = hass.states.get(entity_id)
     assert state_after is not None
@@ -181,9 +193,20 @@ async def test_button_up_event_fired(
     inject_bluetooth_service_info(hass, make_v1_service_info(b"\x80" + b"\x00" * 10))
     await hass.async_block_till_done()
 
+    event_types: list[str] = []
+    async_track_state_change_event(
+        hass,
+        entity_id,
+        lambda event: event_types.append(
+            event.data["new_state"].attributes.get("event_type")
+        ),
+    )
+
     # Transition to released (pressed=False, button_id=0 → raw=0x00)
     inject_bluetooth_service_info(hass, make_v1_service_info())
     await hass.async_block_till_done()
+
+    assert event_types == ["button_up", ButtonEventType.PRESS_END]
 
     state = hass.states.get(entity_id)
     assert state is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
The `button_down`/`button_up` events are now deprecated in favor of the new standard `press_start`/`press_end` events.
These new events can easily be used with the new button event triggers and condition.

For a smoother migration, the old events are still fired, so existing automation triggers will still work. Nevertheless, the event entity states will now be the new standard events instead of the old ones, so some automations and templates might need to be adjusted.


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Deprecate events in favor of standard button event types.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/176682
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47079
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
