### PR TITLE
Restore Victron GX energy sensor state across restarts

### DIFF
--- a/homeassistant/components/victron_gx/button.py
+++ b/homeassistant/components/victron_gx/button.py
@@ -51,6 +51,9 @@ async def async_setup_entry(
 class VictronButton(VictronBaseEntity, ButtonEntity):
     """Implementation of a Victron GX button entity."""
 
+    # Buttons are stateless commands with no metric value to reflect.
+    _follow_metric_availability = False
+
     @callback
     @override
     def _on_update_cb(self, _value: Any) -> None:

--- a/homeassistant/components/victron_gx/device_tracker.py
+++ b/homeassistant/components/victron_gx/device_tracker.py
@@ -50,6 +50,10 @@ async def async_setup_entry(
 class VictronDeviceTracker(VictronBaseEntity, TrackerEntity):
     """Implementation of a Victron GX device tracker."""
 
+    # A missing GPS fix is a valid state (cleared location), not stale data,
+    # so the tracker must not be marked unavailable when the value is None.
+    _follow_metric_availability = False
+
     _altitude: float | None = None
     _course: float | None = None
     _speed: float | None = None

--- a/homeassistant/components/victron_gx/entity.py
+++ b/homeassistant/components/victron_gx/entity.py
@@ -51,6 +51,10 @@ class VictronBaseEntity(Entity):
 
     _attr_should_poll = False
     _attr_has_entity_name = True
+    # When True, the entity is marked unavailable while its metric has no value
+    # (None), instead of exposing that None as the state. Keeping the last known
+    # value avoids persisting None to the restore cache.
+    _follow_metric_availability = True
 
     def __init__(
         self,
@@ -62,6 +66,8 @@ class VictronBaseEntity(Entity):
         """Initialize the entity."""
         self._device = device
         self._metric = metric
+        if self._follow_metric_availability:
+            self._attr_available = metric.value is not None
         self._attr_device_info = device_info
         self._attr_unique_id = f"{installation_id}_{metric.unique_id}"
         self._attr_suggested_display_precision = metric.precision
@@ -116,6 +122,15 @@ class VictronBaseEntity(Entity):
 
     @callback
     def _on_update(self, _: VictronVenusMetric, value: Any) -> None:
+        if self._follow_metric_availability and value is None:
+            # The metric value is stale or unavailable. Mark the entity
+            # unavailable while keeping the last known value, so accumulated or
+            # restored state is preserved across a restart.
+            if self._attr_available:
+                self._attr_available = False
+                self.async_write_ha_state()
+            return
+        self._attr_available = True
         self._on_update_cb(value)
 
     @override

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -119,7 +119,9 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
     @callback
     @override
     def _on_update_cb(self, value: Any) -> None:
-        if self._baseline is not None:
+        # FormulaMetric emits None when a dependency is unavailable or stale;
+        # only add the baseline to numeric values.
+        if self._baseline is not None and isinstance(value, int | float):
             value += self._baseline
         self._attr_native_value = VictronSensor._normalize_value(value)
         self.async_write_ha_state()

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -164,7 +164,7 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
 
         try:
             self._baseline = float(last_state.state)
-        except (ValueError, TypeError):
+        except ValueError, TypeError:
             _LOGGER.warning(
                 "Could not restore state for %s: invalid value '%s' (type: %s)",
                 self.entity_id,

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -147,8 +147,8 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
             await super().async_added_to_hass()
             return
 
-        last_state = await self.async_get_last_state()
-        if last_state is None or last_state.state in (None, "unknown", "unavailable"):
+        last_sensor_data = await self.async_get_last_sensor_data()
+        if last_sensor_data is None or last_sensor_data.native_value is None:
             _LOGGER.debug(
                 "Baseline is missing. Probably first load for %s", self.entity_id
             )
@@ -164,19 +164,20 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
             await super().async_added_to_hass()
             return
 
-        try:
-            self._baseline = float(last_state.state)
-        except ValueError, TypeError:
+        if not isinstance(last_sensor_data.native_value, int | float):
             _LOGGER.warning(
                 "Could not restore state for %s: invalid value '%s' (type: %s)",
                 self.entity_id,
-                last_state.state,
-                type(last_state.state).__name__,
+                last_sensor_data.native_value,
+                type(last_sensor_data.native_value).__name__,
             )
-        else:
-            self._attr_native_value += self._baseline
-            _LOGGER.debug(
-                "Restored baseline of %.3f for %s", self._baseline, self.entity_id
-            )
+            await super().async_added_to_hass()
+            return
+
+        self._baseline = float(last_sensor_data.native_value)
+        self._attr_native_value += self._baseline
+        _LOGGER.debug(
+            "Restored baseline of %.3f for %s", self._baseline, self.entity_id
+        )
 
         await super().async_added_to_hass()

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -120,8 +120,8 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
     @callback
     @override
     def _on_update_cb(self, value: Any) -> None:
-        # FormulaMetric emits None when a dependency is unavailable or stale;
-        # only add the baseline to numeric values.
+        # Enum sensors emit non-numeric values; only add the baseline to numeric
+        # cumulative values.
         if self._baseline is not None and isinstance(value, int | float):
             value += self._baseline
         self._attr_native_value = VictronSensor._normalize_value(value)

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -1,9 +1,11 @@
 """Support for Victron GX sensors."""
 
+import logging
 from typing import Any, override
 
 from victron_mqtt import (
     Device as VictronVenusDevice,
+    FormulaMetric as VictronFormulaMetric,
     Metric as VictronVenusMetric,
     MetricKind,
     MetricNature,
@@ -12,8 +14,8 @@ from victron_mqtt import (
 )
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
-    SensorEntity,
     SensorStateClass,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -22,6 +24,8 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .entity import VictronBaseEntity
 from .hub import VictronGxConfigEntry
+
+_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0  # There is no I/O in the entity itself.
 
@@ -82,8 +86,10 @@ async def async_setup_entry(
     hub.register_new_metric_callback(MetricKind.SENSOR, on_new_metric)
 
 
-class VictronSensor(VictronBaseEntity, SensorEntity):
+class VictronSensor(VictronBaseEntity, RestoreSensor):
     """Implementation of a Victron GX sensor."""
+
+    _baseline: float | None = None
 
     def __init__(
         self,
@@ -113,6 +119,8 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
     @callback
     @override
     def _on_update_cb(self, value: Any) -> None:
+        if self._baseline is not None:
+            value += self._baseline
         self._attr_native_value = VictronSensor._normalize_value(value)
         self.async_write_ha_state()
 
@@ -122,3 +130,51 @@ class VictronSensor(VictronBaseEntity, SensorEntity):
         if isinstance(value, VictronEnum):
             return value.id
         return value
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Restore persistent state for FormulaMetric energy sensors."""
+        # Cumulative FormulaMetric sensors (TOTAL / TOTAL_INCREASING) start from
+        # 0 on each HA restart, so we restore the previous accumulated value as a
+        # baseline and add new increments on top.
+        should_restore = self.state_class in (
+            SensorStateClass.TOTAL_INCREASING,
+            SensorStateClass.TOTAL,
+        ) and isinstance(self._metric, VictronFormulaMetric)
+        if not should_restore:
+            await super().async_added_to_hass()
+            return
+
+        last_state = await self.async_get_last_state()
+        if last_state is None or last_state.state in (None, "unknown", "unavailable"):
+            _LOGGER.debug(
+                "Baseline is missing. Probably first load for %s", self.entity_id
+            )
+            await super().async_added_to_hass()
+            return
+
+        if not isinstance(self._attr_native_value, int | float):
+            _LOGGER.warning(
+                "Cannot restore baseline for %s: current value is %r (expected numeric)",
+                self.entity_id,
+                self._attr_native_value,
+            )
+            await super().async_added_to_hass()
+            return
+
+        try:
+            self._baseline = float(last_state.state)
+        except (ValueError, TypeError):
+            _LOGGER.warning(
+                "Could not restore state for %s: invalid value '%s' (type: %s)",
+                self.entity_id,
+                last_state.state,
+                type(last_state.state).__name__,
+            )
+        else:
+            self._attr_native_value += self._baseline
+            _LOGGER.debug(
+                "Restored baseline of %.3f for %s", self._baseline, self.entity_id
+            )
+
+        await super().async_added_to_hass()

--- a/homeassistant/components/victron_gx/sensor.py
+++ b/homeassistant/components/victron_gx/sensor.py
@@ -1,6 +1,7 @@
 """Support for Victron GX sensors."""
 
 import logging
+import math
 from typing import Any, override
 
 from victron_mqtt import (
@@ -164,17 +165,19 @@ class VictronSensor(VictronBaseEntity, RestoreSensor):
             await super().async_added_to_hass()
             return
 
-        if not isinstance(last_sensor_data.native_value, int | float):
+        native_value = last_sensor_data.native_value
+        # float() accepts nan/inf, but SensorEntity rejects non-finite values.
+        if not isinstance(native_value, int | float) or not math.isfinite(native_value):
             _LOGGER.warning(
                 "Could not restore state for %s: invalid value '%s' (type: %s)",
                 self.entity_id,
-                last_sensor_data.native_value,
-                type(last_sensor_data.native_value).__name__,
+                native_value,
+                type(native_value).__name__,
             )
             await super().async_added_to_hass()
             return
 
-        self._baseline = float(last_sensor_data.native_value)
+        self._baseline = float(native_value)
         self._attr_native_value += self._baseline
         _LOGGER.debug(
             "Restored baseline of %.3f for %s", self._baseline, self.entity_id

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -264,6 +264,36 @@ async def test_formula_sensor_restores_baseline(
     assert state.state == "15.0"
 
 
+async def test_formula_sensor_none_update_after_restore(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+) -> None:
+    """Test a None update after restore does not add the baseline."""
+    victron_hub, _mock_config_entry = init_integration
+
+    mock_restore_cache(hass, (State(ENERGY_ENTITY_ID, "5.0"),))
+
+    await _inject_pv_power(victron_hub, 100)
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_ENTITY_ID)
+    assert state is not None
+    assert state.state == "5.0"
+
+    # A None update (stale/unavailable dependency) must not add the baseline,
+    # which would otherwise raise a TypeError.
+    with patch.object(
+        FormulaMetric, "value", new_callable=PropertyMock, return_value=None
+    ):
+        await _inject_pv_power(victron_hub, 200)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"
+
+
 @pytest.mark.parametrize(
     ("restore_cache", "expected_log"),
     [

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import MOCK_INSTALLATION_ID
 
-from tests.common import MockConfigEntry, mock_restore_cache
+from tests.common import MockConfigEntry, mock_restore_cache_with_extra_data
 
 ENERGY_ENTITY_ID = "sensor.victron_venus_pv_energy"
 
@@ -233,6 +233,14 @@ async def _inject_pv_power(victron_hub: VictronVenusHub, value: int) -> None:
     )
 
 
+def _restore_energy(native_value: object) -> tuple[State, dict[str, object]]:
+    """Build a restore-cache entry with a persisted native sensor value."""
+    return (
+        State(ENERGY_ENTITY_ID, str(native_value)),
+        {"native_value": native_value, "native_unit_of_measurement": "kWh"},
+    )
+
+
 async def test_formula_sensor_restores_baseline(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
@@ -240,7 +248,7 @@ async def test_formula_sensor_restores_baseline(
     """Test cumulative FormulaMetric sensor restores previous value as baseline."""
     victron_hub, _mock_config_entry = init_integration
 
-    mock_restore_cache(hass, (State(ENERGY_ENTITY_ID, "5.0"),))
+    mock_restore_cache_with_extra_data(hass, (_restore_energy(5.0),))
 
     await _inject_pv_power(victron_hub, 100)
     await finalize_injection(victron_hub)
@@ -271,7 +279,7 @@ async def test_formula_sensor_none_update_after_restore(
     """Test a None update after restore does not add the baseline."""
     victron_hub, _mock_config_entry = init_integration
 
-    mock_restore_cache(hass, (State(ENERGY_ENTITY_ID, "5.0"),))
+    mock_restore_cache_with_extra_data(hass, (_restore_energy(5.0),))
 
     await _inject_pv_power(victron_hub, 100)
     await finalize_injection(victron_hub)
@@ -299,14 +307,14 @@ async def test_formula_sensor_none_update_after_restore(
     [
         pytest.param((), "Baseline is missing", id="first_load"),
         pytest.param(
-            (State(ENERGY_ENTITY_ID, "unknown"),),
+            (_restore_energy(None),),
             "Baseline is missing",
-            id="unknown_state",
+            id="missing_native_value",
         ),
         pytest.param(
-            (State(ENERGY_ENTITY_ID, "not_a_number"),),
+            (_restore_energy("not_a_number"),),
             "Could not restore state",
-            id="invalid_state",
+            id="invalid_native_value",
         ),
     ],
 )
@@ -314,13 +322,13 @@ async def test_formula_sensor_no_baseline(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
     caplog: pytest.LogCaptureFixture,
-    restore_cache: tuple[State, ...],
+    restore_cache: tuple[tuple[State, dict[str, object]], ...],
     expected_log: str,
 ) -> None:
     """Test FormulaMetric sensor keeps fresh value when no valid baseline exists."""
     victron_hub, _mock_config_entry = init_integration
 
-    mock_restore_cache(hass, restore_cache)
+    mock_restore_cache_with_extra_data(hass, restore_cache)
 
     with caplog.at_level(logging.DEBUG, logger="homeassistant.components.victron_gx"):
         await _inject_pv_power(victron_hub, 100)
@@ -341,7 +349,7 @@ async def test_formula_sensor_non_numeric_value(
     """Test FormulaMetric sensor with non-numeric value does not restore baseline."""
     victron_hub, _mock_config_entry = init_integration
 
-    mock_restore_cache(hass, (State(ENERGY_ENTITY_ID, "5.0"),))
+    mock_restore_cache_with_extra_data(hass, (_restore_energy(5.0),))
 
     with (
         patch.object(

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -1,6 +1,7 @@
 """Tests for Victron GX MQTT sensors."""
 
 import logging
+import math
 from unittest.mock import PropertyMock, patch
 
 import pytest
@@ -317,12 +318,12 @@ async def test_formula_sensor_none_update_after_restore(
             id="invalid_native_value",
         ),
         pytest.param(
-            (_restore_energy(float("nan")),),
+            (_restore_energy(math.nan),),
             "Could not restore state",
             id="nan_native_value",
         ),
         pytest.param(
-            (_restore_energy(float("inf")),),
+            (_restore_energy(math.inf),),
             "Could not restore state",
             id="inf_native_value",
         ),

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -8,10 +8,17 @@ import pytest
 from victron_mqtt import FormulaMetric, Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.components.sensor import (
+    DOMAIN as SENSOR_DOMAIN,
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.components.victron_gx.const import DOMAIN
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity_component import DATA_INSTANCES, EntityComponent
 
 from .const import MOCK_INSTALLATION_ID
 
@@ -277,7 +284,7 @@ async def test_formula_sensor_none_update_after_restore(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
 ) -> None:
-    """Test a None update after restore does not add the baseline."""
+    """Test a None update marks the sensor unavailable but keeps its value."""
     victron_hub, _mock_config_entry = init_integration
 
     mock_restore_cache_with_extra_data(hass, (_restore_energy(5.0),))
@@ -290,8 +297,9 @@ async def test_formula_sensor_none_update_after_restore(
     assert state is not None
     assert state.state == "5.0"
 
-    # A None update (stale/unavailable dependency) must not add the baseline,
-    # which would otherwise raise a TypeError.
+    # A None update (stale/unavailable dependency) marks the entity unavailable
+    # while keeping the last known value, so the restored total is not persisted
+    # as None and lost on the next restart.
     with patch.object(
         FormulaMetric, "value", new_callable=PropertyMock, return_value=None
     ):
@@ -300,7 +308,14 @@ async def test_formula_sensor_none_update_after_restore(
 
     state = hass.states.get(ENERGY_ENTITY_ID)
     assert state is not None
-    assert state.state == "unknown"
+    assert state.state == STATE_UNAVAILABLE
+
+    # The last known value is retained on the entity, so RestoreSensor persists
+    # the accumulated total instead of None.
+    component: EntityComponent[SensorEntity] = hass.data[DATA_INSTANCES][SENSOR_DOMAIN]
+    entity = component.get_entity(ENERGY_ENTITY_ID)
+    assert entity is not None
+    assert entity.native_value == 5.0
 
 
 @pytest.mark.parametrize(
@@ -374,5 +389,5 @@ async def test_formula_sensor_non_numeric_value(
 
     state = hass.states.get(ENERGY_ENTITY_ID)
     assert state is not None
-    assert state.state == "unknown"
+    assert state.state == STATE_UNAVAILABLE
     assert "Cannot restore baseline" in caplog.text

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -316,6 +316,16 @@ async def test_formula_sensor_none_update_after_restore(
             "Could not restore state",
             id="invalid_native_value",
         ),
+        pytest.param(
+            (_restore_energy(float("nan")),),
+            "Could not restore state",
+            id="nan_native_value",
+        ),
+        pytest.param(
+            (_restore_energy(float("inf")),),
+            "Could not restore state",
+            id="inf_native_value",
+        ),
     ],
 )
 async def test_formula_sensor_no_baseline(

--- a/tests/components/victron_gx/test_sensor.py
+++ b/tests/components/victron_gx/test_sensor.py
@@ -1,17 +1,22 @@
 """Tests for Victron GX MQTT sensors."""
 
+import logging
+from unittest.mock import PropertyMock, patch
+
 import pytest
-from victron_mqtt import Hub as VictronVenusHub
+from victron_mqtt import FormulaMetric, Hub as VictronVenusHub
 from victron_mqtt.testing import finalize_injection, inject_message
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.components.victron_gx.const import DOMAIN
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import MOCK_INSTALLATION_ID
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, mock_restore_cache
+
+ENERGY_ENTITY_ID = "sensor.victron_venus_pv_energy"
 
 
 async def test_victron_battery_sensor(
@@ -217,3 +222,108 @@ async def test_native_unit_of_measurement_special_unit(
     state = hass.states.get("sensor.battery_charge")
     assert state is not None
     assert state.attributes["unit_of_measurement"] == "%"
+
+
+async def _inject_pv_power(victron_hub: VictronVenusHub, value: int) -> None:
+    """Inject a PV power metric, which drives the pv_energy FormulaMetric."""
+    await inject_message(
+        victron_hub,
+        f"N/{MOCK_INSTALLATION_ID}/system/0/Dc/Pv/Power",
+        f'{{"value": {value}}}',
+    )
+
+
+async def test_formula_sensor_restores_baseline(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+) -> None:
+    """Test cumulative FormulaMetric sensor restores previous value as baseline."""
+    victron_hub, _mock_config_entry = init_integration
+
+    mock_restore_cache(hass, (State(ENERGY_ENTITY_ID, "5.0"),))
+
+    await _inject_pv_power(victron_hub, 100)
+    await finalize_injection(victron_hub)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_ENTITY_ID)
+    assert state is not None
+    assert state.attributes["state_class"] == SensorStateClass.TOTAL
+    # Fresh formula value is 0.0, restored baseline of 5.0 is added on top.
+    assert state.state == "5.0"
+
+    # A new reading of 10.0 is accumulated on top of the restored baseline.
+    with patch.object(
+        FormulaMetric, "value", new_callable=PropertyMock, return_value=10.0
+    ):
+        await _inject_pv_power(victron_hub, 200)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_ENTITY_ID)
+    assert state is not None
+    assert state.state == "15.0"
+
+
+@pytest.mark.parametrize(
+    ("restore_cache", "expected_log"),
+    [
+        pytest.param((), "Baseline is missing", id="first_load"),
+        pytest.param(
+            (State(ENERGY_ENTITY_ID, "unknown"),),
+            "Baseline is missing",
+            id="unknown_state",
+        ),
+        pytest.param(
+            (State(ENERGY_ENTITY_ID, "not_a_number"),),
+            "Could not restore state",
+            id="invalid_state",
+        ),
+    ],
+)
+async def test_formula_sensor_no_baseline(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    caplog: pytest.LogCaptureFixture,
+    restore_cache: tuple[State, ...],
+    expected_log: str,
+) -> None:
+    """Test FormulaMetric sensor keeps fresh value when no valid baseline exists."""
+    victron_hub, _mock_config_entry = init_integration
+
+    mock_restore_cache(hass, restore_cache)
+
+    with caplog.at_level(logging.DEBUG, logger="homeassistant.components.victron_gx"):
+        await _inject_pv_power(victron_hub, 100)
+        await finalize_injection(victron_hub)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_ENTITY_ID)
+    assert state is not None
+    assert state.state == "0.0"
+    assert expected_log in caplog.text
+
+
+async def test_formula_sensor_non_numeric_value(
+    hass: HomeAssistant,
+    init_integration: tuple[VictronVenusHub, MockConfigEntry],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test FormulaMetric sensor with non-numeric value does not restore baseline."""
+    victron_hub, _mock_config_entry = init_integration
+
+    mock_restore_cache(hass, (State(ENERGY_ENTITY_ID, "5.0"),))
+
+    with (
+        patch.object(
+            FormulaMetric, "value", new_callable=PropertyMock, return_value=None
+        ),
+        caplog.at_level(logging.WARNING, logger="homeassistant.components.victron_gx"),
+    ):
+        await _inject_pv_power(victron_hub, 100)
+        await finalize_injection(victron_hub)
+        await hass.async_block_till_done()
+
+    state = hass.states.get(ENERGY_ENTITY_ID)
+    assert state is not None
+    assert state.state == "unknown"
+    assert "Cannot restore baseline" in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Cumulative FormulaMetric sensors reset to 0 on restart. Make VictronSensor a RestoreSensor that restores the previous value as a baseline and adds new increments on top. Invalid previous states are ignored gracefully.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #172369
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
