### PR TITLE
rainbird: Add config option to display zones as switches or valves

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -295,9 +295,7 @@ def _async_migrate_zone_entity_type(
     inactive_domain = (
         Platform.VALVE if zone_type == ZONE_TYPE_SWITCH else Platform.SWITCH
     )
-    active_domain = (
-        Platform.SWITCH if zone_type == ZONE_TYPE_SWITCH else Platform.VALVE
-    )
+    active_domain = Platform.SWITCH if zone_type == ZONE_TYPE_SWITCH else Platform.VALVE
     entity_reg = er.async_get(hass)
     all_entries = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
 

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -25,7 +25,13 @@ from homeassistant.helpers import (
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.helpers.typing import ConfigType
 
-from .const import CONF_SERIAL_NUMBER, DOMAIN, TIMEOUT_SECONDS
+from .const import (
+    CONF_SERIAL_NUMBER,
+    CONF_ZONE_TYPE,
+    DOMAIN,
+    TIMEOUT_SECONDS,
+    ZONE_TYPE_SWITCH,
+)
 from .coordinator import (
     RainbirdScheduleUpdateCoordinator,
     RainbirdUpdateCoordinator,
@@ -131,6 +137,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: RainbirdConfigEntry) -> 
     await data.coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = data
+    _async_migrate_zone_entity_type(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
@@ -271,6 +278,25 @@ def _async_fix_device_id(
         device_registry.async_update_device(
             old_entry.id, new_identifiers={(DOMAIN, new_unique_id)}
         )
+
+
+def _async_migrate_zone_entity_type(
+    hass: HomeAssistant, entry: RainbirdConfigEntry
+) -> None:
+    """Remove entity registry entries for the inactive zone entity type.
+
+    When switching between switch and valve modes, a config entry reload
+    preserves the old platform's registry entries as unavailable. This removes
+    those stale entries so only the active platform's entities remain.
+    """
+    zone_type = entry.options.get(CONF_ZONE_TYPE, ZONE_TYPE_SWITCH)
+    inactive_domain = (
+        Platform.VALVE if zone_type == ZONE_TYPE_SWITCH else Platform.SWITCH
+    )
+    entity_reg = er.async_get(hass)
+    for entity_entry in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
+        if entity_entry.domain == inactive_domain:
+            entity_reg.async_remove(entity_entry.entity_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: RainbirdConfigEntry) -> bool:

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -137,8 +137,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: RainbirdConfigEntry) -> 
     await data.coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = data
-    _async_migrate_zone_entity_type(hass, entry)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    _async_migrate_zone_entity_type(hass, entry)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))
 
@@ -283,20 +283,49 @@ def _async_fix_device_id(
 def _async_migrate_zone_entity_type(
     hass: HomeAssistant, entry: RainbirdConfigEntry
 ) -> None:
-    """Remove entity registry entries for the inactive zone entity type.
+    """Migrate zone entity registry entries when switching between switch and valve.
 
-    When switching between switch and valve modes, a config entry reload
-    preserves the old platform's registry entries as unavailable. This removes
-    those stale entries so only the active platform's entities remain.
+    After platform setup, any active-domain entities already exist. Copy
+    user customizations (name, icon, area, visibility, labels) from the
+    corresponding inactive-domain entry to the new active-domain entry so
+    that switching type back and forth does not lose user settings. Then
+    remove the stale inactive-domain entries.
     """
     zone_type = entry.options.get(CONF_ZONE_TYPE, ZONE_TYPE_SWITCH)
     inactive_domain = (
         Platform.VALVE if zone_type == ZONE_TYPE_SWITCH else Platform.SWITCH
     )
+    active_domain = (
+        Platform.SWITCH if zone_type == ZONE_TYPE_SWITCH else Platform.VALVE
+    )
     entity_reg = er.async_get(hass)
-    for entity_entry in er.async_entries_for_config_entry(entity_reg, entry.entry_id):
-        if entity_entry.domain == inactive_domain:
-            entity_reg.async_remove(entity_entry.entity_id)
+    all_entries = er.async_entries_for_config_entry(entity_reg, entry.entry_id)
+
+    inactive: dict[str | None, er.RegistryEntry] = {
+        e.unique_id: e for e in all_entries if e.domain == inactive_domain
+    }
+    if not inactive:
+        return
+
+    # Copy customizations from old inactive entries to the new active entries.
+    for active_entry in all_entries:
+        if active_entry.domain != active_domain:
+            continue
+        old = inactive.get(active_entry.unique_id)
+        if old is None:
+            continue
+        entity_reg.async_update_entity(
+            active_entry.entity_id,
+            name=old.name,
+            icon=old.icon,
+            area_id=old.area_id,
+            disabled_by=old.disabled_by,
+            hidden_by=old.hidden_by,
+            labels=old.labels,
+        )
+
+    for old_entry in inactive.values():
+        entity_reg.async_remove(old_entry.entity_id)
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: RainbirdConfigEntry) -> bool:

--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -43,6 +43,7 @@ PLATFORMS = [
     Platform.NUMBER,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.VALVE,
 ]
 
 

--- a/homeassistant/components/rainbird/config_flow.py
+++ b/homeassistant/components/rainbird/config_flow.py
@@ -20,9 +20,12 @@ from . import RainbirdConfigEntry
 from .const import (
     ATTR_DURATION,
     CONF_SERIAL_NUMBER,
+    CONF_ZONE_TYPE,
     DEFAULT_TRIGGER_TIME_MINUTES,
     DOMAIN,
     TIMEOUT_SECONDS,
+    ZONE_TYPE_SWITCH,
+    ZONE_TYPE_VALVE,
 )
 from .coordinator import async_create_clientsession
 
@@ -120,7 +123,10 @@ class RainbirdConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                         CONF_SERIAL_NUMBER: serial_number,
                         CONF_MAC: wifi_params.mac_address,
                     },
-                    options={ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES},
+                    options={
+                        ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES,
+                        CONF_ZONE_TYPE: ZONE_TYPE_SWITCH,
+                    },
                 )
 
         return self.async_show_form(
@@ -211,6 +217,17 @@ class RainBirdOptionsFlowHandler(OptionsFlow):
                         ATTR_DURATION,
                         default=self.config_entry.options[ATTR_DURATION],
                     ): cv.positive_int,
+                    vol.Optional(
+                        CONF_ZONE_TYPE,
+                        default=self.config_entry.options.get(
+                            CONF_ZONE_TYPE, ZONE_TYPE_SWITCH
+                        ),
+                    ): selector.SelectSelector(
+                        selector.SelectSelectorConfig(
+                            options=[ZONE_TYPE_SWITCH, ZONE_TYPE_VALVE],
+                            translation_key="zone_type",
+                        )
+                    ),
                 }
             ),
         )

--- a/homeassistant/components/rainbird/const.py
+++ b/homeassistant/components/rainbird/const.py
@@ -6,6 +6,10 @@ DEFAULT_TRIGGER_TIME_MINUTES = 6
 
 CONF_SERIAL_NUMBER = "serial_number"
 CONF_IMPORTED_NAMES = "imported_names"
+CONF_ZONE_TYPE = "zone_type"
+
+ZONE_TYPE_SWITCH = "switch"
+ZONE_TYPE_VALVE = "valve"
 
 ATTR_DURATION = "duration"
 

--- a/homeassistant/components/rainbird/entity.py
+++ b/homeassistant/components/rainbird/entity.py
@@ -17,12 +17,8 @@ from .const import ATTR_DURATION, DOMAIN, MANUFACTURER
 from .coordinator import RainbirdUpdateCoordinator
 
 
-class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
-    """Representation of a Rain Bird valve."""
-
-    _attr_device_class = ValveDeviceClass.WATER
-    _attr_reports_position = False
-    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
+class RainBirdZoneEntity(CoordinatorEntity[RainbirdUpdateCoordinator]):
+    """Base entity for a Rain Bird irrigation zone."""
 
     def __init__(
         self,
@@ -31,7 +27,7 @@ class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
         duration_minutes: int,
         imported_name: str | None,
     ) -> None:
-        """Initialize a Rain Bird Valve Device."""
+        """Initialize a Rain Bird zone entity."""
         super().__init__(coordinator)
         self._zone = zone
         if coordinator.unique_id is not None:
@@ -58,9 +54,8 @@ class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
         """Return state attributes."""
         return {"zone": self._zone}
 
-    @override
-    async def async_open_valve(self, **kwargs: Any) -> None:
-        """Open the valve."""
+    async def _async_irrigate(self, **kwargs: Any) -> None:
+        """Start irrigation for this zone."""
         try:
             await self.coordinator.controller.irrigate_zone(
                 int(self._zone),
@@ -77,9 +72,8 @@ class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
-    @override
-    async def async_close_valve(self) -> None:
-        """Close the valve."""
+    async def _async_stop_irrigation(self) -> None:
+        """Stop irrigation for this zone."""
         try:
             await self.coordinator.controller.stop_irrigation()
         except RainbirdDeviceBusyException as err:
@@ -89,10 +83,28 @@ class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
         except RainbirdApiException as err:
             raise HomeAssistantError("Rain Bird device failure") from err
 
-        if self.is_closed is False:
+        if self._zone in self.coordinator.data.active_zones:
             self.coordinator.data.active_zones.remove(self._zone)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
+
+
+class RainBirdValve(RainBirdZoneEntity, ValveEntity):
+    """Representation of a Rain Bird valve."""
+
+    _attr_device_class = ValveDeviceClass.WATER
+    _attr_reports_position = False
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
+
+    @override
+    async def async_open_valve(self, **kwargs: Any) -> None:
+        """Open the valve."""
+        await self._async_irrigate(**kwargs)
+
+    @override
+    async def async_close_valve(self) -> None:
+        """Close the valve."""
+        await self._async_stop_irrigation()
 
     @property
     @override

--- a/homeassistant/components/rainbird/entity.py
+++ b/homeassistant/components/rainbird/entity.py
@@ -1,0 +1,101 @@
+"""Rain Bird entity classes."""
+
+from typing import Any, override
+
+from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
+
+from homeassistant.components.valve import (
+    ValveDeviceClass,
+    ValveEntity,
+    ValveEntityFeature,
+)
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import ATTR_DURATION, DOMAIN, MANUFACTURER
+from .coordinator import RainbirdUpdateCoordinator
+
+
+class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
+    """Representation of a Rain Bird valve."""
+
+    _attr_device_class = ValveDeviceClass.WATER
+    _attr_reports_position = False
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
+
+    def __init__(
+        self,
+        coordinator: RainbirdUpdateCoordinator,
+        zone: int,
+        duration_minutes: int,
+        imported_name: str | None,
+    ) -> None:
+        """Initialize a Rain Bird Valve Device."""
+        super().__init__(coordinator)
+        self._zone = zone
+        if coordinator.unique_id is not None:
+            self._attr_unique_id = f"{coordinator.unique_id}-{zone}"
+        device_name = f"{MANUFACTURER} Sprinkler {zone}"
+        if imported_name:
+            self._attr_name = imported_name
+            self._attr_has_entity_name = False
+        else:
+            self._attr_name = None if coordinator.unique_id is not None else device_name
+            self._attr_has_entity_name = True
+        self._duration_minutes = duration_minutes
+        if coordinator.unique_id is not None and self._attr_unique_id is not None:
+            self._attr_device_info = DeviceInfo(
+                name=device_name,
+                identifiers={(DOMAIN, self._attr_unique_id)},
+                manufacturer=MANUFACTURER,
+                via_device=(DOMAIN, coordinator.unique_id),
+            )
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return state attributes."""
+        return {"zone": self._zone}
+
+    @override
+    async def async_open_valve(self, **kwargs: Any) -> None:
+        """Open the valve."""
+        try:
+            await self.coordinator.controller.irrigate_zone(
+                int(self._zone),
+                int(kwargs.get(ATTR_DURATION, self._duration_minutes)),
+            )
+        except RainbirdDeviceBusyException as err:
+            raise HomeAssistantError(
+                "Rain Bird device is busy; Wait and try again"
+            ) from err
+        except RainbirdApiException as err:
+            raise HomeAssistantError("Rain Bird device failure") from err
+
+        self.coordinator.data.active_zones.add(self._zone)
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @override
+    async def async_close_valve(self) -> None:
+        """Close the valve."""
+        try:
+            await self.coordinator.controller.stop_irrigation()
+        except RainbirdDeviceBusyException as err:
+            raise HomeAssistantError(
+                "Rain Bird device is busy; Wait and try again"
+            ) from err
+        except RainbirdApiException as err:
+            raise HomeAssistantError("Rain Bird device failure") from err
+
+        if self.is_closed is False:
+            self.coordinator.data.active_zones.remove(self._zone)
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @property
+    @override
+    def is_closed(self) -> bool:
+        """Return true if valve is closed."""
+        return self._zone not in self.coordinator.data.active_zones

--- a/homeassistant/components/rainbird/services.py
+++ b/homeassistant/components/rainbird/services.py
@@ -4,10 +4,8 @@ from functools import partial
 
 import voluptuous as vol
 
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.components.switch import SwitchEntity
-from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
-from homeassistant.components.valve import ValveEntity
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN, ValveEntity
 from homeassistant.core import HassJob, HassJobType, HomeAssistant, ServiceCall, callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity

--- a/homeassistant/components/rainbird/services.py
+++ b/homeassistant/components/rainbird/services.py
@@ -6,7 +6,13 @@ import voluptuous as vol
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN, SwitchEntity
 from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN, ValveEntity
-from homeassistant.core import HassJob, HassJobType, HomeAssistant, ServiceCall, callback
+from homeassistant.core import (
+    HassJob,
+    HassJobType,
+    HomeAssistant,
+    ServiceCall,
+    callback,
+)
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES

--- a/homeassistant/components/rainbird/services.py
+++ b/homeassistant/components/rainbird/services.py
@@ -1,10 +1,18 @@
 """Rain Bird Irrigation system services."""
 
+from functools import partial
+
 import voluptuous as vol
 
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import config_validation as cv, service
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
+from homeassistant.components.valve import ValveEntity
+from homeassistant.core import HassJob, HassJobType, HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.entity_platform import DATA_DOMAIN_PLATFORM_ENTITIES
+from homeassistant.helpers.service import entity_service_call
 from homeassistant.helpers.typing import VolDictType
 
 from .const import ATTR_DURATION, DOMAIN
@@ -16,15 +24,36 @@ SERVICE_SCHEMA_IRRIGATION: VolDictType = {
 }
 
 
+def _get_rainbird_irrigation_entities(hass: HomeAssistant) -> dict[str, Entity]:
+    """Return all rainbird switch and valve entities eligible for irrigation."""
+    data = hass.data.get(DATA_DOMAIN_PLATFORM_ENTITIES, {})
+    entities: dict[str, Entity] = {}
+    entities.update(data.get((SWITCH_DOMAIN, DOMAIN), {}))
+    entities.update(data.get((VALVE_DOMAIN, DOMAIN), {}))
+    return entities
+
+
+async def _async_start_irrigation(entity: Entity, service_call: ServiceCall) -> None:
+    """Start irrigation on a switch or valve entity."""
+    if isinstance(entity, ValveEntity):
+        await entity.async_open_valve(**service_call.data)
+    elif isinstance(entity, SwitchEntity):
+        await entity.async_turn_on(**service_call.data)
+
+
 @callback
 def async_setup_services(hass: HomeAssistant) -> None:
     """Set up services."""
 
-    service.async_register_platform_entity_service(
-        hass,
+    hass.services.async_register(
         DOMAIN,
         SERVICE_START_IRRIGATION,
-        entity_domain=SWITCH_DOMAIN,
-        schema=SERVICE_SCHEMA_IRRIGATION,
-        func="async_turn_on",
+        partial(
+            entity_service_call,
+            hass,
+            partial(_get_rainbird_irrigation_entities, hass),
+            HassJob(_async_start_irrigation),
+        ),
+        cv.make_entity_service_schema(SERVICE_SCHEMA_IRRIGATION),
+        job_type=HassJobType.Coroutinefunction,
     )

--- a/homeassistant/components/rainbird/services.yaml
+++ b/homeassistant/components/rainbird/services.yaml
@@ -2,7 +2,9 @@ start_irrigation:
   target:
     entity:
       integration: rainbird
-      domain: switch
+      domain:
+        - switch
+        - valve
   fields:
     duration:
       required: true

--- a/homeassistant/components/rainbird/strings.json
+++ b/homeassistant/components/rainbird/strings.json
@@ -55,12 +55,22 @@
     "step": {
       "init": {
         "data": {
-          "duration": "Default irrigation time in minutes"
+          "duration": "Default irrigation time in minutes",
+          "zone_type": "Zone entity type"
         },
         "data_description": {
-          "duration": "The default duration the sprinkler will run when turned on."
+          "duration": "The default duration the sprinkler will run when turned on.",
+          "zone_type": "Whether sprinkler zones are exposed as switches or valves."
         },
         "title": "[%key:component::rainbird::config::step::user::title%]"
+      }
+    }
+  },
+  "selector": {
+    "zone_type": {
+      "options": {
+        "switch": "Switch",
+        "valve": "Valve"
       }
     }
   },

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -6,12 +6,7 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import (
-    ATTR_DURATION,
-    CONF_IMPORTED_NAMES,
-    CONF_ZONE_TYPE,
-    ZONE_TYPE_VALVE,
-)
+from .const import ATTR_DURATION, CONF_IMPORTED_NAMES, CONF_ZONE_TYPE, ZONE_TYPE_VALVE
 from .entity import RainBirdZoneEntity
 from .types import RainbirdConfigEntry
 

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -1,29 +1,19 @@
 """Support for Rain Bird Irrigation system LNK Wi-Fi Module."""
 
-import logging
 from typing import Any, override
-
-from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_DURATION,
     CONF_IMPORTED_NAMES,
     CONF_ZONE_TYPE,
-    DOMAIN,
-    MANUFACTURER,
     ZONE_TYPE_VALVE,
 )
-from .coordinator import RainbirdUpdateCoordinator
+from .entity import RainBirdZoneEntity
 from .types import RainbirdConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -46,83 +36,18 @@ async def async_setup_entry(
     )
 
 
-class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity):
+class RainBirdSwitch(RainBirdZoneEntity, SwitchEntity):
     """Representation of a Rain Bird switch."""
-
-    def __init__(
-        self,
-        coordinator: RainbirdUpdateCoordinator,
-        zone: int,
-        duration_minutes: int,
-        imported_name: str | None,
-    ) -> None:
-        """Initialize a Rain Bird Switch Device."""
-        super().__init__(coordinator)
-        self._zone = zone
-        _LOGGER.debug("coordinator.unique_id=%s", coordinator.unique_id)
-        if coordinator.unique_id is not None:
-            self._attr_unique_id = f"{coordinator.unique_id}-{zone}"
-        device_name = f"{MANUFACTURER} Sprinkler {zone}"
-        if imported_name:
-            self._attr_name = imported_name
-            self._attr_has_entity_name = False
-        else:
-            self._attr_name = None if coordinator.unique_id is not None else device_name
-            self._attr_has_entity_name = True
-        self._duration_minutes = duration_minutes
-        if coordinator.unique_id is not None and self._attr_unique_id is not None:
-            self._attr_device_info = DeviceInfo(
-                name=device_name,
-                identifiers={(DOMAIN, self._attr_unique_id)},
-                manufacturer=MANUFACTURER,
-                via_device=(DOMAIN, coordinator.unique_id),
-            )
-
-    @property
-    @override
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return state attributes."""
-        return {"zone": self._zone}
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
-        try:
-            await self.coordinator.controller.irrigate_zone(
-                int(self._zone),
-                int(kwargs.get(ATTR_DURATION, self._duration_minutes)),
-            )
-        except RainbirdDeviceBusyException as err:
-            raise HomeAssistantError(
-                "Rain Bird device is busy; Wait and try again"
-            ) from err
-        except RainbirdApiException as err:
-            raise HomeAssistantError("Rain Bird device failure") from err
-
-        # The device reflects the old state for a few moments. Update the
-        # state manually and trigger a refresh after a short debounced delay.
-        self.coordinator.data.active_zones.add(self._zone)
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        await self._async_irrigate(**kwargs)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
-        try:
-            await self.coordinator.controller.stop_irrigation()
-        except RainbirdDeviceBusyException as err:
-            raise HomeAssistantError(
-                "Rain Bird device is busy; Wait and try again"
-            ) from err
-        except RainbirdApiException as err:
-            raise HomeAssistantError("Rain Bird device failure") from err
-
-        # The device reflects the old state for a few moments. Update the
-        # state manually and trigger a refresh after a short debounced delay.
-        if self.is_on:
-            self.coordinator.data.active_zones.remove(self._zone)
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
+        await self._async_stop_irrigation()
 
     @property
     @override

--- a/homeassistant/components/rainbird/valve.py
+++ b/homeassistant/components/rainbird/valve.py
@@ -1,30 +1,12 @@
 """Support for Rain Bird Irrigation system LNK Wi-Fi Module."""
 
 import logging
-from typing import Any, override
 
-from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
-
-from homeassistant.components.valve import (
-    ValveDeviceClass,
-    ValveEntity,
-    ValveEntityFeature,
-)
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    ATTR_DURATION,
-    CONF_IMPORTED_NAMES,
-    CONF_ZONE_TYPE,
-    DOMAIN,
-    MANUFACTURER,
-    ZONE_TYPE_VALVE,
-)
-from .coordinator import RainbirdUpdateCoordinator
+from .const import ATTR_DURATION, CONF_IMPORTED_NAMES, CONF_ZONE_TYPE, ZONE_TYPE_VALVE
+from .entity import RainBirdValve
 from .types import RainbirdConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
@@ -50,87 +32,3 @@ async def async_setup_entry(
         )
         for zone in coordinator.data.zones
     )
-
-
-class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
-    """Representation of a Rain Bird valve."""
-
-    _attr_device_class = ValveDeviceClass.WATER
-    _attr_reports_position = False
-    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
-
-    def __init__(
-        self,
-        coordinator: RainbirdUpdateCoordinator,
-        zone: int,
-        duration_minutes: int,
-        imported_name: str | None,
-    ) -> None:
-        """Initialize a Rain Bird Valve Device."""
-        super().__init__(coordinator)
-        self._zone = zone
-        if coordinator.unique_id is not None:
-            self._attr_unique_id = f"{coordinator.unique_id}-{zone}"
-        device_name = f"{MANUFACTURER} Sprinkler {zone}"
-        if imported_name:
-            self._attr_name = imported_name
-            self._attr_has_entity_name = False
-        else:
-            self._attr_name = None if coordinator.unique_id is not None else device_name
-            self._attr_has_entity_name = True
-        self._duration_minutes = duration_minutes
-        if coordinator.unique_id is not None and self._attr_unique_id is not None:
-            self._attr_device_info = DeviceInfo(
-                name=device_name,
-                identifiers={(DOMAIN, self._attr_unique_id)},
-                manufacturer=MANUFACTURER,
-                via_device=(DOMAIN, coordinator.unique_id),
-            )
-
-    @property
-    @override
-    def extra_state_attributes(self) -> dict[str, Any]:
-        """Return state attributes."""
-        return {"zone": self._zone}
-
-    @override
-    async def async_open_valve(self, **kwargs: Any) -> None:
-        """Open the valve."""
-        try:
-            await self.coordinator.controller.irrigate_zone(
-                int(self._zone),
-                int(kwargs.get(ATTR_DURATION, self._duration_minutes)),
-            )
-        except RainbirdDeviceBusyException as err:
-            raise HomeAssistantError(
-                "Rain Bird device is busy; Wait and try again"
-            ) from err
-        except RainbirdApiException as err:
-            raise HomeAssistantError("Rain Bird device failure") from err
-
-        self.coordinator.data.active_zones.add(self._zone)
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
-
-    @override
-    async def async_close_valve(self) -> None:
-        """Close the valve."""
-        try:
-            await self.coordinator.controller.stop_irrigation()
-        except RainbirdDeviceBusyException as err:
-            raise HomeAssistantError(
-                "Rain Bird device is busy; Wait and try again"
-            ) from err
-        except RainbirdApiException as err:
-            raise HomeAssistantError("Rain Bird device failure") from err
-
-        if self.is_closed is False:
-            self.coordinator.data.active_zones.remove(self._zone)
-        self.async_write_ha_state()
-        await self.coordinator.async_request_refresh()
-
-    @property
-    @override
-    def is_closed(self) -> bool:
-        """Return true if valve is closed."""
-        return self._zone not in self.coordinator.data.active_zones

--- a/homeassistant/components/rainbird/valve.py
+++ b/homeassistant/components/rainbird/valve.py
@@ -1,15 +1,11 @@
 """Support for Rain Bird Irrigation system LNK Wi-Fi Module."""
 
-import logging
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import ATTR_DURATION, CONF_IMPORTED_NAMES, CONF_ZONE_TYPE, ZONE_TYPE_VALVE
 from .entity import RainBirdValve
 from .types import RainbirdConfigEntry
-
-_LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 1
 

--- a/homeassistant/components/rainbird/valve.py
+++ b/homeassistant/components/rainbird/valve.py
@@ -5,7 +5,11 @@ from typing import Any, override
 
 from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyException
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.valve import (
+    ValveDeviceClass,
+    ValveEntity,
+    ValveEntityFeature,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -31,12 +35,12 @@ async def async_setup_entry(
     config_entry: RainbirdConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    """Set up entry for a Rain Bird irrigation switches."""
-    if config_entry.options.get(CONF_ZONE_TYPE) == ZONE_TYPE_VALVE:
+    """Set up entry for Rain Bird irrigation valves."""
+    if config_entry.options.get(CONF_ZONE_TYPE) != ZONE_TYPE_VALVE:
         return
     coordinator = config_entry.runtime_data.coordinator
     async_add_entities(
-        RainBirdSwitch(
+        RainBirdValve(
             coordinator,
             zone,
             config_entry.options[ATTR_DURATION],
@@ -46,8 +50,12 @@ async def async_setup_entry(
     )
 
 
-class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity):
-    """Representation of a Rain Bird switch."""
+class RainBirdValve(CoordinatorEntity[RainbirdUpdateCoordinator], ValveEntity):
+    """Representation of a Rain Bird valve."""
+
+    _attr_device_class = ValveDeviceClass.WATER
+    _attr_reports_position = False
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
 
     def __init__(
         self,
@@ -56,10 +64,9 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         duration_minutes: int,
         imported_name: str | None,
     ) -> None:
-        """Initialize a Rain Bird Switch Device."""
+        """Initialize a Rain Bird Valve Device."""
         super().__init__(coordinator)
         self._zone = zone
-        _LOGGER.debug("coordinator.unique_id=%s", coordinator.unique_id)
         if coordinator.unique_id is not None:
             self._attr_unique_id = f"{coordinator.unique_id}-{zone}"
         device_name = f"{MANUFACTURER} Sprinkler {zone}"
@@ -85,8 +92,8 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         return {"zone": self._zone}
 
     @override
-    async def async_turn_on(self, **kwargs: Any) -> None:
-        """Turn the switch on."""
+    async def async_open_valve(self, **kwargs: Any) -> None:
+        """Open the valve."""
         try:
             await self.coordinator.controller.irrigate_zone(
                 int(self._zone),
@@ -99,15 +106,13 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         except RainbirdApiException as err:
             raise HomeAssistantError("Rain Bird device failure") from err
 
-        # The device reflects the old state for a few moments. Update the
-        # state manually and trigger a refresh after a short debounced delay.
         self.coordinator.data.active_zones.add(self._zone)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     @override
-    async def async_turn_off(self, **kwargs: Any) -> None:
-        """Turn the switch off."""
+    async def async_close_valve(self) -> None:
+        """Close the valve."""
         try:
             await self.coordinator.controller.stop_irrigation()
         except RainbirdDeviceBusyException as err:
@@ -117,15 +122,13 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
         except RainbirdApiException as err:
             raise HomeAssistantError("Rain Bird device failure") from err
 
-        # The device reflects the old state for a few moments. Update the
-        # state manually and trigger a refresh after a short debounced delay.
-        if self.is_on:
+        if self.is_closed is False:
             self.coordinator.data.active_zones.remove(self._zone)
         self.async_write_ha_state()
         await self.coordinator.async_request_refresh()
 
     @property
     @override
-    def is_on(self) -> bool:
-        """Return true if switch is on."""
-        return self._zone in self.coordinator.data.active_zones
+    def is_closed(self) -> bool:
+        """Return true if valve is closed."""
+        return self._zone not in self.coordinator.data.active_zones

--- a/homeassistant/components/rainbird/valve.py
+++ b/homeassistant/components/rainbird/valve.py
@@ -29,6 +29,8 @@ from .types import RainbirdConfigEntry
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -114,6 +114,7 @@ async def test_controller_flow(
     assert "result" in result
     assert dict(result["result"].data) == expected_config_entry
     assert result["result"].options == {ATTR_DURATION: 6, "zone_type": "switch"}
+    assert result["result"].unique_id == expected_unique_id
 
     assert len(mock_setup.mock_calls) == 1
 
@@ -495,4 +496,35 @@ async def test_options_flow(hass: HomeAssistant, mock_setup: Mock) -> None:
     assert config_entry.options == {
         ATTR_DURATION: 5,
         "zone_type": "switch",
+    }
+
+
+async def test_options_flow_valve(hass: HomeAssistant, mock_setup: Mock) -> None:
+    """Test config flow options with valve zone type."""
+
+    # Setup config flow
+    result = await complete_flow(hass)
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert result.get("title") == HOST
+    assert "result" in result
+    assert result["result"].data == CONFIG_ENTRY_DATA
+    assert result["result"].options == {ATTR_DURATION: 6, "zone_type": "switch"}
+
+    # Assert single config entry is loaded
+    config_entry = next(iter(hass.config_entries.async_entries(DOMAIN)))
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Initiate the options flow
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result.get("type") is FlowResultType.FORM
+    assert result.get("step_id") == "init"
+
+    # Switch to valve zone type
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={ATTR_DURATION: 6, "zone_type": "valve"}
+    )
+    assert result.get("type") is FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {
+        ATTR_DURATION: 6,
+        "zone_type": "valve",
     }

--- a/tests/components/rainbird/test_config_flow.py
+++ b/tests/components/rainbird/test_config_flow.py
@@ -113,8 +113,7 @@ async def test_controller_flow(
     assert result.get("title") == HOST
     assert "result" in result
     assert dict(result["result"].data) == expected_config_entry
-    assert result["result"].options == {ATTR_DURATION: 6}
-    assert result["result"].unique_id == expected_unique_id
+    assert result["result"].options == {ATTR_DURATION: 6, "zone_type": "switch"}
 
     assert len(mock_setup.mock_calls) == 1
 
@@ -477,7 +476,7 @@ async def test_options_flow(hass: HomeAssistant, mock_setup: Mock) -> None:
     assert result.get("title") == HOST
     assert "result" in result
     assert result["result"].data == CONFIG_ENTRY_DATA
-    assert result["result"].options == {ATTR_DURATION: 6}
+    assert result["result"].options == {ATTR_DURATION: 6, "zone_type": "switch"}
 
     # Assert single config entry is loaded
     config_entry = next(iter(hass.config_entries.async_entries(DOMAIN)))
@@ -490,9 +489,10 @@ async def test_options_flow(hass: HomeAssistant, mock_setup: Mock) -> None:
 
     # Change the default duration
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={ATTR_DURATION: 5}
+        result["flow_id"], user_input={ATTR_DURATION: 5, "zone_type": "switch"}
     )
     assert result.get("type") is FlowResultType.CREATE_ENTRY
     assert config_entry.options == {
         ATTR_DURATION: 5,
+        "zone_type": "switch",
     }

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -7,7 +7,14 @@ from unittest.mock import patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from homeassistant.components.rainbird.const import DOMAIN
+from homeassistant.components.rainbird.const import (
+    ATTR_DURATION,
+    CONF_ZONE_TYPE,
+    DEFAULT_TRIGGER_TIME_MINUTES,
+    DOMAIN,
+    ZONE_TYPE_SWITCH,
+    ZONE_TYPE_VALVE,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_MAC, Platform
 from homeassistant.core import HomeAssistant
@@ -577,3 +584,80 @@ async def test_options_listener(
 
     # The entry should have been reloaded
     assert len(mock_setup_entry.mock_calls) == 1
+
+
+@pytest.mark.parametrize(
+    ("config_entry_data", "config_entry_unique_id"),
+    [(None, None)],
+    ids=["no_default_entry"],
+)
+@pytest.mark.parametrize(
+    ("initial_zone_type", "target_zone_type", "initial_entity_id", "target_entity_id"),
+    [
+        pytest.param(
+            ZONE_TYPE_SWITCH,
+            ZONE_TYPE_VALVE,
+            "switch.rain_bird_sprinkler_1",
+            "valve.rain_bird_sprinkler_1",
+            id="switch_to_valve",
+        ),
+        pytest.param(
+            ZONE_TYPE_VALVE,
+            ZONE_TYPE_SWITCH,
+            "valve.rain_bird_sprinkler_1",
+            "switch.rain_bird_sprinkler_1",
+            id="valve_to_switch",
+        ),
+    ],
+)
+@pytest.mark.parametrize("platforms", [[Platform.SWITCH, Platform.VALVE]])
+async def test_zone_type_change(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    responses: list[AiohttpClientMockResponse],
+    api_responses: list[str],
+    initial_zone_type: str,
+    target_zone_type: str,
+    initial_entity_id: str,
+    target_entity_id: str,
+) -> None:
+    """Test that changing zone type migrates entity registry entries."""
+    config_entry = MockConfigEntry(
+        unique_id=MAC_ADDRESS_UNIQUE_ID,
+        domain=DOMAIN,
+        data=CONFIG_ENTRY_DATA,
+        options={
+            ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES,
+            CONF_ZONE_TYPE: initial_zone_type,
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    # Provide responses for both the initial setup and the reload.
+    responses.extend([mock_response(r) for r in api_responses])
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # Only the initial entity type is present.
+    assert hass.states.get(initial_entity_id) is not None
+    assert hass.states.get(target_entity_id) is None
+
+    # Change zone type via options flow, which triggers a reload.
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES,
+            CONF_ZONE_TYPE: target_zone_type,
+        },
+    )
+    await hass.async_block_till_done()
+
+    # After reload: target entity exists, initial entity removed from state and registry.
+    assert hass.states.get(initial_entity_id) is None
+    assert hass.states.get(target_entity_id) is not None
+    assert entity_registry.async_get(initial_entity_id) is None
+    assert entity_registry.async_get(target_entity_id) is not None
+

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -660,4 +660,3 @@ async def test_zone_type_change(
     assert hass.states.get(target_entity_id) is not None
     assert entity_registry.async_get(initial_entity_id) is None
     assert entity_registry.async_get(target_entity_id) is not None
-

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -644,6 +644,13 @@ async def test_zone_type_change(
     assert hass.states.get(initial_entity_id) is not None
     assert hass.states.get(target_entity_id) is None
 
+    # Apply user customizations to the initial entity so the migration can be verified.
+    entity_registry.async_update_entity(
+        initial_entity_id,
+        name="Front Yard Zone",
+        icon="mdi:sprinkler-variant",
+    )
+
     # Change zone type via options flow, which triggers a reload.
     result = await hass.config_entries.options.async_init(config_entry.entry_id)
     result = await hass.config_entries.options.async_configure(
@@ -659,4 +666,9 @@ async def test_zone_type_change(
     assert hass.states.get(initial_entity_id) is None
     assert hass.states.get(target_entity_id) is not None
     assert entity_registry.async_get(initial_entity_id) is None
-    assert entity_registry.async_get(target_entity_id) is not None
+
+    # Verify customizations were carried over to the replacement entity.
+    target_entry = entity_registry.async_get(target_entity_id)
+    assert target_entry is not None
+    assert target_entry.name == "Front Yard Zone"
+    assert target_entry.icon == "mdi:sprinkler-variant"

--- a/tests/components/rainbird/test_valve.py
+++ b/tests/components/rainbird/test_valve.py
@@ -4,6 +4,13 @@ from http import HTTPStatus
 
 import pytest
 
+from homeassistant.components.rainbird.const import (
+    ATTR_DURATION,
+    CONF_ZONE_TYPE,
+    DEFAULT_TRIGGER_TIME_MINUTES,
+    DOMAIN,
+    ZONE_TYPE_VALVE,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
@@ -20,13 +27,6 @@ from .conftest import (
     ZONE_OFF_RESPONSE,
     mock_response,
     mock_response_error,
-)
-from homeassistant.components.rainbird.const import (
-    ATTR_DURATION,
-    CONF_ZONE_TYPE,
-    DEFAULT_TRIGGER_TIME_MINUTES,
-    DOMAIN,
-    ZONE_TYPE_VALVE,
 )
 
 from tests.common import MockConfigEntry

--- a/tests/components/rainbird/test_valve.py
+++ b/tests/components/rainbird/test_valve.py
@@ -25,6 +25,7 @@ from homeassistant.components.rainbird.const import (
     ATTR_DURATION,
     CONF_ZONE_TYPE,
     DEFAULT_TRIGGER_TIME_MINUTES,
+    DOMAIN,
     ZONE_TYPE_VALVE,
 )
 
@@ -46,7 +47,7 @@ async def config_entry(
     """Fixture for MockConfigEntry with valve zone type."""
     return MockConfigEntry(
         unique_id=config_entry_unique_id,
-        domain="rainbird",
+        domain=DOMAIN,
         data=config_entry_data,
         options={
             ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES,
@@ -206,3 +207,35 @@ async def test_valve_error(
             {ATTR_ENTITY_ID: "valve.rain_bird_sprinkler_3"},
             blocking=True,
         )
+
+
+async def test_irrigation_service(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test calling the start_irrigation service in valve mode."""
+    zone = hass.states.get("valve.rain_bird_sprinkler_3")
+    assert zone is not None
+    assert zone.state == "closed"
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend(
+        [
+            mock_response(ACK_ECHO),
+            mock_response(ZONE_3_ON_RESPONSE),
+            mock_response(RAIN_SENSOR_OFF),
+            mock_response(RAIN_DELAY_OFF),
+        ]
+    )
+
+    await hass.services.async_call(
+        DOMAIN,
+        "start_irrigation",
+        {ATTR_ENTITY_ID: "valve.rain_bird_sprinkler_3", "duration": 30},
+        blocking=True,
+    )
+
+    zone = hass.states.get("valve.rain_bird_sprinkler_3")
+    assert zone is not None
+    assert zone.state == "open"

--- a/tests/components/rainbird/test_valve.py
+++ b/tests/components/rainbird/test_valve.py
@@ -1,0 +1,208 @@
+"""Tests for rainbird valve platform."""
+
+from http import HTTPStatus
+
+import pytest
+
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+
+from .conftest import (
+    ACK_ECHO,
+    EMPTY_STATIONS_RESPONSE,
+    RAIN_DELAY_OFF,
+    RAIN_SENSOR_OFF,
+    ZONE_3_ON_RESPONSE,
+    ZONE_5_ON_RESPONSE,
+    ZONE_OFF_RESPONSE,
+    mock_response,
+    mock_response_error,
+)
+from homeassistant.components.rainbird.const import (
+    ATTR_DURATION,
+    CONF_ZONE_TYPE,
+    DEFAULT_TRIGGER_TIME_MINUTES,
+    ZONE_TYPE_VALVE,
+)
+
+from tests.common import MockConfigEntry
+from tests.test_util.aiohttp import AiohttpClientMocker, AiohttpClientMockResponse
+
+
+@pytest.fixture
+def platforms() -> list[str]:
+    """Fixture to specify platforms to test."""
+    return [Platform.VALVE]
+
+
+@pytest.fixture
+async def config_entry(
+    config_entry_data: dict,
+    config_entry_unique_id: str | None,
+) -> MockConfigEntry:
+    """Fixture for MockConfigEntry with valve zone type."""
+    return MockConfigEntry(
+        unique_id=config_entry_unique_id,
+        domain="rainbird",
+        data=config_entry_data,
+        options={
+            ATTR_DURATION: DEFAULT_TRIGGER_TIME_MINUTES,
+            CONF_ZONE_TYPE: ZONE_TYPE_VALVE,
+        },
+    )
+
+
+@pytest.fixture(autouse=True)
+async def setup_config_entry(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> list[Platform]:
+    """Fixture to setup the config entry."""
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.parametrize(
+    "stations_response",
+    [EMPTY_STATIONS_RESPONSE],
+)
+async def test_no_zones(
+    hass: HomeAssistant,
+) -> None:
+    """Test case where listing stations returns no stations."""
+    assert hass.states.get("valve.rain_bird_sprinkler_1") is None
+
+
+@pytest.mark.parametrize(
+    "zone_state_response",
+    [ZONE_5_ON_RESPONSE],
+)
+async def test_zones(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test valve platform with fake data that creates 7 zones with one open."""
+    zone = hass.states.get("valve.rain_bird_sprinkler_1")
+    assert zone is not None
+    assert zone.state == "closed"
+    assert zone.attributes.get("zone") == 1
+
+    zone = hass.states.get("valve.rain_bird_sprinkler_5")
+    assert zone is not None
+    assert zone.state == "open"
+
+    assert not hass.states.get("valve.rain_bird_sprinkler_8")
+
+    entity_entry = entity_registry.async_get("valve.rain_bird_sprinkler_3")
+    assert entity_entry.unique_id == "4c:a1:61:00:11:22-3"
+
+
+async def test_valve_open(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+) -> None:
+    """Test opening an irrigation valve."""
+    zone = hass.states.get("valve.rain_bird_sprinkler_3")
+    assert zone is not None
+    assert zone.state == "closed"
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend(
+        [
+            mock_response(ACK_ECHO),
+            mock_response(ZONE_3_ON_RESPONSE),
+            mock_response(RAIN_SENSOR_OFF),
+            mock_response(RAIN_DELAY_OFF),
+        ]
+    )
+    await hass.services.async_call(
+        "valve",
+        "open_valve",
+        {ATTR_ENTITY_ID: "valve.rain_bird_sprinkler_3"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    zone = hass.states.get("valve.rain_bird_sprinkler_3")
+    assert zone is not None
+    assert zone.state == "open"
+
+
+@pytest.mark.parametrize(
+    ("zone_state_response", "start_state"),
+    [
+        pytest.param(ZONE_3_ON_RESPONSE, "open", id="zone_open"),
+        pytest.param(ZONE_OFF_RESPONSE, "closed", id="zone_closed"),
+    ],
+)
+async def test_valve_close(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+    start_state: str,
+) -> None:
+    """Test closing an irrigation valve."""
+    zone = hass.states.get("valve.rain_bird_sprinkler_3")
+    assert zone is not None
+    assert zone.state == start_state
+
+    aioclient_mock.mock_calls.clear()
+    responses.extend(
+        [
+            mock_response(ACK_ECHO),
+            mock_response(ZONE_OFF_RESPONSE),
+            mock_response(RAIN_SENSOR_OFF),
+            mock_response(RAIN_DELAY_OFF),
+        ]
+    )
+    await hass.services.async_call(
+        "valve",
+        "close_valve",
+        {ATTR_ENTITY_ID: "valve.rain_bird_sprinkler_3"},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    zone = hass.states.get("valve.rain_bird_sprinkler_3")
+    assert zone is not None
+    assert zone.state == "closed"
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_msg"),
+    [
+        (HTTPStatus.SERVICE_UNAVAILABLE, "Rain Bird device is busy"),
+        (HTTPStatus.INTERNAL_SERVER_ERROR, "Rain Bird device failure"),
+    ],
+)
+async def test_valve_error(
+    hass: HomeAssistant,
+    aioclient_mock: AiohttpClientMocker,
+    responses: list[AiohttpClientMockResponse],
+    status: HTTPStatus,
+    expected_msg: str,
+) -> None:
+    """Test an error talking to the device."""
+    aioclient_mock.mock_calls.clear()
+    responses.append(mock_response_error(status=status))
+
+    with pytest.raises(HomeAssistantError, match=expected_msg):
+        await hass.services.async_call(
+            "valve",
+            "open_valve",
+            {ATTR_ENTITY_ID: "valve.rain_bird_sprinkler_3"},
+            blocking=True,
+        )
+
+    responses.append(mock_response_error(status=status))
+
+    with pytest.raises(HomeAssistantError, match=expected_msg):
+        await hass.services.async_call(
+            "valve",
+            "close_valve",
+            {ATTR_ENTITY_ID: "valve.rain_bird_sprinkler_3"},
+            blocking=True,
+        )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a new options flow setting (`zone_type`) that lets users choose whether Rain Bird sprinkler zones are exposed as **Switch** entities (default, preserving existing behavior) or **Valve** entities.

When the setting is changed, the existing `async_update_listener` triggers a config entry reload, which cleanly removes the old entities and creates the new ones.

The `start_irrigation` custom service works in both modes — it dispatches to `async_turn_on` for switches and `async_open_valve` for valves, so automations using `rainbird.start_irrigation` continue to work regardless of which zone type is selected.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47084
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
