### PR TITLE
Bump pyliebherrhomeapi to 0.5.0

### DIFF
--- a/homeassistant/components/liebherr/manifest.json
+++ b/homeassistant/components/liebherr/manifest.json
@@ -8,7 +8,7 @@
   "iot_class": "cloud_polling",
   "loggers": ["pyliebherrhomeapi"],
   "quality_scale": "platinum",
-  "requirements": ["pyliebherrhomeapi==0.4.1"],
+  "requirements": ["pyliebherrhomeapi==0.5.0"],
   "zeroconf": [
     {
       "name": "liebherr*",

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2345,7 +2345,7 @@ pylgnetcast==0.3.9
 pylibrespot-java==0.1.1
 
 # homeassistant.components.liebherr
-pyliebherrhomeapi==0.4.1
+pyliebherrhomeapi==0.5.0
 
 # homeassistant.components.litejet
 pylitejet==0.6.3

--- a/tests/components/liebherr/conftest.py
+++ b/tests/components/liebherr/conftest.py
@@ -104,12 +104,14 @@ MOCK_DEVICE_STATE = DeviceState(
             name="hydrobreeze",
             type="HydroBreezeControl",
             zone_id=1,
+            zone_position=ZonePosition.TOP,
             current_mode=HydroBreezeMode.LOW,
         ),
         BioFreshPlusControl(
             name="biofreshplus",
             type="BioFreshPlusControl",
             zone_id=1,
+            zone_position=ZonePosition.TOP,
             current_mode=BioFreshPlusMode.ZERO_ZERO,
             supported_modes=[
                 BioFreshPlusMode.ZERO_ZERO,

--- a/tests/components/liebherr/snapshots/test_diagnostics.ambr
+++ b/tests/components/liebherr/snapshots/test_diagnostics.ambr
@@ -73,6 +73,7 @@
               'name': 'hydrobreeze',
               'type': 'HydroBreezeControl',
               'zone_id': 1,
+              'zone_position': 'top',
             }),
             dict({
               'current_mode': 'zero_zero',
@@ -86,6 +87,7 @@
               'temperature_unit': None,
               'type': 'BioFreshPlusControl',
               'zone_id': 1,
+              'zone_position': 'top',
             }),
             dict({
               'max': 5,


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Pump pyliebherrhomeapi to 0.5.0
https://github.com/mettolen/pyliebherrhomeapi/releases/tag/0.5.0
https://github.com/mettolen/pyliebherrhomeapi/compare/0.4.1...0.5.0


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
