### PR TITLE
Fetch Reolink recordings over Baichuan in the playback proxy

### DIFF
--- a/homeassistant/components/reolink/views.py
+++ b/homeassistant/components/reolink/views.py
@@ -1,8 +1,17 @@
 """Reolink Integration views."""
 
+import asyncio
 from base64 import urlsafe_b64decode, urlsafe_b64encode
+from contextlib import aclosing, suppress
+from enum import Enum, auto
+import hashlib
 from http import HTTPStatus
 import logging
+import os
+from pathlib import Path
+import tempfile
+import time
+from typing import IO, Any
 
 from aiohttp import ClientError, ClientTimeout, web
 from reolink_aio.enums import VodRequestType
@@ -14,9 +23,110 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.ssl import SSLCipherList
 
+from .host import ReolinkHost
 from .util import get_host
 
 _LOGGER = logging.getLogger(__name__)
+
+VOD_CACHE_DIR = "reolink_vod"
+VOD_CACHE_MAX_AGE = 3600.0
+VOD_CACHE_MAX_BYTES = 2 * 1024**3
+VOD_WRITE_BUFFER = 4 * 1024**2
+VOD_CACHE_GRACE = 60.0
+
+
+class _CacheState(Enum):
+    """What a request can do with the recording it asked for."""
+
+    CACHED = auto()
+    DOWNLOAD = auto()
+    FULL = auto()
+
+
+def _open_part(cache_dir: Path) -> tuple[IO[bytes], Path]:
+    """Create the temporary file a recording is downloaded into."""
+    cache_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, name = tempfile.mkstemp(dir=cache_dir, suffix=".part")
+    return os.fdopen(descriptor, "wb"), Path(name)
+
+
+def _discard_part(handle: IO[bytes], part: Path) -> None:
+    """Close and remove a partially downloaded recording, never raising."""
+    with suppress(OSError):
+        handle.close()
+    with suppress(OSError):
+        part.unlink(missing_ok=True)
+
+
+def _finish_part(handle: IO[bytes], part: Path, path: Path) -> bool:
+    """Move a completed download into the cache."""
+    try:
+        handle.close()
+        part.replace(path)
+    except OSError:
+        _discard_part(handle, part)
+        return False
+    return True
+
+
+def _prepare_cache(path: Path, size: int, serving: set[Path]) -> _CacheState:
+    """Prune the cache and report what can be done with this recording."""
+    now = time.time()
+    try:
+        stat = path.stat()
+    except OSError:
+        pass
+    else:
+        if stat.st_size == size and now - stat.st_mtime <= VOD_CACHE_MAX_AGE:
+            return _CacheState.CACHED
+        with suppress(OSError):
+            path.unlink(missing_ok=True)
+
+    if _prune_cache(path.parent, size, serving):
+        return _CacheState.DOWNLOAD
+    return _CacheState.FULL
+
+
+def _prune_cache(cache_dir: Path, size: int, serving: set[Path]) -> bool:
+    """Drop aged out and excess recordings, reporting whether size still fits."""
+    now = time.time()
+    try:
+        contents = list(cache_dir.iterdir())
+    except OSError:
+        return True
+
+    used = 0
+    entries: list[tuple[float, int, Path]] = []
+    for item in contents:
+        try:
+            stat = item.stat()
+        except OSError:
+            continue
+        if item.suffix == ".part":
+            # only a part left behind by an interrupted download gets this old
+            if now - stat.st_mtime > VOD_CACHE_MAX_AGE:
+                with suppress(OSError):
+                    item.unlink()
+                    continue
+            used += stat.st_size
+            continue
+        entries.append((stat.st_mtime, stat.st_size, item))
+
+    for mtime, cached, item in sorted(
+        entries, key=lambda entry: entry[0], reverse=True
+    ):
+        # one just handed to a response may still be on its way to a client
+        expendable = item not in serving and now - mtime > VOD_CACHE_GRACE
+        if expendable and (
+            now - mtime > VOD_CACHE_MAX_AGE
+            or used + cached + size > VOD_CACHE_MAX_BYTES
+        ):
+            with suppress(OSError):
+                item.unlink()
+                continue
+        used += cached
+
+    return used + size <= VOD_CACHE_MAX_BYTES
 
 
 @callback
@@ -55,6 +165,9 @@ class PlaybackProxyView(HomeAssistantView):
             ssl_cipher=SSLCipherList.INSECURE,
         )
         self._vod_type: str | None = None
+        self._vod_locks: dict[str, asyncio.Lock] = {}
+        self._vod_cache_lock = asyncio.Lock()
+        self._vod_serving: dict[Path, float] = {}
 
     async def get(
         self,
@@ -71,6 +184,8 @@ class PlaybackProxyView(HomeAssistantView):
 
         filename_decoded = urlsafe_b64decode(filename.encode("utf-8")).decode("utf-8")
         ch = int(channel)
+        # this has to be read before the remembered type overrides it below
+        nvr_download = VodRequestType(vod_type) is VodRequestType.NVR_DOWNLOAD
         if self._vod_type is not None:
             vod_type = self._vod_type
         try:
@@ -82,6 +197,14 @@ class PlaybackProxyView(HomeAssistantView):
             )
             _LOGGER.warning(err_str)
             return web.Response(body=err_str, status=HTTPStatus.BAD_REQUEST)
+
+        # an NVR download asks for a time range rather than a stored file
+        if not nvr_download:
+            baichuan_response = await self._async_serve_vod_over_baichuan(
+                config_entry_id, host, ch, stream_res, filename_decoded
+            )
+            if baichuan_response is not None:
+                return baichuan_response
 
         try:
             _mime_type, reolink_url = await host.api.get_vod_source(
@@ -196,3 +319,123 @@ class PlaybackProxyView(HomeAssistantView):
 
         await response.write_eof()
         return response
+
+    async def _async_serve_vod_over_baichuan(
+        self,
+        config_entry_id: str,
+        host: ReolinkHost,
+        channel: int,
+        stream: str,
+        filename: str,
+    ) -> web.StreamResponse | None:
+        """Serve a recording fetched over Baichuan, or None to fall back to HTTP."""
+        cache_dir = Path(self.hass.config.cache_path(VOD_CACHE_DIR))
+        key = f"{config_entry_id}|{channel}|{stream}|{filename}".encode()
+        path = cache_dir / f"{hashlib.sha256(key).hexdigest()[:32]}.mp4"
+
+        # one Baichuan VOD session per host, claimed by asking as well as downloading
+        lock = self._vod_locks.setdefault(config_entry_id, asyncio.Lock())
+        async with lock:
+            try:
+                info = await host.api.baichuan.get_vod_file_info(
+                    channel, filename, stream
+                )
+            except ReolinkError as err:
+                _LOGGER.debug(
+                    "Reolink %s cannot fetch %s over Baichuan, using HTTP playback: %s",
+                    host.api.nvr_name,
+                    filename,
+                    err,
+                )
+                return None
+
+            if info.size > VOD_CACHE_MAX_BYTES:
+                _LOGGER.debug(
+                    "Reolink %s recording %s is too large to cache,"
+                    " using HTTP playback",
+                    host.api.nvr_name,
+                    filename,
+                )
+                return None
+
+            # pruning runs in the executor, so another config entry could delete
+            # this recording between it being accepted and the claim below
+            async with self._vod_cache_lock:
+                state = await self.hass.async_add_executor_job(
+                    _prepare_cache, path, info.size, self._async_vod_serving()
+                )
+                # aiohttp opens the file only after this handler returns
+                self._vod_serving[path] = time.monotonic()
+
+            if state is _CacheState.FULL:
+                _LOGGER.debug(
+                    "Reolink %s has no room to cache %s, using HTTP playback",
+                    host.api.nvr_name,
+                    filename,
+                )
+                return None
+            if state is _CacheState.DOWNLOAD and not await self._async_cache_vod(
+                host, channel, filename, path, info
+            ):
+                return None
+
+        return web.FileResponse(path, headers={"Content-Type": "video/mp4"})
+
+    @callback
+    def _async_vod_serving(self) -> set[Path]:
+        """Return the cached paths that may still be streaming to a client."""
+        cutoff = time.monotonic() - VOD_CACHE_GRACE
+        self._vod_serving = {
+            item: seen for item, seen in self._vod_serving.items() if seen > cutoff
+        }
+        return set(self._vod_serving)
+
+    async def _async_cache_vod(
+        self,
+        host: ReolinkHost,
+        channel: int,
+        filename: str,
+        path: Path,
+        info: dict[str, Any],
+    ) -> bool:
+        """Download a recording into the cache, False when that did not work."""
+        try:
+            handle, part = await self.hass.async_add_executor_job(
+                _open_part, path.parent
+            )
+        except OSError as err:
+            _LOGGER.warning("Reolink cannot write to the recording cache: %s", err)
+            return False
+
+        buffer: list[bytes] = []
+        buffered = 0
+        try:
+            stream = host.api.baichuan.download_vod(channel, filename, info=info)
+            async with aclosing(stream) as chunks:
+                async for chunk in chunks:
+                    buffer.append(chunk)
+                    buffered += len(chunk)
+                    if buffered >= VOD_WRITE_BUFFER:
+                        await self.hass.async_add_executor_job(
+                            handle.write, b"".join(buffer)
+                        )
+                        buffer.clear()
+                        buffered = 0
+            if buffer:
+                await self.hass.async_add_executor_job(handle.write, b"".join(buffer))
+        except (ReolinkError, OSError) as err:
+            _LOGGER.warning(
+                "Reolink %s failed to download %s over Baichuan,"
+                " using HTTP playback: %s",
+                host.api.nvr_name,
+                filename,
+                err,
+            )
+            await self.hass.async_add_executor_job(_discard_part, handle, part)
+            return False
+        except BaseException:  # the request task is cancelled when a client leaves
+            # not awaited, since awaiting again during cancellation would not return
+            self.hass.async_add_executor_job(_discard_part, handle, part)
+            raise
+
+        return await self.hass.async_add_executor_job(_finish_part, handle, part, path)

--- a/tests/components/reolink/conftest.py
+++ b/tests/components/reolink/conftest.py
@@ -222,6 +222,10 @@ def _init_host_mock(host_mock: MagicMock) -> None:
     host_mock.baichuan.day_night_state.return_value = "day"
     host_mock.baichuan.siren_state.return_value = True
     host_mock.baichuan.subscribe_events.side_effect = ReolinkError("Test error")
+    host_mock.baichuan.get_vod_file_info = AsyncMock(
+        side_effect=ReolinkError("Test error")
+    )
+    host_mock.baichuan.download_vod = MagicMock()
     host_mock.baichuan.active_scene = "off"
     host_mock.baichuan.scene_names = ["off", "home"]
     host_mock.baichuan.abilities = {

--- a/tests/components/reolink/test_views.py
+++ b/tests/components/reolink/test_views.py
@@ -1,7 +1,10 @@
 """Tests for the Reolink views platform."""
 
+from collections.abc import AsyncIterator
 from http import HTTPStatus
 import logging
+import os
+from pathlib import Path
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
@@ -9,8 +12,12 @@ from aiohttp import ClientConnectionError, ClientResponse
 import pytest
 from reolink_aio.enums import VodRequestType
 from reolink_aio.exceptions import ReolinkError
+from reolink_aio.typings import VOD_file_info
 
-from homeassistant.components.reolink.views import async_generate_playback_proxy_url
+from homeassistant.components.reolink.views import (
+    VOD_CACHE_MAX_BYTES,
+    async_generate_playback_proxy_url,
+)
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -26,6 +33,10 @@ TEST_FILE_NAME_MP4 = (
     f"Mp4Record/{TEST_YEAR}-{TEST_MONTH}-{TEST_DAY}/RecS04_"
     f"{TEST_YEAR}{TEST_MONTH}{TEST_DAY}{TEST_HOUR}{TEST_MINUTE}"
     f"00_123456_AB123C.mp4"
+)
+TEST_TIME_RANGE = (
+    f"{TEST_YEAR}{TEST_MONTH}{TEST_DAY}{TEST_HOUR}{TEST_MINUTE}00_"
+    f"{TEST_YEAR}{TEST_MONTH}{TEST_DAY}{TEST_HOUR}{TEST_MINUTE}30"
 )
 TEST_STREAM = "sub"
 TEST_CHANNEL = "0"
@@ -255,3 +266,317 @@ async def test_playback_connect_error(
     response = cast(ClientResponse, await http_client.get(proxy_url))
 
     assert response.status == HTTPStatus.BAD_REQUEST
+
+
+TEST_VOD_DATA = b"0123456789" * 100
+
+
+def mock_baichuan_vod(reolink_host: MagicMock, data: bytes = TEST_VOD_DATA) -> None:
+    """Make the Baichuan VOD download hand back data."""
+    reolink_host.baichuan.get_vod_file_info = AsyncMock(
+        return_value=VOD_file_info(
+            size=len(data),
+            handle="0",
+            file_id=TEST_FILE_NAME_MP4,
+            resolved=True,
+            file_type="h264",
+            contains_audio=True,
+        )
+    )
+
+    async def _download(
+        channel: int, filename: str, **kwargs: Any
+    ) -> AsyncIterator[bytes]:
+        yield data
+
+    reolink_host.baichuan.download_vod = Mock(side_effect=_download)
+
+
+async def test_playback_proxy_baichuan(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    tmp_path: Path,
+) -> None:
+    """Test the recording is served from the Baichuan download."""
+    mock_baichuan_vod(reolink_host)
+
+    with patch.object(hass.config, "cache_path", return_value=str(tmp_path)):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+
+        http_client = await hass_client()
+        response = cast(ClientResponse, await http_client.get(proxy_url))
+
+        assert response.status == 200
+        assert response.headers["Content-Length"] == str(len(TEST_VOD_DATA))
+        assert await response.content.read() == TEST_VOD_DATA
+
+    reolink_host.get_vod_source.assert_not_called()
+
+
+async def test_playback_proxy_baichuan_cache_expiry(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    tmp_path: Path,
+) -> None:
+    """Test a recording is fetched again once its cached copy has aged out."""
+    mock_baichuan_vod(reolink_host)
+
+    with patch.object(hass.config, "cache_path", return_value=str(tmp_path)):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+
+        http_client = await hass_client()
+        first = cast(ClientResponse, await http_client.get(proxy_url))
+        assert first.status == 200
+        await first.read()
+
+        for cached in tmp_path.glob("*.mp4"):
+            os.utime(cached, (0, 0))
+
+        response = cast(ClientResponse, await http_client.get(proxy_url))
+
+        assert response.status == 200
+        assert await response.content.read() == TEST_VOD_DATA
+
+    assert reolink_host.baichuan.download_vod.call_count == 2
+
+
+async def test_playback_proxy_baichuan_skipped_for_nvr_download(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+) -> None:
+    """Test an NVR download, which asks for a time range, never reaches Baichuan."""
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+    reolink_host.baichuan.get_vod_file_info = AsyncMock(
+        side_effect=ReolinkError("Test error")
+    )
+    mock_session = get_mock_session(content_type="video/x-flv")
+
+    with patch(
+        "homeassistant.components.reolink.views.async_get_clientsession",
+        return_value=mock_session,
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+        http_client = await hass_client()
+
+        # an flv answer to a playback request makes the view remember to ask for
+        # a download from then on, which must not change what an NVR download is
+        flv_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+        flv_response = cast(ClientResponse, await http_client.get(flv_url))
+        assert flv_response.status == HTTPStatus.BAD_REQUEST
+
+        mock_session.get.return_value.content_type = TEST_MIME_TYPE_MP4
+        mock_baichuan_vod(reolink_host)
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_TIME_RANGE,
+            TEST_STREAM,
+            VodRequestType.NVR_DOWNLOAD.value,
+        )
+        response = cast(ClientResponse, await http_client.get(proxy_url))
+
+        assert response.status == 200
+
+    reolink_host.baichuan.get_vod_file_info.assert_not_called()
+
+
+async def test_playback_proxy_baichuan_too_large(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    tmp_path: Path,
+) -> None:
+    """Test a recording too large to cache is played over HTTP instead."""
+    mock_baichuan_vod(reolink_host)
+    reolink_host.baichuan.get_vod_file_info.return_value = VOD_file_info(
+        size=VOD_CACHE_MAX_BYTES + 1,
+        handle="0",
+        file_id=TEST_FILE_NAME_MP4,
+        resolved=True,
+        file_type="h264",
+        contains_audio=True,
+    )
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+
+    with (
+        patch.object(hass.config, "cache_path", return_value=str(tmp_path)),
+        patch(
+            "homeassistant.components.reolink.views.async_get_clientsession",
+            return_value=get_mock_session(),
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+
+        http_client = await hass_client()
+        response = cast(ClientResponse, await http_client.get(proxy_url))
+
+        assert response.status == 200
+
+    reolink_host.baichuan.download_vod.assert_not_called()
+    reolink_host.get_vod_source.assert_called_once()
+
+
+async def test_playback_proxy_baichuan_range_request(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    tmp_path: Path,
+) -> None:
+    """Test a range request into a recording, which is what seeking uses."""
+    mock_baichuan_vod(reolink_host)
+
+    with patch.object(hass.config, "cache_path", return_value=str(tmp_path)):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+
+        http_client = await hass_client()
+        response = cast(
+            ClientResponse,
+            await http_client.get(proxy_url, headers={"Range": "bytes=10-19"}),
+        )
+
+        assert response.status == HTTPStatus.PARTIAL_CONTENT
+        assert await response.content.read() == TEST_VOD_DATA[10:20]
+
+
+async def test_playback_proxy_baichuan_download_error(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    tmp_path: Path,
+) -> None:
+    """Test a failing Baichuan download falls back to HTTP playback."""
+    mock_baichuan_vod(reolink_host)
+
+    async def _fail(channel: int, filename: str, **kwargs: Any) -> AsyncIterator[bytes]:
+        yield TEST_VOD_DATA[:10]
+        raise ReolinkError(TEST_ERROR)
+
+    reolink_host.baichuan.download_vod = Mock(side_effect=_fail)
+    reolink_host.get_vod_source.return_value = (TEST_MIME_TYPE_MP4, TEST_URL)
+
+    mock_session = get_mock_session()
+
+    with (
+        patch.object(hass.config, "cache_path", return_value=str(tmp_path)),
+        patch(
+            "homeassistant.components.reolink.views.async_get_clientsession",
+            return_value=mock_session,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+
+        http_client = await hass_client()
+        response = cast(ClientResponse, await http_client.get(proxy_url))
+
+        assert response.status == 200
+        assert await response.content.read() == b"testtest"
+
+    reolink_host.get_vod_source.assert_called_once()
+
+
+async def test_playback_proxy_baichuan_conditional_range(
+    hass: HomeAssistant,
+    reolink_host: MagicMock,
+    config_entry: MockConfigEntry,
+    hass_client: ClientSessionGenerator,
+    tmp_path: Path,
+) -> None:
+    """Test seeking with If-Range, which needs the validator to stay stable."""
+    mock_baichuan_vod(reolink_host)
+
+    with patch.object(hass.config, "cache_path", return_value=str(tmp_path)):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        proxy_url = async_generate_playback_proxy_url(
+            config_entry.entry_id,
+            TEST_CHANNEL,
+            TEST_FILE_NAME_MP4,
+            TEST_STREAM,
+            TEST_VOD_TYPE,
+        )
+
+        http_client = await hass_client()
+        first = cast(ClientResponse, await http_client.get(proxy_url))
+        assert first.status == 200
+        last_modified = first.headers["Last-Modified"]
+        await first.read()
+
+        served_from_cache = cast(ClientResponse, await http_client.get(proxy_url))
+        assert served_from_cache.headers["Last-Modified"] == last_modified
+        await served_from_cache.read()
+
+        response = cast(
+            ClientResponse,
+            await http_client.get(
+                proxy_url,
+                headers={"Range": "bytes=10-19", "If-Range": last_modified},
+            ),
+        )
+
+        assert response.status == HTTPStatus.PARTIAL_CONTENT
+        assert await response.content.read() == TEST_VOD_DATA[10:20]
+
+    assert reolink_host.baichuan.download_vod.call_count == 1


### PR DESCRIPTION
## Proposed change

The Reolink playback proxy now asks the camera for a recording over the Baichuan
connection, the way Reolink's own CLI does, and falls back to the existing HTTP
playback command when that is not possible. No existing code path is removed.

Baichuan reports the exact file size before the transfer starts and then sends the
stored mp4 as-is, with its `moov` atom at the front. The proxy caches that and
serves it with `web.FileResponse`, so the browser gets a `Content-Length`, a real
duration and working range requests.

Today, on cameras that answer `cmd=Playback` with `video/x-flv`, the proxy falls
back to `cmd=Download` to obtain an mp4. That fallback is what this avoids:
`cmd=Download`, and `cmd=Playback` with `output=`, make the camera prepare a
temporary file on its SD card. On some models that leaves recording playback dead
until the camera is power cycled — the camera's own web UI can then only show the
live view either, so it is not client side — and its responses can carry a
malformed header that aiohttp rejects. The streaming `cmd=Playback` response
avoids the temporary file but is a live flv stream of unknown length, so it offers
no duration and no seeking. See
[#147960](https://github.com/home-assistant/core/issues/147960#issuecomment-5013173669).

An NVR download is left alone: those requests carry a time range rather than one
of the recorder's stored files, so they keep using the existing path.

The recording is streamed from the library's async iterator and written through
the executor, and downloads are serialised per config entry because a host has a
single Baichuan VOD session shared by all of its channels. The cache follows the
same shape as the one in `brands`: a directory under `cache_path()` held by the
view, with the filesystem work in module level helpers run in the executor. It is
owner only so it stays out of backups, entries age out, and a recording that
would not fit is played over HTTP instead. Any failure returns to the existing
HTTP path, so playback can never end up worse than it is today.

### Dependency

**This cannot be merged before
[starkillerOG/reolink_aio#186](https://github.com/starkillerOG/reolink_aio/pull/186)
is released**, since that is what adds `get_vod_file_info()` and `download_vod()`.
Until then `manifest.json` cannot be bumped, so the mypy check stays red and the
call raises `AttributeError` against the currently pinned version. Both PRs were
developed and tested together against the same two cameras.

Once the library is released, the `reolink-aio` bump belongs in its own PR, as the
review process asks for; this one should then be rebased on top of it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #147960 (see [these field notes](https://github.com/home-assistant/core/issues/147960#issuecomment-5013173669)), #144001
- Depends on: https://github.com/starkillerOG/reolink_aio/pull/186
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

---

## Tests

`pytest tests/components/reolink/` on current `dev` — **194 passed**, 327
snapshots passed, no failures. The seven new tests cover the Baichuan path, a
range request, a seek carrying `If-Range`, a cached copy being fetched again
once it has aged out, the fallback to HTTP playback when the download fails part
way through, the same fallback for a recording too large to cache, and an NVR
download never reaching Baichuan at all.

`mypy homeassistant/components/reolink/views.py` reports only the two
`attr-defined` errors for `get_vod_file_info` / `download_vod`, which disappear
once the pinned `reolink-aio` is bumped. `ruff`, `pylint` and `pylint on tests`
are clean.

## Validation on a real installation

Reolink Lumus Pro, firmware `v3.2.0.4243`:

* A 30 s 4K recording is fetched in ~2 s (~9 MB/s) and served with
  `Content-Length: 17073566` and `Accept-Ranges: bytes`; a range request answers
  `206` with the correct `Content-Range`.
* In the browser the player reports `duration: 31.199`, `seekable: [0, 31.199]`,
  seeks forward to 25 s and plays on from there, then seeks back to 5 s, with no
  decode errors. Before this change the same clip played with no duration and no
  seeking at all.
* The served bytes are identical to the file on the camera's SD card
  (`md5 6dde021f735141fa75db68b0207f83a9`), and `ffprobe` reads it as a normal
  `hevc 3840x2160` + `aac` mp4.
* After a **power cycle, with no priming of any kind**, the first playback request
  succeeds. That is the case that previously left recording playback dead on this
  camera.
* Seeking still works from cache: `Last-Modified` stays stable across hits, so a
  `Range` request carrying `If-Range` is answered `206` rather than a full `200`.
* Backdating the cached copy past `VOD_CACHE_MAX_AGE` makes the next request
  fetch it again, and the bytes still match.
* The cache directory is created `drwx------` under `cache_path()`, and works on a
  config that has no `.cache` directory yet.
* No blocking-call warnings from the event loop.

An E1 Zoom on the same installation also plays over Baichuan, on both
resolutions: a 15 MB main stream recording is served in 3.5 s cold and 0.26 s
once cached, a sub stream one in 0.4 s, and range requests answer `206`. Where
HTTP playback already worked, as it does on this camera, this is a speed up
rather than a fix — the same bytes, faster, and seekable from cache.

Streams the library has no Baichuan name for — `autotrack_*` and `telephoto_*` —
stay on the HTTP path; working out what Baichuan calls them needs a camera that
records them, which I do not have. As does anything else the Baichuan route
cannot do, so playback can never end up worse than it is today.
