### PR TITLE
Fix swallowed exceptions in action handlers for NFAndroidTV

### DIFF
--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -154,7 +154,7 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                     duration = int(
                         data.get(ATTR_DURATION, Notifications.DEFAULT_DURATION)
                     )
-                except (TypeError, ValueError) as err:
+                except (OverflowError, TypeError, ValueError) as err:
                     raise ServiceValidationError(
                         translation_domain=DOMAIN,
                         translation_key="invalid_duration",

--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -154,7 +154,7 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                     duration = int(
                         data.get(ATTR_DURATION, Notifications.DEFAULT_DURATION)
                     )
-                except ValueError as err:
+                except (TypeError, ValueError) as err:
                     raise ServiceValidationError(
                         translation_domain=DOMAIN,
                         translation_key="invalid_duration",

--- a/homeassistant/components/nfandroidtv/notify.py
+++ b/homeassistant/components/nfandroidtv/notify.py
@@ -154,11 +154,14 @@ class NFAndroidTVNotificationService(BaseNotificationService):
                     duration = int(
                         data.get(ATTR_DURATION, Notifications.DEFAULT_DURATION)
                     )
-                # pylint: disable-next=home-assistant-action-swallowed-exception
-                except ValueError:
-                    _LOGGER.warning(
-                        "Invalid duration-value: %s", data.get(ATTR_DURATION)
-                    )
+                except ValueError as err:
+                    raise ServiceValidationError(
+                        translation_domain=DOMAIN,
+                        translation_key="invalid_duration",
+                        translation_placeholders={
+                            "duration": str(data.get(ATTR_DURATION))
+                        },
+                    ) from err
             if ATTR_FONTSIZE in data:
                 if data.get(ATTR_FONTSIZE) in Notifications.FONTSIZES:
                     fontsize = data.get(ATTR_FONTSIZE)
@@ -189,10 +192,14 @@ class NFAndroidTVNotificationService(BaseNotificationService):
             if ATTR_INTERRUPT in data:
                 try:
                     interrupt = cv.boolean(data.get(ATTR_INTERRUPT))
-                except vol.Invalid:
-                    _LOGGER.warning(
-                        "Invalid interrupt-value: %s", data.get(ATTR_INTERRUPT)
-                    )
+                except vol.Invalid as err:
+                    raise ServiceValidationError(
+                        translation_domain=DOMAIN,
+                        translation_key="invalid_interrupt",
+                        translation_placeholders={
+                            "interrupt": str(data.get(ATTR_INTERRUPT))
+                        },
+                    ) from err
             if imagedata := data.get(ATTR_IMAGE):
                 if isinstance(imagedata, str):
                     image_file = (

--- a/homeassistant/components/nfandroidtv/strings.json
+++ b/homeassistant/components/nfandroidtv/strings.json
@@ -34,6 +34,12 @@
     "connection_failed": {
       "message": "Failed to connect to host: {host}"
     },
+    "invalid_duration": {
+      "message": "Invalid duration value: {duration}"
+    },
+    "invalid_interrupt": {
+      "message": "Invalid interrupt value: {interrupt}"
+    },
     "invalid_notification_icon": {
       "message": "Invalid icon data provided. Got {type}"
     },

--- a/tests/components/nfandroidtv/test_notify.py
+++ b/tests/components/nfandroidtv/test_notify.py
@@ -1,7 +1,7 @@
 """Tests for the Notifications for Android TV / Fire TV notify platform."""
 
-from collections.abc import AsyncGenerator
-from unittest.mock import patch
+from collections.abc import AsyncGenerator, Generator
+from unittest.mock import MagicMock, patch
 
 from notifications_android_tv.notifications import ConnectError
 import pytest
@@ -16,12 +16,14 @@ from homeassistant.components.notify import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, CONF_NAME, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 
 from . import NAME
 
 from tests.common import AsyncMock, MockConfigEntry, snapshot_platform
+
+LEGACY_SERVICE_NAME = "android_tv_fire_tv_1_2_3_4"
 
 
 @pytest.fixture(autouse=True)
@@ -123,3 +125,47 @@ async def test_send_message_exception(
     mock_notifications_android_tv.send.assert_called_once_with(
         message="Hello", title="World"
     )
+
+
+@pytest.fixture
+def mock_legacy_notifications() -> Generator[MagicMock]:
+    """Mock the client used by the legacy notify service."""
+    with patch(
+        "homeassistant.components.nfandroidtv.notify.Notifications",
+        autospec=True,
+    ) as mock_client:
+        yield mock_client.return_value
+
+
+@pytest.mark.usefixtures("mock_notifications_android_tv")
+@pytest.mark.parametrize(
+    ("service_data", "translation_key"),
+    [
+        pytest.param({"duration": "invalid"}, "invalid_duration", id="duration"),
+        pytest.param({"interrupt": "invalid"}, "invalid_interrupt", id="interrupt"),
+    ],
+)
+async def test_legacy_send_message_invalid_data(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_legacy_notifications: MagicMock,
+    service_data: dict[str, str],
+    translation_key: str,
+) -> None:
+    """Test that invalid service data raises and sends nothing."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert hass.services.has_service(NOTIFY_DOMAIN, LEGACY_SERVICE_NAME)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            LEGACY_SERVICE_NAME,
+            {"message": "Hello", "data": service_data},
+            blocking=True,
+        )
+
+    assert err.value.translation_key == translation_key
+    mock_legacy_notifications.send.assert_not_called()

--- a/tests/components/nfandroidtv/test_notify.py
+++ b/tests/components/nfandroidtv/test_notify.py
@@ -142,6 +142,7 @@ def mock_legacy_notifications() -> Generator[MagicMock]:
     ("service_data", "translation_key"),
     [
         pytest.param({"duration": "invalid"}, "invalid_duration", id="duration"),
+        pytest.param({"duration": None}, "invalid_duration", id="duration_none"),
         pytest.param({"interrupt": "invalid"}, "invalid_interrupt", id="interrupt"),
     ],
 )

--- a/tests/components/nfandroidtv/test_notify.py
+++ b/tests/components/nfandroidtv/test_notify.py
@@ -150,7 +150,7 @@ async def test_legacy_send_message_invalid_data(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     mock_legacy_notifications: MagicMock,
-    service_data: dict[str, str],
+    service_data: dict[str, str | None],
     translation_key: str,
 ) -> None:
     """Test that invalid service data raises and sends nothing."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The nfandroidtv notify service only logged a warning when the `duration` or `interrupt` service data was invalid, so users got no feedback and automations continued as if the action had succeeded. Both except blocks now raise `ServiceValidationError` with translated messages (`invalid_duration`, `invalid_interrupt`), matching the integration's existing handling of invalid image and icon data. `ServiceValidationError` is the convention for invalid action input and a subclass of the `HomeAssistantError` requested in the issue. The fontsize, position, transparency and color warnings are plain if/else validation rather than except blocks and stay unchanged. The pylint suppression is removed and a parametrized test covers both invalid inputs through the notify service.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170698
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
