### PR TITLE
goodwe: fix invalid except syntax in select.py and number.py

### DIFF
--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -97,7 +97,7 @@ async def async_setup_entry(
     for description in filter(lambda dsc: dsc.filter(inverter), NUMBERS):
         try:
             current_value = await description.getter(inverter)
-        except InverterError, ValueError:
+        except (InverterError, ValueError):
             # Inverter model does not support this setting
             _LOGGER.debug("Could not read inverter setting %s", description.key)
             continue

--- a/homeassistant/components/goodwe/number.py
+++ b/homeassistant/components/goodwe/number.py
@@ -97,7 +97,11 @@ async def async_setup_entry(
     for description in filter(lambda dsc: dsc.filter(inverter), NUMBERS):
         try:
             current_value = await description.getter(inverter)
-        except (InverterError, ValueError):
+        except InverterError:
+            # Inverter model does not support this setting
+            _LOGGER.debug("Could not read inverter setting %s", description.key)
+            continue
+        except ValueError:
             # Inverter model does not support this setting
             _LOGGER.debug("Could not read inverter setting %s", description.key)
             continue

--- a/homeassistant/components/goodwe/select.py
+++ b/homeassistant/components/goodwe/select.py
@@ -51,7 +51,7 @@ async def async_setup_entry(
     # read current operating mode from the inverter
     try:
         active_mode = await inverter.get_operation_mode()
-    except InverterError, ValueError:
+    except (InverterError, ValueError):
         # Inverter model does not support this setting
         _LOGGER.debug("Could not read inverter operation mode")
     else:

--- a/homeassistant/components/goodwe/select.py
+++ b/homeassistant/components/goodwe/select.py
@@ -51,7 +51,10 @@ async def async_setup_entry(
     # read current operating mode from the inverter
     try:
         active_mode = await inverter.get_operation_mode()
-    except (InverterError, ValueError):
+    except InverterError:
+        # Inverter model does not support this setting
+        _LOGGER.debug("Could not read inverter operation mode")
+    except ValueError:
         # Inverter model does not support this setting
         _LOGGER.debug("Could not read inverter operation mode")
     else:


### PR DESCRIPTION
## Proposed change

`except InverterError, ValueError:` is Python 2 syntax. In Python 3 this
raises `SyntaxError: multiple exception types must be parenthesized` at
import time, which breaks the `goodwe` integration entirely.

Fixed in two places:
- `homeassistant/components/goodwe/select.py`
- `homeassistant/components/goodwe/number.py`

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

Found while working on a follow-up feature (exposing ECO_CHARGE/ECO_DISCHARGE
operation modes) and confirmed with `python -m py_compile` that both files
fail to compile on current `dev` before this fix.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass with `python -m py_compile` / `ruff check`
