### PR TITLE
Add WS command config/device_registry/list_linked_devices

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -19,7 +19,7 @@ def async_setup(hass: HomeAssistant) -> bool:
 
     websocket_api.async_register_command(hass, websocket_list_composite_splits)
     websocket_api.async_register_command(hass, websocket_list_devices)
-    websocket_api.async_register_command(hass, websocket_list_related_devices)
+    websocket_api.async_register_command(hass, websocket_list_linked_devices)
     websocket_api.async_register_command(hass, websocket_update_device)
     websocket_api.async_register_command(
         hass, websocket_remove_config_entry_from_device
@@ -99,20 +99,20 @@ def websocket_list_devices(
 @callback
 @websocket_api.websocket_command(
     {
-        vol.Required("type"): "config/device_registry/list_related_devices",
+        vol.Required("type"): "config/device_registry/list_linked_devices",
         vol.Required("device_id"): str,
     }
 )
-def websocket_list_related_devices(
+def websocket_list_linked_devices(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Handle list related devices command.
+    """Handle list linked devices command.
 
-    Related devices share at least one connection or identifier with the given
+    Linked devices share at least one connection or identifier with the given
     device. Each such connection or identifier is unique within a config entry, so
-    the related devices belong to other config entries.
+    the linked devices belong to other config entries.
     """
     registry = dr.async_get(hass)
     device_id = msg["device_id"]
@@ -123,7 +123,7 @@ def websocket_list_related_devices(
         )
         return
 
-    related_devices = [
+    linked_devices = [
         entry.id
         for entry in registry.async_get_devices(
             identifiers=device.identifiers, connections=device.connections
@@ -131,7 +131,7 @@ def websocket_list_related_devices(
         if entry.id != device_id
     ]
 
-    connection.send_result(msg["id"], {"related_devices": related_devices})
+    connection.send_result(msg["id"], {"linked_devices": linked_devices})
 
 
 @require_admin

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -18,6 +18,7 @@ def async_setup(hass: HomeAssistant) -> bool:
     """Enable the Device Registry views."""
 
     websocket_api.async_register_command(hass, websocket_list_devices)
+    websocket_api.async_register_command(hass, websocket_list_related_devices)
     websocket_api.async_register_command(hass, websocket_update_device)
     websocket_api.async_register_command(
         hass, websocket_remove_config_entry_from_device
@@ -53,6 +54,44 @@ def websocket_list_devices(
     )
     msg_json = b"".join((msg_json_prefix, inner, b"]}"))
     connection.send_message(msg_json)
+
+
+@callback
+@websocket_api.websocket_command(
+    {
+        vol.Required("type"): "config/device_registry/list_related_devices",
+        vol.Required("device_id"): str,
+    }
+)
+def websocket_list_related_devices(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Handle list related devices command.
+
+    Related devices share at least one connection or identifier with the given
+    device. Each such connection or identifier is unique within a config entry, so
+    the related devices belong to other config entries.
+    """
+    registry = dr.async_get(hass)
+    device_id = msg["device_id"]
+
+    if (device := registry.async_get(device_id)) is None:
+        connection.send_error(
+            msg["id"], websocket_api.ERR_NOT_FOUND, "Device not found"
+        )
+        return
+
+    related_devices = [
+        entry.id
+        for entry in registry.async_get_devices(
+            identifiers=device.identifiers, connections=device.connections
+        )
+        if entry.id != device_id
+    ]
+
+    connection.send_result(msg["id"], {"related_devices": related_devices})
 
 
 @require_admin

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -677,7 +677,7 @@ async def test_remove_config_entry_from_device_if_integration_remove(
     }
 
 
-async def test_list_related_devices(
+async def test_list_linked_devices(
     hass: HomeAssistant,
     client: MockHAClientWebSocket,
     device_registry: dr.DeviceRegistry,
@@ -713,40 +713,40 @@ async def test_list_related_devices(
     )
     assert len({device_1.id, device_2.id, device_3.id, device_4.id}) == 4
 
-    async def list_related(device_id: str) -> dict:
+    async def list_linked(device_id: str) -> dict:
         await client.send_json_auto_id(
             {
-                "type": "config/device_registry/list_related_devices",
+                "type": "config/device_registry/list_linked_devices",
                 "device_id": device_id,
             }
         )
         return await client.receive_json()
 
-    # device_1 is related to both device_2 (identifier) and device_3 (connection)
-    msg = await list_related(device_1.id)
+    # device_1 is linked to both device_2 (identifier) and device_3 (connection)
+    msg = await list_linked(device_1.id)
     assert msg["success"]
-    assert msg["result"]["related_devices"] == unordered([device_2.id, device_3.id])
+    assert msg["result"]["linked_devices"] == unordered([device_2.id, device_3.id])
 
     # device_2 and device_3 each only share with device_1, not with each other
-    msg = await list_related(device_2.id)
-    assert msg["result"]["related_devices"] == [device_1.id]
+    msg = await list_linked(device_2.id)
+    assert msg["result"]["linked_devices"] == [device_1.id]
 
-    msg = await list_related(device_3.id)
-    assert msg["result"]["related_devices"] == [device_1.id]
+    msg = await list_linked(device_3.id)
+    assert msg["result"]["linked_devices"] == [device_1.id]
 
-    # device_4 has no related devices
-    msg = await list_related(device_4.id)
-    assert msg["result"]["related_devices"] == []
+    # device_4 has no linked devices
+    msg = await list_linked(device_4.id)
+    assert msg["result"]["linked_devices"] == []
 
 
-async def test_list_related_devices_unknown_device(
+async def test_list_linked_devices_unknown_device(
     hass: HomeAssistant,
     client: MockHAClientWebSocket,
 ) -> None:
-    """Test listing related devices for an unknown device returns an error."""
+    """Test listing linked devices for an unknown device returns an error."""
     await client.send_json_auto_id(
         {
-            "type": "config/device_registry/list_related_devices",
+            "type": "config/device_registry/list_linked_devices",
             "device_id": "does_not_exist",
         }
     )

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -558,3 +558,83 @@ async def test_remove_config_entry_from_device_if_integration_remove(
     assert device_registry.async_get(device_entry_1.id).config_entries == {
         entry_1.entry_id
     }
+
+
+async def test_list_related_devices(
+    hass: HomeAssistant,
+    client: MockHAClientWebSocket,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test listing devices sharing a connection or identifier."""
+    entry_1 = MockConfigEntry()
+    entry_1.add_to_hass(hass)
+    entry_2 = MockConfigEntry()
+    entry_2.add_to_hass(hass)
+    entry_3 = MockConfigEntry()
+    entry_3.add_to_hass(hass)
+
+    mac = (dr.CONNECTION_NETWORK_MAC, "12:34:56:ab:cd:ef")
+
+    # device_1 shares its identifier with device_2 and its connection with device_3
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id,
+        connections={mac},
+        identifiers={("bridgeid", "0123")},
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=entry_2.entry_id,
+        identifiers={("bridgeid", "0123")},
+    )
+    device_3 = device_registry.async_get_or_create(
+        config_entry_id=entry_3.entry_id,
+        connections={mac},
+    )
+    # device_4 shares nothing with the others
+    device_4 = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id,
+        identifiers={("bridgeid", "9999")},
+    )
+    assert len({device_1.id, device_2.id, device_3.id, device_4.id}) == 4
+
+    async def list_related(device_id: str) -> dict:
+        await client.send_json_auto_id(
+            {
+                "type": "config/device_registry/list_related_devices",
+                "device_id": device_id,
+            }
+        )
+        return await client.receive_json()
+
+    # device_1 is related to both device_2 (identifier) and device_3 (connection)
+    msg = await list_related(device_1.id)
+    assert msg["success"]
+    assert msg["result"]["related_devices"] == unordered([device_2.id, device_3.id])
+
+    # device_2 and device_3 each only share with device_1, not with each other
+    msg = await list_related(device_2.id)
+    assert msg["result"]["related_devices"] == [device_1.id]
+
+    msg = await list_related(device_3.id)
+    assert msg["result"]["related_devices"] == [device_1.id]
+
+    # device_4 has no related devices
+    msg = await list_related(device_4.id)
+    assert msg["result"]["related_devices"] == []
+
+
+async def test_list_related_devices_unknown_device(
+    hass: HomeAssistant,
+    client: MockHAClientWebSocket,
+) -> None:
+    """Test listing related devices for an unknown device returns an error."""
+    await client.send_json_auto_id(
+        {
+            "type": "config/device_registry/list_related_devices",
+            "device_id": "does_not_exist",
+        }
+    )
+    msg = await client.receive_json()
+
+    assert not msg["success"]
+    assert msg["error"]["code"] == "not_found"
+    assert msg["error"]["message"] == "Device not found"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS command config/device_registry/list_linked_devices

Intended to be used by frontend to show links from the device page to other devices which share connections or identifiers

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
