### PR TITLE
KNX: expose write back

### DIFF
--- a/homeassistant/components/knx/dpt.py
+++ b/homeassistant/components/knx/dpt.py
@@ -44,28 +44,28 @@ def get_supported_dpts() -> Mapping[str, DPTInfo]:
     dpts: dict[str, DPTInfo] = {}
     for dpt_class in DPTBase.dpt_class_tree():
         dpt_number_str = dpt_class.dpt_number_str()
-        ha_dpt_class = _ha_dpt_class(dpt_class)
+        dpt_kind = ha_dpt_class(dpt_class)
         info = DPTInfo(
-            dpt_class=ha_dpt_class,
+            dpt_class=dpt_kind,
             main=dpt_class.dpt_main_number,  # type: ignore[typeddict-item] # checked in xknx unit tests
             sub=dpt_class.dpt_sub_number,
             name=dpt_class.value_type,
             unit=_sensor_unit_overrides.get(dpt_number_str, dpt_class.unit),
             sensor_device_class=_sensor_device_classes.get(dpt_number_str),
-            sensor_state_class=_get_sensor_state_class(ha_dpt_class, dpt_number_str),
+            sensor_state_class=_get_sensor_state_class(dpt_kind, dpt_number_str),
             payload_length=dpt_class.payload_length,
         )
-        if ha_dpt_class == "numeric":
+        if dpt_kind == "numeric":
             _add_numeric_details(info, cast(type[DPTNumeric], dpt_class))
-        elif ha_dpt_class == "enum":
+        elif dpt_kind == "enum":
             _add_enum_details(info, cast(type[DPTEnum], dpt_class))
-        elif ha_dpt_class == "complex":
+        elif dpt_kind == "complex":
             _add_complex_details(info, cast(type[DPTComplex], dpt_class))
         dpts[dpt_number_str] = info
     return dpts
 
 
-def _ha_dpt_class(dpt_cls: type[DPTBase]) -> HaDptClass:
+def ha_dpt_class(dpt_cls: type[DPTBase]) -> HaDptClass:
     """Return the DPT class identifier string."""
     if issubclass(dpt_cls, DPTNumeric):
         return "numeric"
@@ -187,10 +187,10 @@ _sensor_unit_overrides: Mapping[str, str] = {
 
 
 def _get_sensor_state_class(
-    ha_dpt_class: HaDptClass, dpt_number_str: str
+    dpt_kind: HaDptClass, dpt_number_str: str
 ) -> SensorStateClass | None:
     """Return the SensorStateClass for a given DPT."""
-    if ha_dpt_class != "numeric":
+    if dpt_kind != "numeric":
         return None
 
     return _sensor_state_class_overrides.get(

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -314,19 +314,24 @@ class KnxExposeEntity:
                 return
             # Reflect the received value and pre-seed the ExposeSensor's last-sent
             # payload so the entity state change we trigger re-encodes identically
-            # and is skipped by skip_unchanged. xknx exposes no public API for this;
-            # guard the private attribute so a future xknx change surfaces as a
-            # warning instead of silently echoing the value back onto the bus.
+            # and is skipped by skip_unchanged. Seed the canonical re-encoding
+            # (sensor_value.last_payload, i.e. to_knx(value)) rather than the raw
+            # telegram payload: lossy DPTs (e.g. 5.001) re-encode a decoded value to
+            # a different payload than the one received. xknx exposes no public API
+            # for this; guard the private attribute so a future xknx change surfaces
+            # as a warning instead of silently echoing the value back onto the bus.
             with suppress(ConversionError):
                 xknx_expose.sensor_value.value = call.echo_value
-            if hasattr(xknx_expose, "_payload_after_cooldown"):
-                xknx_expose._payload_after_cooldown = telegram.payload.value  # noqa: SLF001
-            else:
-                _LOGGER.warning(
-                    "KNX expose %s: cannot suppress write_back echo (unexpected xknx "
-                    "internals); the value may be re-sent to the bus",
-                    self.entity_id,
-                )
+                if hasattr(xknx_expose, "_payload_after_cooldown"):
+                    xknx_expose._payload_after_cooldown = (  # noqa: SLF001
+                        xknx_expose.sensor_value.last_payload
+                    )
+                else:
+                    _LOGGER.warning(
+                        "KNX expose %s: cannot suppress write_back echo (unexpected "
+                        "xknx internals); the value may be re-sent to the bus",
+                        self.entity_id,
+                    )
             self.hass.async_create_task(
                 self.hass.services.async_call(
                     call.domain, call.service, call.data, blocking=False

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -12,7 +12,7 @@ from xknx.core.telegram_queue import TelegramQueue
 from xknx.devices import DateDevice, DateTimeDevice, ExposeSensor, TimeDevice
 from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTNumeric, DPTString
 from xknx.dpt.dpt_1 import DPT1BitEnum, DPTSwitch
-from xknx.exceptions import ConversionError
+from xknx.exceptions import ConversionError, CouldNotParseTelegram
 from xknx.telegram import Telegram, TelegramDirection
 from xknx.telegram.address import (
     GroupAddress,
@@ -48,12 +48,19 @@ from homeassistant.helpers.typing import ConfigType, StateType
 from homeassistant.util import dt as dt_util
 
 from .const import CONF_RESPOND_TO_READ, KNX_ADDRESS
+from .dpt import ha_dpt_class
 from .schema import ExposeSchema
 
 if TYPE_CHECKING:
     from .storage.time_server import KNXTimeServerStoreModel
 
 _LOGGER = logging.getLogger(__name__)
+
+# write-back target per (DPT value kind, entity domain): (service domain, service, field)
+_WRITE_BACK_DISPATCH: dict[tuple[str, str], tuple[str, str, str]] = {
+    ("numeric", "number"): ("number", "set_value", "value"),
+    ("numeric", "input_number"): ("input_number", "set_value", "value"),
+}
 
 
 class _WriteBackCall(NamedTuple):
@@ -338,11 +345,25 @@ class KnxExposeEntity:
             return _WriteBackCall(
                 value, entity_domain, service, {ATTR_ENTITY_ID: self.entity_id}
             )
-        _LOGGER.warning(
-            "KNX expose write_back to %s: unsupported target for the configured DPT",
-            self.entity_id,
-        )
-        return None
+        mapping = _WRITE_BACK_DISPATCH.get((ha_dpt_class(option.dpt), entity_domain))
+        if mapping is None:
+            _LOGGER.warning(
+                "KNX expose write_back to %s: unsupported target for the configured DPT",
+                self.entity_id,
+            )
+            return None
+        try:
+            value = option.dpt.from_knx(payload)
+        except (ConversionError, CouldNotParseTelegram) as err:
+            _LOGGER.warning(
+                "Could not decode incoming telegram for KNX expose %s: %s",
+                self.entity_id,
+                err,
+            )
+            return None
+        service_domain, service, field = mapping
+        data = {ATTR_ENTITY_ID: self.entity_id, field: value}
+        return _WriteBackCall(value, service_domain, service, data)
 
     def _get_expose_value(
         self, state: State | None, option: KnxExposeOptions

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -2,24 +2,32 @@
 
 from asyncio import TaskGroup
 from collections.abc import Callable, Iterable
+from contextlib import suppress
 from dataclasses import dataclass
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 from xknx import XKNX
+from xknx.core.telegram_queue import TelegramQueue
 from xknx.devices import DateDevice, DateTimeDevice, ExposeSensor, TimeDevice
-from xknx.dpt import DPTBase, DPTNumeric, DPTString
+from xknx.dpt import DPTArray, DPTBase, DPTBinary, DPTNumeric, DPTString
 from xknx.dpt.dpt_1 import DPT1BitEnum, DPTSwitch
 from xknx.exceptions import ConversionError
+from xknx.telegram import Telegram, TelegramDirection
 from xknx.telegram.address import (
     GroupAddress,
+    IndividualAddress,
     InternalGroupAddress,
     parse_device_group_address,
 )
+from xknx.telegram.apci import GroupValueWrite
 
 from homeassistant.const import (
+    ATTR_ENTITY_ID,
     CONF_ENTITY_ID,
     CONF_VALUE_TEMPLATE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
     STATE_UNAVAILABLE,
@@ -31,6 +39,7 @@ from homeassistant.core import (
     HomeAssistant,
     State,
     callback,
+    split_entity_id,
 )
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers.event import async_track_state_change_event
@@ -45,6 +54,15 @@ if TYPE_CHECKING:
     from .storage.time_server import KNXTimeServerStoreModel
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _WriteBackCall(NamedTuple):
+    """Resolved write-back for an incoming telegram: value + service to call."""
+
+    echo_value: bool | int | float | str
+    domain: str
+    service: str
+    data: dict[str, Any]
 
 
 @callback
@@ -120,6 +138,8 @@ class KnxExposeOptions:
     periodic_send: float
     default: Any | None
     value_template: Template | None
+    write_back: bool = False
+    source_whitelist: frozenset[str] = frozenset()
 
 
 def _yaml_config_to_expose_options(config: ConfigType) -> KnxExposeOptions:
@@ -148,6 +168,11 @@ def _yaml_config_to_expose_options(config: ConfigType) -> KnxExposeOptions:
         periodic_send=periodic_send_seconds,
         default=config.get(ExposeSchema.CONF_KNX_EXPOSE_DEFAULT),
         value_template=config.get(CONF_VALUE_TEMPLATE),
+        write_back=config[ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK],
+        source_whitelist=frozenset(
+            str(IndividualAddress(ia))
+            for ia in config[ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST]
+        ),
     )
 
 
@@ -167,6 +192,7 @@ class KnxExposeEntity:
         self.entity_id = entity_id
 
         self._remove_listener: Callable[[], None] | None = None
+        self._telegram_cb_handle: TelegramQueue.Callback | None = None
         self._exposures = tuple(
             (
                 option,
@@ -197,6 +223,25 @@ class KnxExposeEntity:
         )
         for _option, xknx_expose in self._exposures:
             self.xknx.devices.async_add(xknx_expose)
+        write_back_addresses: list[GroupAddress | InternalGroupAddress] = []
+        for option, _xknx_expose in self._exposures:
+            if not option.write_back:
+                continue
+            write_back_addresses.append(option.group_address)
+            if not option.source_whitelist:
+                _LOGGER.warning(
+                    "KNX expose %s has write_back enabled without a source_whitelist; "
+                    "any KNX device may change its state",
+                    self.entity_id,
+                )
+        if write_back_addresses:
+            self._telegram_cb_handle = (
+                self.xknx.telegram_queue.register_telegram_received_cb(
+                    self._telegram_received_cb,
+                    group_addresses=write_back_addresses,
+                    match_for_outgoing=False,
+                )
+            )
         self._init_expose_state()
 
     @callback
@@ -220,8 +265,84 @@ class KnxExposeEntity:
         if self._remove_listener is not None:
             self._remove_listener()
             self._remove_listener = None
+        if self._telegram_cb_handle is not None:
+            self.xknx.telegram_queue.unregister_telegram_received_cb(
+                self._telegram_cb_handle
+            )
+            self._telegram_cb_handle = None
         for _option, xknx_expose in self._exposures:
             self.xknx.devices.async_remove(xknx_expose)
+
+    def _telegram_received_cb(self, telegram: Telegram) -> None:
+        """Change the exposed entity from a whitelisted incoming GroupValueWrite."""
+        if telegram.direction is not TelegramDirection.INCOMING:
+            return
+        if (
+            not isinstance(telegram.payload, GroupValueWrite)
+            or telegram.payload.value is None
+        ):
+            return
+        for option, xknx_expose in self._exposures:
+            if (
+                not option.write_back
+                or option.group_address != telegram.destination_address
+            ):
+                continue
+            if (
+                option.source_whitelist
+                and str(telegram.source_address) not in option.source_whitelist
+            ):
+                return
+            call = self._write_back_service_call(option, telegram.payload.value)
+            if call is None:
+                return
+            # Reflect the received value and pre-seed the ExposeSensor's last-sent
+            # payload so the entity state change we trigger re-encodes identically
+            # and is skipped by skip_unchanged. xknx exposes no public API for this;
+            # guard the private attribute so a future xknx change surfaces as a
+            # warning instead of silently echoing the value back onto the bus.
+            with suppress(ConversionError):
+                xknx_expose.sensor_value.value = call.echo_value
+            if hasattr(xknx_expose, "_payload_after_cooldown"):
+                xknx_expose._payload_after_cooldown = telegram.payload.value  # noqa: SLF001
+            else:
+                _LOGGER.warning(
+                    "KNX expose %s: cannot suppress write_back echo (unexpected xknx "
+                    "internals); the value may be re-sent to the bus",
+                    self.entity_id,
+                )
+            self.hass.async_create_task(
+                self.hass.services.async_call(
+                    call.domain, call.service, call.data, blocking=False
+                ),
+                f"KNX expose write_back {self.entity_id}",
+            )
+            return
+
+    def _write_back_service_call(
+        self, option: KnxExposeOptions, payload: DPTBinary | DPTArray
+    ) -> _WriteBackCall | None:
+        """Map an incoming payload to the write-back service call, or None."""
+        entity_domain = split_entity_id(self.entity_id)[0]
+        if issubclass(option.dpt, DPT1BitEnum):
+            value = bool(payload.value)
+            service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
+            if not self.hass.services.has_service(entity_domain, service):
+                _LOGGER.warning(
+                    "KNX expose write_back to %s: %s does not support %s",
+                    self.entity_id,
+                    entity_domain,
+                    service,
+                )
+                return None
+            return _WriteBackCall(
+                value, entity_domain, service, {ATTR_ENTITY_ID: self.entity_id}
+            )
+        _LOGGER.warning(
+            "KNX expose write_back to %s: unsupported target for the configured DPT",
+            self.entity_id,
+        )
+        return None
 
     def _get_expose_value(
         self, state: State | None, option: KnxExposeOptions

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -341,7 +341,15 @@ class KnxExposeEntity:
         """Map an incoming payload to the write-back service call, or None."""
         entity_domain = split_entity_id(self.entity_id)[0]
         if issubclass(option.dpt, DPT1BitEnum):
-            value = bool(payload.value)
+            try:
+                value = bool(option.dpt.from_knx(payload).value)
+            except (ConversionError, CouldNotParseTelegram) as err:
+                _LOGGER.warning(
+                    "Could not decode incoming telegram for KNX expose %s: %s",
+                    self.entity_id,
+                    err,
+                )
+                return None
             service = SERVICE_TURN_ON if value else SERVICE_TURN_OFF
             if not self.hass.services.has_service(entity_domain, service):
                 _LOGGER.warning(

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -60,6 +60,8 @@ _LOGGER = logging.getLogger(__name__)
 _WRITE_BACK_DISPATCH: dict[tuple[str, str], tuple[str, str, str]] = {
     ("numeric", "number"): ("number", "set_value", "value"),
     ("numeric", "input_number"): ("input_number", "set_value", "value"),
+    ("string", "text"): ("text", "set_value", "value"),
+    ("string", "input_text"): ("input_text", "set_value", "value"),
 }
 
 

--- a/homeassistant/components/knx/expose.py
+++ b/homeassistant/components/knx/expose.py
@@ -74,6 +74,13 @@ class _WriteBackCall(NamedTuple):
     data: dict[str, Any]
 
 
+def write_back_target_supported(dpt: type[DPTBase], entity_domain: str) -> bool:
+    """Return whether write-back can reach the given entity domain for this DPT."""
+    if issubclass(dpt, DPT1BitEnum):
+        return True  # binary targets are checked at runtime via has_service
+    return (ha_dpt_class(dpt), entity_domain) in _WRITE_BACK_DISPATCH
+
+
 @callback
 def create_knx_exposure(
     hass: HomeAssistant, xknx: XKNX, config: ConfigType

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -3,7 +3,7 @@
 from abc import ABC
 from collections import OrderedDict
 from datetime import timedelta
-from typing import ClassVar, Final
+from typing import Any, ClassVar, Final
 
 import voluptuous as vol
 from xknx.devices.climate import FanSpeedMode, SetpointShiftMode
@@ -74,6 +74,7 @@ from .validation import (
     dpt_base_type_validator,
     ga_list_validator,
     ga_validator,
+    ia_validator,
     numeric_type_validator,
     sensor_type_validator,
     string_type_validator,
@@ -510,6 +511,16 @@ class DateTimeSchema(KNXPlatformSchema):
     )
 
 
+def _validate_expose_write_back(config: dict[str, Any]) -> dict[str, Any]:
+    """`write_back` is not supported for exposures targeting an attribute."""
+    if (
+        config.get(ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK)
+        and config.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE) is not None
+    ):
+        raise vol.Invalid("`write_back` is not supported together with `attribute`")
+    return config
+
+
 class ExposeSchema(KNXPlatformSchema):
     """Voluptuous schema for KNX exposures."""
 
@@ -521,6 +532,8 @@ class ExposeSchema(KNXPlatformSchema):
     CONF_KNX_EXPOSE_COOLDOWN = "cooldown"
     CONF_KNX_EXPOSE_PERIODIC_SEND = "periodic_send"
     CONF_KNX_EXPOSE_DEFAULT = "default"
+    CONF_KNX_EXPOSE_WRITE_BACK = "write_back"
+    CONF_KNX_EXPOSE_SOURCE_WHITELIST = "source_whitelist"
     CONF_TIME = "time"
     CONF_DATE = "date"
     CONF_DATETIME = "datetime"
@@ -551,9 +564,15 @@ class ExposeSchema(KNXPlatformSchema):
             vol.Optional(CONF_KNX_EXPOSE_ATTRIBUTE): cv.string,
             vol.Optional(CONF_KNX_EXPOSE_DEFAULT): cv.match_all,
             vol.Optional(CONF_VALUE_TEMPLATE): cv.template,
+            vol.Optional(CONF_KNX_EXPOSE_WRITE_BACK, default=False): cv.boolean,
+            vol.Optional(CONF_KNX_EXPOSE_SOURCE_WHITELIST, default=list): vol.All(
+                cv.ensure_list, [ia_validator]
+            ),
         }
     )
-    ENTITY_SCHEMA = vol.Any(EXPOSE_SENSOR_SCHEMA, EXPOSE_TIME_SCHEMA)
+    ENTITY_SCHEMA = vol.Any(
+        vol.All(EXPOSE_SENSOR_SCHEMA, _validate_expose_write_back), EXPOSE_TIME_SCHEMA
+    )
 
 
 class FanSchema(KNXPlatformSchema):

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -512,12 +512,17 @@ class DateTimeSchema(KNXPlatformSchema):
 
 
 def _validate_expose_write_back(config: dict[str, Any]) -> dict[str, Any]:
-    """`write_back` is not supported for exposures targeting an attribute."""
-    if (
-        config.get(ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK)
-        and config.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE) is not None
-    ):
+    """`write_back` cannot be combined with `attribute` or `value_template`."""
+    if not config.get(ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK):
+        return config
+    if config.get(ExposeSchema.CONF_KNX_EXPOSE_ATTRIBUTE) is not None:
         raise vol.Invalid("`write_back` is not supported together with `attribute`")
+    # a value_template only transforms outgoing values, so a write-back-triggered
+    # state change would re-encode to a different payload and echo back to the bus
+    if config.get(CONF_VALUE_TEMPLATE) is not None:
+        raise vol.Invalid(
+            "`write_back` is not supported together with `value_template`"
+        )
     return config
 
 

--- a/homeassistant/components/knx/storage/expose_controller.py
+++ b/homeassistant/components/knx/storage/expose_controller.py
@@ -8,7 +8,7 @@ from xknx.dpt import DPTBase
 from xknx.dpt.dpt_1 import DPT1BitEnum
 from xknx.telegram.address import IndividualAddress, parse_device_group_address
 
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant, callback, split_entity_id
 from homeassistant.helpers import (
     config_validation as cv,
     selector,
@@ -16,7 +16,7 @@ from homeassistant.helpers import (
 )
 
 from ..dpt import ha_dpt_class
-from ..expose import KnxExposeEntity, KnxExposeOptions
+from ..expose import KnxExposeEntity, KnxExposeOptions, write_back_target_supported
 from ..validation import ia_validator
 from .entity_store_validation import validate_config_store_data
 from .knx_selector import GASelector
@@ -73,6 +73,12 @@ def _validate_expose_option_write_back(
         return config
     if config.get("attribute") is not None:
         raise vol.Invalid("`write_back` is not supported together with `attribute`")
+    # a value_template only transforms outgoing values, so a write-back-triggered
+    # state change would re-encode to a different payload and echo back to the bus
+    if config.get("value_template") is not None:
+        raise vol.Invalid(
+            "`write_back` is not supported together with `value_template`"
+        )
     transcoder = DPTBase.parse_transcoder(config["ga"]["dpt"])
     # DPT1 binary classifies as "enum", so match it explicitly before numeric/string
     if transcoder is None or not (
@@ -107,17 +113,38 @@ EXPOSE_OPTION_SCHEMA = vol.All(
     _validate_expose_option_write_back,
 )
 
-EXPOSE_CONFIG_SCHEMA = vol.Schema(
-    {
-        vol.Required("entity_id"): selector.EntitySelector(),
-        vol.Required("data"): vol.Schema(
-            {
-                vol.Required("options"): [EXPOSE_OPTION_SCHEMA],
-                vol.Optional("notes"): str,
-            }
-        ),
-    },
-    extra=vol.REMOVE_EXTRA,
+
+def _validate_expose_write_back_targets(config: dict[str, Any]) -> dict[str, Any]:
+    """Reject write-back options whose target entity domain cannot be updated."""
+    entity_domain = split_entity_id(config["entity_id"])[0]
+    for option in config["data"]["options"]:
+        if not option.get("write_back"):
+            continue
+        transcoder = DPTBase.parse_transcoder(option["ga"]["dpt"])
+        if transcoder is not None and not write_back_target_supported(
+            transcoder, entity_domain
+        ):
+            raise vol.Invalid(
+                f"`write_back` is not supported for `{entity_domain}` entities"
+                " with the configured DPT"
+            )
+    return config
+
+
+EXPOSE_CONFIG_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required("entity_id"): selector.EntitySelector(),
+            vol.Required("data"): vol.Schema(
+                {
+                    vol.Required("options"): [EXPOSE_OPTION_SCHEMA],
+                    vol.Optional("notes"): str,
+                }
+            ),
+        },
+        extra=vol.REMOVE_EXTRA,
+    ),
+    _validate_expose_write_back_targets,
 )
 
 

--- a/homeassistant/components/knx/storage/expose_controller.py
+++ b/homeassistant/components/knx/storage/expose_controller.py
@@ -5,7 +5,8 @@ from typing import Any, NotRequired, TypedDict
 import voluptuous as vol
 from xknx import XKNX
 from xknx.dpt import DPTBase
-from xknx.telegram.address import parse_device_group_address
+from xknx.dpt.dpt_1 import DPT1BitEnum
+from xknx.telegram.address import IndividualAddress, parse_device_group_address
 
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import (
@@ -14,7 +15,9 @@ from homeassistant.helpers import (
     template as template_helper,
 )
 
+from ..dpt import ha_dpt_class
 from ..expose import KnxExposeEntity, KnxExposeOptions
+from ..validation import ia_validator
 from .entity_store_validation import validate_config_store_data
 from .knx_selector import GASelector
 
@@ -29,6 +32,8 @@ class KNXExposeStoreOptionModel(TypedDict):
     periodic_send: NotRequired[float]
     respond_to_read: NotRequired[bool]
     value_template: NotRequired[str]
+    write_back: NotRequired[bool]
+    source_whitelist: NotRequired[list[str]]
 
 
 class KNXExposeStoreConfigModel(TypedDict):
@@ -60,21 +65,46 @@ def validate_expose_template_no_coerce(value: str) -> str:
     return value  # return original string for storage and later template creation
 
 
-EXPOSE_OPTION_SCHEMA = vol.Schema(
-    {
-        vol.Required("ga"): GASelector(
-            state=False,
-            passive=False,
-            write_required=True,
-            dpt=["numeric", "enum", "complex", "string"],
-        ),
-        vol.Optional("attribute"): str,
-        vol.Optional("default"): object,
-        vol.Optional("cooldown"): cv.positive_float,  # frontend renders to duration
-        vol.Optional("periodic_send"): cv.positive_float,
-        vol.Optional("respond_to_read"): bool,
-        vol.Optional("value_template"): validate_expose_template_no_coerce,
-    }
+def _validate_expose_option_write_back(
+    config: KNXExposeStoreOptionModel,
+) -> KNXExposeStoreOptionModel:
+    """Validate write-back constraints for a UI expose option."""
+    if not config.get("write_back"):
+        return config
+    if config.get("attribute") is not None:
+        raise vol.Invalid("`write_back` is not supported together with `attribute`")
+    transcoder = DPTBase.parse_transcoder(config["ga"]["dpt"])
+    # DPT1 binary classifies as "enum", so match it explicitly before numeric/string
+    if transcoder is None or not (
+        issubclass(transcoder, DPT1BitEnum)
+        or ha_dpt_class(transcoder) in ("numeric", "string")
+    ):
+        raise vol.Invalid("`write_back` is not supported for the configured DPT")
+    return config
+
+
+EXPOSE_OPTION_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Required("ga"): GASelector(
+                state=False,
+                passive=False,
+                write_required=True,
+                dpt=["numeric", "enum", "complex", "string"],
+            ),
+            vol.Optional("attribute"): str,
+            vol.Optional("default"): object,
+            vol.Optional("cooldown"): cv.positive_float,  # frontend renders to duration
+            vol.Optional("periodic_send"): cv.positive_float,
+            vol.Optional("respond_to_read"): bool,
+            vol.Optional("value_template"): validate_expose_template_no_coerce,
+            vol.Optional("write_back", default=False): bool,
+            vol.Optional("source_whitelist", default=list): vol.All(
+                cv.ensure_list, [ia_validator]
+            ),
+        }
+    ),
+    _validate_expose_option_write_back,
 )
 
 EXPOSE_CONFIG_SCHEMA = vol.Schema(
@@ -114,6 +144,10 @@ def _store_to_expose_option(
         periodic_send=config.get("periodic_send", 0),
         respond_to_read=config.get("respond_to_read", True),
         value_template=value_template,
+        write_back=config.get("write_back", False),
+        source_whitelist=frozenset(
+            str(IndividualAddress(ia)) for ia in config.get("source_whitelist", ())
+        ),
     )
 
 

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1042,11 +1042,19 @@
           "title": "Additional settings"
         },
         "show_raw_values": "Show raw values",
+        "source_whitelist": {
+          "description": "KNX individual addresses (e.g. `1.1.5`) allowed to change the entity through write-back. Leave empty to accept writes from any address.",
+          "label": "Allowed source addresses"
+        },
         "title": "Add exposure",
         "value_template": {
           "description": "Optionally transform the entity state or attribute value before sending it to KNX using a template. The template receives the entity state or attribute value as `value` variable.",
           "label": "Value template"
         },
+        "write_back": {
+          "description": "Update the Home Assistant entity when a write telegram is received on the exposed group address. Supported for binary, numeric and string exposures.",
+          "label": "Write-back"
+	},
         "yaml": {
           "mode_hint": "This is an internal representation of the expose configuration and may change in future Home Assistant versions. YAML mode is intended for debugging, and for sharing or copying configurations — prefer the visual editor for everyday use.",
           "yaml_error": "[%key:component::knx::config_panel::entities::create::yaml::yaml_error%]"

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -1054,7 +1054,7 @@
         "write_back": {
           "description": "Update the Home Assistant entity when a write telegram is received on the exposed group address. Supported for binary, numeric and string exposures.",
           "label": "Write-back"
-	},
+        },
         "yaml": {
           "mode_hint": "This is an internal representation of the expose configuration and may change in future Home Assistant versions. YAML mode is intended for debugging, and for sharing or copying configurations — prefer the visual editor for everyday use.",
           "yaml_error": "[%key:component::knx::config_panel::entities::create::yaml::yaml_error%]"

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -683,6 +683,116 @@ async def test_ui_expose_with_options(
     await knx.assert_write(GROUP_ADDRESS_1, (50,))
 
 
+async def test_ui_expose_write_back(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test a UI expose with write-back enabled updates the entity."""
+    entity_id = "switch.test"
+    group_address = "1/1/8"
+
+    await knx.setup_integration()
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "knx/update_expose",
+            "entity_id": entity_id,
+            "data": {
+                "options": [
+                    {
+                        "ga": {"write": group_address, "dpt": "1.001"},
+                        "write_back": True,
+                        "source_whitelist": ["1.1.5"],
+                    }
+                ],
+            },
+        }
+    )
+    res = await ws_client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is True, res["result"]
+
+    stored = hass_storage[KNX_CONFIG_STORAGE_KEY]["data"]["expose"][entity_id]
+    assert stored["options"][0]["write_back"] is True
+    assert stored["options"][0]["source_whitelist"] == ["1.1.5"]
+
+    turn_on = async_mock_service(hass, "switch", SERVICE_TURN_ON)
+
+    # Whitelisted source updates the entity
+    await knx.receive_write(group_address, 1, source="1.1.5")
+    assert len(turn_on) == 1
+    assert turn_on[0].data == {"entity_id": entity_id}
+
+    # Non-whitelisted source is ignored
+    await knx.receive_write(group_address, 1, source="1.1.99")
+    assert len(turn_on) == 1
+
+
+@pytest.mark.parametrize(
+    ("option", "expected_success"),
+    [
+        pytest.param(
+            {"ga": {"write": "1/1/1", "dpt": "1.001"}, "write_back": True},
+            True,
+            id="binary",
+        ),
+        pytest.param(
+            {"ga": {"write": "1/1/1", "dpt": "5.001"}, "write_back": True},
+            True,
+            id="numeric",
+        ),
+        pytest.param(
+            {"ga": {"write": "1/1/1", "dpt": "16.000"}, "write_back": True},
+            True,
+            id="string",
+        ),
+        pytest.param(
+            {"ga": {"write": "1/1/1", "dpt": "232.600"}, "write_back": True},
+            False,
+            id="complex",
+        ),
+        pytest.param(
+            {"ga": {"write": "1/1/1", "dpt": "20.102"}, "write_back": True},
+            False,
+            id="enum",
+        ),
+        pytest.param(
+            {
+                "ga": {"write": "1/1/1", "dpt": "5.001"},
+                "write_back": True,
+                "attribute": "brightness",
+            },
+            False,
+            id="attribute",
+        ),
+    ],
+)
+async def test_ui_expose_validate_write_back(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    option: dict[str, Any],
+    expected_success: bool,
+) -> None:
+    """Test write-back validation against the configured DPT and attribute."""
+    await knx.setup_integration()
+    ws_client = await hass_ws_client(hass)
+
+    await ws_client.send_json_auto_id(
+        {
+            "type": "knx/validate_expose",
+            "entity_id": "switch.test",
+            "data": {"options": [option]},
+        }
+    )
+    res = await ws_client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is expected_success, res["result"]
+
+
 @pytest.mark.freeze_time("2022-1-7 9:13:14")  # UTC -> +1h = Vienna in winter (9 -> 0xA)
 @pytest.mark.parametrize(
     ("time_type", "raw"),

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -184,12 +184,16 @@ async def test_value_expose_write_back(
 async def test_numeric_expose_write_back_no_echo(
     hass: HomeAssistant, knx: KNXTestKit
 ) -> None:
-    """Test a state change resulting from a numeric write-back is not re-sent."""
+    """Test a state change resulting from a numeric write-back is not re-sent.
+
+    Uses the lossy DPT 5.001 (scaling): raw 127 decodes to 50%, which re-encodes
+    to 128. Echo suppression must key off the re-encoded payload, not the raw one.
+    """
     entity_id = "number.fake"
     await knx.setup_integration(
         {
             CONF_KNX_EXPOSE: {
-                CONF_TYPE: "5.010",
+                CONF_TYPE: "5.001",
                 KNX_ADDRESS: "1/1/8",
                 CONF_ENTITY_ID: entity_id,
                 ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
@@ -199,8 +203,8 @@ async def test_numeric_expose_write_back_no_echo(
     )
     async_mock_service(hass, "number", "set_value")
 
-    await knx.receive_write("1/1/8", (42,), source="1.1.5")
-    hass.states.async_set(entity_id, "42")
+    await knx.receive_write("1/1/8", (127,), source="1.1.5")
+    hass.states.async_set(entity_id, "50")
     await hass.async_block_till_done()
     await knx.assert_no_telegram()
 

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -116,6 +116,31 @@ async def test_binary_expose_write_back_source_filter(
     assert len(turn_on) == 0
 
 
+async def test_binary_expose_write_back_invalid_payload(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test a malformed 1-bit payload does not change the entity state."""
+    entity_id = _SWITCH_ENTITY
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "binary",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+                ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST: ["1.1.5"],
+            }
+        },
+    )
+    turn_on = async_mock_service(hass, "switch", SERVICE_TURN_ON)
+    turn_off = async_mock_service(hass, "switch", SERVICE_TURN_OFF)
+
+    # a DPTBinary carrying a value other than 0/1 is not a valid 1-bit payload
+    await knx.receive_write("1/1/8", 2, source="1.1.5")
+    assert len(turn_on) == 0
+    assert len(turn_off) == 0
+
+
 @pytest.mark.parametrize(
     ("expose_type", "payload", "expected", "domain"),
     [

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -114,6 +114,93 @@ async def test_binary_expose_write_back_source_filter(
     assert len(turn_on) == 0
 
 
+@pytest.mark.parametrize(
+    ("expose_type", "payload", "expected", "domain"),
+    [
+        pytest.param("5.010", (42,), 42, "number", id="number"),
+        pytest.param("5.010", (42,), 42, "input_number", id="input_number"),
+    ],
+)
+async def test_value_expose_write_back(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    expose_type: str,
+    payload: tuple[int, ...],
+    expected: int | str,
+    domain: str,
+) -> None:
+    """Test write_back sets a value helper from a whitelisted incoming write."""
+    entity_id = f"{domain}.fake"
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: expose_type,
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+                ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST: ["1.1.5"],
+            }
+        },
+    )
+    set_value = async_mock_service(hass, domain, "set_value")
+
+    await knx.receive_write("1/1/8", payload, source="1.1.5")
+    assert len(set_value) == 1
+    assert set_value[0].data == {"entity_id": entity_id, "value": expected}
+
+    # The write-back must not echo back onto the bus
+    await knx.assert_no_telegram()
+
+
+async def test_numeric_expose_write_back_no_echo(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test a state change resulting from a numeric write-back is not re-sent."""
+    entity_id = "number.fake"
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "5.010",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+                ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST: ["1.1.5"],
+            }
+        },
+    )
+    async_mock_service(hass, "number", "set_value")
+
+    await knx.receive_write("1/1/8", (42,), source="1.1.5")
+    hass.states.async_set(entity_id, "42")
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()
+
+
+async def test_expose_write_back_unsupported_domain(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a numeric write-back to an unsupported domain is skipped with a warning."""
+    entity_id = "sensor.fake"
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "5.010",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+                ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST: ["1.1.5"],
+            }
+        },
+    )
+    set_value = async_mock_service(hass, "sensor", "set_value")
+
+    await knx.receive_write("1/1/8", (42,), source="1.1.5")
+    assert len(set_value) == 0
+    assert "unsupported target" in caplog.text
+
+
 def test_expose_write_back_allows_numeric() -> None:
     """Test write_back is allowed for a numeric exposure."""
     ExposeSchema.ENTITY_SCHEMA(

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -6,6 +6,7 @@ from typing import Any
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 import voluptuous as vol
+from xknx.dpt import DPTString
 
 from homeassistant.components.knx.const import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
@@ -27,6 +28,7 @@ from .conftest import KNXTestKit
 from tests.common import async_fire_time_changed, async_mock_service
 from tests.typing import WebSocketGenerator
 
+_STRING_PAYLOAD = tuple(DPTString.to_knx("Hello").value)
 _SWITCH_ENTITY = "switch.fake"
 
 
@@ -119,6 +121,8 @@ async def test_binary_expose_write_back_source_filter(
     [
         pytest.param("5.010", (42,), 42, "number", id="number"),
         pytest.param("5.010", (42,), 42, "input_number", id="input_number"),
+        pytest.param("16.000", _STRING_PAYLOAD, "Hello", "text", id="text"),
+        pytest.param("16.000", _STRING_PAYLOAD, "Hello", "input_text", id="input_text"),
     ],
 )
 async def test_value_expose_write_back(

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
+import voluptuous as vol
 
 from homeassistant.components.knx.const import CONF_KNX_EXPOSE, DOMAIN, KNX_ADDRESS
 from homeassistant.components.knx.schema import ExposeSchema
@@ -52,6 +53,32 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     hass.states.async_set(entity_id, "off", {"brightness": 0})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)
+
+
+def test_expose_write_back_allows_numeric() -> None:
+    """Test write_back is allowed for a numeric exposure."""
+    ExposeSchema.ENTITY_SCHEMA(
+        {
+            CONF_TYPE: "5.010",
+            KNX_ADDRESS: "1/1/8",
+            CONF_ENTITY_ID: "number.fake",
+            ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+        }
+    )
+
+
+def test_expose_write_back_rejects_attribute() -> None:
+    """Test write_back is rejected together with an attribute exposure."""
+    with pytest.raises(vol.Invalid):
+        ExposeSchema.ENTITY_SCHEMA(
+            {
+                CONF_TYPE: "5.010",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: "number.fake",
+                CONF_ATTRIBUTE: "foo",
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+            }
+        )
 
 
 async def test_expose_attribute(hass: HomeAssistant, knx: KNXTestKit) -> None:

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -231,6 +231,20 @@ def test_expose_write_back_rejects_attribute() -> None:
         )
 
 
+def test_expose_write_back_rejects_value_template() -> None:
+    """Test write_back is rejected together with a value_template."""
+    with pytest.raises(vol.Invalid):
+        ExposeSchema.ENTITY_SCHEMA(
+            {
+                CONF_TYPE: "5.010",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: "number.fake",
+                CONF_VALUE_TEMPLATE: "{{ value }}",
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+            }
+        )
+
+
 async def test_expose_attribute(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test an expose to only send telegrams on attribute change."""
     entity_id = "fake.entity"
@@ -732,34 +746,46 @@ async def test_ui_expose_write_back(
 
 
 @pytest.mark.parametrize(
-    ("option", "expected_success"),
+    ("entity_id", "option", "expected_success"),
     [
         pytest.param(
+            "switch.test",
             {"ga": {"write": "1/1/1", "dpt": "1.001"}, "write_back": True},
             True,
             id="binary",
         ),
         pytest.param(
+            "number.test",
             {"ga": {"write": "1/1/1", "dpt": "5.001"}, "write_back": True},
             True,
             id="numeric",
         ),
         pytest.param(
+            "text.test",
             {"ga": {"write": "1/1/1", "dpt": "16.000"}, "write_back": True},
             True,
             id="string",
         ),
         pytest.param(
+            "switch.test",
+            {"ga": {"write": "1/1/1", "dpt": "5.001"}, "write_back": True},
+            False,
+            id="numeric_wrong_domain",
+        ),
+        pytest.param(
+            "number.test",
             {"ga": {"write": "1/1/1", "dpt": "232.600"}, "write_back": True},
             False,
             id="complex",
         ),
         pytest.param(
+            "number.test",
             {"ga": {"write": "1/1/1", "dpt": "20.102"}, "write_back": True},
             False,
             id="enum",
         ),
         pytest.param(
+            "number.test",
             {
                 "ga": {"write": "1/1/1", "dpt": "5.001"},
                 "write_back": True,
@@ -768,23 +794,34 @@ async def test_ui_expose_write_back(
             False,
             id="attribute",
         ),
+        pytest.param(
+            "number.test",
+            {
+                "ga": {"write": "1/1/1", "dpt": "5.001"},
+                "write_back": True,
+                "value_template": "{{ value }}",
+            },
+            False,
+            id="value_template",
+        ),
     ],
 )
 async def test_ui_expose_validate_write_back(
     hass: HomeAssistant,
     knx: KNXTestKit,
     hass_ws_client: WebSocketGenerator,
+    entity_id: str,
     option: dict[str, Any],
     expected_success: bool,
 ) -> None:
-    """Test write-back validation against the configured DPT and attribute."""
+    """Test write-back validation against DPT, target domain, attribute and template."""
     await knx.setup_integration()
     ws_client = await hass_ws_client(hass)
 
     await ws_client.send_json_auto_id(
         {
             "type": "knx/validate_expose",
-            "entity_id": "switch.test",
+            "entity_id": entity_id,
             "data": {"options": [option]},
         }
     )

--- a/tests/components/knx/test_expose.py
+++ b/tests/components/knx/test_expose.py
@@ -17,13 +17,17 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_TYPE,
     CONF_VALUE_TEMPLATE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
 )
 from homeassistant.core import HomeAssistant
 
 from .conftest import KNXTestKit
 
-from tests.common import async_fire_time_changed
+from tests.common import async_fire_time_changed, async_mock_service
 from tests.typing import WebSocketGenerator
+
+_SWITCH_ENTITY = "switch.fake"
 
 
 async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -53,6 +57,61 @@ async def test_binary_expose(hass: HomeAssistant, knx: KNXTestKit) -> None:
     hass.states.async_set(entity_id, "off", {"brightness": 0})
     await hass.async_block_till_done()
     await knx.assert_write("1/1/8", False)
+
+
+async def test_binary_expose_write_back(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test write_back updates the entity from a whitelisted incoming write."""
+    entity_id = _SWITCH_ENTITY
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "binary",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+                ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST: ["1.1.5"],
+            }
+        },
+    )
+    turn_on = async_mock_service(hass, "switch", SERVICE_TURN_ON)
+    turn_off = async_mock_service(hass, "switch", SERVICE_TURN_OFF)
+
+    # Whitelisted source turns the entity on, then off
+    await knx.receive_write("1/1/8", 1, source="1.1.5")
+    assert len(turn_on) == 1
+    assert turn_on[0].data == {"entity_id": entity_id}
+    await knx.receive_write("1/1/8", 0, source="1.1.5")
+    assert len(turn_off) == 1
+
+    # The write-back must not echo back onto the bus
+    await knx.assert_no_telegram()
+
+    # A resulting state change matching the received value is not re-sent
+    await knx.receive_write("1/1/8", 1, source="1.1.5")
+    hass.states.async_set(entity_id, "on", {})
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()
+
+
+async def test_binary_expose_write_back_source_filter(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test that only whitelisted source addresses may change the state."""
+    entity_id = _SWITCH_ENTITY
+    await knx.setup_integration(
+        {
+            CONF_KNX_EXPOSE: {
+                CONF_TYPE: "binary",
+                KNX_ADDRESS: "1/1/8",
+                CONF_ENTITY_ID: entity_id,
+                ExposeSchema.CONF_KNX_EXPOSE_WRITE_BACK: True,
+                ExposeSchema.CONF_KNX_EXPOSE_SOURCE_WHITELIST: ["1.1.5"],
+            }
+        },
+    )
+    turn_on = async_mock_service(hass, "switch", SERVICE_TURN_ON)
+    await knx.receive_write("1/1/8", 1, source="1.1.99")
+    assert len(turn_on) == 0
 
 
 def test_expose_write_back_allows_numeric() -> None:


### PR DESCRIPTION
## Proposed change

This feature allows entity exposed to the KNX bus to become "bidirectional" and thus be updated *from* the KNX bus.
This way an exposed entity won't only advertise its state to the KNX bus, but will also receive updates via GroupValueWrite messages.

## Type of change
- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR is related to issue: https://github.com/XKNX/knx-integration/issues/65
- Link to frontend pull request: https://github.com/XKNX/knx-frontend/pull/422

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]: https://github.com/home-assistant/home-assistant.io/pull/47107

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.