### PR TITLE
Clear Entity.device_entry when entity is detached from device

### DIFF
--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1620,6 +1620,8 @@ class Entity(
 
         if device_id := registry_entry.device_id:
             self.device_entry = dr.async_get(self.hass).async_get(device_id)
+        else:
+            self.device_entry = None
 
         if registry_entry.disabled:
             await self.async_remove()

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1658,9 +1658,7 @@ async def test_device_entry_cleared_when_detached_from_device(
 
     When the device is removed, the entity registry detaches the cross-entry
     entity (a device_id=None update) instead of removing it; the detach must
-    clear the cached device_entry, which the device registry listener cannot
-    do - processing the detach unsubscribes it before the removal event
-    reaches it.
+    clear the cached device_entry.
     """
     other_entry = MockConfigEntry(domain="other")
     other_entry.add_to_hass(hass)

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -1649,6 +1649,108 @@ async def test_friendly_name_updated(
     assert state.attributes.get(ATTR_FRIENDLY_NAME) == expected_friendly_name3
 
 
+async def test_device_entry_cleared_when_detached_from_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test device_entry of an entity attached to another entry's device.
+
+    When the device is removed, the entity registry detaches the cross-entry
+    entity (a device_id=None update) instead of removing it; the detach must
+    clear the cached device_entry, which the device registry listener cannot
+    do - processing the detach unsubscribes it before the removal event
+    reaches it.
+    """
+    other_entry = MockConfigEntry(domain="other")
+    other_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=other_entry.entry_id, identifiers={("other", "dev1")}
+    )
+
+    ent = MockEntity(unique_id="qwer")
+
+    async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        """Mock setup entry method."""
+        async_add_entities([ent])
+
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
+    entity_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    assert await entity_platform.async_setup_entry(config_entry)
+    await hass.async_block_till_done()
+
+    # Attach the entity to the other config entry's device, as e.g. a
+    # ScannerEntity attaches to the tracked device by MAC
+    entity_registry.async_update_entity(ent.entity_id, device_id=device.id)
+    await hass.async_block_till_done()
+    assert ent.device_entry is not None
+
+    device_registry.async_remove_device(device.id)
+    await hass.async_block_till_done()
+
+    # The registry entry was detached from the removed device, clearing the
+    # cached device entry
+    registry_entry = entity_registry.async_get(ent.entity_id)
+    assert registry_entry is not None
+    assert registry_entry.device_id is None
+    assert ent.device_entry is None
+
+
+async def test_device_entry_cleared_on_registry_detach(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the cached device entry is cleared when the entity is detached.
+
+    A registry update setting device_id to None must clear the cached
+    device_entry, even while the device itself still exists.
+    """
+    ent = MockEntity(unique_id="qwer")
+
+    async def async_setup_entry(
+        hass: HomeAssistant,
+        config_entry: ConfigEntry,
+        async_add_entities: AddConfigEntryEntitiesCallback,
+    ) -> None:
+        """Mock setup entry method."""
+        async_add_entities([ent])
+
+    platform = MockPlatform(async_setup_entry=async_setup_entry)
+    config_entry = MockConfigEntry(entry_id="super-mock-id")
+    config_entry.add_to_hass(hass)
+    entity_platform = MockEntityPlatform(
+        hass, platform_name=config_entry.domain, platform=platform
+    )
+
+    assert await entity_platform.async_setup_entry(config_entry)
+    await hass.async_block_till_done()
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("test", "dev1")}
+    )
+    entity_registry.async_update_entity(ent.entity_id, device_id=device.id)
+    await hass.async_block_till_done()
+    assert ent.device_entry is not None
+    assert ent.device_entry.id == device.id
+
+    # Detach the entity while the device remains; the cache must still clear
+    entity_registry.async_update_entity(ent.entity_id, device_id=None)
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(device.id) is not None
+    assert ent.device_entry is None
+
+
 async def test_translation_key(hass: HomeAssistant) -> None:
     """Test translation key property."""
     mock_entity1 = entity.Entity()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Clear Entity.device_entry when entity is detached from device

Split out from https://github.com/home-assistant/core/pull/176941

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
