### PR TITLE
Migrate nmbs to config entry runtime data

### DIFF
--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -1,9 +1,9 @@
 """The NMBS component."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import logging
 
 from pyrail import iRail
+from pyrail.models import StationDetails
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -17,29 +17,33 @@ from .const import DOMAIN
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.SENSOR]
 
+type NMBSConfigEntry = ConfigEntry[list[StationDetails]]
+
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: NMBSConfigEntry) -> bool:
     """Set up NMBS from a config entry."""
 
-    # The station list is shared by all entries, so fetch and cache it only
-    # once. Raise ConfigEntryNotReady if the API is unavailable so setup is
-    # retried instead of failing permanently.
-    if not hass.data.get(DOMAIN):
+    # The station list is shared by all entries, so fetch it only once and
+    # reuse it from an already loaded entry. Raise ConfigEntryNotReady if the
+    # API is unavailable so setup is retried instead of failing permanently.
+    if loaded_entries := hass.config_entries.async_loaded_entries(DOMAIN):
+        entry.runtime_data = loaded_entries[0].runtime_data
+    else:
         api_client = iRail(session=async_get_clientsession(hass))
         station_response = await api_client.get_stations()
         if station_response is None:
             raise ConfigEntryNotReady(
                 "Unable to fetch the NMBS station list; the iRail API is unavailable"
             )
-        hass.data[DOMAIN] = station_response.stations
+        entry.runtime_data = station_response.stations
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: NMBSConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -1,5 +1,6 @@
 """The NMBS component."""
 
+import asyncio
 import logging
 
 from pyrail import iRail
@@ -11,6 +12,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
 
@@ -19,26 +21,41 @@ PLATFORMS = [Platform.SENSOR]
 
 type NMBSConfigEntry = ConfigEntry[list[StationDetails]]
 
+NMBS_KEY: HassKey[asyncio.Task[list[StationDetails] | None]] = HassKey(DOMAIN)
+
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
+
+
+async def _async_fetch_stations(hass: HomeAssistant) -> list[StationDetails] | None:
+    """Fetch the station list from the iRail API."""
+    api_client = iRail(session=async_get_clientsession(hass))
+    station_response = await api_client.get_stations()
+    if station_response is None:
+        return None
+    return station_response.stations
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NMBSConfigEntry) -> bool:
     """Set up NMBS from a config entry."""
 
-    # The station list is shared by all entries, so fetch it only once and
-    # reuse it from an already loaded entry. Raise ConfigEntryNotReady if the
-    # API is unavailable so setup is retried instead of failing permanently.
-    if loaded_entries := hass.config_entries.async_loaded_entries(DOMAIN):
-        entry.runtime_data = loaded_entries[0].runtime_data
-    else:
-        api_client = iRail(session=async_get_clientsession(hass))
-        station_response = await api_client.get_stations()
-        if station_response is None:
-            raise ConfigEntryNotReady(
-                "Unable to fetch the NMBS station list; the iRail API is unavailable"
-            )
-        entry.runtime_data = station_response.stations
+    # The station list is shared by all entries and fetched only once. The
+    # shared task is stored before any await, so entries that are set up
+    # concurrently await the same fetch. A failed fetch is not reused, so a
+    # later setup retry fetches again. Raise ConfigEntryNotReady if the API
+    # is unavailable so setup is retried instead of failing permanently.
+    task = hass.data.get(NMBS_KEY)
+    if task is None or (
+        task.done()
+        and (task.cancelled() or task.exception() is not None or task.result() is None)
+    ):
+        task = hass.data[NMBS_KEY] = hass.async_create_task(_async_fetch_stations(hass))
+    stations = await task
+    if stations is None:
+        raise ConfigEntryNotReady(
+            "Unable to fetch the NMBS station list; the iRail API is unavailable"
+        )
+    entry.runtime_data = stations
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -1,5 +1,6 @@
 """The NMBS component."""
 
+from dataclasses import dataclass
 import logging
 
 from pyrail import iRail
@@ -8,18 +9,27 @@ from pyrail.models import StationDetails
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.singleton import singleton
 from homeassistant.util.hass_dict import HassKey
 
-from .const import DOMAIN
+from .const import CONF_STATION_FROM, CONF_STATION_TO, DOMAIN, find_station
 
 _LOGGER = logging.getLogger(__name__)
 PLATFORMS = [Platform.SENSOR]
 
-type NMBSConfigEntry = ConfigEntry[list[StationDetails]]
+
+@dataclass
+class NMBSData:
+    """Data for an NMBS config entry."""
+
+    station_from: StationDetails
+    station_to: StationDetails
+
+
+type NMBSConfigEntry = ConfigEntry[NMBSData]
 
 NMBS_KEY: HassKey[list[StationDetails]] = HassKey(DOMAIN)
 
@@ -41,7 +51,20 @@ async def _async_get_stations(hass: HomeAssistant) -> list[StationDetails]:
 
 async def async_setup_entry(hass: HomeAssistant, entry: NMBSConfigEntry) -> bool:
     """Set up NMBS from a config entry."""
-    entry.runtime_data = await _async_get_stations(hass)
+    stations = await _async_get_stations(hass)
+    station_from = find_station(stations, entry.data[CONF_STATION_FROM])
+    station_to = find_station(stations, entry.data[CONF_STATION_TO])
+    if station_from is None or station_to is None:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="station_not_found",
+            translation_placeholders={
+                "station": entry.data[CONF_STATION_FROM]
+                if station_from is None
+                else entry.data[CONF_STATION_TO]
+            },
+        )
+    entry.runtime_data = NMBSData(station_from=station_from, station_to=station_to)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/nmbs/__init__.py
+++ b/homeassistant/components/nmbs/__init__.py
@@ -1,6 +1,5 @@
 """The NMBS component."""
 
-import asyncio
 import logging
 
 from pyrail import iRail
@@ -12,6 +11,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.singleton import singleton
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
@@ -21,41 +21,27 @@ PLATFORMS = [Platform.SENSOR]
 
 type NMBSConfigEntry = ConfigEntry[list[StationDetails]]
 
-NMBS_KEY: HassKey[asyncio.Task[list[StationDetails] | None]] = HassKey(DOMAIN)
+NMBS_KEY: HassKey[list[StationDetails]] = HassKey(DOMAIN)
 
 
 CONFIG_SCHEMA = cv.empty_config_schema(DOMAIN)
 
 
-async def _async_fetch_stations(hass: HomeAssistant) -> list[StationDetails] | None:
-    """Fetch the station list from the iRail API."""
+@singleton(NMBS_KEY, async_=True)
+async def _async_get_stations(hass: HomeAssistant) -> list[StationDetails]:
+    """Fetch the station list, which is shared by all entries."""
     api_client = iRail(session=async_get_clientsession(hass))
     station_response = await api_client.get_stations()
     if station_response is None:
-        return None
+        raise ConfigEntryNotReady(
+            "Unable to fetch the NMBS station list; the iRail API is unavailable"
+        )
     return station_response.stations
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: NMBSConfigEntry) -> bool:
     """Set up NMBS from a config entry."""
-
-    # The station list is shared by all entries and fetched only once. The
-    # shared task is stored before any await, so entries that are set up
-    # concurrently await the same fetch. A failed fetch is not reused, so a
-    # later setup retry fetches again. Raise ConfigEntryNotReady if the API
-    # is unavailable so setup is retried instead of failing permanently.
-    task = hass.data.get(NMBS_KEY)
-    if task is None or (
-        task.done()
-        and (task.cancelled() or task.exception() is not None or task.result() is None)
-    ):
-        task = hass.data[NMBS_KEY] = hass.async_create_task(_async_fetch_stations(hass))
-    stations = await task
-    if stations is None:
-        raise ConfigEntryNotReady(
-            "Unable to fetch the NMBS station list; the iRail API is unavailable"
-        )
-    entry.runtime_data = stations
+    entry.runtime_data = await _async_get_stations(hass)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/homeassistant/components/nmbs/const.py
+++ b/homeassistant/components/nmbs/const.py
@@ -2,8 +2,9 @@
 
 from typing import Final
 
+from pyrail.models import StationDetails
+
 from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
 
 DOMAIN: Final = "nmbs"
 
@@ -15,17 +16,17 @@ CONF_STATION_LIVE = "station_live"
 CONF_EXCLUDE_VIAS = "exclude_vias"
 
 
-def find_station_by_name(hass: HomeAssistant, station_name: str):
+def find_station_by_name(stations: list[StationDetails], station_name: str):
     """Find given station_name in the station list."""
     return next(
-        (s for s in hass.data[DOMAIN] if station_name in (s.standard_name, s.name)),
+        (s for s in stations if station_name in (s.standard_name, s.name)),
         None,
     )
 
 
-def find_station(hass: HomeAssistant, station_name: str):
+def find_station(stations: list[StationDetails], station_name: str):
     """Find given station_id in the station list."""
     return next(
-        (s for s in hass.data[DOMAIN] if station_name in s.id),
+        (s for s in stations if station_name in s.id),
         None,
     )

--- a/homeassistant/components/nmbs/const.py
+++ b/homeassistant/components/nmbs/const.py
@@ -16,7 +16,9 @@ CONF_STATION_LIVE = "station_live"
 CONF_EXCLUDE_VIAS = "exclude_vias"
 
 
-def find_station_by_name(stations: list[StationDetails], station_name: str):
+def find_station_by_name(
+    stations: list[StationDetails], station_name: str
+) -> StationDetails | None:
     """Find given station_name in the station list."""
     return next(
         (s for s in stations if station_name in (s.standard_name, s.name)),
@@ -24,7 +26,9 @@ def find_station_by_name(stations: list[StationDetails], station_name: str):
     )
 
 
-def find_station(stations: list[StationDetails], station_name: str):
+def find_station(
+    stations: list[StationDetails], station_name: str
+) -> StationDetails | None:
     """Find given station_id in the station list."""
     return next(
         (s for s in stations if station_name in s.id),

--- a/homeassistant/components/nmbs/sensor.py
+++ b/homeassistant/components/nmbs/sensor.py
@@ -27,7 +27,6 @@ from .const import (  # noqa: F401
     CONF_STATION_TO,
     DOMAIN,
     PLATFORMS,
-    find_station,
     find_station_by_name,
 )
 
@@ -70,9 +69,8 @@ async def async_setup_entry(
     show_on_map = config_entry.data.get(CONF_SHOW_ON_MAP, False)
     excl_vias = config_entry.data.get(CONF_EXCLUDE_VIAS, False)
 
-    stations = config_entry.runtime_data
-    station_from = find_station(stations, config_entry.data[CONF_STATION_FROM])
-    station_to = find_station(stations, config_entry.data[CONF_STATION_TO])
+    station_from = config_entry.runtime_data.station_from
+    station_to = config_entry.runtime_data.station_to
 
     # setup the connection from station to station
     # setup a disabled liveboard for both from and to station

--- a/homeassistant/components/nmbs/sensor.py
+++ b/homeassistant/components/nmbs/sensor.py
@@ -8,7 +8,6 @@ from pyrail import iRail
 from pyrail.models import ConnectionDetails, LiveboardDeparture, StationDetails
 
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     CONF_NAME,
     CONF_SHOW_ON_MAP,
@@ -20,6 +19,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util import dt as dt_util
 
+from . import NMBSConfigEntry
 from .const import (  # noqa: F401
     CONF_EXCLUDE_VIAS,
     CONF_STATION_FROM,
@@ -60,7 +60,7 @@ def get_ride_duration(departure_time: datetime, arrival_time: datetime, delay=0)
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: NMBSConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up NMBS sensor entities based on a config entry."""
@@ -70,8 +70,9 @@ async def async_setup_entry(
     show_on_map = config_entry.data.get(CONF_SHOW_ON_MAP, False)
     excl_vias = config_entry.data.get(CONF_EXCLUDE_VIAS, False)
 
-    station_from = find_station(hass, config_entry.data[CONF_STATION_FROM])
-    station_to = find_station(hass, config_entry.data[CONF_STATION_TO])
+    stations = config_entry.runtime_data
+    station_from = find_station(stations, config_entry.data[CONF_STATION_FROM])
+    station_to = find_station(stations, config_entry.data[CONF_STATION_TO])
 
     # setup the connection from station to station
     # setup a disabled liveboard for both from and to station

--- a/homeassistant/components/nmbs/strings.json
+++ b/homeassistant/components/nmbs/strings.json
@@ -25,5 +25,10 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "station_not_found": {
+      "message": "Station {station} is not available in the NMBS station list"
+    }
   }
 }

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -2,6 +2,11 @@
 
 from unittest.mock import AsyncMock
 
+from homeassistant.components.nmbs.const import (
+    CONF_STATION_FROM,
+    CONF_STATION_TO,
+    DOMAIN,
+)
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
@@ -35,3 +40,31 @@ async def test_setup_entry_api_unavailable(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_second_entry_reuses_station_list(
+    hass: HomeAssistant,
+    mock_nmbs_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a second entry reuses the station list of a loaded entry."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Train from Brussel-Zuid/Bruxelles-Midi to Brussel-Noord/Bruxelles-Nord",
+        data={
+            CONF_STATION_FROM: "BE.NMBS.008814001",
+            CONF_STATION_TO: "BE.NMBS.008812005",
+        },
+        unique_id="BE.NMBS.008814001_BE.NMBS.008812005",
+    )
+    second_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(second_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert second_entry.state is ConfigEntryState.LOADED
+    assert second_entry.runtime_data is mock_config_entry.runtime_data
+    mock_nmbs_client.get_stations.assert_called_once()

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -105,11 +105,12 @@ async def test_concurrent_setup_shares_station_fetch(
     # Release the fetch only after both entry setups are underway, so the
     # second entry sees the first entry's fetch in flight rather than a
     # completed task.
-    while (
-        mock_config_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
-        or second_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
-    ):
-        await asyncio.sleep(0)
+    async with asyncio.timeout(10):
+        while (
+            mock_config_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
+            or second_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
+        ):
+            await asyncio.sleep(0)
     release_fetch.set()
 
     assert await setup_task

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import AsyncMock
 
 from pyrail.models import StationsApiResponse
+import pytest
 
 from homeassistant.components.nmbs.const import (
     CONF_STATION_FROM,
@@ -46,6 +47,44 @@ async def test_setup_entry_api_unavailable(
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
 
 
+@pytest.mark.parametrize(
+    ("station_from", "station_to", "missing_station"),
+    [
+        pytest.param(
+            "BE.NMBS.000000000",
+            "BE.NMBS.008814001",
+            "BE.NMBS.000000000",
+            id="departure",
+        ),
+        pytest.param(
+            "BE.NMBS.008812005", "BE.NMBS.000000000", "BE.NMBS.000000000", id="arrival"
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_nmbs_client")
+async def test_setup_entry_unknown_station(
+    hass: HomeAssistant,
+    station_from: str,
+    station_to: str,
+    missing_station: str,
+) -> None:
+    """Test the entry errors when a configured station is not in the station list."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Train from an unknown station",
+        data={CONF_STATION_FROM: station_from, CONF_STATION_TO: station_to},
+        unique_id=f"{station_from}_{station_to}",
+    )
+    entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    assert entry.error_reason_translation_key == "station_not_found"
+    assert entry.error_reason_translation_placeholders == {"station": missing_station}
+
+
 async def test_second_entry_reuses_station_list(
     hass: HomeAssistant,
     mock_nmbs_client: AsyncMock,
@@ -70,7 +109,12 @@ async def test_second_entry_reuses_station_list(
     await hass.async_block_till_done()
 
     assert second_entry.state is ConfigEntryState.LOADED
-    assert second_entry.runtime_data is mock_config_entry.runtime_data
+    # The two entries use the same stations swapped, so resolving both against
+    # the same shared list yields the very same station objects.
+    assert (
+        second_entry.runtime_data.station_from
+        is mock_config_entry.runtime_data.station_to
+    )
     mock_nmbs_client.get_stations.assert_called_once()
 
 
@@ -118,7 +162,10 @@ async def test_concurrent_setup_shares_station_fetch(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
     assert second_entry.state is ConfigEntryState.LOADED
-    assert second_entry.runtime_data is mock_config_entry.runtime_data
+    assert (
+        second_entry.runtime_data.station_from
+        is mock_config_entry.runtime_data.station_to
+    )
     mock_nmbs_client.get_stations.assert_called_once()
 
 

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -1,5 +1,6 @@
 """Test the NMBS integration setup."""
 
+import asyncio
 from unittest.mock import AsyncMock
 
 from pyrail.models import StationsApiResponse
@@ -78,7 +79,16 @@ async def test_concurrent_setup_shares_station_fetch(
     mock_nmbs_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test that entries set up concurrently share one station fetch."""
+    """Test that entries set up concurrently share one in-flight station fetch."""
+    stations_response = mock_nmbs_client.get_stations.return_value
+    release_fetch = asyncio.Event()
+
+    async def _blocked_get_stations() -> StationsApiResponse:
+        await release_fetch.wait()
+        return stations_response
+
+    mock_nmbs_client.get_stations.side_effect = _blocked_get_stations
+
     mock_config_entry.add_to_hass(hass)
     second_entry = MockConfigEntry(
         domain=DOMAIN,
@@ -91,7 +101,18 @@ async def test_concurrent_setup_shares_station_fetch(
     )
     second_entry.add_to_hass(hass)
 
-    assert await async_setup_component(hass, DOMAIN, {})
+    setup_task = hass.async_create_task(async_setup_component(hass, DOMAIN, {}))
+    # Release the fetch only after both entry setups are underway, so the
+    # second entry sees the first entry's fetch in flight rather than a
+    # completed task.
+    while (
+        mock_config_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
+        or second_entry.state is not ConfigEntryState.SETUP_IN_PROGRESS
+    ):
+        await asyncio.sleep(0)
+    release_fetch.set()
+
+    assert await setup_task
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/nmbs/test_init.py
+++ b/tests/components/nmbs/test_init.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import AsyncMock
 
+from pyrail.models import StationsApiResponse
+
 from homeassistant.components.nmbs.const import (
     CONF_STATION_FROM,
     CONF_STATION_TO,
@@ -9,8 +11,9 @@ from homeassistant.components.nmbs.const import (
 )
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.setup import async_setup_component
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_load_json_object_fixture
 
 
 async def test_setup_entry(
@@ -68,3 +71,52 @@ async def test_second_entry_reuses_station_list(
     assert second_entry.state is ConfigEntryState.LOADED
     assert second_entry.runtime_data is mock_config_entry.runtime_data
     mock_nmbs_client.get_stations.assert_called_once()
+
+
+async def test_concurrent_setup_shares_station_fetch(
+    hass: HomeAssistant,
+    mock_nmbs_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that entries set up concurrently share one station fetch."""
+    mock_config_entry.add_to_hass(hass)
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Train from Brussel-Zuid/Bruxelles-Midi to Brussel-Noord/Bruxelles-Nord",
+        data={
+            CONF_STATION_FROM: "BE.NMBS.008814001",
+            CONF_STATION_TO: "BE.NMBS.008812005",
+        },
+        unique_id="BE.NMBS.008814001_BE.NMBS.008812005",
+    )
+    second_entry.add_to_hass(hass)
+
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert second_entry.state is ConfigEntryState.LOADED
+    assert second_entry.runtime_data is mock_config_entry.runtime_data
+    mock_nmbs_client.get_stations.assert_called_once()
+
+
+async def test_setup_retry_after_failed_fetch(
+    hass: HomeAssistant,
+    mock_nmbs_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that a failed station fetch is not reused on a setup retry."""
+    mock_nmbs_client.get_stations.return_value = None
+    mock_config_entry.add_to_hass(hass)
+
+    assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+    mock_nmbs_client.get_stations.return_value = StationsApiResponse.from_dict(
+        await async_load_json_object_fixture(hass, "stations.json", DOMAIN)
+    )
+    await hass.config_entries.async_reload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate the `nmbs` integration from the legacy `hass.data[DOMAIN]` pattern to `entry.runtime_data`. The shared station list is fetched once through the `singleton` helper with `async_` enabled, so entries that are set up concurrently at startup await the same fetch and sequential setups reuse the cached result; a failed fetch clears the cache, so setup retries fetch again. The `find_station` helpers take the station list instead of `hass` and gained return type annotations, and the file level pylint suppression is removed.

The configured stations are resolved during setup and stored in `entry.runtime_data` as a small dataclass, so the sensor platform no longer looks them up itself. If a configured station is not in the station list, setup now raises `ConfigEntryError` with a translated message instead of passing `None` into the sensors. That check lives in `__init__.py` because a forwarded platform is not allowed to raise it.

Tests cover sequential reuse, concurrent setup sharing a single fetch, recovery after a failed fetch, and both missing station cases.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168790
- This PR is related to issue: home-assistant/epics#43
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

