### PR TITLE
Prefix Uptime Kuma entity IDs without changing names

### DIFF
--- a/homeassistant/components/uptime_kuma/sensor.py
+++ b/homeassistant/components/uptime_kuma/sensor.py
@@ -229,6 +229,7 @@ class UptimeKumaSensorEntity(
 
     entity_description: UptimeKumaSensorEntityDescription
 
+    _attr_entity_id_prefix = DOMAIN
     _attr_has_entity_name = True
 
     def __init__(
@@ -261,6 +262,17 @@ class UptimeKumaSensorEntity(
             manufacturer="Uptime Kuma",
             configuration_url=configuration_url,
             sw_version=coordinator.api.version.version,
+        )
+
+    @property
+    @override
+    def suggested_object_id(self) -> str | None:
+        """Return the suggested object ID."""
+        object_id = super().suggested_object_id
+        return (
+            f"{self.coordinator.data[self.monitor].monitor_name} {object_id}"
+            if object_id is not None
+            else None
         )
 
     @property

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -437,6 +437,7 @@ CACHED_PROPERTIES_WITH_ATTR_ = {
     "device_class",
     "device_info",
     "entity_category",
+    "entity_id_prefix",
     "has_entity_name",
     "entity_picture",
     "entity_registry_enabled_default",
@@ -577,6 +578,7 @@ class Entity(
     _attr_device_class: str | None
     _attr_device_info: DeviceInfo | None = None
     _attr_entity_category: EntityCategory | None
+    _attr_entity_id_prefix: str | None = None
     _attr_has_entity_name: bool
     _attr_entity_picture: str | None = None
     _attr_entity_registry_enabled_default: bool
@@ -627,6 +629,11 @@ class Entity(
     def unique_id(self) -> str | None:
         """Return a unique ID."""
         return self._attr_unique_id
+
+    @cached_property
+    def entity_id_prefix(self) -> str | None:
+        """Return the prefix for a suggested entity ID."""
+        return self._attr_entity_id_prefix
 
     @cached_property
     def has_entity_name(self) -> bool:

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -1276,9 +1276,12 @@ def _async_derive_object_ids(
             object_id = f"{platform.platform_name}_{entity.unique_id}"
         object_id = f"{platform.entity_namespace} {object_id}"
 
-    if entity.entity_id_prefix is not None and object_id is not None:
+    if entity.entity_id_prefix is not None:
         is_base = False
-        object_id = f"{entity.entity_id_prefix} {object_id}"
+        if entity.unique_id is not None and not object_id:
+            object_id = f"{platform.platform_name}_{entity.unique_id}"
+        if object_id is not None:
+            object_id = f"{entity.entity_id_prefix} {object_id}"
 
     suggested_object_id: str | None = None
     object_id_base: str | None = None

--- a/homeassistant/helpers/entity_platform.py
+++ b/homeassistant/helpers/entity_platform.py
@@ -1276,6 +1276,10 @@ def _async_derive_object_ids(
             object_id = f"{platform.platform_name}_{entity.unique_id}"
         object_id = f"{platform.entity_namespace} {object_id}"
 
+    if entity.entity_id_prefix is not None and object_id is not None:
+        is_base = False
+        object_id = f"{entity.entity_id_prefix} {object_id}"
+
     suggested_object_id: str | None = None
     object_id_base: str | None = None
     if is_base:

--- a/tests/components/uptime_kuma/snapshots/test_sensor.ambr
+++ b/tests/components/uptime_kuma/snapshots/test_sensor.ambr
@@ -1,5 +1,5 @@
 # serializer version: 1
-# name: test_setup[sensor.monitor_1_certificate_expiry-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_certificate_expiry-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -13,7 +13,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_certificate_expiry',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_certificate_expiry',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -21,7 +21,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Certificate expiry',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -32,14 +32,14 @@
     'original_name': 'Certificate expiry',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Certificate expiry',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.CERT_DAYS_REMAINING: 'cert_days_remaining'>,
     'unique_id': '123456789_1_cert_days_remaining',
     'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
   })
 # ---
-# name: test_setup[sensor.monitor_1_certificate_expiry-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_certificate_expiry-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -47,14 +47,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.DAYS: 'd'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_certificate_expiry',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_certificate_expiry',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '90',
   })
 # ---
-# name: test_setup[sensor.monitor_1_monitor_type-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_monitor_type-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -103,7 +103,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_1_monitor_type',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_monitor_type',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -111,7 +111,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitor type',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
@@ -119,14 +119,14 @@
     'original_name': 'Monitor type',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Monitor type',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.TYPE: 'type'>,
     'unique_id': '123456789_1_type',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_1_monitor_type-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_monitor_type-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -167,14 +167,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_monitor_type',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_monitor_type',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'http',
   })
 # ---
-# name: test_setup[sensor.monitor_1_monitored_url-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_monitored_url-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -188,7 +188,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_1_monitored_url',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_monitored_url',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -196,7 +196,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitored URL',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -204,27 +204,27 @@
     'original_name': 'Monitored URL',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Monitored URL',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.URL: 'url'>,
     'unique_id': '123456789_1_url',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_1_monitored_url-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_monitored_url-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 1 Monitored URL',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_monitored_url',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_monitored_url',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'https://example.org',
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -240,7 +240,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_response_time',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -248,7 +248,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -259,14 +259,14 @@
     'original_name': 'Response time',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Response time',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.RESPONSE_TIME: 'response_time'>,
     'unique_id': '123456789_1_response_time',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -275,14 +275,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_response_time',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '120',
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time_o_1_day-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time_o_1_day-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -298,7 +298,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_response_time_o_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time_o_1_day',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -306,7 +306,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (1 day)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -320,14 +320,14 @@
     'original_name': 'Response time Ø (1 day)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Response time Ø (1 day)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_1D: 'avg_response_time_1d'>,
     'unique_id': '123456789_1_avg_response_time_1d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time_o_1_day-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time_o_1_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -336,14 +336,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_response_time_o_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time_o_1_day',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '109.206498194946',
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time_o_30_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time_o_30_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -359,7 +359,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_response_time_o_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time_o_30_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -367,7 +367,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (30 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -381,14 +381,14 @@
     'original_name': 'Response time Ø (30 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Response time Ø (30 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_30D: 'avg_response_time_30d'>,
     'unique_id': '123456789_1_avg_response_time_30d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time_o_30_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time_o_30_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -397,14 +397,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_response_time_o_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time_o_30_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '99.3296843901052',
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time_o_365_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time_o_365_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -420,7 +420,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_response_time_o_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time_o_365_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -428,7 +428,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (365 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -442,14 +442,14 @@
     'original_name': 'Response time Ø (365 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Response time Ø (365 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_365D: 'avg_response_time_365d'>,
     'unique_id': '123456789_1_avg_response_time_365d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_1_response_time_o_365_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_response_time_o_365_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -458,14 +458,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_response_time_o_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_response_time_o_365_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '104.39716460819',
   })
 # ---
-# name: test_setup[sensor.monitor_1_status-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -486,7 +486,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_status',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_status',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -494,7 +494,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Status',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
@@ -502,14 +502,14 @@
     'original_name': 'Status',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Status',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.STATUS: 'status'>,
     'unique_id': '123456789_1_status',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_1_status-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -522,14 +522,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_status',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'up',
   })
 # ---
-# name: test_setup[sensor.monitor_1_tags-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_tags-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -543,7 +543,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_1_tags',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_tags',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -551,7 +551,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tags',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -559,14 +559,14 @@
     'original_name': 'Tags',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Tags',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.TAGS: 'tags'>,
     'unique_id': '123456789_1_tags',
     'unit_of_measurement': 'tags',
   })
 # ---
-# name: test_setup[sensor.monitor_1_tags-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_tags-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 1 Tags',
@@ -577,14 +577,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'tags',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_tags',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_tags',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_setup[sensor.monitor_1_uptime_1_day-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_uptime_1_day-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -600,7 +600,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_uptime_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_uptime_1_day',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -608,7 +608,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (1 day)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -619,14 +619,14 @@
     'original_name': 'Uptime (1 day)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Uptime (1 day)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_1D: 'uptime_1d'>,
     'unique_id': '123456789_1_uptime_1d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_1_uptime_1_day-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_uptime_1_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 1 Uptime (1 day)',
@@ -634,14 +634,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_uptime_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_uptime_1_day',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '100',
   })
 # ---
-# name: test_setup[sensor.monitor_1_uptime_30_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_uptime_30_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -657,7 +657,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_uptime_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_uptime_30_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -665,7 +665,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (30 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -676,14 +676,14 @@
     'original_name': 'Uptime (30 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Uptime (30 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_30D: 'uptime_30d'>,
     'unique_id': '123456789_1_uptime_30d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_1_uptime_30_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_uptime_30_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 1 Uptime (30 days)',
@@ -691,14 +691,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_uptime_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_uptime_30_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '99.9336995643114',
   })
 # ---
-# name: test_setup[sensor.monitor_1_uptime_365_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_1_uptime_365_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -714,7 +714,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_1_uptime_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_uptime_365_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -722,7 +722,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (365 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -733,14 +733,14 @@
     'original_name': 'Uptime (365 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 1 Uptime (365 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_365D: 'uptime_365d'>,
     'unique_id': '123456789_1_uptime_365d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_1_uptime_365_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_1_uptime_365_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 1 Uptime (365 days)',
@@ -748,14 +748,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_1_uptime_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_1_uptime_365_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '99.4197742885182',
   })
 # ---
-# name: test_setup[sensor.monitor_2_monitor_type-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_monitor_type-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -804,7 +804,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_2_monitor_type',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_monitor_type',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -812,7 +812,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitor type',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
@@ -820,14 +820,14 @@
     'original_name': 'Monitor type',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Monitor type',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.TYPE: 'type'>,
     'unique_id': '123456789_2_type',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_2_monitor_type-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_monitor_type-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -868,14 +868,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_monitor_type',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_monitor_type',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'port',
   })
 # ---
-# name: test_setup[sensor.monitor_2_monitored_hostname-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_monitored_hostname-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -889,7 +889,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_2_monitored_hostname',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_monitored_hostname',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -897,7 +897,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitored hostname',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -905,27 +905,27 @@
     'original_name': 'Monitored hostname',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Monitored hostname',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.HOSTNAME: 'hostname'>,
     'unique_id': '123456789_2_hostname',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_2_monitored_hostname-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_monitored_hostname-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 2 Monitored hostname',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_monitored_hostname',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_monitored_hostname',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_2_monitored_port-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_monitored_port-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -939,7 +939,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_2_monitored_port',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_monitored_port',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -947,7 +947,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitored port',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -955,27 +955,27 @@
     'original_name': 'Monitored port',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Monitored port',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.PORT: 'port'>,
     'unique_id': '123456789_2_port',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_2_monitored_port-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_monitored_port-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 2 Monitored port',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_monitored_port',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_monitored_port',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -991,7 +991,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_response_time',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -999,7 +999,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1010,14 +1010,14 @@
     'original_name': 'Response time',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Response time',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.RESPONSE_TIME: 'response_time'>,
     'unique_id': '123456789_2_response_time',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1026,14 +1026,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_response_time',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '28',
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time_o_1_day-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time_o_1_day-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1049,7 +1049,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_response_time_o_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time_o_1_day',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1057,7 +1057,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (1 day)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1071,14 +1071,14 @@
     'original_name': 'Response time Ø (1 day)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Response time Ø (1 day)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_1D: 'avg_response_time_1d'>,
     'unique_id': '123456789_2_avg_response_time_1d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time_o_1_day-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time_o_1_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1087,14 +1087,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_response_time_o_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time_o_1_day',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '163.902723735409',
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time_o_30_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time_o_30_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1110,7 +1110,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_response_time_o_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time_o_30_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1118,7 +1118,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (30 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1132,14 +1132,14 @@
     'original_name': 'Response time Ø (30 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Response time Ø (30 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_30D: 'avg_response_time_30d'>,
     'unique_id': '123456789_2_avg_response_time_30d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time_o_30_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time_o_30_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1148,14 +1148,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_response_time_o_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time_o_30_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '337.127322404372',
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time_o_365_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time_o_365_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1171,7 +1171,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_response_time_o_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time_o_365_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1179,7 +1179,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (365 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1193,14 +1193,14 @@
     'original_name': 'Response time Ø (365 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Response time Ø (365 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_365D: 'avg_response_time_365d'>,
     'unique_id': '123456789_2_avg_response_time_365d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_2_response_time_o_365_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_response_time_o_365_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1209,14 +1209,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_response_time_o_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_response_time_o_365_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '342.700987478866',
   })
 # ---
-# name: test_setup[sensor.monitor_2_status-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1237,7 +1237,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_status',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_status',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1245,7 +1245,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Status',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
@@ -1253,14 +1253,14 @@
     'original_name': 'Status',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Status',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.STATUS: 'status'>,
     'unique_id': '123456789_2_status',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_2_status-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -1273,14 +1273,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_status',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'up',
   })
 # ---
-# name: test_setup[sensor.monitor_2_tags-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_tags-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1294,7 +1294,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_2_tags',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_tags',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1302,7 +1302,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tags',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -1310,14 +1310,14 @@
     'original_name': 'Tags',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Tags',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.TAGS: 'tags'>,
     'unique_id': '123456789_2_tags',
     'unit_of_measurement': 'tags',
   })
 # ---
-# name: test_setup[sensor.monitor_2_tags-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_tags-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 2 Tags',
@@ -1328,14 +1328,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'tags',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_tags',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_tags',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '2',
   })
 # ---
-# name: test_setup[sensor.monitor_2_uptime_1_day-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_uptime_1_day-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1351,7 +1351,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_uptime_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_uptime_1_day',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1359,7 +1359,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (1 day)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1370,14 +1370,14 @@
     'original_name': 'Uptime (1 day)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Uptime (1 day)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_1D: 'uptime_1d'>,
     'unique_id': '123456789_2_uptime_1d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_2_uptime_1_day-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_uptime_1_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 2 Uptime (1 day)',
@@ -1385,14 +1385,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_uptime_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_uptime_1_day',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '99.9222395023328',
   })
 # ---
-# name: test_setup[sensor.monitor_2_uptime_30_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_uptime_30_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1408,7 +1408,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_uptime_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_uptime_30_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1416,7 +1416,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (30 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1427,14 +1427,14 @@
     'original_name': 'Uptime (30 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Uptime (30 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_30D: 'uptime_30d'>,
     'unique_id': '123456789_2_uptime_30d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_2_uptime_30_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_uptime_30_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 2 Uptime (30 days)',
@@ -1442,14 +1442,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_uptime_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_uptime_30_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '99.9097987086973',
   })
 # ---
-# name: test_setup[sensor.monitor_2_uptime_365_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_2_uptime_365_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1465,7 +1465,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_2_uptime_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_uptime_365_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1473,7 +1473,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (365 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1484,14 +1484,14 @@
     'original_name': 'Uptime (365 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 2 Uptime (365 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_365D: 'uptime_365d'>,
     'unique_id': '123456789_2_uptime_365d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_2_uptime_365_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_2_uptime_365_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 2 Uptime (365 days)',
@@ -1499,14 +1499,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_2_uptime_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_2_uptime_365_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '99.9461220091593',
   })
 # ---
-# name: test_setup[sensor.monitor_3_certificate_expiry-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_certificate_expiry-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1520,7 +1520,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_certificate_expiry',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_certificate_expiry',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1528,7 +1528,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Certificate expiry',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -1539,14 +1539,14 @@
     'original_name': 'Certificate expiry',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Certificate expiry',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.CERT_DAYS_REMAINING: 'cert_days_remaining'>,
     'unique_id': '123456789_3_cert_days_remaining',
     'unit_of_measurement': <UnitOfTime.DAYS: 'd'>,
   })
 # ---
-# name: test_setup[sensor.monitor_3_certificate_expiry-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_certificate_expiry-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1554,14 +1554,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.DAYS: 'd'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_certificate_expiry',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_certificate_expiry',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '90',
   })
 # ---
-# name: test_setup[sensor.monitor_3_monitor_type-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_monitor_type-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1610,7 +1610,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_3_monitor_type',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_monitor_type',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1618,7 +1618,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitor type',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
@@ -1626,14 +1626,14 @@
     'original_name': 'Monitor type',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Monitor type',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.TYPE: 'type'>,
     'unique_id': '123456789_3_type',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_3_monitor_type-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_monitor_type-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -1674,14 +1674,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_monitor_type',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_monitor_type',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'json_query',
   })
 # ---
-# name: test_setup[sensor.monitor_3_monitored_url-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_monitored_url-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1695,7 +1695,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_3_monitored_url',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_monitored_url',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1703,7 +1703,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Monitored URL',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -1711,27 +1711,27 @@
     'original_name': 'Monitored URL',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Monitored URL',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.URL: 'url'>,
     'unique_id': '123456789_3_url',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_3_monitored_url-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_monitored_url-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 3 Monitored URL',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_monitored_url',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_monitored_url',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'https://down.example.org',
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1747,7 +1747,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_response_time',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1755,7 +1755,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1766,14 +1766,14 @@
     'original_name': 'Response time',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Response time',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.RESPONSE_TIME: 'response_time'>,
     'unique_id': '123456789_3_response_time',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1782,14 +1782,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_response_time',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '120',
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time_o_1_day-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time_o_1_day-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1805,7 +1805,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_response_time_o_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time_o_1_day',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1813,7 +1813,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (1 day)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1827,14 +1827,14 @@
     'original_name': 'Response time Ø (1 day)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Response time Ø (1 day)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_1D: 'avg_response_time_1d'>,
     'unique_id': '123456789_3_avg_response_time_1d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time_o_1_day-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time_o_1_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1843,14 +1843,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_response_time_o_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time_o_1_day',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time_o_30_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time_o_30_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1866,7 +1866,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_response_time_o_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time_o_30_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1874,7 +1874,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (30 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1888,14 +1888,14 @@
     'original_name': 'Response time Ø (30 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Response time Ø (30 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_30D: 'avg_response_time_30d'>,
     'unique_id': '123456789_3_avg_response_time_30d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time_o_30_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time_o_30_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1904,14 +1904,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_response_time_o_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time_o_30_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time_o_365_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time_o_365_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1927,7 +1927,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_response_time_o_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time_o_365_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -1935,7 +1935,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Response time Ø (365 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 0,
@@ -1949,14 +1949,14 @@
     'original_name': 'Response time Ø (365 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Response time Ø (365 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.AVG_RESPONSE_TIME_365D: 'avg_response_time_365d'>,
     'unique_id': '123456789_3_avg_response_time_365d',
     'unit_of_measurement': <UnitOfTime.MILLISECONDS: 'ms'>,
   })
 # ---
-# name: test_setup[sensor.monitor_3_response_time_o_365_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_response_time_o_365_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'duration',
@@ -1965,14 +1965,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTime.MILLISECONDS: 'ms'>,
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_response_time_o_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_response_time_o_365_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_3_status-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_status-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -1993,7 +1993,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_status',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_status',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2001,7 +2001,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Status',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': <SensorDeviceClass.ENUM: 'enum'>,
@@ -2009,14 +2009,14 @@
     'original_name': 'Status',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Status',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.STATUS: 'status'>,
     'unique_id': '123456789_3_status',
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup[sensor.monitor_3_status-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_status-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'enum',
@@ -2029,14 +2029,14 @@
       ]),
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_status',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_status',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'down',
   })
 # ---
-# name: test_setup[sensor.monitor_3_tags-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_tags-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2050,7 +2050,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.monitor_3_tags',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_tags',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2058,7 +2058,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Tags',
+    'object_id_base': None,
     'options': dict({
     }),
     'original_device_class': None,
@@ -2066,14 +2066,14 @@
     'original_name': 'Tags',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Tags',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.TAGS: 'tags'>,
     'unique_id': '123456789_3_tags',
     'unit_of_measurement': 'tags',
   })
 # ---
-# name: test_setup[sensor.monitor_3_tags-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_tags-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 3 Tags',
@@ -2081,14 +2081,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: 'tags',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_tags',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_tags',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': '0',
   })
 # ---
-# name: test_setup[sensor.monitor_3_uptime_1_day-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_uptime_1_day-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2104,7 +2104,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_uptime_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_uptime_1_day',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2112,7 +2112,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (1 day)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -2123,14 +2123,14 @@
     'original_name': 'Uptime (1 day)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Uptime (1 day)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_1D: 'uptime_1d'>,
     'unique_id': '123456789_3_uptime_1d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_3_uptime_1_day-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_uptime_1_day-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 3 Uptime (1 day)',
@@ -2138,14 +2138,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_uptime_1_day',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_uptime_1_day',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_3_uptime_30_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_uptime_30_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2161,7 +2161,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_uptime_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_uptime_30_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2169,7 +2169,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (30 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -2180,14 +2180,14 @@
     'original_name': 'Uptime (30 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Uptime (30 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_30D: 'uptime_30d'>,
     'unique_id': '123456789_3_uptime_30d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_3_uptime_30_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_uptime_30_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 3 Uptime (30 days)',
@@ -2195,14 +2195,14 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_uptime_30_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_uptime_30_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
     'state': 'unknown',
   })
 # ---
-# name: test_setup[sensor.monitor_3_uptime_365_days-entry]
+# name: test_setup[sensor.uptime_kuma_monitor_3_uptime_365_days-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -2218,7 +2218,7 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': None,
-    'entity_id': 'sensor.monitor_3_uptime_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_uptime_365_days',
     'has_entity_name': True,
     'hidden_by': None,
     'icon': None,
@@ -2226,7 +2226,7 @@
     'labels': set({
     }),
     'name': None,
-    'object_id_base': 'Uptime (365 days)',
+    'object_id_base': None,
     'options': dict({
       'sensor': dict({
         'suggested_display_precision': 2,
@@ -2237,14 +2237,14 @@
     'original_name': 'Uptime (365 days)',
     'platform': 'uptime_kuma',
     'previous_unique_id': None,
-    'suggested_object_id': None,
+    'suggested_object_id': 'uptime_kuma Monitor 3 Uptime (365 days)',
     'supported_features': 0,
     'translation_key': <UptimeKumaSensor.UPTIME_RATIO_365D: 'uptime_365d'>,
     'unique_id': '123456789_3_uptime_365d',
     'unit_of_measurement': '%',
   })
 # ---
-# name: test_setup[sensor.monitor_3_uptime_365_days-state]
+# name: test_setup[sensor.uptime_kuma_monitor_3_uptime_365_days-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Monitor 3 Uptime (365 days)',
@@ -2252,7 +2252,7 @@
       <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
     }),
     'context': <ANY>,
-    'entity_id': 'sensor.monitor_3_uptime_365_days',
+    'entity_id': 'sensor.uptime_kuma_monitor_3_uptime_365_days',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,

--- a/tests/components/uptime_kuma/test_sensor.py
+++ b/tests/components/uptime_kuma/test_sensor.py
@@ -46,6 +46,31 @@ async def test_setup(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
 
+@pytest.mark.usefixtures("mock_pythonkuma", "entity_registry_enabled_by_default")
+async def test_existing_entity_id_is_preserved(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test an existing entity ID is not changed."""
+    config_entry.add_to_hass(hass)
+    entity_registry.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{config_entry.entry_id}_1_cert_days_remaining",
+        config_entry=config_entry,
+        suggested_object_id="monitor_1_certificate_expiry",
+    )
+
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_registry.async_get("sensor.monitor_1_certificate_expiry")
+    assert not entity_registry.async_get(
+        "sensor.uptime_kuma_monitor_1_certificate_expiry"
+    )
+
+
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 async def test_migrate_unique_id(
     hass: HomeAssistant,
@@ -76,7 +101,7 @@ async def test_migrate_unique_id(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    assert (entity := entity_registry.async_get("sensor.monitor_status"))
+    assert (entity := entity_registry.async_get("sensor.uptime_kuma_monitor_status"))
     assert entity.unique_id == "123456789_Monitor_status"
 
     mock_pythonkuma.metrics.return_value = {
@@ -97,7 +122,7 @@ async def test_migrate_unique_id(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert (entity := entity_registry.async_get("sensor.monitor_status"))
+    assert (entity := entity_registry.async_get("sensor.uptime_kuma_monitor_status"))
     assert entity.unique_id == "123456789_1_status"
 
     assert (

--- a/tests/components/uptime_kuma/test_sensor.py
+++ b/tests/components/uptime_kuma/test_sensor.py
@@ -66,6 +66,7 @@ async def test_existing_entity_id_is_preserved(
     await hass.async_block_till_done()
 
     assert entity_registry.async_get("sensor.monitor_1_certificate_expiry")
+    assert hass.states.get("sensor.monitor_1_certificate_expiry")
     assert not entity_registry.async_get(
         "sensor.uptime_kuma_monitor_1_certificate_expiry"
     )

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -810,6 +810,10 @@ async def test_registry_respect_entity_id_prefix(hass: HomeAssistant) -> None:
     await platform.async_add_entities([entity])
     assert entity.entity_id == "test_domain.integration_device_name"
 
+    unnamed_entity = EntityWithIdPrefix(unique_id="5678")
+    await platform.async_add_entities([unnamed_entity])
+    assert unnamed_entity.entity_id == "test_domain.integration_test_platform_5678"
+
 
 async def test_registry_respect_entity_disabled(hass: HomeAssistant) -> None:
     """Test that the registry respects entity disabled."""

--- a/tests/helpers/test_entity_platform.py
+++ b/tests/helpers/test_entity_platform.py
@@ -797,6 +797,20 @@ async def test_registry_respect_entity_namespace(
     assert entity.entity_id == "test_domain.ns_device_name"
 
 
+async def test_registry_respect_entity_id_prefix(hass: HomeAssistant) -> None:
+    """Test that the registry respects an entity ID prefix."""
+
+    class EntityWithIdPrefix(MockEntity):
+        """Mock entity with an entity ID prefix."""
+
+        _attr_entity_id_prefix = "integration"
+
+    platform = MockEntityPlatform(hass)
+    entity = EntityWithIdPrefix(unique_id="1234", name="Device Name")
+    await platform.async_add_entities([entity])
+    assert entity.entity_id == "test_domain.integration_device_name"
+
+
 async def test_registry_respect_entity_disabled(hass: HomeAssistant) -> None:
     """Test that the registry respects entity disabled."""
     mock_registry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not applicable. Existing registry entries retain their current entity IDs and user customizations.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add an optional per-entity `entity_id_prefix` used only when generating a new registry entity ID, and use it for Uptime Kuma monitor sensors so new IDs follow `sensor.uptime_kuma_<monitor>_<entity>`.

Uptime Kuma represents many service monitors whose generated entity IDs currently start directly with the monitor name, for example `sensor.bookstack_certificate_expiry`. This makes the integration's entities difficult to identify and group consistently by entity ID.

Prefixing the device name produced the desired IDs but also changed every composed display name to `Uptime Kuma <monitor> <entity>`. The per-entity prefix separates those concerns: it participates only in initial entity-ID generation, while device names and human-facing entity names remain unchanged. It also covers unnamed entities that fall back to `platform_unique_id`.

The prefix is stored as a suggested object ID, so existing registry entries retain their current IDs.

Validation:

- `pytest -q tests/components/uptime_kuma tests/helpers/test_entity_platform.py` — 157 passed
- Focused review-fix suite — 121 passed
- Ruff check and format — passed
- Codespell — passed
- Pylint — passed

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr