### PR TITLE
Remove dead device cleanup code in acmeda

### DIFF
--- a/homeassistant/components/acmeda/const.py
+++ b/homeassistant/components/acmeda/const.py
@@ -6,4 +6,3 @@ LOGGER = logging.getLogger(__package__)
 DOMAIN = "acmeda"
 
 ACMEDA_HUB_UPDATE = "acmeda_hub_update_{}"
-ACMEDA_ENTITY_REMOVE = "acmeda_entity_remove_{}"

--- a/homeassistant/components/acmeda/entity.py
+++ b/homeassistant/components/acmeda/entity.py
@@ -5,10 +5,9 @@ from typing import override
 import aiopulse
 
 from homeassistant.core import callback
-from homeassistant.helpers import device_registry as dr, entity, entity_registry as er
-from homeassistant.helpers.dispatcher import async_dispatcher_connect
+from homeassistant.helpers import device_registry as dr, entity
 
-from .const import ACMEDA_ENTITY_REMOVE, DOMAIN, LOGGER
+from .const import DOMAIN, LOGGER
 
 
 class AcmedaEntity(entity.Entity):
@@ -21,31 +20,10 @@ class AcmedaEntity(entity.Entity):
         """Initialize the roller."""
         self.roller = roller
 
-    async def async_remove_and_unregister(self) -> None:
-        """Unregister from registries and call entity remove function."""
-        LOGGER.error("Removing %s %s", self.__class__.__name__, self.unique_id)
-
-        ent_registry = er.async_get(self.hass)
-        if self.entity_id in ent_registry.entities:
-            ent_registry.async_remove(self.entity_id)
-
-        if self.device_entry:
-            dr.async_get(self.hass).async_remove_device(self.device_entry.id)
-
-        await self.async_remove(force_remove=True)
-
     @override
     async def async_added_to_hass(self) -> None:
         """Entity has been added to hass."""
         self.roller.callback_subscribe(self.notify_update)
-
-        self.async_on_remove(
-            async_dispatcher_connect(
-                self.hass,
-                ACMEDA_ENTITY_REMOVE.format(self.roller.id),
-                self.async_remove_and_unregister,
-            )
-        )
 
     @override
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/components/acmeda/hub.py
+++ b/homeassistant/components/acmeda/hub.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
-from .const import ACMEDA_ENTITY_REMOVE, ACMEDA_HUB_UPDATE, LOGGER
+from .const import ACMEDA_HUB_UPDATE, LOGGER
 from .helpers import update_devices
 
 
@@ -23,7 +23,6 @@ class PulseHub:
         self.config_entry = config_entry
         self.hass = hass
         self.tasks: list[asyncio.Task[None]] = []
-        self.current_rollers: dict[int, aiopulse.Roller] = {}
         self.cleanup_callbacks: list[Callable[[], None]] = []
 
     @property
@@ -79,11 +78,3 @@ class PulseHub:
             async_dispatcher_send(
                 self.hass, ACMEDA_HUB_UPDATE.format(self.config_entry.entry_id)
             )
-
-            for unique_id in list(self.current_rollers):
-                if unique_id not in self.api.rollers:
-                    LOGGER.debug("Notifying remove of %s", unique_id)
-                    self.current_rollers.pop(unique_id)
-                    async_dispatcher_send(
-                        self.hass, ACMEDA_ENTITY_REMOVE.format(unique_id)
-                    )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove dead device cleanup code in acmeda

The device cleanup did nothing, because it looped over the dict `PulseHub.current_rollers` which was never populated

Spotted in https://github.com/home-assistant/core/pull/176909 + https://github.com/home-assistant/core/pull/176941

@atmurray You're welcome to reintroduce the intended cleanup, but note that the cleanup should not be done by the entities to prevent the racy behavior identified in https://github.com/home-assistant/core/pull/176941. Please DM me on Discord if you want to discuss the approach.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
