### PR TITLE
Use module logger in homematicip_cloud config flow

### DIFF
--- a/homeassistant/components/homematicip_cloud/config_flow.py
+++ b/homeassistant/components/homematicip_cloud/config_flow.py
@@ -1,14 +1,17 @@
 """Config flow to configure the HomematicIP Cloud integration."""
 
 from collections.abc import Mapping
+import logging
 from typing import Any, override
 
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 
-from .const import DOMAIN, HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN, LOGGER
+from .const import DOMAIN, HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN
 from .hap import HomematicipAuth
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -43,10 +46,10 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
             self.auth = HomematicipAuth(self.hass, user_input)
             connected = await self.auth.async_setup()
             if connected:
-                LOGGER.debug("Connection to HomematicIP Cloud established")
+                _LOGGER.debug("Connection to HomematicIP Cloud established")
                 return await self.async_step_link()
 
-            LOGGER.debug("Connection to HomematicIP Cloud failed")
+            _LOGGER.debug("Connection to HomematicIP Cloud failed")
             errors["base"] = "invalid_sgtin_or_pin"
 
         return self.async_show_form(
@@ -69,7 +72,7 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
         if pressed:
             authtoken = await self.auth.async_register()
             if authtoken:
-                LOGGER.debug("Write config entry for HomematicIP Cloud")
+                _LOGGER.debug("Write config entry for HomematicIP Cloud")
                 if self.source == "reauth":
                     return self.async_update_reload_and_abort(
                         self._get_reauth_entry(),
@@ -136,7 +139,7 @@ class HomematicipCloudFlowHandler(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(hapid)
         self._abort_if_unique_id_configured()
 
-        LOGGER.debug("Imported authentication for %s", hapid)
+        _LOGGER.debug("Imported authentication for %s", hapid)
         return self.async_create_entry(
             title=hapid,
             data={HMIPC_AUTHTOKEN: authtoken, HMIPC_HAPID: hapid, HMIPC_NAME: name},

--- a/homeassistant/components/homematicip_cloud/const.py
+++ b/homeassistant/components/homematicip_cloud/const.py
@@ -1,10 +1,6 @@
 """Constants for the HomematicIP Cloud integration."""
 
-import logging
-
 from homeassistant.const import Platform
-
-LOGGER = logging.getLogger(".")
 
 DOMAIN = "homematicip_cloud"
 


### PR DESCRIPTION
## Proposed change

`config_flow.py` was the only module importing the shared `LOGGER` from `const.py`. It was created as `logging.getLogger(".")`, so its logs went to a logger named `.` instead of the integration namespace. This is a leftover from the home-assistant/core#22235 relative-imports refactor (2019), which rewrote the namespace string to `"."`.

Gives `config_flow.py` its own `_LOGGER = logging.getLogger(__name__)` like every other module, and drops the shared logger from `const.py`.

Follow-up to home-assistant/core#177377 (epic home-assistant/epics#115).

## Type of change

<!--
    What type of change does your PR introduce to Home Assistant?
    NOTE: Please, check only 1! box!
    If your PR requires multiple boxes to be checked, you'll most likely need to
    split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

<!--
    Details are important, and help maintainers processing your PR.
    Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/epics#115
- Link to documentation pull request:

## Checklist

<!--
    Put an `x` in the boxes that apply. You can also fill these out after
    creating the PR. If you're unsure about any of them, don't hesitate to ask.
    We're here to help! This is simply a reminder of what we are going to look
    for before merging your code.

    AI tools are welcome, but contributors are responsible for *fully*
    understanding the code before submitting a PR. Please follow our AI policy:
    https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.
- [ ] Untested files have been added to `.coveragerc`.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
