### PR TITLE
Fix Hue button automations not triggering after a restart

### DIFF
--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -1,10 +1,12 @@
 """Provides device automations for Philips Hue events."""
 
+import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.device_automation import InvalidDeviceAutomationConfig
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_DEVICE_ID
-from homeassistant.core import CALLBACK_TYPE
+from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType
 
@@ -25,6 +27,8 @@ if TYPE_CHECKING:
     from homeassistant.helpers.trigger import TriggerActionType, TriggerInfo
 
     from .bridge import HueConfigEntry
+
+LOGGER = logging.getLogger(__name__)
 
 
 async def async_validate_trigger_config(
@@ -64,20 +68,27 @@ async def async_attach_trigger(
     if (device_entry := dev_reg.async_get(device_id)) is None:
         raise InvalidDeviceAutomationConfig(f"Device ID {device_id} is not valid")
 
-    entry: HueConfigEntry
-    for entry in hass.config_entries.async_loaded_entries(DOMAIN):
-        if entry.entry_id not in device_entry.config_entries:
-            continue
-        bridge = entry.runtime_data
-        if bridge.api_version == 1:
-            return await async_attach_trigger_v1(
-                bridge, device_entry, config, action, trigger_info
-            )
-        return await async_attach_trigger_v2(
-            bridge, device_entry, config, action, trigger_info
+    entry: HueConfigEntry | None = next(
+        (
+            entry
+            for entry in hass.config_entries.async_entries(DOMAIN)
+            if entry.entry_id in device_entry.config_entries
+        ),
+        None,
+    )
+    if entry is None:
+        raise InvalidDeviceAutomationConfig(
+            f"Device ID {device_id} is not found on any Hue bridge"
         )
-    raise InvalidDeviceAutomationConfig(
-        f"Device ID {device_id} is not found on any Hue bridge"
+
+    if entry.state is not ConfigEntryState.LOADED:
+        # The bridge is still setting up when automations are attached at startup.
+        return _async_attach_on_entry_load(
+            hass, entry, device_entry, config, action, trigger_info
+        )
+
+    return await _async_attach_bridge_trigger(
+        entry, device_entry, config, action, trigger_info
     )
 
 
@@ -104,3 +115,78 @@ async def async_get_triggers(
             return async_get_triggers_v1(bridge, device_entry)
         return async_get_triggers_v2(bridge, device_entry)
     return []
+
+
+async def _async_attach_bridge_trigger(
+    entry: HueConfigEntry,
+    device_entry: dr.DeviceEntry,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach the trigger to the bridge of a loaded config entry."""
+    bridge = entry.runtime_data
+    if bridge.api_version == 1:
+        return await async_attach_trigger_v1(
+            bridge, device_entry, config, action, trigger_info
+        )
+    return await async_attach_trigger_v2(
+        bridge, device_entry, config, action, trigger_info
+    )
+
+
+@callback
+def _async_attach_on_entry_load(
+    hass: HomeAssistant,
+    entry: HueConfigEntry,
+    device_entry: dr.DeviceEntry,
+    config: ConfigType,
+    action: TriggerActionType,
+    trigger_info: TriggerInfo,
+) -> CALLBACK_TYPE:
+    """Attach the trigger as soon as the given config entry is loaded.
+
+    The returned callback detaches the trigger and is safe to call while the
+    config entry is still loading.
+    """
+    remove_trigger: CALLBACK_TYPE | None = None
+    attach_scheduled = False
+    detached = False
+
+    async def _async_attach() -> None:
+        nonlocal remove_trigger
+        try:
+            remove_trigger = await _async_attach_bridge_trigger(
+                entry, device_entry, config, action, trigger_info
+            )
+        except InvalidDeviceAutomationConfig as err:
+            LOGGER.error(
+                "Got error '%s' when setting up triggers for %s",
+                err,
+                trigger_info["name"],
+            )
+            return
+        if detached:
+            remove_trigger()
+
+    @callback
+    def _handle_entry_state_change() -> None:
+        nonlocal attach_scheduled
+        # Unsubscribing here would mutate the list this callback is iterated from,
+        # so the subscription is kept until the trigger is detached.
+        if attach_scheduled or entry.state is not ConfigEntryState.LOADED:
+            return
+        attach_scheduled = True
+        hass.async_create_task(_async_attach())
+
+    unsub_state_change = entry.async_on_state_change(_handle_entry_state_change)
+
+    @callback
+    def _remove() -> None:
+        nonlocal detached
+        detached = True
+        unsub_state_change()
+        if remove_trigger is not None:
+            remove_trigger()
+
+    return _remove

--- a/homeassistant/components/hue/device_trigger.py
+++ b/homeassistant/components/hue/device_trigger.py
@@ -151,7 +151,6 @@ def _async_attach_on_entry_load(
     """
     remove_trigger: CALLBACK_TYPE | None = None
     attach_scheduled = False
-    detached = False
 
     async def _async_attach() -> None:
         nonlocal remove_trigger
@@ -165,9 +164,6 @@ def _async_attach_on_entry_load(
                 err,
                 trigger_info["name"],
             )
-            return
-        if detached:
-            remove_trigger()
 
     @callback
     def _handle_entry_state_change() -> None:
@@ -183,8 +179,6 @@ def _async_attach_on_entry_load(
 
     @callback
     def _remove() -> None:
-        nonlocal detached
-        detached = True
         unsub_state_change()
         if remove_trigger is not None:
             remove_trigger()

--- a/homeassistant/components/hue/v1/device_trigger.py
+++ b/homeassistant/components/hue/v1/device_trigger.py
@@ -155,7 +155,9 @@ async def async_attach_trigger(
 
     hue_event = _get_hue_event_from_device_id(hass, device_entry.id)
     if hue_event is None:
-        raise InvalidDeviceAutomationConfig
+        raise InvalidDeviceAutomationConfig(
+            f"Device {device_entry.id} is not available on the Hue bridge"
+        )
 
     trigger_key: tuple[str, str] = (config[CONF_TYPE], config[CONF_SUBTYPE])
 

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -1,7 +1,8 @@
 """The tests for Philips Hue device triggers for V1 bridge."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
+import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components import automation, hue
@@ -12,7 +13,7 @@ from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
-from .conftest import setup_platform
+from .conftest import create_config_entry, setup_platform
 from .test_sensor_v1 import HUE_DIMMER_REMOTE_1, HUE_TAP_REMOTE_1
 
 from tests.common import async_get_device_automations
@@ -181,3 +182,49 @@ async def test_if_fires_on_state_change(
     await hass.async_block_till_done()
     assert len(mock_bridge_v1.mock_requests) == 3
     assert len(service_calls) == 1
+
+
+async def test_error_when_remote_is_gone_after_config_entry_loads(
+    hass: HomeAssistant,
+    mock_bridge_v1: Mock,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a trigger for a remote that is no longer on the bridge is reported."""
+    mock_bridge_v1.mock_sensor_responses.append(REMOTES_RESPONSE)
+    config_entry = create_config_entry(api_version=1)
+    config_entry.add_to_hass(hass)
+    gone_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(hue.DOMAIN, "00:00:00:00:00:00:00:00")},
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": hue.DOMAIN,
+                        "device_id": gone_device.id,
+                        "type": "remote_button_short_press",
+                        "subtype": "button_4",
+                    },
+                    "action": {"service": "test.automation"},
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+
+    mock_bridge_v1.config_entry = config_entry
+    with (
+        patch.object(hue.migration, "is_v2_bridge", return_value=False),
+        patch("homeassistant.components.hue.HueBridge", return_value=mock_bridge_v1),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert "when setting up triggers for automation 0" in caplog.text

--- a/tests/components/hue/test_device_trigger_v1.py
+++ b/tests/components/hue/test_device_trigger_v1.py
@@ -227,4 +227,7 @@ async def test_error_when_remote_is_gone_after_config_entry_loads(
         await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert "when setting up triggers for automation 0" in caplog.text
+    assert (
+        f"Got error 'Device {gone_device.id} is not available on the Hue bridge' "
+        "when setting up triggers for automation 0" in caplog.text
+    )

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -1,20 +1,22 @@
 """The tests for Philips Hue device triggers for V2 bridge."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aiohue.v2.models.button import ButtonEvent
 from pytest_unordered import unordered
 
-from homeassistant.components import hue
+from homeassistant.components import automation, hue
 from homeassistant.components.device_automation import DeviceAutomationType
 from homeassistant.components.hue.v2.device import async_setup_devices
 from homeassistant.components.hue.v2.hue_event import async_setup_hue_events
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.setup import async_setup_component
 from homeassistant.util.json import JsonArrayType
 
-from .conftest import setup_platform
+from .conftest import create_config_entry, setup_platform
 
 from tests.common import async_capture_events, async_get_device_automations
 
@@ -143,3 +145,80 @@ async def test_get_triggers_for_removed_device(
         hass, DeviceAutomationType.TRIGGER, orphaned_device.id
     )
     assert triggers == []
+
+
+async def test_if_fires_when_config_entry_loads_late(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test a trigger attached before the bridge is loaded still fires.
+
+    Regression test for https://github.com/home-assistant/core/issues/156390
+    """
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    config_entry = create_config_entry(api_version=2)
+    config_entry.add_to_hass(hass)
+
+    # the device is restored from the registry while the bridge is still setting up
+    wall_switch_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da")},
+    )
+
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "device",
+                        "domain": hue.DOMAIN,
+                        "device_id": wall_switch_device.id,
+                        "type": ButtonEvent.INITIAL_PRESS.value,
+                        "subtype": 1,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {"some": "{{ trigger.event.data.type }}"},
+                    },
+                }
+            ]
+        },
+    )
+    await hass.async_block_till_done()
+    assert config_entry.state is not ConfigEntryState.LOADED
+
+    mock_bridge_v2.config_entry = config_entry
+    with (
+        patch.object(hue.migration, "is_v2_bridge", return_value=True),
+        patch("homeassistant.components.hue.HueBridge", return_value=mock_bridge_v2),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+    await async_setup_hue_events(mock_bridge_v2)
+    await hass.async_block_till_done()
+
+    # Emit button update event
+    mock_bridge_v2.api.emit_event(
+        "update",
+        {
+            "button": {
+                "button_report": {
+                    "event": "initial_press",
+                    "updated": "2021-10-01T12:00:00Z",
+                }
+            },
+            "id": "c658d3d8-a013-4b81-8ac6-78b248537e70",
+            "metadata": {"control_id": 1},
+            "type": "button",
+        },
+    )
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 1
+    assert service_calls[0].data["some"] == ButtonEvent.INITIAL_PRESS.value

--- a/tests/components/hue/test_device_trigger_v2.py
+++ b/tests/components/hue/test_device_trigger_v2.py
@@ -1,24 +1,56 @@
 """The tests for Philips Hue device triggers for V2 bridge."""
 
+from typing import Any
 from unittest.mock import Mock, patch
 
 from aiohue.v2.models.button import ButtonEvent
+import pytest
 from pytest_unordered import unordered
 
 from homeassistant.components import automation, hue
-from homeassistant.components.device_automation import DeviceAutomationType
+from homeassistant.components.device_automation import (
+    DeviceAutomationType,
+    InvalidDeviceAutomationConfig,
+)
+from homeassistant.components.hue import device_trigger
 from homeassistant.components.hue.v2.device import async_setup_devices
 from homeassistant.components.hue.v2.hue_event import async_setup_hue_events
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import Platform
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    CONF_DEVICE_ID,
+    CONF_DOMAIN,
+    CONF_PLATFORM,
+    CONF_TYPE,
+    SERVICE_TURN_OFF,
+    Platform,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.trigger import TriggerInfo
 from homeassistant.setup import async_setup_component
 from homeassistant.util.json import JsonArrayType
 
 from .conftest import create_config_entry, setup_platform
 
-from tests.common import async_capture_events, async_get_device_automations
+from tests.common import (
+    MockConfigEntry,
+    async_capture_events,
+    async_get_device_automations,
+)
+
+WALL_SWITCH_DEVICE_ID = "3ff06175-29e8-44a8-8fe7-af591b0025da"
+WALL_SWITCH_BUTTON_PRESS = {
+    "button": {
+        "button_report": {
+            "event": "initial_press",
+            "updated": "2021-10-01T12:00:00Z",
+        }
+    },
+    "id": "c658d3d8-a013-4b81-8ac6-78b248537e70",
+    "metadata": {"control_id": 1},
+    "type": "button",
+}
 
 
 async def test_hue_event(
@@ -165,60 +197,142 @@ async def test_if_fires_when_config_entry_loads_late(
     # the device is restored from the registry while the bridge is still setting up
     wall_switch_device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
-        identifiers={(hue.DOMAIN, "3ff06175-29e8-44a8-8fe7-af591b0025da")},
+        identifiers={(hue.DOMAIN, WALL_SWITCH_DEVICE_ID)},
     )
 
     assert await async_setup_component(
-        hass,
-        automation.DOMAIN,
-        {
-            automation.DOMAIN: [
-                {
-                    "trigger": {
-                        "platform": "device",
-                        "domain": hue.DOMAIN,
-                        "device_id": wall_switch_device.id,
-                        "type": ButtonEvent.INITIAL_PRESS.value,
-                        "subtype": 1,
-                    },
-                    "action": {
-                        "service": "test.automation",
-                        "data_template": {"some": "{{ trigger.event.data.type }}"},
-                    },
-                }
-            ]
-        },
+        hass, automation.DOMAIN, _automation_config(wall_switch_device.id)
     )
     await hass.async_block_till_done()
     assert config_entry.state is not ConfigEntryState.LOADED
 
-    mock_bridge_v2.config_entry = config_entry
-    with (
-        patch.object(hue.migration, "is_v2_bridge", return_value=True),
-        patch("homeassistant.components.hue.HueBridge", return_value=mock_bridge_v2),
-    ):
-        await hass.config_entries.async_setup(config_entry.entry_id)
-    assert config_entry.state is ConfigEntryState.LOADED
-    await async_setup_hue_events(mock_bridge_v2)
-    await hass.async_block_till_done()
+    await _load_bridge(hass, mock_bridge_v2, config_entry)
 
-    # Emit button update event
-    mock_bridge_v2.api.emit_event(
-        "update",
-        {
-            "button": {
-                "button_report": {
-                    "event": "initial_press",
-                    "updated": "2021-10-01T12:00:00Z",
-                }
-            },
-            "id": "c658d3d8-a013-4b81-8ac6-78b248537e70",
-            "metadata": {"control_id": 1},
-            "type": "button",
-        },
-    )
+    mock_bridge_v2.api.emit_event("update", WALL_SWITCH_BUTTON_PRESS)
     await hass.async_block_till_done()
     await hass.async_block_till_done()
 
     assert len(service_calls) == 1
     assert service_calls[0].data["some"] == ButtonEvent.INITIAL_PRESS.value
+
+    # turning the automation off detaches the trigger again
+    await _turn_off_automation(hass)
+    service_calls.clear()
+    mock_bridge_v2.api.emit_event("update", WALL_SWITCH_BUTTON_PRESS)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 0
+
+
+async def test_trigger_removed_before_config_entry_loads(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    device_registry: dr.DeviceRegistry,
+    service_calls: list[ServiceCall],
+) -> None:
+    """Test a trigger removed while the bridge is still loading never fires."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    config_entry = create_config_entry(api_version=2)
+    config_entry.add_to_hass(hass)
+    wall_switch_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(hue.DOMAIN, WALL_SWITCH_DEVICE_ID)},
+    )
+
+    assert await async_setup_component(
+        hass, automation.DOMAIN, _automation_config(wall_switch_device.id)
+    )
+    await hass.async_block_till_done()
+
+    await _turn_off_automation(hass)
+    service_calls.clear()
+
+    await _load_bridge(hass, mock_bridge_v2, config_entry)
+
+    mock_bridge_v2.api.emit_event("update", WALL_SWITCH_BUTTON_PRESS)
+    await hass.async_block_till_done()
+    await hass.async_block_till_done()
+
+    assert len(service_calls) == 0
+
+
+async def test_attach_trigger_for_device_without_hue_bridge(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test attaching a trigger for a device that is not on any Hue bridge."""
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id,
+        identifiers={("other", "not-a-hue-device")},
+    )
+    trigger_info: TriggerInfo = {
+        "domain": automation.DOMAIN,
+        "name": "test",
+        "variables": None,
+        "trigger_data": {"id": "", "idx": "0", "alias": None},
+    }
+
+    with pytest.raises(InvalidDeviceAutomationConfig):
+        await device_trigger.async_attach_trigger(
+            hass,
+            {
+                CONF_PLATFORM: "device",
+                CONF_DOMAIN: hue.DOMAIN,
+                CONF_DEVICE_ID: device.id,
+                CONF_TYPE: ButtonEvent.INITIAL_PRESS.value,
+                "subtype": 1,
+            },
+            Mock(),
+            trigger_info,
+        )
+
+
+def _automation_config(device_id: str) -> dict[str, Any]:
+    """Return an automation config triggering on a button press of the device."""
+    return {
+        automation.DOMAIN: [
+            {
+                "trigger": {
+                    "platform": "device",
+                    "domain": hue.DOMAIN,
+                    "device_id": device_id,
+                    "type": ButtonEvent.INITIAL_PRESS.value,
+                    "subtype": 1,
+                },
+                "action": {
+                    "service": "test.automation",
+                    "data_template": {"some": "{{ trigger.event.data.type }}"},
+                },
+            }
+        ]
+    }
+
+
+async def _load_bridge(
+    hass: HomeAssistant, mock_bridge: Mock, config_entry: MockConfigEntry
+) -> None:
+    """Set up a config entry that was already added to hass."""
+    mock_bridge.config_entry = config_entry
+    with (
+        patch.object(hue.migration, "is_v2_bridge", return_value=True),
+        patch("homeassistant.components.hue.HueBridge", return_value=mock_bridge),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+
+    assert config_entry.state is ConfigEntryState.LOADED
+    await async_setup_hue_events(mock_bridge)
+    await hass.async_block_till_done()
+
+
+async def _turn_off_automation(hass: HomeAssistant) -> None:
+    """Turn off the automation created by `_automation_config`."""
+    await hass.services.async_call(
+        automation.DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: "automation.automation_0"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Automations that start from a Hue button press (Tap, dimmer, wall switch, dial) could
silently stop working after a restart.

Automations are set up while Home Assistant is still starting, which can happen before
the Hue bridge has finished loading. When that happened the trigger was thrown away with
an error and never reconnected, so the automation stayed dead until it was saved again or
switched off and on.

The trigger now waits for the bridge and connects itself as soon as it is ready.

- Wait for the Hue bridge to finish loading instead of discarding the trigger when it is not ready yet
- Keep reporting an error for a device that really does not belong to any Hue bridge
- Add a test for a button automation that is set up before the bridge has loaded

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #156390
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
