### PR TITLE
feat: add icons for mode "silent" and "full" of climate

### DIFF
--- a/homeassistant/components/climate/icons.json
+++ b/homeassistant/components/climate/icons.json
@@ -35,12 +35,14 @@
             "auto": "mdi:fan-auto",
             "diffuse": "mdi:weather-windy",
             "focus": "mdi:target",
+            "full": "mdi:fan-alert",
             "high": "mdi:speedometer",
             "low": "mdi:speedometer-slow",
             "medium": "mdi:speedometer-medium",
             "middle": "mdi:speedometer-medium",
             "off": "mdi:fan-off",
-            "on": "mdi:fan"
+            "on": "mdi:fan",
+            "silent": "mdi:fan-clock"
           }
         },
         "hvac_action": {

--- a/homeassistant/components/climate/strings.json
+++ b/homeassistant/components/climate/strings.json
@@ -163,12 +163,14 @@
             "auto": "[%key:common::state::auto%]",
             "diffuse": "Diffuse",
             "focus": "Focus",
+            "full": "Full",
             "high": "[%key:common::state::high%]",
             "low": "[%key:common::state::low%]",
             "medium": "[%key:common::state::medium%]",
             "middle": "Middle",
             "off": "[%key:common::state::off%]",
             "on": "[%key:common::state::on%]",
+            "silent": "Silent",
             "top": "Top"
           }
         },


### PR DESCRIPTION
## Proposed change

Adds the icons for `silent` and `full` in the climate domain (e.g. for ACs)

Before: 
<img width="195" height="305" alt="image" src="https://github.com/user-attachments/assets/6cfbe178-507a-4975-a47f-7c0fb2745f8a" />

After: 

<img width="194" height="317" alt="image" src="https://github.com/user-attachments/assets/6c286fba-962d-4196-8e6b-f19fa85375b1" />

## Type of change

UI


## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
