### PR TITLE
Add Omada controller device and entities

### DIFF
--- a/homeassistant/components/tplink_omada/__init__.py
+++ b/homeassistant/components/tplink_omada/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.typing import ConfigType
 from .config_flow import CONF_SITE, create_omada_client
 from .const import DOMAIN
 from .controller import OmadaSiteController
+from .entity import controller_device_identifier
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
@@ -66,8 +67,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmadaConfigEntry) -> boo
             f"Unexpected error connecting to Omada controller: {ex}"
         ) from ex
 
+    controller_info = await client.get_controller_info()
+    controller_type = await client.get_controller_type()
+    controller_name = await client.get_controller_name()
+    controller_status = await client.get_controller_status()
     site_client = await client.get_site_client(OmadaSite("", entry.data[CONF_SITE]))
-    controller = OmadaSiteController(hass, entry, site_client)
+    controller = OmadaSiteController(
+        hass,
+        entry,
+        client,
+        site_client,
+        controller_info,
+        controller_type,
+        controller_status,
+        controller_name,
+    )
     await controller.initialize_first_refresh()
 
     entry.runtime_data = controller
@@ -97,7 +111,11 @@ def _remove_old_devices(
         mac = next(
             (i[1] for i in registered_device.identifiers if i[0] == DOMAIN), None
         )
-        if mac and mac not in omada_devices:
+        if (
+            mac
+            and mac != controller_device_identifier(entry)
+            and mac not in omada_devices
+        ):
             device_registry.async_remove_device(registered_device.id)
 
 

--- a/homeassistant/components/tplink_omada/controller.py
+++ b/homeassistant/components/tplink_omada/controller.py
@@ -3,7 +3,12 @@
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING
 
-from tplink_omada_client import OmadaSiteClient
+from tplink_omada_client import OmadaClient, OmadaSiteClient
+from tplink_omada_client.definitions import (
+    OmadaControllerInfo,
+    OmadaControllerStatus,
+    OmadaControllerType,
+)
 from tplink_omada_client.devices import OmadaListDevice, OmadaSwitch
 
 from homeassistant.core import HomeAssistant, callback
@@ -28,12 +33,22 @@ class OmadaSiteController:
         self,
         hass: HomeAssistant,
         config_entry: OmadaConfigEntry,
+        controller_client: OmadaClient,
         omada_client: OmadaSiteClient,
+        controller_info: OmadaControllerInfo,
+        controller_type: OmadaControllerType,
+        controller_status: OmadaControllerStatus,
+        controller_name: str,
     ) -> None:
         """Create the controller."""
         self._hass = hass
         self._config_entry = config_entry
+        self._controller_client = controller_client
         self._omada_client = omada_client
+        self._controller_info = controller_info
+        self._controller_type = controller_type
+        self._controller_status = controller_status
+        self._controller_name = controller_name
 
         self._switch_port_coordinators: dict[str, OmadaSwitchPortCoordinator] = {}
         self._devices_coordinator = OmadaDevicesCoordinator(
@@ -100,6 +115,31 @@ class OmadaSiteController:
 
         # Call once on initial setup
         await _async_register_entities()
+
+    @property
+    def controller_client(self) -> OmadaClient:
+        """Get the connected controller-level API client."""
+        return self._controller_client
+
+    @property
+    def controller_info(self) -> OmadaControllerInfo:
+        """Get information about the Omada controller."""
+        return self._controller_info
+
+    @property
+    def controller_type(self) -> OmadaControllerType:
+        """Get the Omada controller type."""
+        return self._controller_type
+
+    @property
+    def controller_status(self) -> OmadaControllerStatus:
+        """Get status information about the Omada controller."""
+        return self._controller_status
+
+    @property
+    def controller_name(self) -> str:
+        """Get the display name of the Omada controller."""
+        return self._controller_name
 
     @property
     def omada_client(self) -> OmadaSiteClient:

--- a/homeassistant/components/tplink_omada/coordinator.py
+++ b/homeassistant/components/tplink_omada/coordinator.py
@@ -5,8 +5,9 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, NamedTuple, override
 
-from tplink_omada_client import OmadaSiteClient, OmadaSwitchPortDetails
+from tplink_omada_client import OmadaClient, OmadaSiteClient, OmadaSwitchPortDetails
 from tplink_omada_client.clients import OmadaWirelessClient
+from tplink_omada_client.definitions import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import (
     OmadaFirmwareUpdate,
     OmadaGateway,
@@ -153,6 +154,39 @@ class OmadaClientsCoordinator(OmadaCoordinator[OmadaWirelessClient]):
             async for c in self.omada_client.get_connected_clients()
             if isinstance(c, OmadaWirelessClient)
         }
+
+
+class OmadaControllerUpdateCoordinator(
+    DataUpdateCoordinator[OmadaControllerUpdateInfo]
+):
+    """Coordinator for Omada controller update information."""
+
+    config_entry: OmadaConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: OmadaConfigEntry,
+        omada_client: OmadaClient,
+    ) -> None:
+        """Initialize the controller update coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name="Omada Controller Updates",
+            update_interval=timedelta(seconds=POLL_DEVICES),
+        )
+        self.omada_client = omada_client
+
+    @override
+    async def _async_update_data(self) -> OmadaControllerUpdateInfo:
+        """Fetch controller update information."""
+        try:
+            async with asyncio.timeout(10):
+                return await self.omada_client.check_firmware_updates()
+        except OmadaClientException as err:
+            raise UpdateFailed(f"Error communicating with API: {err}") from err
 
 
 class FirmwareUpdateStatus(NamedTuple):

--- a/homeassistant/components/tplink_omada/entity.py
+++ b/homeassistant/components/tplink_omada/entity.py
@@ -1,14 +1,25 @@
 """Base entity definitions."""
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from tplink_omada_client.definitions import (
+    OmadaControllerInfo,
+    OmadaControllerStatus,
+    OmadaControllerType,
+)
 from tplink_omada_client.devices import OmadaDevice, OmadaSwitchPortDetails
 
 from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorEntity,
+    DataUpdateCoordinator,
+)
 
 from .const import DOMAIN
 from .coordinator import OmadaCoordinator
+
+if TYPE_CHECKING:
+    from . import OmadaConfigEntry
 
 
 class OmadaDeviceEntity[_T: OmadaCoordinator[Any]](CoordinatorEntity[_T]):
@@ -34,3 +45,49 @@ def get_switch_port_base_name(port: OmadaSwitchPortDetails) -> str:
     if port.name == f"Port{port.port}":
         return str(port.port)
     return f"{port.port} ({port.name})"
+
+
+def controller_device_identifier(config_entry: "OmadaConfigEntry") -> str:
+    """Return the controller device identifier for a config entry."""
+    return f"controller_{config_entry.unique_id or config_entry.entry_id}"
+
+
+def controller_device_model(controller_type: OmadaControllerType) -> str:
+    """Return the model description for an Omada controller."""
+    if controller_type.is_soft_controller:
+        return "Omada Controller Software"
+
+    return "Omada Controller Hardware"
+
+
+class OmadaControllerEntity[_T: DataUpdateCoordinator[Any]](
+    CoordinatorEntity[_T]
+):
+    """Common base class for entities associated with an Omada controller."""
+
+    _attr_has_entity_name = True
+
+    def __init__(
+        self,
+        coordinator: _T,
+        config_entry: "OmadaConfigEntry",
+        controller_info: OmadaControllerInfo,
+        controller_type: OmadaControllerType,
+        controller_status: OmadaControllerStatus,
+        controller_name: str,
+    ) -> None:
+        """Initialize the controller entity."""
+        super().__init__(coordinator)
+
+        self._attr_device_info = dr.DeviceInfo(
+            identifiers={
+                (DOMAIN, controller_device_identifier(config_entry))
+            },
+            connections={
+                (dr.CONNECTION_NETWORK_MAC, controller_status.mac_address)
+            },
+            manufacturer="TP-Link",
+            model=controller_device_model(controller_type),
+            name=controller_name,
+            sw_version=controller_info.controller_version,
+        )

--- a/homeassistant/components/tplink_omada/sensor.py
+++ b/homeassistant/components/tplink_omada/sensor.py
@@ -1,10 +1,18 @@
-"""Support for TPLink Omada binary sensors."""
+"""Support for TPLink Omada sensors."""
 
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import override
 
-from tplink_omada_client.definitions import DeviceStatus, DeviceStatusCategory, PortType
+from tplink_omada_client.definitions import (
+    DeviceStatus,
+    DeviceStatusCategory,
+    OmadaControllerInfo,
+    OmadaControllerStatus,
+    OmadaControllerType,
+    PortType,
+)
+
 from tplink_omada_client.devices import (
     OmadaListDevice,
     OmadaSwitch,
@@ -17,6 +25,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+
 from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfPower
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import Entity
@@ -26,7 +35,12 @@ from homeassistant.helpers.typing import StateType
 from . import OmadaConfigEntry
 from .const import OmadaDeviceStatus
 from .coordinator import OmadaDevicesCoordinator, OmadaSwitchPortCoordinator
-from .entity import OmadaDeviceEntity, get_switch_port_base_name
+from .entity import (
+    OmadaControllerEntity,
+    OmadaDeviceEntity,
+    controller_device_identifier,
+    get_switch_port_base_name,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -57,6 +71,7 @@ def _map_device_status(device: OmadaListDevice) -> str | None:
     display_status = DEVICE_STATUS_MAP.get(
         device.status
     ) or DEVICE_STATUS_CATEGORY_MAP.get(device.status_category)
+
     return display_status.value if display_status else None
 
 
@@ -67,8 +82,20 @@ async def async_setup_entry(
 ) -> None:
     """Set up sensors."""
     controller = config_entry.runtime_data
-
     devices_coordinator = controller.devices_coordinator
+
+    async_add_entities(
+        [
+            OmadaControllerStatusSensor(
+                devices_coordinator,
+                config_entry,
+                controller.controller_info,
+                controller.controller_type,
+                controller.controller_status,
+                controller.controller_name,
+            )
+        ]
+    )
 
     async def _create_device_sensor_entities(
         device: OmadaListDevice,
@@ -76,9 +103,9 @@ async def async_setup_entry(
         """Create sensor entities for a device."""
         async_add_entities(
             [
-                OmadaDeviceSensor(devices_coordinator, device, desc)
-                for desc in OMADA_DEVICE_SENSORS
-                if desc.exists_func(device)
+                OmadaDeviceSensor(devices_coordinator, device, description)
+                for description in OMADA_DEVICE_SENSORS
+                if description.exists_func(device)
             ]
         )
 
@@ -117,6 +144,42 @@ async def async_setup_entry(
     )
 
 
+class OmadaControllerStatusSensor(
+    OmadaControllerEntity[OmadaDevicesCoordinator],
+    SensorEntity,
+):
+    """Connection status sensor for an Omada controller."""
+
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_options = [value.value for value in OmadaDeviceStatus]
+    _attr_translation_key = "device_status"
+    _attr_native_value = OmadaDeviceStatus.CONNECTED.value
+
+    def __init__(
+        self,
+        coordinator: OmadaDevicesCoordinator,
+        config_entry: OmadaConfigEntry,
+        controller_info: OmadaControllerInfo,
+        controller_type: OmadaControllerType,
+        controller_status: OmadaControllerStatus,
+        controller_name: str,
+    ) -> None:
+        """Initialize the controller status sensor."""
+        super().__init__(
+            coordinator,
+            config_entry,
+            controller_info,
+            controller_type,
+            controller_status,
+            controller_name,
+        )
+
+        self._attr_unique_id = (
+            f"{controller_device_identifier(config_entry)}_device_status"
+        )
+
+
 @dataclass(frozen=True, kw_only=True)
 class OmadaDeviceSensorEntityDescription(SensorEntityDescription):
     """Entity description for status from an Omada device."""
@@ -132,7 +195,7 @@ OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
         device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         update_func=_map_device_status,
-        options=[v.value for v in OmadaDeviceStatus],
+        options=[value.value for value in OmadaDeviceStatus],
     ),
     OmadaDeviceSensorEntityDescription(
         key="cpu_usage",
@@ -153,8 +216,11 @@ OMADA_DEVICE_SENSORS: list[OmadaDeviceSensorEntityDescription] = [
 ]
 
 
-class OmadaDeviceSensor(OmadaDeviceEntity[OmadaDevicesCoordinator], SensorEntity):
-    """Sensor for property of a generic Omada device."""
+class OmadaDeviceSensor(
+    OmadaDeviceEntity[OmadaDevicesCoordinator],
+    SensorEntity,
+):
+    """Sensor for property of a generic device."""
 
     entity_description: OmadaDeviceSensorEntityDescription
 
@@ -166,6 +232,7 @@ class OmadaDeviceSensor(OmadaDeviceEntity[OmadaDevicesCoordinator], SensorEntity
     ) -> None:
         """Initialize the device sensor."""
         super().__init__(coordinator, device)
+
         self.entity_description = entity_description
         self._attr_unique_id = f"{device.mac}_{entity_description.key}"
 

--- a/homeassistant/components/tplink_omada/strings.json
+++ b/homeassistant/components/tplink_omada/strings.json
@@ -100,6 +100,11 @@
       "wan_connect_ipv6": {
         "name": "Port {port_name} Internet connected (IPv6)"
       }
+    },
+    "update": {
+      "firmware": {
+        "name": "Firmware"
+      }
     }
   },
   "services": {

--- a/homeassistant/components/tplink_omada/update.py
+++ b/homeassistant/components/tplink_omada/update.py
@@ -1,7 +1,14 @@
-"""Support for TPLink Omada device firmware updates."""
+"""Support for TP-Link Omada updates."""
 
 from typing import Any, override
 
+from tplink_omada_client.definitions import (
+    OmadaControllerInfo,
+    OmadaControllerStatus,
+    OmadaControllerType,
+    OmadaHardwareUpdateInfo,
+    OmadaSoftwareUpdateInfo,
+)
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -12,11 +19,19 @@ from homeassistant.components.update import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import OmadaConfigEntry
-from .coordinator import OmadaFirmwareUpdateCoordinator
-from .entity import OmadaDeviceEntity
+from .coordinator import (
+    OmadaControllerUpdateCoordinator,
+    OmadaFirmwareUpdateCoordinator,
+)
+from .entity import (
+    OmadaControllerEntity,
+    OmadaDeviceEntity,
+    controller_device_identifier,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -26,19 +41,41 @@ async def async_setup_entry(
     config_entry: OmadaConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up switches."""
+    """Set up Omada update entities."""
     controller = config_entry.runtime_data
 
     devices = controller.devices_coordinator.data
 
-    coordinator = OmadaFirmwareUpdateCoordinator(
+    device_coordinator = OmadaFirmwareUpdateCoordinator(
         hass, config_entry, controller.omada_client, controller.devices_coordinator
     )
 
-    async_add_entities(
-        OmadaDeviceUpdate(coordinator, device) for device in devices.values()
+    controller_coordinator = OmadaControllerUpdateCoordinator(
+        hass, config_entry, controller.controller_client
     )
-    await coordinator.async_request_refresh()
+    await controller_coordinator.async_config_entry_first_refresh()
+
+    controller_entities: list[UpdateEntity] = [
+        OmadaControllerUpdate(
+            controller_coordinator,
+            config_entry,
+            controller.controller_info,
+            controller.controller_type,
+            controller.controller_status,
+            controller.controller_name,
+        )
+    ]
+
+    async_add_entities(
+        [
+            *(
+                OmadaDeviceUpdate(device_coordinator, device)
+                for device in devices.values()
+            ),
+            *controller_entities,
+        ]
+    )
+    await device_coordinator.async_request_refresh()
 
 
 class OmadaDeviceUpdate(
@@ -53,6 +90,7 @@ class OmadaDeviceUpdate(
         | UpdateEntityFeature.RELEASE_NOTES
     )
     _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_translation_key = "firmware"
 
     def __init__(
         self,
@@ -109,3 +147,115 @@ class OmadaDeviceUpdate(
         self._attr_in_progress = status.device.fw_download
 
         self.async_write_ha_state()
+
+
+class OmadaControllerUpdate(
+    OmadaControllerEntity[OmadaControllerUpdateCoordinator],
+    UpdateEntity,
+):
+    """Firmware update status for an Omada controller."""
+
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_translation_key = "firmware"
+
+    def __init__(
+        self,
+        coordinator: OmadaControllerUpdateCoordinator,
+        config_entry: OmadaConfigEntry,
+        controller_info: OmadaControllerInfo,
+        controller_type: OmadaControllerType,
+        controller_status: OmadaControllerStatus,
+        controller_name: str,
+    ) -> None:
+        """Initialize the controller update entity."""
+        super().__init__(
+            coordinator,
+            config_entry,
+            controller_info,
+            controller_type,
+            controller_status,
+            controller_name,
+        )
+        self._attr_unique_id = (
+            f"{controller_device_identifier(config_entry)}_firmware"
+        )
+        self._controller_type = controller_type
+
+    @property
+    def update_info(
+        self,
+    ) -> OmadaHardwareUpdateInfo | OmadaSoftwareUpdateInfo | None:
+        """Return update information for this controller type."""
+        updates = self.coordinator.data
+        if self._controller_type.is_soft_controller:
+            return updates.software
+        return updates.hardware
+
+    @property
+    def hardware_update(self) -> OmadaHardwareUpdateInfo | None:
+        """Return installable controller hardware firmware information."""
+        if self._controller_type.is_soft_controller:
+            return None
+        return self.coordinator.data.hardware
+
+    @property
+    @override
+    def supported_features(self) -> UpdateEntityFeature:
+        """Flag supported update features."""
+        features = UpdateEntityFeature.RELEASE_NOTES
+        if self.hardware_update is not None:
+            features |= UpdateEntityFeature.INSTALL
+        return features
+
+    @property
+    @override
+    def installed_version(self) -> str:
+        """Version currently installed."""
+        if self.update_info is not None:
+            return self.update_info.current_version
+        return (
+            self.coordinator.config_entry.runtime_data.controller_info.controller_version
+        )
+
+    @property
+    @override
+    def latest_version(self) -> str:
+        """Latest version available."""
+        if self.update_info is not None:
+            return self.update_info.latest_version
+        return (
+            self.coordinator.config_entry.runtime_data.controller_info.controller_version
+        )
+
+    @override
+    def release_notes(self) -> str | None:
+        """Get the release notes for the latest controller update."""
+        if self.update_info is None:
+            return None
+        return self.update_info.release_notes
+
+    @override
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Install a controller hardware firmware update."""
+        firmware = self.hardware_update
+        if firmware is None:
+            raise HomeAssistantError("No controller firmware update is available")
+
+        try:
+            await self.coordinator.omada_client.upgrade_controller_firmware(
+                version or firmware.latest_version
+            )
+        except RequestFailed as ex:
+            raise HomeAssistantError(
+                "Controller firmware update request rejected"
+            ) from ex
+        except OmadaClientException as ex:
+            raise HomeAssistantError(
+                "Unable to update the Omada controller firmware."
+                " Check the controller is online."
+            ) from ex
+        finally:
+            await self.coordinator.async_request_refresh()

--- a/tests/components/tplink_omada/conftest.py
+++ b/tests/components/tplink_omada/conftest.py
@@ -12,6 +12,10 @@ from tplink_omada_client.clients import (
     OmadaWiredClient,
     OmadaWirelessClient,
 )
+from tplink_omada_client.definitions import (
+    OmadaControllerInfo,
+    OmadaControllerUpdateInfo,
+)
 from tplink_omada_client.devices import (
     OmadaFirmwareUpdate,
     OmadaGateway,
@@ -188,6 +192,20 @@ def mock_omada_client(mock_omada_site_client: AsyncMock) -> Generator[MagicMock]
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_site_client
+        client.get_controller_info.return_value = OmadaControllerInfo(
+            {
+                "controllerVer": "6.2.14",
+                "apiVer": "2",
+                "configured": True,
+                "type": 1,
+                "supportApp": True,
+                "omadacId": "12345",
+                "omadacCategory": "OC200",
+                "mspMode": False,
+            }
+        )
+        client.check_firmware_updates.return_value = OmadaControllerUpdateInfo({})
+        client.upgrade_controller_firmware = AsyncMock()
         client.login.return_value = "12345"
         client.get_controller_name.return_value = "OC200"
         client.get_sites.return_value = [OmadaSite("Display Name", "SiteId")]
@@ -206,6 +224,20 @@ def mock_omada_clients_only_client(
         client = client_mock.return_value
 
         client.get_site_client.return_value = mock_omada_clients_only_site_client
+        client.get_controller_info.return_value = OmadaControllerInfo(
+            {
+                "controllerVer": "6.2.14",
+                "apiVer": "2",
+                "configured": True,
+                "type": 1,
+                "supportApp": True,
+                "omadacId": "12345",
+                "omadacCategory": "OC200",
+                "mspMode": False,
+            }
+        )
+        client.check_firmware_updates.return_value = OmadaControllerUpdateInfo({})
+        client.get_controller_name.return_value = "OC200"
         yield client
 
 

--- a/tests/components/tplink_omada/snapshots/test_update.ambr
+++ b/tests/components/tplink_omada/snapshots/test_update.ambr
@@ -31,7 +31,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 21>,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': '54-AF-97-00-00-01_firmware',
     'unit_of_measurement': None,
   })
@@ -94,7 +94,7 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': <UpdateEntityFeature: 21>,
-    'translation_key': None,
+    'translation_key': 'firmware',
     'unique_id': 'AA-BB-CC-DD-EE-FF_firmware',
     'unit_of_measurement': None,
   })

--- a/tests/components/tplink_omada/test_init.py
+++ b/tests/components/tplink_omada/test_init.py
@@ -10,6 +10,7 @@ from tplink_omada_client.exceptions import (
 )
 
 from homeassistant.components.tplink_omada.const import DOMAIN
+from homeassistant.components.tplink_omada.entity import controller_device_identifier
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -83,12 +84,22 @@ async def test_missing_devices_removed_at_startup(
         model="Some old model",
     )
 
+    controller_entry = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, controller_device_identifier(mock_config_entry))},
+        manufacturer="TP-Link",
+        name="OC200",
+        model="OC200",
+    )
+
     assert device_registry.async_get(device_entry.id) == device_entry
+    assert device_registry.async_get(controller_entry.id) == controller_entry
 
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
     assert device_registry.async_get(device_entry.id) is None
+    assert device_registry.async_get(controller_entry.id) == controller_entry
 
 
 async def test_migrate_entry_v1_to_v2(

--- a/tests/components/tplink_omada/test_sensor.py
+++ b/tests/components/tplink_omada/test_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.components.tplink_omada.coordinator import (
     POLL_SWITCH_PORT,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import (
@@ -52,6 +53,34 @@ async def test_entities(
 ) -> None:
     """Test the creation of the TP-Link Omada sensor entities."""
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+async def test_controller_status_sensor(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test the controller status sensor belongs to the controller device."""
+    entity_id = entity_registry.async_get_entity_id(
+        "sensor",
+        DOMAIN,
+        "controller_12345_Default_device_status",
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == "connected"
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry is not None
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "controller_12345_Default")}
+    )
+    assert device is not None
+    assert entity_entry.device_id == device.id
+    assert device.model == "Omada Controller Software"
 
 
 async def test_device_specific_status(

--- a/tests/components/tplink_omada/test_update.py
+++ b/tests/components/tplink_omada/test_update.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
+from tplink_omada_client.definitions import OmadaControllerUpdateInfo
 from tplink_omada_client.devices import OmadaListDevice
 from tplink_omada_client.exceptions import OmadaClientException, RequestFailed
 
@@ -18,6 +19,7 @@ from homeassistant.components.update import (
 from homeassistant.const import ATTR_ENTITY_ID, STATE_ON, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 
 from tests.common import (
@@ -60,6 +62,114 @@ async def init_integration(
         await hass.async_block_till_done()
 
     return mock_config_entry
+
+
+async def _setup_controller_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    update_data: dict,
+) -> MockConfigEntry:
+    """Set up the integration with controller update data."""
+    mock_omada_client.check_firmware_updates.return_value = (
+        OmadaControllerUpdateInfo(update_data)
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.tplink_omada.PLATFORMS", [Platform.UPDATE]):
+        assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    return mock_config_entry
+
+
+async def test_hardware_controller_update(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test a hardware controller update entity and device."""
+    await _setup_controller_update(
+        hass,
+        mock_config_entry,
+        mock_omada_client,
+        {
+            "hardware": {
+                "upgrade": True,
+                "currentVersion": "1.28.2",
+                "latestVersion": "1.31.3",
+                "fwReleaseLog": "Hardware controller release notes",
+            }
+        },
+    )
+
+    entity_id = entity_registry.async_get_entity_id(
+        UPDATE_DOMAIN,
+        "tplink_omada",
+        "controller_12345_Default_firmware",
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes["installed_version"] == "1.28.2"
+    assert state.attributes["latest_version"] == "1.31.3"
+    assert state.attributes["device_class"] == "firmware"
+
+    device = device_registry.async_get_device(
+        identifiers={("tplink_omada", "controller_12345_Default")}
+    )
+    assert device is not None
+    assert device.manufacturer == "TP-Link"
+    assert device.model == "OC200"
+    assert device.name == "OC200"
+    assert device.sw_version == "6.2.14"
+
+
+async def test_software_controller_update(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test a software controller update entity."""
+    await _setup_controller_update(
+        hass,
+        mock_config_entry,
+        mock_omada_client,
+        {
+            "software": {
+                "upgrade": True,
+                "currentVersion": "6.2.14",
+                "latestVersion": "6.2.16",
+                "releaseLog": "Software controller release notes",
+            }
+        },
+    )
+
+    entity_id = entity_registry.async_get_entity_id(
+        UPDATE_DOMAIN,
+        "tplink_omada",
+        "controller_12345_Default_firmware",
+    )
+    assert entity_id is not None
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_ON
+    assert state.attributes["installed_version"] == "6.2.14"
+    assert state.attributes["latest_version"] == "6.2.16"
+    assert state.attributes["device_class"] == "firmware"
+
+    device = device_registry.async_get_device(
+        identifiers={("tplink_omada", "controller_12345_Default")}
+    )
+    assert device is not None
+    assert device.model == "Omada Controller Software"
 
 
 async def test_entities(
@@ -130,6 +240,44 @@ async def test_install_firmware_success(
     assert await_args[0].mac == "54-AF-97-00-00-01"
 
 
+async def test_install_hardware_controller_firmware(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+) -> None:
+    """Test successful hardware controller firmware installation."""
+    await _setup_controller_update(
+        hass,
+        mock_config_entry,
+        mock_omada_client,
+        {
+            "hardware": {
+                "upgrade": True,
+                "currentVersion": "1.28.2",
+                "latestVersion": "1.31.3",
+                "fwReleaseLog": "Hardware controller release notes",
+            }
+        },
+    )
+
+    entity_id = entity_registry.async_get_entity_id(
+        UPDATE_DOMAIN,
+        "tplink_omada",
+        "controller_12345_Default_firmware",
+    )
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        UPDATE_DOMAIN,
+        SERVICE_INSTALL,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+
+    mock_omada_client.upgrade_controller_firmware.assert_awaited_once_with("1.31.3")
+
+
 @pytest.mark.parametrize(
     ("exception_type", "error_message"),
     [
@@ -172,6 +320,58 @@ async def test_install_firmware_exceptions(
 
 
 @pytest.mark.parametrize(
+    ("exception_type", "error_message"),
+    [
+        (
+            RequestFailed(500, "Update rejected"),
+            "Controller firmware update request rejected",
+        ),
+        (
+            OmadaClientException("Connection error"),
+            "Unable to update the Omada controller firmware",
+        ),
+    ],
+)
+async def test_install_controller_firmware_exceptions(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    exception_type: Exception,
+    error_message: str,
+) -> None:
+    """Test hardware controller firmware installation exception handling."""
+    await _setup_controller_update(
+        hass,
+        mock_config_entry,
+        mock_omada_client,
+        {
+            "hardware": {
+                "upgrade": True,
+                "currentVersion": "1.28.2",
+                "latestVersion": "1.31.3",
+            }
+        },
+    )
+    mock_omada_client.upgrade_controller_firmware.side_effect = exception_type
+
+    entity_id = entity_registry.async_get_entity_id(
+        UPDATE_DOMAIN,
+        "tplink_omada",
+        "controller_12345_Default_firmware",
+    )
+    assert entity_id is not None
+
+    with pytest.raises(HomeAssistantError, match=error_message):
+        await hass.services.async_call(
+            UPDATE_DOMAIN,
+            SERVICE_INSTALL,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+
+
+@pytest.mark.parametrize(
     ("entity_name", "expected_notes"),
     [
         ("test_router", None),
@@ -202,3 +402,64 @@ async def test_release_notes(
     result = await client.receive_json()
 
     assert expected_notes == result["result"]
+
+
+@pytest.mark.parametrize(
+    ("update_data", "unique_id", "expected_notes"),
+    [
+        (
+            {
+                "hardware": {
+                    "upgrade": True,
+                    "currentVersion": "1.28.2",
+                    "latestVersion": "1.31.3",
+                    "fwReleaseLog": "Hardware controller release notes",
+                }
+            },
+            "controller_12345_Default_firmware",
+            "Hardware controller release notes",
+        ),
+        (
+            {
+                "software": {
+                    "upgrade": True,
+                    "currentVersion": "6.2.14",
+                    "latestVersion": "6.2.16",
+                    "releaseLog": "Software controller release notes",
+                }
+            },
+            "controller_12345_Default_firmware",
+            "Software controller release notes",
+        ),
+    ],
+)
+async def test_controller_release_notes(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_client: MagicMock,
+    update_data: dict,
+    unique_id: str,
+    expected_notes: str,
+) -> None:
+    """Test controller release notes."""
+    await _setup_controller_update(
+        hass, mock_config_entry, mock_omada_client, update_data
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        UPDATE_DOMAIN, "tplink_omada", unique_id
+    )
+    assert entity_id is not None
+
+    client = await hass_ws_client(hass)
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": entity_id,
+        }
+    )
+    result = await client.receive_json()
+
+    assert result["result"] == expected_notes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Represent the TP-Link Omada controller as its own Home Assistant device and expose controller-level entities backed by the controller APIs added in tplink-omada-client 1.5.9.

This adds:
- A controller device registered from the Omada controller ID and controller information.
- A controller device status diagnostic sensor, matching the existing device_status sensor convention used for Omada gateways, switches, and access points.
- A controller firmware update entity.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
