### PR TITLE
Add exception translations for Dropbox

### DIFF
--- a/homeassistant/components/dropbox/__init__.py
+++ b/homeassistant/components/dropbox/__init__.py
@@ -55,9 +55,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: DropboxConfigEntry) -> b
     try:
         await client.get_account_info()
     except DropboxAuthException as err:
-        raise ConfigEntryAuthFailed from err
+        raise ConfigEntryAuthFailed(
+            translation_domain=DOMAIN,
+            translation_key="authentication_failed",
+        ) from err
     except (DropboxUnknownException, TimeoutError) as err:
-        raise ConfigEntryNotReady from err
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="cannot_connect",
+        ) from err
 
     entry.runtime_data = client
 

--- a/homeassistant/components/dropbox/backup.py
+++ b/homeassistant/components/dropbox/backup.py
@@ -51,11 +51,13 @@ def handle_backup_errors[_R, **P](
         try:
             return await func(self, *args, **kwargs)
         except DropboxFileOrFolderNotFoundException as err:
+            # pylint: disable-next=home-assistant-exception-not-translated
             raise BackupNotFound(
                 f"Failed to {func.__name__.removeprefix('async_').replace('_', ' ')}"
             ) from err
         except DropboxAuthException as err:
             self._entry.async_start_reauth(self._hass)
+            # pylint: disable-next=home-assistant-exception-not-translated
             raise BackupAgentError("Authentication error") from err
         except DropboxUnknownException as err:
             _LOGGER.error(
@@ -64,6 +66,7 @@ def handle_backup_errors[_R, **P](
                 err,
             )
             _LOGGER.debug("Full error: %s", err, exc_info=True)
+            # pylint: disable-next=home-assistant-exception-not-translated
             raise BackupAgentError(
                 f"Failed to {func.__name__.removeprefix('async_').replace('_', ' ')}"
             ) from err
@@ -198,6 +201,7 @@ class DropboxBackupAgent(BackupAgent):
             if backup.backup_id == backup_id:
                 return self._api.download_file(f"/{filename}")
 
+        # pylint: disable-next=home-assistant-exception-not-translated
         raise BackupNotFound(f"Backup {backup_id} not found")
 
     @handle_backup_errors
@@ -214,6 +218,7 @@ class DropboxBackupAgent(BackupAgent):
             if backup.backup_id == backup_id:
                 return backup
 
+        # pylint: disable-next=home-assistant-exception-not-translated
         raise BackupNotFound(f"Backup {backup_id} not found")
 
     @handle_backup_errors
@@ -232,4 +237,5 @@ class DropboxBackupAgent(BackupAgent):
                 await self._api.delete_file(f"/{metadata_filename}")
                 return
 
+        # pylint: disable-next=home-assistant-exception-not-translated
         raise BackupNotFound(f"Backup {backup_id} not found")

--- a/homeassistant/components/dropbox/quality_scale.yaml
+++ b/homeassistant/components/dropbox/quality_scale.yaml
@@ -102,7 +102,7 @@ rules:
   entity-translations:
     status: exempt
     comment: Integration does not have any entities.
-  exception-translations: todo
+  exception-translations: done
   icon-translations:
     status: exempt
     comment: Integration does not have any entities.

--- a/homeassistant/components/dropbox/strings.json
+++ b/homeassistant/components/dropbox/strings.json
@@ -32,6 +32,12 @@
     }
   },
   "exceptions": {
+    "authentication_failed": {
+      "message": "Authentication with Dropbox failed"
+    },
+    "cannot_connect": {
+      "message": "Error communicating with Dropbox"
+    },
     "missing_refresh_token": {
       "message": "[%key:component::dropbox::config::step::reauth_confirm::description%]"
     },

--- a/tests/components/dropbox/test_init.py
+++ b/tests/components/dropbox/test_init.py
@@ -43,6 +43,7 @@ async def test_setup_entry_auth_failed(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+    assert mock_config_entry.error_reason_translation_key == "authentication_failed"
 
 
 @pytest.mark.parametrize(
@@ -63,6 +64,7 @@ async def test_setup_entry_not_ready(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+    assert mock_config_entry.error_reason_translation_key == "cannot_connect"
 
 
 async def test_setup_entry_implementation_unavailable(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add exception translations for Dropbox to satisfy the [quality scale rule](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/exception-translations/).

Add exception translations for two exceptions in `async_setup_entry()`.

Exceptions in `backup.py` were left untranslated to match other backup integrations.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
