### PR TITLE
bosch_shc: add test coverage for entity base classes

### DIFF
--- a/tests/components/bosch_shc/conftest.py
+++ b/tests/components/bosch_shc/conftest.py
@@ -1,10 +1,39 @@
 """bosch_shc session fixtures."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, create_autospec
 
+from boschshcpy import SHCDevice, SHCIntrusionSystem
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def bosch_shc_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
     """Auto mock zeroconf."""
+
+
+@pytest.fixture
+def mock_device() -> MagicMock:
+    """Build a minimal SHCDevice double."""
+    device = create_autospec(SHCDevice, instance=True, spec_set=True)
+    device.id = "hdm:HomeMaticIP:contact1"
+    device.serial = "serial-contact1"
+    device.root_device_id = "test-mac"
+    device.manufacturer = "Bosch"
+    device.device_model = "SWD"
+    device.name = "Contact"
+    device.status = "AVAILABLE"
+    device.deleted = False
+    device.device_services = []
+    return device
+
+
+@pytest.fixture
+def mock_intrusion_system() -> MagicMock:
+    """Build a minimal SHCIntrusionSystem double."""
+    domain = create_autospec(SHCIntrusionSystem, instance=True, spec_set=True)
+    domain.id = "intrusionSystem"
+    domain.manufacturer = "Bosch"
+    domain.device_model = "IDS"
+    domain.name = "Intrusion System"
+    domain.deleted = False
+    return domain

--- a/tests/components/bosch_shc/conftest.py
+++ b/tests/components/bosch_shc/conftest.py
@@ -1,9 +1,24 @@
 """bosch_shc session fixtures."""
 
-from unittest.mock import MagicMock, create_autospec
+from __future__ import annotations
 
-from boschshcpy import SHCDevice, SHCIntrusionSystem
+from collections.abc import Generator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, create_autospec, patch
+
+from boschshcpy import BatteryLevelService, SHCBatteryDevice, SHCIntrusionSystem
 import pytest
+
+from homeassistant.components.bosch_shc.const import (
+    CONF_SSL_CERTIFICATE,
+    CONF_SSL_KEY,
+    DOMAIN,
+)
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
 
 
 @pytest.fixture(autouse=True)
@@ -12,24 +27,12 @@ def bosch_shc_mock_async_zeroconf(mock_async_zeroconf: MagicMock) -> None:
 
 
 @pytest.fixture
-def mock_device() -> MagicMock:
-    """Build a minimal SHCDevice double."""
-    device = create_autospec(SHCDevice, instance=True, spec_set=True)
-    device.id = "hdm:HomeMaticIP:contact1"
-    device.serial = "serial-contact1"
-    device.root_device_id = "test-mac"
-    device.manufacturer = "Bosch"
-    device.device_model = "SWD"
-    device.name = "Contact"
-    device.status = "AVAILABLE"
-    device.deleted = False
-    device.device_services = []
-    return device
-
-
-@pytest.fixture
 def mock_intrusion_system() -> MagicMock:
-    """Build a minimal SHCIntrusionSystem double."""
+    """Build a minimal SHCIntrusionSystem double.
+
+    No ha-core platform instantiates SHCDomainEntity today, so there is no
+    config entry setup to route this through.
+    """
     domain = create_autospec(SHCIntrusionSystem, instance=True, spec_set=True)
     domain.id = "intrusionSystem"
     domain.manufacturer = "Bosch"
@@ -37,3 +40,93 @@ def mock_intrusion_system() -> MagicMock:
     domain.name = "Intrusion System"
     domain.deleted = False
     return domain
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Mock bosch_shc config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "1.1.1.1",
+            CONF_SSL_CERTIFICATE: "cert",
+            CONF_SSL_KEY: "key",
+        },
+        unique_id="test-mac",
+    )
+
+
+# Keep in sync with binary_sensor.py's device_helper buckets — a bucket
+# missing here breaks the mock_session fixture.
+_EMPTY_DEVICE_BUCKETS: dict[str, list[Any]] = {
+    bucket: []
+    for bucket in (
+        "motion_detectors",
+        "shutter_contacts",
+        "shutter_contacts2",
+        "smoke_detectors",
+        "thermostats",
+        "twinguards",
+        "universal_switches",
+        "wallthermostats",
+        "water_leakage_detectors",
+    )
+}
+
+
+@pytest.fixture
+def device_buckets(request: pytest.FixtureRequest) -> dict[str, list[Any]]:
+    """device_helper buckets for the mock session.
+
+    Empty by default; a test overrides specific buckets via
+    ``@pytest.mark.parametrize("device_buckets", [{...}], indirect=True)``.
+    """
+    overrides: dict[str, list[Any]] = getattr(request, "param", {})
+    return {**_EMPTY_DEVICE_BUCKETS, **overrides}
+
+
+@pytest.fixture
+def mock_session(device_buckets: dict[str, list[Any]]) -> Generator[MagicMock]:
+    """Mock SHCSession, patched in for the duration of the test."""
+    session = MagicMock()
+    session.information.unique_id = "test-mac"
+    session.information.updateState.name = "UP_TO_DATE"
+    session.information.version = "2.0"
+    session.device_helper = SimpleNamespace(**device_buckets)
+    with patch("homeassistant.components.bosch_shc.SHCSession", return_value=session):
+        yield session
+
+
+async def setup_integration(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+) -> None:
+    """Set up the bosch_shc integration for testing."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+
+def battery_only_device(
+    device_id: str = "hdm:HomeMaticIP:motion1",
+    name: str = "Motion",
+    device_services: list[Any] | None = None,
+) -> SHCBatteryDevice:
+    """Build a minimal device double for the motion_detectors bucket.
+
+    motion_detectors only ever backs a single BatterySensor entity (unlike
+    shutter_contacts, which backs both a ShutterContactSensor and a
+    BatterySensor for the same device) — the single-entity shape keeps these
+    entity.py tests free of a second entity's subscribe/unsubscribe calls.
+    """
+    device = create_autospec(SHCBatteryDevice, instance=True, spec_set=True)
+    device.name = name
+    device.id = device_id
+    device.root_device_id = "test-mac"
+    device.serial = f"serial-{device_id}"
+    device.batterylevel = BatteryLevelService.State.OK
+    device.device_services = device_services or []
+    device.manufacturer = "Bosch"
+    device.device_model = "MD"
+    device.status = "AVAILABLE"
+    device.deleted = False
+    return device

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -1,0 +1,160 @@
+"""Tests for the Bosch SHC base entity classes."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from homeassistant.components.bosch_shc.const import DOMAIN
+from homeassistant.components.bosch_shc.entity import SHCDomainEntity, SHCEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+ENTITY_ID = "binary_sensor.test"
+
+
+@pytest.fixture
+def shc_entity(mock_device: MagicMock) -> SHCEntity:
+    """A bare SHCEntity wired up for lifecycle testing."""
+    return SHCEntity(device=mock_device, parent_id="test-mac", entry_id="entry-id")
+
+
+async def test_device_id_returns_device_id(shc_entity: SHCEntity) -> None:
+    """device_id exposes the underlying device's id."""
+    assert shc_entity.device_id == "hdm:HomeMaticIP:contact1"
+
+
+async def test_async_added_to_hass_subscribes_callback(
+    hass: HomeAssistant, shc_entity: SHCEntity, mock_device: MagicMock
+) -> None:
+    """async_added_to_hass registers a per-service callback with the device."""
+    shc_entity.hass = hass
+    shc_entity.entity_id = ENTITY_ID
+
+    await shc_entity.async_added_to_hass()
+
+    mock_device.subscribe_callback.assert_called_once()
+    assert mock_device.subscribe_callback.call_args.args[0] == ENTITY_ID
+
+
+async def test_async_will_remove_from_hass_unsubscribes(
+    hass: HomeAssistant, shc_entity: SHCEntity, mock_device: MagicMock
+) -> None:
+    """async_will_remove_from_hass unsubscribes the device callback."""
+    shc_entity.hass = hass
+    shc_entity.entity_id = ENTITY_ID
+    await shc_entity.async_added_to_hass()
+
+    await shc_entity.async_will_remove_from_hass()
+
+    mock_device.unsubscribe_callback.assert_called_once_with(ENTITY_ID)
+
+
+async def test_on_state_changed_schedules_update(
+    hass: HomeAssistant, shc_entity: SHCEntity, mock_device: MagicMock
+) -> None:
+    """The registered callback schedules a state update while the device exists."""
+    shc_entity.hass = hass
+    shc_entity.entity_id = ENTITY_ID
+    await shc_entity.async_added_to_hass()
+    on_state_changed = mock_device.subscribe_callback.call_args.args[1]
+
+    with patch.object(shc_entity, "schedule_update_ha_state") as mock_schedule:
+        on_state_changed()
+
+    mock_schedule.assert_called_once_with()
+
+
+async def test_on_state_changed_removes_deleted_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_device: MagicMock,
+) -> None:
+    """A device reporting deleted=True is dropped from this config entry."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, mock_device.id)},
+    )
+    entity = SHCEntity(
+        device=mock_device, parent_id="test-mac", entry_id=entry.entry_id
+    )
+    entity.hass = hass
+    entity.entity_id = ENTITY_ID
+    await entity.async_added_to_hass()
+    on_state_changed = mock_device.subscribe_callback.call_args.args[1]
+    mock_device.deleted = True
+
+    on_state_changed()
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get(device_entry.id) is None
+
+
+async def test_shc_entity_available_reflects_device_status(
+    mock_device: MagicMock,
+) -> None:
+    """Available is true exactly when the device status is AVAILABLE."""
+    entity = SHCEntity(device=mock_device, parent_id="test-mac", entry_id="entry-id")
+    assert entity.available is True
+
+    mock_device.status = "UNAVAILABLE"
+
+    assert entity.available is False
+
+
+async def test_shc_entity_subscribes_every_device_service(
+    hass: HomeAssistant, mock_device: MagicMock
+) -> None:
+    """SHCEntity subscribes/unsubscribes each of the device's services."""
+    service_a = MagicMock()
+    service_b = MagicMock()
+    mock_device.device_services = [service_a, service_b]
+    entity = SHCEntity(device=mock_device, parent_id="test-mac", entry_id="entry-id")
+    entity.hass = hass
+    entity.entity_id = ENTITY_ID
+
+    await entity.async_added_to_hass()
+
+    service_a.subscribe_callback.assert_called_once()
+    assert service_a.subscribe_callback.call_args.args[0] == ENTITY_ID
+    service_b.subscribe_callback.assert_called_once()
+
+    on_state_changed = service_a.subscribe_callback.call_args.args[1]
+    with patch.object(entity, "schedule_update_ha_state") as mock_schedule:
+        on_state_changed()
+    mock_schedule.assert_called_once_with()
+
+    await entity.async_will_remove_from_hass()
+
+    service_a.unsubscribe_callback.assert_called_once_with(ENTITY_ID)
+    service_b.unsubscribe_callback.assert_called_once_with(ENTITY_ID)
+
+
+async def test_shc_domain_entity_device_info(mock_intrusion_system: MagicMock) -> None:
+    """SHCDomainEntity builds device info from the domain object."""
+    entity = SHCDomainEntity(
+        domain=mock_intrusion_system, parent_id="test-mac", entry_id="entry-id"
+    )
+
+    assert entity.unique_id == "intrusionSystem"
+    assert entity.device_info is not None
+    assert entity.device_info["identifiers"] == {(DOMAIN, "intrusionSystem")}
+    assert entity.device_info["via_device"] == (DOMAIN, "test-mac")
+
+
+async def test_shc_domain_entity_available_reflects_system_availability(
+    mock_intrusion_system: MagicMock,
+) -> None:
+    """Available mirrors the intrusion system's system_availability flag."""
+    entity = SHCDomainEntity(
+        domain=mock_intrusion_system, parent_id="test-mac", entry_id="entry-id"
+    )
+    mock_intrusion_system.system_availability = True
+    assert entity.available is True
+
+    mock_intrusion_system.system_availability = False
+
+    assert entity.available is False

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -14,17 +14,17 @@ from unittest.mock import MagicMock, patch
 from boschshcpy import BatteryLevelService
 import pytest
 
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
 from homeassistant.components.bosch_shc.const import DOMAIN
 from homeassistant.components.bosch_shc.entity import SHCDomainEntity
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import battery_only_device, setup_integration
 
 from tests.common import MockConfigEntry
 
-BATTERY_ENTITY_ID = "binary_sensor.motion"
 MOTION_IDENTIFIER = (DOMAIN, "hdm:HomeMaticIP:motion1")
 
 
@@ -39,8 +39,19 @@ def platforms() -> Generator[None]:
 
 @pytest.fixture
 def motion_device(mock_session: MagicMock) -> MagicMock:
-    """The mock device backing binary_sensor.motion."""
+    """The mock device backing the motion detector's battery sensor."""
     return mock_session.device_helper.motion_detectors[0]
+
+
+def _battery_entity_id(
+    entity_registry: er.EntityRegistry, motion_device: MagicMock
+) -> str:
+    """Look up the real entity_id, without assuming a specific naming slug."""
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{motion_device.serial}_battery"
+    )
+    assert entity_id is not None
+    return entity_id
 
 
 @pytest.mark.parametrize(
@@ -51,6 +62,7 @@ def motion_device(mock_session: MagicMock) -> MagicMock:
 @pytest.mark.usefixtures("mock_session")
 async def test_async_added_to_hass_subscribes_device_and_services(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     motion_device: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -60,12 +72,13 @@ async def test_async_added_to_hass_subscribes_device_and_services(
     motion_device.device_services = [service_a, service_b]
 
     await setup_integration(hass, mock_config_entry)
+    entity_id = _battery_entity_id(entity_registry, motion_device)
 
     motion_device.subscribe_callback.assert_called_once_with(
-        BATTERY_ENTITY_ID, motion_device.subscribe_callback.call_args.args[1]
+        entity_id, motion_device.subscribe_callback.call_args.args[1]
     )
     service_a.subscribe_callback.assert_called_once_with(
-        BATTERY_ENTITY_ID, service_a.subscribe_callback.call_args.args[1]
+        entity_id, service_a.subscribe_callback.call_args.args[1]
     )
     service_b.subscribe_callback.assert_called_once()
 
@@ -74,7 +87,7 @@ async def test_async_added_to_hass_subscribes_device_and_services(
     service_a_on_state_changed()
     await hass.async_block_till_done()
 
-    assert (state := hass.states.get(BATTERY_ENTITY_ID)) is not None
+    assert (state := hass.states.get(entity_id)) is not None
     assert state.state == STATE_ON
 
 
@@ -86,18 +99,20 @@ async def test_async_added_to_hass_subscribes_device_and_services(
 @pytest.mark.usefixtures("mock_session")
 async def test_on_state_changed_updates_state(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     motion_device: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """The device-level callback refreshes the entity's state."""
     await setup_integration(hass, mock_config_entry)
+    entity_id = _battery_entity_id(entity_registry, motion_device)
     on_state_changed = motion_device.subscribe_callback.call_args.args[1]
     motion_device.batterylevel = BatteryLevelService.State.LOW_BATTERY
 
     on_state_changed()
     await hass.async_block_till_done()
 
-    assert (state := hass.states.get(BATTERY_ENTITY_ID)) is not None
+    assert (state := hass.states.get(entity_id)) is not None
     assert state.state == STATE_ON
 
 
@@ -132,6 +147,7 @@ async def test_on_state_changed_removes_deleted_device(
 @pytest.mark.usefixtures("mock_session")
 async def test_async_will_remove_from_hass_unsubscribes_device_and_services(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     motion_device: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
@@ -139,12 +155,13 @@ async def test_async_will_remove_from_hass_unsubscribes_device_and_services(
     service = MagicMock()
     motion_device.device_services = [service]
     await setup_integration(hass, mock_config_entry)
+    entity_id = _battery_entity_id(entity_registry, motion_device)
 
     assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    motion_device.unsubscribe_callback.assert_called_once_with(BATTERY_ENTITY_ID)
-    service.unsubscribe_callback.assert_called_once_with(BATTERY_ENTITY_ID)
+    motion_device.unsubscribe_callback.assert_called_once_with(entity_id)
+    service.unsubscribe_callback.assert_called_once_with(entity_id)
 
 
 @pytest.mark.parametrize(
@@ -155,18 +172,20 @@ async def test_async_will_remove_from_hass_unsubscribes_device_and_services(
 @pytest.mark.usefixtures("mock_session")
 async def test_shc_entity_available_reflects_device_status(
     hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
     motion_device: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """The entity becomes unavailable once the device status is no longer AVAILABLE."""
     await setup_integration(hass, mock_config_entry)
+    entity_id = _battery_entity_id(entity_registry, motion_device)
     on_state_changed = motion_device.subscribe_callback.call_args.args[1]
     motion_device.status = "UNAVAILABLE"
 
     on_state_changed()
     await hass.async_block_till_done()
 
-    assert (state := hass.states.get(BATTERY_ENTITY_ID)) is not None
+    assert (state := hass.states.get(entity_id)) is not None
     assert state.state == STATE_UNAVAILABLE
 
 

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -1,136 +1,173 @@
-"""Tests for the Bosch SHC base entity classes."""
+"""Tests for the Bosch SHC base entity classes.
 
+Exercised through the binary_sensor platform's BatterySensor (a real
+SHCEntity subclass) wherever possible, rather than constructing SHCEntity
+directly, so these tests fail if entity creation or registration through a
+config entry breaks. SHCDomainEntity is the one exception: no ha-core
+platform instantiates it today (see its class docstring), so there is no
+config entry flow to route it through.
+"""
+
+from collections.abc import Generator
 from unittest.mock import MagicMock, patch
 
+from boschshcpy import BatteryLevelService
 import pytest
 
 from homeassistant.components.bosch_shc.const import DOMAIN
-from homeassistant.components.bosch_shc.entity import SHCDomainEntity, SHCEntity
+from homeassistant.components.bosch_shc.entity import SHCDomainEntity
+from homeassistant.const import STATE_ON, STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
+from .conftest import battery_only_device, setup_integration
+
 from tests.common import MockConfigEntry
 
-ENTITY_ID = "binary_sensor.test"
+BATTERY_ENTITY_ID = "binary_sensor.motion"
+MOTION_IDENTIFIER = (DOMAIN, "hdm:HomeMaticIP:motion1")
+
+
+@pytest.fixture(autouse=True)
+def platforms() -> Generator[None]:
+    """Restrict bosch_shc setup to the binary_sensor platform."""
+    with patch(
+        "homeassistant.components.bosch_shc.PLATFORMS", [Platform.BINARY_SENSOR]
+    ):
+        yield
 
 
 @pytest.fixture
-def shc_entity(mock_device: MagicMock) -> SHCEntity:
-    """A bare SHCEntity wired up for lifecycle testing."""
-    return SHCEntity(device=mock_device, parent_id="test-mac", entry_id="entry-id")
+def motion_device(mock_session: MagicMock) -> MagicMock:
+    """The mock device backing binary_sensor.motion."""
+    return mock_session.device_helper.motion_detectors[0]
 
 
-async def test_device_id_returns_device_id(shc_entity: SHCEntity) -> None:
-    """device_id exposes the underlying device's id."""
-    assert shc_entity.device_id == "hdm:HomeMaticIP:contact1"
-
-
-async def test_async_added_to_hass_subscribes_callback(
-    hass: HomeAssistant, shc_entity: SHCEntity, mock_device: MagicMock
-) -> None:
-    """async_added_to_hass registers a per-service callback with the device."""
-    shc_entity.hass = hass
-    shc_entity.entity_id = ENTITY_ID
-
-    await shc_entity.async_added_to_hass()
-
-    mock_device.subscribe_callback.assert_called_once()
-    assert mock_device.subscribe_callback.call_args.args[0] == ENTITY_ID
-
-
-async def test_async_will_remove_from_hass_unsubscribes(
-    hass: HomeAssistant, shc_entity: SHCEntity, mock_device: MagicMock
-) -> None:
-    """async_will_remove_from_hass unsubscribes the device callback."""
-    shc_entity.hass = hass
-    shc_entity.entity_id = ENTITY_ID
-    await shc_entity.async_added_to_hass()
-
-    await shc_entity.async_will_remove_from_hass()
-
-    mock_device.unsubscribe_callback.assert_called_once_with(ENTITY_ID)
-
-
-async def test_on_state_changed_schedules_update(
-    hass: HomeAssistant, shc_entity: SHCEntity, mock_device: MagicMock
-) -> None:
-    """The registered callback schedules a state update while the device exists."""
-    shc_entity.hass = hass
-    shc_entity.entity_id = ENTITY_ID
-    await shc_entity.async_added_to_hass()
-    on_state_changed = mock_device.subscribe_callback.call_args.args[1]
-
-    with patch.object(shc_entity, "schedule_update_ha_state") as mock_schedule:
-        on_state_changed()
-
-    mock_schedule.assert_called_once_with()
-
-
-async def test_on_state_changed_removes_deleted_device(
+@pytest.mark.parametrize(
+    "device_buckets",
+    [{"motion_detectors": [battery_only_device()]}],
+    indirect=True,
+)
+@pytest.mark.usefixtures("mock_session")
+async def test_async_added_to_hass_subscribes_device_and_services(
     hass: HomeAssistant,
-    device_registry: dr.DeviceRegistry,
-    mock_device: MagicMock,
+    motion_device: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """A device reporting deleted=True is dropped from this config entry."""
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-    device_entry = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, mock_device.id)},
+    """SHCEntity subscribes the device itself and every one of its services."""
+    service_a = MagicMock()
+    service_b = MagicMock()
+    motion_device.device_services = [service_a, service_b]
+
+    await setup_integration(hass, mock_config_entry)
+
+    motion_device.subscribe_callback.assert_called_once_with(
+        BATTERY_ENTITY_ID, motion_device.subscribe_callback.call_args.args[1]
     )
-    entity = SHCEntity(
-        device=mock_device, parent_id="test-mac", entry_id=entry.entry_id
+    service_a.subscribe_callback.assert_called_once_with(
+        BATTERY_ENTITY_ID, service_a.subscribe_callback.call_args.args[1]
     )
-    entity.hass = hass
-    entity.entity_id = ENTITY_ID
-    await entity.async_added_to_hass()
-    on_state_changed = mock_device.subscribe_callback.call_args.args[1]
-    mock_device.deleted = True
+    service_b.subscribe_callback.assert_called_once()
+
+    motion_device.batterylevel = BatteryLevelService.State.LOW_BATTERY
+    service_a_on_state_changed = service_a.subscribe_callback.call_args.args[1]
+    service_a_on_state_changed()
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(BATTERY_ENTITY_ID)) is not None
+    assert state.state == STATE_ON
+
+
+@pytest.mark.parametrize(
+    "device_buckets",
+    [{"motion_detectors": [battery_only_device()]}],
+    indirect=True,
+)
+@pytest.mark.usefixtures("mock_session")
+async def test_on_state_changed_updates_state(
+    hass: HomeAssistant,
+    motion_device: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """The device-level callback refreshes the entity's state."""
+    await setup_integration(hass, mock_config_entry)
+    on_state_changed = motion_device.subscribe_callback.call_args.args[1]
+    motion_device.batterylevel = BatteryLevelService.State.LOW_BATTERY
 
     on_state_changed()
     await hass.async_block_till_done()
 
-    assert device_registry.async_get(device_entry.id) is None
+    assert (state := hass.states.get(BATTERY_ENTITY_ID)) is not None
+    assert state.state == STATE_ON
 
 
+@pytest.mark.parametrize(
+    "device_buckets",
+    [{"motion_detectors": [battery_only_device()]}],
+    indirect=True,
+)
+@pytest.mark.usefixtures("mock_session")
+async def test_on_state_changed_removes_deleted_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    motion_device: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """A device reporting deleted=True is dropped from the device registry."""
+    await setup_integration(hass, mock_config_entry)
+    on_state_changed = motion_device.subscribe_callback.call_args.args[1]
+    motion_device.deleted = True
+
+    on_state_changed()
+    await hass.async_block_till_done()
+
+    assert device_registry.async_get_device(identifiers={MOTION_IDENTIFIER}) is None
+
+
+@pytest.mark.parametrize(
+    "device_buckets",
+    [{"motion_detectors": [battery_only_device()]}],
+    indirect=True,
+)
+@pytest.mark.usefixtures("mock_session")
+async def test_async_will_remove_from_hass_unsubscribes_device_and_services(
+    hass: HomeAssistant,
+    motion_device: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Unloading the entry unsubscribes the device and every one of its services."""
+    service = MagicMock()
+    motion_device.device_services = [service]
+    await setup_integration(hass, mock_config_entry)
+
+    assert await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    motion_device.unsubscribe_callback.assert_called_once_with(BATTERY_ENTITY_ID)
+    service.unsubscribe_callback.assert_called_once_with(BATTERY_ENTITY_ID)
+
+
+@pytest.mark.parametrize(
+    "device_buckets",
+    [{"motion_detectors": [battery_only_device()]}],
+    indirect=True,
+)
+@pytest.mark.usefixtures("mock_session")
 async def test_shc_entity_available_reflects_device_status(
-    mock_device: MagicMock,
+    hass: HomeAssistant,
+    motion_device: MagicMock,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Available is true exactly when the device status is AVAILABLE."""
-    entity = SHCEntity(device=mock_device, parent_id="test-mac", entry_id="entry-id")
-    assert entity.available is True
+    """The entity becomes unavailable once the device status is no longer AVAILABLE."""
+    await setup_integration(hass, mock_config_entry)
+    on_state_changed = motion_device.subscribe_callback.call_args.args[1]
+    motion_device.status = "UNAVAILABLE"
 
-    mock_device.status = "UNAVAILABLE"
+    on_state_changed()
+    await hass.async_block_till_done()
 
-    assert entity.available is False
-
-
-async def test_shc_entity_subscribes_every_device_service(
-    hass: HomeAssistant, mock_device: MagicMock
-) -> None:
-    """SHCEntity subscribes/unsubscribes each of the device's services."""
-    service_a = MagicMock()
-    service_b = MagicMock()
-    mock_device.device_services = [service_a, service_b]
-    entity = SHCEntity(device=mock_device, parent_id="test-mac", entry_id="entry-id")
-    entity.hass = hass
-    entity.entity_id = ENTITY_ID
-
-    await entity.async_added_to_hass()
-
-    service_a.subscribe_callback.assert_called_once()
-    assert service_a.subscribe_callback.call_args.args[0] == ENTITY_ID
-    service_b.subscribe_callback.assert_called_once()
-
-    on_state_changed = service_a.subscribe_callback.call_args.args[1]
-    with patch.object(entity, "schedule_update_ha_state") as mock_schedule:
-        on_state_changed()
-    mock_schedule.assert_called_once_with()
-
-    await entity.async_will_remove_from_hass()
-
-    service_a.unsubscribe_callback.assert_called_once_with(ENTITY_ID)
-    service_b.unsubscribe_callback.assert_called_once_with(ENTITY_ID)
+    assert (state := hass.states.get(BATTERY_ENTITY_ID)) is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 async def test_shc_domain_entity_device_info(mock_intrusion_system: MagicMock) -> None:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`bosch_shc`'s `entity.py` (`SHCBaseEntity`/`SHCEntity`/`SHCDomainEntity`) had
zero direct test coverage. Even with the pending per-platform test PRs
(#176108, #176150, #176151, #176153, #176331) merged, several code paths in
this shared base module stay unexercised: the device-removal cleanup
(`async_remove_devices`), both branches of the state-change callback
(schedule an update vs. remove a deleted device), the `device_id` property,
and `SHCEntity`'s per-service subscribe/unsubscribe loop.

This PR adds `tests/components/bosch_shc/test_entity.py`, taking `entity.py`
from 76% (measured with all 5 pending platform PRs merged in) to 100%.

No production code changes.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr