### PR TITLE
Fix person support for legacy device trackers

### DIFF
--- a/homeassistant/components/person/__init__.py
+++ b/homeassistant/components/person/__init__.py
@@ -611,19 +611,22 @@ class Person(
         self._in_zones = in_zones or []
 
         # A legacy scanner (one that doesn't report in_zones) reports "home"
-        # without coordinates. Use the home zone's coordinates for backwards
-        # compatibility with legacy zone conditions and triggers. Modern
-        # trackers report in_zones and keep their own (possibly absent)
-        # coordinates.
+        # without zone membership or coordinates. Synthesize home-zone
+        # membership and borrow the home zone's coordinates so zone counting,
+        # conditions and triggers keep working as they did before the in_zones
+        # model was introduced. Modern trackers report in_zones and keep their
+        # own (possibly absent) coordinates.
         if (
             in_zones is None
             and state.state == STATE_HOME
-            and self._latitude is None
-            and self._longitude is None
             and (home_zone := self.hass.states.get(ENTITY_ID_HOME)) is not None
         ):
-            self._latitude = home_zone.attributes.get(EntityStateAttribute.LATITUDE)
-            self._longitude = home_zone.attributes.get(EntityStateAttribute.LONGITUDE)
+            self._in_zones = [ENTITY_ID_HOME]
+            if self._latitude is None and self._longitude is None:
+                self._latitude = home_zone.attributes.get(EntityStateAttribute.LATITUDE)
+                self._longitude = home_zone.attributes.get(
+                    EntityStateAttribute.LONGITUDE
+                )
 
     @callback
     def _update_extra_state_attributes(self) -> None:

--- a/tests/components/person/test_init.py
+++ b/tests/components/person/test_init.py
@@ -153,16 +153,19 @@ async def test_setup_tracker(hass: HomeAssistant, hass_admin_user: MockUser) -> 
     hass.bus.async_fire(EVENT_HOMEASSISTANT_START)
     await hass.async_block_till_done()
 
-    # A legacy tracker reporting home (no coordinates) is placed at the home zone.
+    # A legacy tracker reporting home (no in_zones) is placed in the home zone
+    # and given the home zone's coordinates.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
+        ATTR_IN_ZONES: ["zone.home"],
         ATTR_LATITUDE: 32.87336,
         ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
     }
 
-    # Test home with coordinates
+    # Test home with coordinates: a legacy tracker reporting "home" is placed in
+    # the home zone while keeping its own coordinates.
     hass.states.async_set(
         DEVICE_TRACKER,
         "home",
@@ -174,6 +177,7 @@ async def test_setup_tracker(hass: HomeAssistant, hass_admin_user: MockUser) -> 
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
         ATTR_GPS_ACCURACY: 10,
+        ATTR_IN_ZONES: ["zone.home"],
         ATTR_LATITUDE: 10.123456,
         ATTR_LONGITUDE: 11.123456,
         ATTR_SOURCE: DEVICE_TRACKER,
@@ -295,10 +299,12 @@ async def test_setup_two_trackers(
     hass.states.async_set(DEVICE_TRACKER_2, "zone2", {ATTR_SOURCE_TYPE: SourceType.GPS})
     await hass.async_block_till_done()
 
-    # Legacy router reporting home (no in_zones) is placed at the home zone.
+    # Legacy router reporting home (no in_zones) is placed in the home zone and
+    # given the home zone's coordinates.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
+        ATTR_IN_ZONES: ["zone.home"],
         ATTR_LATITUDE: 32.87336,
         ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,
@@ -499,12 +505,13 @@ async def _async_setup_person_two_trackers(hass: HomeAssistant, user_id: str) ->
             id="scanner_beats_gps",
         ),
         # A legacy "home" tracker (no in_zones) likewise outranks GPS; it is
-        # placed at the home zone.
+        # placed in the home zone.
         pytest.param(
             _LEGACY_HOME,
             _GPS_NOT_HOME,
             "home",
             {
+                ATTR_IN_ZONES: ["zone.home"],
                 ATTR_LATITUDE: 32.87336,
                 ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
@@ -614,12 +621,13 @@ async def test_state_priority_overrides_recency(
             id="not_home_newer",
         ),
         # A pair of legacy "home" trackers (no in_zones) likewise picks the
-        # most recent; it is placed at the home zone.
+        # most recent; it is placed in the home zone.
         pytest.param(
             _LEGACY_HOME,
             _LEGACY_HOME,
             "home",
             {
+                ATTR_IN_ZONES: ["zone.home"],
                 ATTR_LATITUDE: 32.87336,
                 ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER_2,
@@ -706,12 +714,13 @@ async def test_scanner_associated_with_other_zone(
 @pytest.mark.parametrize(
     ("tracker", "expected_state", "expected_extra"),
     [
-        # A legacy "home" tracker has no coordinates of its own, so it is
-        # placed at the home zone.
+        # A legacy "home" tracker has no in_zones or coordinates of its own, so
+        # it is placed in the home zone with the home zone's coordinates.
         pytest.param(
             _LEGACY_HOME,
             "home",
             {
+                ATTR_IN_ZONES: ["zone.home"],
                 ATTR_LATITUDE: 32.87336,
                 ATTR_LONGITUDE: -117.22743,
                 ATTR_SOURCE: DEVICE_TRACKER,
@@ -973,6 +982,7 @@ async def test_restore_home_state(
     assert await async_setup_component(hass, DOMAIN, config)
 
     # When restoring state the entity_id of the person will be used as source.
+    # A restored "home" state without in_zones is placed in the home zone.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == {
@@ -981,7 +991,7 @@ async def test_restore_home_state(
         ATTR_ENTITY_PICTURE: "/bla",
         ATTR_FRIENDLY_NAME: "tracked person",
         ATTR_ID: "1234",
-        ATTR_IN_ZONES: [],
+        ATTR_IN_ZONES: ["zone.home"],
         ATTR_LATITUDE: 10.12346,
         ATTR_LONGITUDE: 11.12346,
         ATTR_SOURCE: "person.tracked_person",
@@ -1042,10 +1052,12 @@ async def test_load_person_storage(
     hass.states.async_set(DEVICE_TRACKER, "home")
     await hass.async_block_till_done()
 
-    # A legacy tracker reporting home (no coordinates) is placed at the home zone.
+    # A legacy tracker reporting home (no in_zones) is placed in the home zone
+    # and given the home zone's coordinates.
     state = hass.states.get("person.tracked_person")
     assert state.state == "home"
     assert state.attributes == expected_attributes | {
+        ATTR_IN_ZONES: ["zone.home"],
         ATTR_LATITUDE: 32.87336,
         ATTR_LONGITUDE: -117.22743,
         ATTR_SOURCE: DEVICE_TRACKER,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix person support for legacy device trackers

This fixes a regression introduced by https://github.com/home-assistant/core/pull/172942, reported in https://github.com/home-assistant/core/issues/175376 and maybe others

Replaces https://github.com/home-assistant/core/pull/177117

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/175376
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
