### PR TITLE
Fix legacy port redirect hanging Home Assistant shutdown

### DIFF
--- a/homeassistant/components/http/server.py
+++ b/homeassistant/components/http/server.py
@@ -612,13 +612,22 @@ class HomeAssistantHTTP:
 
     async def _async_stop_legacy_redirect(self) -> None:
         """Stop the legacy redirect server and free its port."""
-        if self._legacy_redirect_server is not None:
-            self._legacy_redirect_server.close()
-            await self._legacy_redirect_server.wait_closed()
-            self._legacy_redirect_server = None
-        if self._legacy_redirect_runner is not None:
-            await self._legacy_redirect_runner.cleanup()
-            self._legacy_redirect_runner = None
+        server = self._legacy_redirect_server
+        runner = self._legacy_redirect_runner
+        # Drop the references up front: both the onboarding listener and the
+        # stop event tear the redirect down, so a second call must not wait on
+        # a teardown that is already in flight.
+        self._legacy_redirect_server = None
+        self._legacy_redirect_runner = None
+        if server is not None:
+            # Stop accepting new connections, but do not await wait_closed()
+            # yet: it only returns once every open connection is done, and the
+            # runner cleanup below is what actually closes them.
+            server.close()
+        if runner is not None:
+            await runner.cleanup()
+        if server is not None:
+            await server.wait_closed()
 
     async def stop(self) -> None:
         """Stop the aiohttp server."""

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1851,6 +1851,88 @@ async def test_legacy_redirect_serves_method_preserving_307(
             assert resp.headers["Location"] == "http://127.0.0.1/api/foo?bar=1"
 
 
+async def test_legacy_redirect_stops_with_connection_open(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test the redirect tears down while a client holds a connection open.
+
+    A client keeps its connection alive after the redirect response, so
+    awaiting the server's wait_closed() before the runner has closed the open
+    connections never returned, hanging every shutdown stage in turn.
+    """
+    captured: dict[str, int] = {}
+
+    async def _bind_serving(self: http.HomeAssistantHTTP) -> asyncio.Server:
+        assert self._legacy_redirect_runner is not None
+        server = await self.hass.loop.create_server(
+            self._legacy_redirect_runner.server, "127.0.0.1", 0
+        )
+        captured["port"] = server.sockets[0].getsockname()[1]
+        return server
+
+    with (
+        patch.dict(os.environ, {ENV_SUPERVISOR: "core"}, clear=True),
+        patch(
+            "homeassistant.components.http.config._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server._DEFAULT_CONFIG", DEFAULT_80_CONFIG
+        ),
+        patch(
+            "homeassistant.components.http.server.HomeAssistantHTTP._async_create_redirect_server",
+            autospec=True,
+            side_effect=_bind_serving,
+        ),
+    ):
+        await _setup_http_with_onboarding(hass)
+        server = hass.http
+        assert server._legacy_redirect_server is not None
+
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                f"http://127.0.0.1:{captured['port']}/", allow_redirects=False
+            ) as resp:
+                assert resp.status == 307
+
+            # The connection is returned to the pool, not closed, so the
+            # redirect still has an open connection at teardown.
+            _complete_onboarding(hass)
+            async with asyncio.timeout(10):
+                await hass.async_block_till_done()
+
+        assert server._legacy_redirect_server is None
+        assert server._legacy_redirect_runner is None
+
+
+async def test_legacy_redirect_stop_is_reentrant(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test overlapping redirect teardowns do not wait on each other.
+
+    Onboarding completing and the stop event both tear the redirect down, so
+    the second call must not await the first call's server again.
+    """
+    with _supervisor_default_config():
+        await _setup_http_with_onboarding(hass)
+        server = hass.http
+        assert server._legacy_redirect_server is not None
+
+        async with asyncio.timeout(10):
+            await asyncio.gather(
+                server._async_stop_legacy_redirect(),
+                server._async_stop_legacy_redirect(),
+            )
+
+        assert server._legacy_redirect_server is None
+        assert server._legacy_redirect_runner is None
+
+        # The stop event fires the same teardown once more.
+        async with asyncio.timeout(10):
+            await server._async_stop_legacy_redirect()
+
+
 @pytest.mark.usefixtures("freezer")
 async def test_websocket_http_config(
     hass: HomeAssistant,


### PR DESCRIPTION
## Proposed change

The legacy port 8123 redirect added in #174278 hangs Home Assistant shutdown for over three minutes.

`_async_stop_legacy_redirect()` awaited the asyncio server's `wait_closed()` before cleaning up the aiohttp runner:

```python
if self._legacy_redirect_server is not None:
    self._legacy_redirect_server.close()
    await self._legacy_redirect_server.wait_closed()   # <-- waits here forever
    self._legacy_redirect_server = None
if self._legacy_redirect_runner is not None:
    await self._legacy_redirect_runner.cleanup()       # <-- what closes the connections
```

`wait_closed()` only returns once every connection handler is done, but `AppRunner.cleanup()` is what closes those handlers (via `Server.shutdown()`). The redirect binds through a raw `loop.create_server()` rather than a `TCPSite`, so the runner has no sites and `cleanup()` never closes the listening socket on its own — the two steps were simply in the wrong order. A single client holding a keep-alive connection to port 8123, which is the normal case for a browser sitting on the onboarding page, made the teardown wait indefinitely.

Both callers hang on this, and they compound. Because the first call never reached the line clearing `_legacy_redirect_server`, the object stayed non-`None`, so the stop event re-entered the same wait behind the onboarding listener's already-stuck teardown. All three core shutdown stages then timed out in turn:

```
Shutdown stage 'stop integrations': still running: <Task pending name='Task-709'
  coro=<async_setup.<locals>.stop_server() running at homeassistant/components/http/__init__.py:180>
Shutdown stage 'final write': still running: <Task pending name='Task-709' ...>
Task <Task pending name='Task-334' coro=<HomeAssistantHTTP._async_stop_legacy_redirect()
  running at homeassistant/components/http/server.py:617> ...> was still running after
  final writes shutdown stage
Shutdown stage 'close': still running: <Task pending name='Task-709' ...>
```

That is 100 s + 60 s + 30 s of pure waiting. On a HAOS reboot the host teardown afterwards took ~25 s, so the delay is entirely in core. Observed twice on 2026.8.0.dev202607280828:

| Reboot | SIGTERM | Host down | Total |
|---|---|---|---|
| 1 | 13:55:19 | 13:58:53 | 3 m 34 s |
| 2 | 14:31:57 | 14:35:33 | 3 m 36 s |

The fix closes the listening socket first to stop accepting new connections, lets `runner.cleanup()` close the open ones (bounded by the runner's `shutdown_timeout`), and only then awaits `wait_closed()`, which is now guaranteed to return. Both references are cleared up front so an overlapping teardown does not wait on a teardown that is already in flight.

Only reachable while onboarding is incomplete, since `_async_manage_port_transition()` skips the redirect once `async_is_onboarded()` is true. Reproduce with a fresh Supervisor install on port 80: open the onboarding page on port 8123, complete onboarding, then reboot.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: regression from #174278
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
