### PR TITLE
Return None from async_is_composite_device_id for unknown ids

### DIFF
--- a/homeassistant/components/template/entity.py
+++ b/homeassistant/components/template/entity.py
@@ -90,7 +90,9 @@ class AbstractTemplateEntity(Entity):
         device_registry = dr.async_get(hass)
         if (
             device_id := config.get(CONF_DEVICE_ID)
-        ) is not None and not device_registry.async_is_composite_device_id(device_id):
+        ) is not None and device_registry.async_is_composite_device_id(
+            device_id
+        ) is False:
             self.device_entry = device_registry.async_get(device_id)
 
     @property

--- a/homeassistant/components/template/repairs.py
+++ b/homeassistant/components/template/repairs.py
@@ -41,8 +41,9 @@ class CompositeDeviceIdRepairFlow(RepairsFlow):
         errors: dict[str, str] = {}
         if user_input is not None:
             device_id = user_input.get(CONF_DEVICE_ID)
-            if device_id is None or not device_registry.async_is_composite_device_id(
-                device_id
+            if (
+                device_id is None
+                or device_registry.async_is_composite_device_id(device_id) is False
             ):
                 options = {**entry.options}
                 if device_id:
@@ -52,7 +53,7 @@ class CompositeDeviceIdRepairFlow(RepairsFlow):
                 self.hass.config_entries.async_update_entry(entry, options=options)
                 await self.hass.config_entries.async_reload(entry.entry_id)
                 return self.async_create_entry(data={})
-            # The suggested composite device id was submitted unchanged
+            # A composite or unknown device id was submitted
             errors[CONF_DEVICE_ID] = "invalid_device"
 
         return self.async_show_form(

--- a/homeassistant/helpers/device_registry.py
+++ b/homeassistant/helpers/device_registry.py
@@ -1659,15 +1659,18 @@ class DeviceRegistry(BaseRegistry[dict[str, list[dict[str, Any]]]]):
         return self.devices.get_devices_for_composite_device_id(composite_device_id)
 
     @callback
-    def async_is_composite_device_id(self, device_id: str) -> bool:
+    def async_is_composite_device_id(self, device_id: str) -> bool | None:
         """Return True if device_id is a pre-migration composite device id.
 
         A composite device was split into one device per config entry; the
-        composite device id no longer refers to a registered device.
+        composite device id no longer refers to a registered device. Returns
+        False for a registered device id, and None for an unknown id.
         """
-        return device_id not in self.devices and bool(
-            self.devices.get_devices_for_composite_device_id(device_id)
-        )
+        if device_id in self.devices:
+            return False
+        if self.devices.get_devices_for_composite_device_id(device_id):
+            return True
+        return None
 
     @callback
     def _resolve_via_device_id(

--- a/tests/helpers/test_device_registry.py
+++ b/tests/helpers/test_device_registry.py
@@ -3095,7 +3095,7 @@ async def test_async_is_composite_device_id(
     assert device_registry.async_is_composite_device_id(old_id) is True
     assert device_registry.async_is_composite_device_id(device_1.id) is False
     assert device_registry.async_is_composite_device_id(device_2.id) is False
-    assert device_registry.async_is_composite_device_id("unknown_id") is False
+    assert device_registry.async_is_composite_device_id("unknown_id") is None
 
 
 @pytest.mark.parametrize("load_registries", [False])


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Return `None` from `async_is_composite_device_id` for unknown ids.

Stays compatible with the previous behaviour of boolean checks.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
