### PR TITLE
Make entity_platform check entity can attach to device

### DIFF
--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -833,8 +833,8 @@ class EntityPlatform:
                 already_exists = True
         return (already_exists, restored)
 
-    def _report_rejected_device_attach(self, entity: Entity, reason: str) -> None:
-        """Report a rejected attempt to attach a device to an entity.
+    def _check_device_attach(self, entity: Entity, reason: str) -> None:
+        """Check the entity does not attach a device and report it if it does.
 
         A device can only be attached to an entity which has a unique ID and
         belongs to a config entry.
@@ -970,7 +970,7 @@ class EntityPlatform:
                 else:
                     device = entity.device_entry
             else:
-                self._report_rejected_device_attach(entity, "without a config entry")
+                self._check_device_attach(entity, "without a config entry")
                 device = None
                 entity.device_entry = None
 
@@ -1043,7 +1043,7 @@ class EntityPlatform:
             entity.entity_id = entry.entity_id
 
         else:  # entity.unique_id is None
-            self._report_rejected_device_attach(entity, "without a unique ID")
+            self._check_device_attach(entity, "without a unique ID")
             entity.device_entry = None
 
             # We won't generate an entity ID if the platform has already set one

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -40,7 +40,7 @@ from homeassistant.util.hass_dict import HassKey
 from . import device_registry as dr, entity_registry as er, service, translation
 from .entity_registry import EntityRegistry, RegistryEntryDisabler, RegistryEntryHider
 from .event import async_call_later
-from .frame import report_usage
+from .frame import ReportBehavior, report_usage
 from .issue_registry import IssueSeverity, async_create_issue
 from .typing import UNDEFINED, ConfigType, DiscoveryInfoType, VolDictType, VolSchemaType
 
@@ -833,6 +833,21 @@ class EntityPlatform:
                 already_exists = True
         return (already_exists, restored)
 
+    def _report_rejected_device_attach(self, entity: Entity, reason: str) -> None:
+        """Report a rejected attempt to attach a device to an entity.
+
+        A device can only be attached to an entity which has a unique ID and
+        belongs to a config entry.
+        """
+        if entity.device_info is None and entity.device_entry is None:
+            return
+        report_usage(
+            f"attempts to attach a device to an entity {reason}",
+            core_behavior=ReportBehavior.LOG,
+            breaks_in_ha_version="2027.8.0",
+            integration_domain=self.platform_name,
+        )
+
     async def _async_add_entity(  # noqa: C901
         self,
         entity: Entity,
@@ -955,7 +970,9 @@ class EntityPlatform:
                 else:
                     device = entity.device_entry
             else:
+                self._report_rejected_device_attach(entity, "without a config entry")
                 device = None
+                entity.device_entry = None
 
             suggested_object_id, object_id_base = _async_derive_object_ids(entity, self)
 
@@ -1025,7 +1042,10 @@ class EntityPlatform:
             entity.registry_entry = entry
             entity.entity_id = entry.entity_id
 
-        else:  # entity.unique_id is None  # noqa: PLR5501
+        else:  # entity.unique_id is None
+            self._report_rejected_device_attach(entity, "without a unique ID")
+            entity.device_entry = None
+
             # We won't generate an entity ID if the platform has already set one
             # We will however make sure that platform cannot pick a registered ID
             if entity.entity_id is None or entity_registry.async_is_registered(

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -1,7 +1,7 @@
 """Tests for the EntityPlatform helper."""
 
 import asyncio
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from datetime import timedelta
 import logging
 import types
@@ -2822,6 +2822,90 @@ async def test_device_type_error_checking(
     assert len(device_registry.devices) == 0
     assert len(entity_registry.entities) == number_of_entities
     assert len(hass.states.async_all()) == number_of_entities
+
+
+def _mock_entity_implementing_device_info(
+    device: dr.DeviceEntry, unique_id: str | None
+) -> MockEntity:
+    """Return an entity attaching a device by implementing device_info."""
+    return MockEntity(
+        unique_id=unique_id, device_info=DeviceInfo(identifiers={("test", "dev1")})
+    )
+
+
+def _mock_entity_setting_attr_device_info(
+    device: dr.DeviceEntry, unique_id: str | None
+) -> MockEntity:
+    """Return an entity attaching a device by setting _attr_device_info."""
+    ent = MockEntity(unique_id=unique_id)
+    ent._attr_device_info = DeviceInfo(identifiers={("test", "dev1")})
+    return ent
+
+
+def _mock_entity_setting_device_entry(
+    device: dr.DeviceEntry, unique_id: str | None
+) -> MockEntity:
+    """Return an entity attaching a device by setting device_entry."""
+    ent = MockEntity(unique_id=unique_id)
+    ent.device_entry = device
+    return ent
+
+
+@pytest.mark.parametrize(
+    "make_entity",
+    [
+        pytest.param(_mock_entity_implementing_device_info, id="device_info"),
+        pytest.param(_mock_entity_setting_attr_device_info, id="attr_device_info"),
+        pytest.param(_mock_entity_setting_device_entry, id="device_entry"),
+    ],
+)
+@pytest.mark.parametrize(
+    ("unique_id", "reason"),
+    [
+        ("qwer", "without a config entry"),
+        (None, "without a unique ID"),
+    ],
+)
+async def test_reject_device_attach_reports_usage(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    make_entity: Callable[[dr.DeviceEntry, str | None], MockEntity],
+    unique_id: str | None,
+    reason: str,
+) -> None:
+    """Test attaching a device is rejected and reports usage.
+
+    A device can only be attached to an entity which has a unique ID and belongs
+    to a config entry. The platform here has no config entry, so an entity that
+    attaches a device is rejected: the attempt is reported and device_entry is
+    cleared.
+    """
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id, identifiers={("test", "dev1")}
+    )
+
+    ent = make_entity(device, unique_id)
+    platform = MockEntityPlatform(hass)
+
+    mock_integration = Mock(is_built_in=True, domain="test_platform")
+    with (
+        caplog.at_level(logging.WARNING),
+        patch(
+            "homeassistant.helpers.frame.async_get_issue_integration",
+            return_value=mock_integration,
+        ),
+    ):
+        await platform.async_add_entities([ent])
+
+    assert (
+        f"Detected that integration 'test_platform' "
+        f"attempts to attach a device to an entity {reason}. "
+        f"This will stop working in Home Assistant 2027.8.0"
+    ) in caplog.text
+    assert ent.device_entry is None
 
 
 async def test_add_entity_unknown_subentry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make entity_platform check entity can attach to device, and warn if it can't:
- An entity which doesn't belong to a config entry (already not supported, but the attempt was silently ignored)
- An entity without a unique_id

In HA Core 2027.8, we will instead raise.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
