### PR TITLE
Mark Z-Wave power management binary sensors as diagnostic

### DIFF
--- a/homeassistant/components/zwave_js/binary_sensor.py
+++ b/homeassistant/components/zwave_js/binary_sensor.py
@@ -352,6 +352,11 @@ NOTIFICATION_SENSOR_MAPPINGS: tuple[NotificationZWaveJSEntityDescription, ...] =
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
     NotificationZWaveJSEntityDescription(
+        # NotificationType 8: Power Management - All other State Id's
+        key=NOTIFICATION_POWER_MANAGEMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    NotificationZWaveJSEntityDescription(
         # NotificationType 9: System - State Id's 1, 2, 3, 4, 6, 7
         key=NOTIFICATION_SYSTEM,
         states={1, 2, 3, 4, 6, 7},

--- a/tests/components/zwave_js/test_binary_sensor.py
+++ b/tests/components/zwave_js/test_binary_sensor.py
@@ -329,6 +329,23 @@ async def test_notification_sensor(
     assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
 
 
+@pytest.mark.usefixtures("ring_keypad", "integration")
+async def test_power_management_notification_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test Power Management notification sensors are diagnostic."""
+    entity_id = "binary_sensor.keypad_v2_power_has_been_applied"
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_OFF
+    assert state.attributes.get(ATTR_DEVICE_CLASS) is None
+
+    entity_entry = entity_registry.async_get(entity_id)
+    assert entity_entry
+    assert entity_entry.entity_category is EntityCategory.DIAGNOSTIC
+
+
 async def test_notification_off_state(
     hass: HomeAssistant,
     lock_popp_electric_strike_lock_control: Node,


### PR DESCRIPTION
## Proposed change

This PR marks all Z-Wave power management notification binary sensors as diagnostics sensors. This is done by adding a catch-all description to the legacy discovery with no device class and diagnostics category, as described in the [mapping rules](https://github.com/home-assistant/core/blob/a87dccab33d4b9e35fdfadac20556b9df936a960/homeassistant/components/zwave_js/binary_sensor.py#L186-L187).

All other existing entity descriptions for power management are already diagnostic – see [here](https://github.com/home-assistant/core/blob/a87dccab33d4b9e35fdfadac20556b9df936a960/homeassistant/components/zwave_js/binary_sensor.py#L329-L353). This change is somewhat similar to what https://github.com/home-assistant/core/pull/129922 did. A test asserting the device class of the `power_has_been_applied` binary sensors has also been added. 

### Affected entities

Please also see the "LLM-generated PR description" below, as it contains a full list of what other entities are affected by the catch-all for power management. IMO, those are now all correctly marked as diagnostics, but not all of them are individually asserted in tests.

As these all hit the same catch-all case, there's a test asserting the category of `power_has_been_applied` that hits that, and the general rule is for all catch-all cases to be diagnostics anyway, I think the one test should be enough, but we should really add full snapshot tests for entity discovery next then (see the section below).

If wanted, I can also add a test that asserts the diagnostics category for entities created from state IDs 1, 2, 12, 13, 14, and 15, but not 16 and 18, as we're lacking test fixtures for those. See the "AI description" section below for the table of all currently affected entities being marked as diagnostics.

### Future

In the (near) future, we should also migrate these to use the new discovery code, but as this is a bugfix to add the missing diagnostics category (whilst improving test coverage a bit), it should be kept separate from a pure refactor.

We may also want to look at adding full snapshots tests for entity discovery before migrating everything, similar to what Matter and many other integrations already use.

## AI description

Please open the below section for an AI-generated description that contains more detailed information.

<details><summary>LLM-generated PR description with more info (click to expand)</summary>
<p>

Z-Wave devices that report a Power Management notification currently get a non-diagnostic `Power has been applied` binary sensor. On a door sensor, that entity competes with the actual door sensor to be the device's primary entity, which is what was reported in #169449 — only the door sensor should be primary there.

This is the same class of issue that #129922 fixed for the Smoke, CO, CO2, Heat, Water and Gas notification types, and it applies the rule that PR documented in this file:

> The catch all description should not have a device class and be marked as diagnostic.

**Root cause:** Power Management (Notification type 8) is not in `MIGRATED_NOTIFICATION_TYPES`, so it goes through the legacy discovery path, which matches each state id against `NOTIFICATION_SENSOR_MAPPINGS`. Power Management had entity descriptions only for specific state ids — 3 (`plug`), 6/7/8/9 (`safety`) and 10/11/17 (`battery`) — and no catch-all. Any other state id therefore matched no description at all, so the entity was created without an entity category and ended up non-diagnostic. State id 1, `Power has been applied`, is exactly such a state.

#129922 introduced the catch-all rule but its scope was the alarm types in its title; Power Management was never extended to use it. This PR adds the missing catch-all so the remaining Power Management states are diagnostic, consistent with every other Power Management state (all of which were already diagnostic) and with the notification types that already have a catch-all.

### Affected entities

No entity is created, removed or renamed, and no device class changes — only `entity_category` moves to diagnostic. Since `entity_category` is a directly-updated registry field, existing installations pick this up on restart without user action.

These are the Power Management states that previously matched no entity description at all, and so were created without an entity category:

| State id | Label | Entity id suffix | Before | After | Fixture data exists |
| --- | --- | --- | --- | --- | --- |
| 1 | Power has been applied | `_power_has_been_applied` | no entity category | diagnostic | yes |
| 2 | AC mains disconnected | `_ac_mains_disconnected` | no entity category | diagnostic | yes |
| 12 | Battery is charging | `_battery_is_charging` | no entity category | diagnostic | yes |
| 13 | Battery is fully charged | `_battery_is_fully_charged` | no entity category | diagnostic | yes |
| 14 | Charge battery soon | `_charge_battery_soon` | no entity category | diagnostic | yes |
| 15 | Charge battery now | `_charge_battery_now` | no entity category | diagnostic | yes |
| 16 | Back-up battery is low | `_back_up_battery_is_low` | no entity category | diagnostic | no |
| 18 | Back-up battery disconnected | `_back_up_battery_disconnected` | no entity category | diagnostic | no |

That table is the complete delta. Every other Power Management state was already diagnostic and is unchanged: 3 (`plug`), 6/7/8/9 (`safety`) and 10/11/17 (`battery`).

The last column means an existing test fixture already contains that state, so coverage can be extended without adding fixture data — it does not mean the state is currently asserted. Only state 1 is asserted today, see Testing below. States 16 and 18 are listed from the Z-Wave JS notification registry for completeness and have no fixture data, so unlike the other six they have not been observed in practice here.

In the existing test fixtures this affects 10 entities across 5 devices, which shows the change is not specific to door sensors:

- `climate_adc_t3000` — Power has been applied, AC mains disconnected
- `cover_zvidar` — AC mains disconnected
- `lock_home_connect_620` — Power has been applied
- `ring_keypad` — Power has been applied, AC mains disconnected
- `wallmote_central_scene` — Battery is charging, Battery is fully charged, Charge battery soon, Charge battery now

### Why only Power Management

The catch-all pattern deliberately is not generalised to every notification type. Several types are unmapped by design because their states are primary functional states rather than diagnostics — for example Weather Alarm (`Rain alarm`, `Freeze alarm`), Home monitoring (`Home occupied`), Light sensor (`Light detected`) and Water Valve (`Valve operation`). Marking those diagnostic would be wrong. Power Management is a good fit precisely because every one of its states is a power or battery status.

Cross-checking the Z-Wave JS notification registry (`packages/core/src/registries/Notifications.ts`) against `NOTIFICATION_SENSOR_MAPPINGS`, the only other unmapped state in a partially-mapped type is Home Security state 11, `Magnetic field interference detected`. That one is intentionally left out of this PR: no existing test fixture contains it, so covering it properly needs new fixture data. Happy to follow up with it separately if preferred.

### Testing

A regression test is added using the existing `ring_keypad` fixture, which already contains a Power Management value with exactly the states from the reported diagnostics (`{"0": "idle", "1": "Power has been applied"}`). The test asserts state 1 is diagnostic; it fails without the fix and passes with it.

All eight states in the table above resolve through the same single catch-all description — there is no per-state logic — so one assertion covers the branch rather than repeating it per state. Happy to parametrise it over more states if a reviewer would prefer the extra coverage.

</p>
</details> 


## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/169449 (cc @AlCalzone)
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
