### PR TITLE
Fix swallowed exceptions in action handlers for madVR

### DIFF
--- a/homeassistant/components/madvr/remote.py
+++ b/homeassistant/components/madvr/remote.py
@@ -6,8 +6,10 @@ from typing import Any, override
 
 from homeassistant.components.remote import RemoteEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DOMAIN
 from .coordinator import MadVRConfigEntry, MadVRCoordinator
 from .entity import MadVREntity
 
@@ -54,9 +56,11 @@ class MadvrRemote(MadVREntity, RemoteEntity):
         _LOGGER.debug("Turning off")
         try:
             await self.madvr_client.power_off()
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to turn off device %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="power_off_failed",
+            ) from err
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -65,9 +69,11 @@ class MadvrRemote(MadVREntity, RemoteEntity):
 
         try:
             await self.madvr_client.power_on(mac=self.coordinator.mac)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to turn on device %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="power_on_failed",
+            ) from err
 
     @override
     async def async_send_command(self, command: Iterable[str], **kwargs: Any) -> None:
@@ -75,6 +81,9 @@ class MadvrRemote(MadVREntity, RemoteEntity):
         _LOGGER.debug("adding command %s", command)
         try:
             await self.madvr_client.add_command_to_queue(command)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
         except (ConnectionError, NotImplementedError) as err:
-            _LOGGER.error("Failed to send command %s", err)
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_command_failed",
+                translation_placeholders={"command": ", ".join(command)},
+            ) from err

--- a/homeassistant/components/madvr/strings.json
+++ b/homeassistant/components/madvr/strings.json
@@ -131,5 +131,16 @@
         "name": "Mainboard temperature"
       }
     }
+  },
+  "exceptions": {
+    "power_off_failed": {
+      "message": "Failed to turn off the device"
+    },
+    "power_on_failed": {
+      "message": "Failed to turn on the device"
+    },
+    "send_command_failed": {
+      "message": "Failed to send the command {command}"
+    }
   }
 }

--- a/tests/components/madvr/const.py
+++ b/tests/components/madvr/const.py
@@ -13,7 +13,4 @@ MOCK_MAC_NEW = "00:00:00:00:00:01"
 TEST_CON_ERROR = ConnectionError("Connection failed")
 TEST_IMP_ERROR = NotImplementedError("Not implemented")
 
-TEST_FAILED_ON = "Failed to turn on device"
-TEST_FAILED_OFF = "Failed to turn off device"
-TEST_FAILED_CMD = "Failed to send command"
 TEST_COMMAND = "test"

--- a/tests/components/madvr/test_remote.py
+++ b/tests/components/madvr/test_remote.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.madvr.const import DOMAIN
 from homeassistant.components.remote import (
     DOMAIN as REMOTE_DOMAIN,
     SERVICE_SEND_COMMAND,
@@ -18,17 +19,11 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_integration
-from .const import (
-    TEST_COMMAND,
-    TEST_CON_ERROR,
-    TEST_FAILED_CMD,
-    TEST_FAILED_OFF,
-    TEST_FAILED_ON,
-    TEST_IMP_ERROR,
-)
+from .const import TEST_COMMAND, TEST_CON_ERROR, TEST_IMP_ERROR
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -51,7 +46,6 @@ async def test_remote_power(
     hass: HomeAssistant,
     mock_madvr_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test turning on the remote entity."""
 
@@ -74,47 +68,11 @@ async def test_remote_power(
 
     mock_madvr_client.power_on.assert_called_once()
 
-    # cover exception cases
-    caplog.clear()
-    mock_madvr_client.power_off.side_effect = TEST_CON_ERROR
-    await hass.services.async_call(
-        REMOTE_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
-    )
-    assert TEST_FAILED_OFF in caplog.text
-
-    # Test turning off with NotImplementedError
-    caplog.clear()
-    mock_madvr_client.power_off.side_effect = TEST_IMP_ERROR
-    await hass.services.async_call(
-        REMOTE_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True
-    )
-    assert TEST_FAILED_OFF in caplog.text
-
-    # Reset side_effect for power_off
-    mock_madvr_client.power_off.side_effect = None
-
-    # Test turning on with ConnectionError
-    caplog.clear()
-    mock_madvr_client.power_on.side_effect = TEST_CON_ERROR
-    await hass.services.async_call(
-        REMOTE_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-    )
-    assert TEST_FAILED_ON in caplog.text
-
-    # Test turning on with NotImplementedError
-    caplog.clear()
-    mock_madvr_client.power_on.side_effect = TEST_IMP_ERROR
-    await hass.services.async_call(
-        REMOTE_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True
-    )
-    assert TEST_FAILED_ON in caplog.text
-
 
 async def test_send_command(
     hass: HomeAssistant,
     mock_madvr_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
-    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test sending command to the remote entity."""
 
@@ -132,23 +90,45 @@ async def test_send_command(
     )
 
     mock_madvr_client.add_command_to_queue.assert_called_once_with([TEST_COMMAND])
-    # cover exceptions
-    # Test ConnectionError
-    mock_madvr_client.add_command_to_queue.side_effect = TEST_CON_ERROR
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
-        {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: TEST_COMMAND},
-        blocking=True,
-    )
-    assert TEST_FAILED_CMD in caplog.text
 
-    # Test NotImplementedError
-    mock_madvr_client.add_command_to_queue.side_effect = TEST_IMP_ERROR
-    await hass.services.async_call(
-        REMOTE_DOMAIN,
-        SERVICE_SEND_COMMAND,
-        {ATTR_ENTITY_ID: entity_id, ATTR_COMMAND: TEST_COMMAND},
-        blocking=True,
-    )
-    assert TEST_FAILED_CMD in caplog.text
+
+@pytest.mark.parametrize("error", [TEST_CON_ERROR, TEST_IMP_ERROR])
+@pytest.mark.parametrize(
+    ("client_method", "service", "extra_data", "translation_key"),
+    [
+        ("power_off", SERVICE_TURN_OFF, {}, "power_off_failed"),
+        ("power_on", SERVICE_TURN_ON, {}, "power_on_failed"),
+        (
+            "add_command_to_queue",
+            SERVICE_SEND_COMMAND,
+            {ATTR_COMMAND: TEST_COMMAND},
+            "send_command_failed",
+        ),
+    ],
+)
+async def test_remote_action_failures(
+    hass: HomeAssistant,
+    mock_madvr_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    client_method: str,
+    service: str,
+    extra_data: dict[str, str],
+    error: Exception,
+    translation_key: str,
+) -> None:
+    """Test that failing remote actions raise HomeAssistantError."""
+    await setup_integration(hass, mock_config_entry)
+
+    entity_id = "remote.madvr_envy"
+    getattr(mock_madvr_client, client_method).side_effect = error
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            REMOTE_DOMAIN,
+            service,
+            {ATTR_ENTITY_ID: entity_id, **extra_data},
+            blocking=True,
+        )
+
+    assert err.value.translation_domain == DOMAIN
+    assert err.value.translation_key == translation_key


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The madVR remote entity only logged an error when turning the device on or off or sending a command failed, so users got no feedback in the UI and automations continued as if the action had succeeded. The three except blocks now raise `HomeAssistantError` with translated messages (`power_off_failed`, `power_on_failed`, `send_command_failed`), following the merged sky_remote fix (#177001) for this epic. The pylint suppressions are removed, the old log-assertion test blocks are replaced by a parametrized test that asserts the raised error and translation key for all three actions with both error types, and the unused log-message test constants are removed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #170624
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
