### PR TITLE
Add dual-zone support to WiZ lights

### DIFF
--- a/homeassistant/components/wiz/__init__.py
+++ b/homeassistant/components/wiz/__init__.py
@@ -95,11 +95,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: WizConfigEntry) -> bool:
     )
 
     @callback
-    def _async_push_update(state: PilotParser) -> None:
+    def _async_push_update(states: list[PilotParser | None]) -> None:
         """Receive a push update."""
-        _LOGGER.debug("%s: Got push update: %s", bulb.mac, state.pilotResult)
+        _LOGGER.debug(
+            "%s: Got push update: %s",
+            bulb.mac,
+            [push_state.pilotResult if push_state else None for push_state in states],
+        )
         coordinator.async_set_updated_data(coordinator.data)
-        if state.get_source() in OCCUPANCY_SOURCES:
+        if any(
+            push_state and push_state.get_source() in OCCUPANCY_SOURCES
+            for push_state in states
+        ):
             async_dispatcher_send(hass, SIGNAL_WIZ_PIR.format(bulb.mac))
 
     await bulb.start_push(_async_push_update)

--- a/homeassistant/components/wiz/binary_sensor.py
+++ b/homeassistant/components/wiz/binary_sensor.py
@@ -73,5 +73,5 @@ class WizOccupancyEntity(WizEntity, BinarySensorEntity):
     @override
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
-        if self._device.state.get_source() in OCCUPANCY_SOURCES:
-            self._attr_is_on = self._device.status
+        if self._state and self._state.get_source() in OCCUPANCY_SOURCES:
+            self._attr_is_on = self._state.get_state()

--- a/homeassistant/components/wiz/entity.py
+++ b/homeassistant/components/wiz/entity.py
@@ -3,6 +3,7 @@
 from abc import abstractmethod
 from typing import Any, override
 
+from pywizlight import PilotParser, wizlight
 from pywizlight.bulblibrary import BulbType
 
 from homeassistant.const import ATTR_HW_VERSION, ATTR_MODEL
@@ -14,17 +15,37 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import WizCoordinator, WizData
 
 
+def get_wiz_state(device: wizlight, index: int = 0) -> PilotParser | None:
+    """Return the current state for a WiZ device head."""
+    state = device.state
+    if state is None or len(state) <= index:
+        return None
+    return state[index]
+
+
 class WizEntity(CoordinatorEntity[WizCoordinator], Entity):
     """Representation of WiZ entity."""
 
     _attr_has_entity_name = True
 
-    def __init__(self, wiz_data: WizData, name: str) -> None:
+    def __init__(
+        self,
+        wiz_data: WizData,
+        name: str,
+        state_index: int = 0,
+        target_device: int | None = None,
+    ) -> None:
         """Initialize a WiZ entity."""
         super().__init__(wiz_data.coordinator)
         self._device = wiz_data.bulb
+        self._state_index = state_index
+        self._target_device = target_device
         bulb_type: BulbType = self._device.bulbtype
-        self._attr_unique_id = self._device.mac
+        self._attr_unique_id = (
+            self._device.mac
+            if state_index == 0
+            else f"{self._device.mac}_{state_index}"
+        )
         self._attr_device_info = DeviceInfo(
             connections={(CONNECTION_NETWORK_MAC, self._device.mac)},
             name=name,
@@ -39,6 +60,11 @@ class WizEntity(CoordinatorEntity[WizCoordinator], Entity):
         hw_version = f"{board} {hw_data[0]}" if hw_data else board
         self._attr_device_info[ATTR_HW_VERSION] = hw_version
         self._attr_device_info[ATTR_MODEL] = model
+
+    @property
+    def _state(self) -> PilotParser | None:
+        """Return the current state for this entity."""
+        return get_wiz_state(self._device, self._state_index)
 
     @callback
     @override
@@ -60,10 +86,13 @@ class WizToggleEntity(WizEntity, ToggleEntity):
     @override
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
-        self._attr_is_on = self._device.status
+        self._attr_is_on = self._state.get_state() if self._state else None
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Instruct the device to turn off."""
-        await self._device.turn_off()
+        if self._target_device is not None:
+            await self._device.turn_off(device=self._target_device)
+        else:
+            await self._device.turn_off()
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/wiz/fan.py
+++ b/homeassistant/components/wiz/fan.py
@@ -70,7 +70,13 @@ class WizFanEntity(WizEntity, FanEntity):
     @override
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
-        state = self._device.state
+        state = self._state
+        if state is None:
+            self._attr_is_on = None
+            self._attr_percentage = None
+            self._attr_preset_mode = None
+            self._attr_current_direction = None
+            return
 
         self._attr_is_on = state.get_fan_state() > 0
         self._attr_percentage = ranged_value_to_percentage(

--- a/homeassistant/components/wiz/light.py
+++ b/homeassistant/components/wiz/light.py
@@ -57,19 +57,49 @@ async def async_setup_entry(
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     """Set up the WiZ Platform from config_flow."""
-    if entry.runtime_data.bulb.bulbtype.bulb_type != BulbClass.SOCKET:
-        async_add_entities([WizBulbEntity(entry.runtime_data, entry.title)])
+    bulb_type = entry.runtime_data.bulb.bulbtype
+    if bulb_type.bulb_type == BulbClass.SOCKET:
+        return
+    if len(entry.runtime_data.bulb.state) > 1:
+        async_add_entities(
+            [
+                WizBulbEntity(entry.runtime_data, entry.title, zone="A"),
+                WizBulbEntity(
+                    entry.runtime_data,
+                    entry.title,
+                    state_index=1,
+                    zone="B",
+                ),
+            ]
+        )
+        return
+    async_add_entities([WizBulbEntity(entry.runtime_data, entry.title)])
 
 
 class WizBulbEntity(WizToggleEntity, LightEntity):
     """Representation of WiZ Light bulb."""
 
-    _attr_name = None
+    _attr_translation_key = "zone"
     _fixed_color_mode: ColorMode | None = None
 
-    def __init__(self, wiz_data: WizData, name: str) -> None:
+    def __init__(
+        self,
+        wiz_data: WizData,
+        device_name: str,
+        state_index: int = 0,
+        zone: str | None = None,
+    ) -> None:
         """Initialize an WiZLight."""
-        super().__init__(wiz_data, name)
+        if zone is None:
+            self._attr_name = None
+        else:
+            self._attr_translation_placeholders = {"zone": zone}
+        super().__init__(
+            wiz_data,
+            device_name,
+            state_index,
+            target_device=state_index + 1 if zone is not None else None,
+        )
         bulb_type: BulbType = self._device.bulbtype
         features: Features = bulb_type.features
         color_modes = {ColorMode.ONOFF}
@@ -95,7 +125,10 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
     @override
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
-        state = self._device.state
+        state = self._state
+        if state is None:
+            super()._async_update_attrs()
+            return
 
         if (brightness := state.get_brightness()) is not None:
             self._attr_brightness = max(0, min(255, brightness))
@@ -129,5 +162,9 @@ class WizBulbEntity(WizToggleEntity, LightEntity):
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
-        await self._device.turn_on(_async_pilot_builder(**kwargs))
+        pilot_builder = _async_pilot_builder(**kwargs)
+        if self._target_device is not None:
+            await self._device.turn_on(pilot_builder, device=self._target_device)
+        else:
+            await self._device.turn_on(pilot_builder)
         await self.coordinator.async_request_refresh()

--- a/homeassistant/components/wiz/manifest.json
+++ b/homeassistant/components/wiz/manifest.json
@@ -27,5 +27,5 @@
   "documentation": "https://www.home-assistant.io/integrations/wiz",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["pywizlight==0.6.5"]
+  "requirements": ["pywizlight==0.6.6"]
 }

--- a/homeassistant/components/wiz/manifest.json
+++ b/homeassistant/components/wiz/manifest.json
@@ -27,5 +27,5 @@
   "documentation": "https://www.home-assistant.io/integrations/wiz",
   "integration_type": "device",
   "iot_class": "local_push",
-  "requirements": ["pywizlight==0.6.3"]
+  "requirements": ["pywizlight==0.6.5"]
 }

--- a/homeassistant/components/wiz/number.py
+++ b/homeassistant/components/wiz/number.py
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import WizConfigEntry, WizData
-from .entity import WizEntity
+from .entity import WizEntity, get_wiz_state
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -26,8 +26,7 @@ class WizNumberEntityDescription(NumberEntityDescription):
     required_feature: str
     set_value_fn: Callable[[wizlight, int], Coroutine[None, None, None]]
     value_fn: Callable[[wizlight], int | None]
-    # Optional fallback, checked against runtime state when required_feature is
-    # not advertised by the bulb type.
+    # Optional runtime support check used instead of required_feature.
     supported_fn: Callable[[wizlight], bool] | None = None
 
 
@@ -39,6 +38,24 @@ async def _async_set_ratio(device: wizlight, ratio: int) -> None:
     await device.set_ratio(ratio)
 
 
+def _get_speed(device: wizlight) -> int | None:
+    """Return the effect speed."""
+    return (
+        cast(int | None, state.get_speed())
+        if (state := get_wiz_state(device))
+        else None
+    )
+
+
+def _get_ratio(device: wizlight) -> int | None:
+    """Return the dual head ratio."""
+    return (
+        cast(int | None, state.get_ratio())
+        if (state := get_wiz_state(device))
+        else None
+    )
+
+
 NUMBERS: tuple[WizNumberEntityDescription, ...] = (
     WizNumberEntityDescription(
         key="effect_speed",
@@ -46,7 +63,7 @@ NUMBERS: tuple[WizNumberEntityDescription, ...] = (
         native_min_value=10,
         native_max_value=200,
         native_step=1,
-        value_fn=lambda device: cast(int | None, device.state.get_speed()),
+        value_fn=_get_speed,
         set_value_fn=_async_set_speed,
         required_feature="effect",
         entity_category=EntityCategory.CONFIG,
@@ -57,13 +74,11 @@ NUMBERS: tuple[WizNumberEntityDescription, ...] = (
         native_min_value=0,
         native_max_value=100,
         native_step=1,
-        value_fn=lambda device: cast(int | None, device.state.get_ratio()),
+        value_fn=_get_ratio,
         set_value_fn=_async_set_ratio,
         required_feature="dual_head",
         # Some ratio-based dual-head lights do not advertise this feature.
-        supported_fn=lambda device: (
-            device.state is not None and device.state.get_ratio() is not None
-        ),
+        supported_fn=lambda device: _get_ratio(device) is not None,
         entity_category=EntityCategory.CONFIG,
     ),
 )
@@ -74,14 +89,13 @@ def _supports_number_description(
 ) -> bool:
     """Return whether the device supports a number description.
 
-    When the bulb type does not advertise the required feature, ``supported_fn``
-    is evaluated as a fallback. It inspects the current runtime state (e.g.
-    whether a ratio is present), so the result depends on the device state at
-    call time.
+    A runtime support check takes precedence over the advertised feature. Zoned
+    dual-head devices advertise the dual-head feature but do not support a
+    configurable ratio.
     """
-    return getattr(device.bulbtype.features, description.required_feature, False) or (
-        description.supported_fn is not None and description.supported_fn(device)
-    )
+    if description.supported_fn is not None:
+        return description.supported_fn(device)
+    return getattr(device.bulbtype.features, description.required_feature, False)
 
 
 async def async_setup_entry(

--- a/homeassistant/components/wiz/sensor.py
+++ b/homeassistant/components/wiz/sensor.py
@@ -79,8 +79,10 @@ class WizSensor(WizEntity, SensorEntity):
     @override
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
-        self._attr_native_value = self._device.state.pilotResult.get(
-            self.entity_description.key
+        self._attr_native_value = (
+            self._state.pilotResult.get(self.entity_description.key)
+            if self._state
+            else None
         )
 
 
@@ -92,7 +94,7 @@ class WizPowerSensor(WizSensor):
     def _async_update_attrs(self) -> None:
         """Handle updating _attr values."""
         # Newer firmwares will have the power in their state
-        watts_push = self._device.state.get_power()
+        watts_push = self._state.get_power() if self._state else None
         # Older firmwares will be polled and in the coordinator data
         watts_poll = self.coordinator.data
         self._attr_native_value = watts_poll if watts_push is None else watts_push

--- a/homeassistant/components/wiz/strings.json
+++ b/homeassistant/components/wiz/strings.json
@@ -31,6 +31,11 @@
     }
   },
   "entity": {
+    "light": {
+      "zone": {
+        "name": "Zone {zone}"
+      }
+    },
     "number": {
       "dual_head_ratio": {
         "name": "Dual head ratio"

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2850,7 +2850,7 @@ pywemo==1.4.0
 pywilight==0.0.74
 
 # homeassistant.components.wiz
-pywizlight==0.6.5
+pywizlight==0.6.6
 
 # homeassistant.components.wmspro
 pywmspro==0.4.2

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2850,7 +2850,7 @@ pywemo==1.4.0
 pywilight==0.0.74
 
 # homeassistant.components.wiz
-pywizlight==0.6.3
+pywizlight==0.6.5
 
 # homeassistant.components.wmspro
 pywmspro==0.4.2

--- a/tests/components/wiz/__init__.py
+++ b/tests/components/wiz/__init__.py
@@ -243,6 +243,8 @@ def _mocked_wizlight(
     bulb_type: BulbType | None,
 ) -> wizlight:
     bulb = MagicMock(auto_spec=wizlight, name="Mocked wizlight")
+    bulb_type = bulb_type or FAKE_DIMMABLE_BULB
+    state = [FAKE_STATE, None] if bulb_type.features.dual_head else [FAKE_STATE]
 
     async def _save_setup_callback(callback: Callable) -> None:
         bulb.push_callback = callback
@@ -256,7 +258,7 @@ def _mocked_wizlight(
     bulb.get_power = AsyncMock(return_value=None)
     bulb.turn_off = AsyncMock()
     bulb.power_monitoring = False
-    bulb.updateState = AsyncMock(return_value=FAKE_STATE)
+    bulb.updateState = AsyncMock(return_value=state)
     bulb.getSupportedScenes = AsyncMock(return_value=list(SCENES.values()))
     bulb.start_push = AsyncMock(side_effect=_save_setup_callback)
     bulb.async_close = AsyncMock()
@@ -270,10 +272,10 @@ def _mocked_wizlight(
         "roomId": 123,
         "homeId": 34,
     }
-    bulb.state = FAKE_STATE
+    bulb.state = state
     bulb.mac = FAKE_MAC
-    bulb.bulbtype = bulb_type or FAKE_DIMMABLE_BULB
-    bulb.get_bulbtype = AsyncMock(return_value=bulb_type or FAKE_DIMMABLE_BULB)
+    bulb.bulbtype = bulb_type
+    bulb.get_bulbtype = AsyncMock(return_value=bulb_type)
 
     return bulb
 
@@ -332,10 +334,29 @@ async def async_setup_integration(
 
 
 async def async_push_update(
-    hass: HomeAssistant, device: wizlight, params: dict[str, Any]
+    hass: HomeAssistant,
+    device: wizlight,
+    params: dict[str, Any],
 ) -> None:
     """Push an update to the device."""
-    device.state = PilotParser(params)
-    device.status = params.get("state")
+    state = PilotParser(params)
+    if device.bulbtype.features.dual_head:
+        state_index = params.get("devices")
+        if (
+            isinstance(state_index, int)
+            and not isinstance(state_index, bool)
+            and 1 <= state_index <= 2
+        ):
+            while len(device.state) < 2:
+                device.state.append(None)
+            device.state[state_index - 1] = state
+        elif len(device.state) > 1:
+            return
+        else:
+            device.state = [state]
+    else:
+        device.state = [state]
+    if isinstance(device.updateState, AsyncMock):
+        device.updateState.return_value = device.state
     device.push_callback(device.state)
-    await hass.async_block_till_done()
+    await hass.async_block_till_done(wait_background_tasks=True)

--- a/tests/components/wiz/test_light.py
+++ b/tests/components/wiz/test_light.py
@@ -1,6 +1,6 @@
 """Tests for light platform."""
 
-from pywizlight import PilotBuilder
+from pywizlight import PilotBuilder, PilotParser
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -13,20 +13,25 @@ from homeassistant.components.light import (
 )
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    ATTR_FRIENDLY_NAME,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
     STATE_OFF,
     STATE_ON,
+    STATE_UNKNOWN,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import (
+    FAKE_DUAL_HEAD_RGBWW_BULB,
     FAKE_MAC,
     FAKE_OLD_FIRMWARE_DIMMABLE_BULB,
     FAKE_RGBW_BULB,
     FAKE_RGBWW_BULB,
+    FAKE_STATE,
     FAKE_TURNABLE_BULB,
+    _mocked_wizlight,
     async_push_update,
     async_setup_integration,
 )
@@ -41,6 +46,7 @@ async def test_light_unique_id(
     assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Mock Title"
 
 
 async def test_light_operation(
@@ -68,6 +74,93 @@ async def test_light_operation(
 
     await async_push_update(hass, bulb, {"mac": FAKE_MAC, "state": True})
     assert hass.states.get(entity_id).state == STATE_ON
+
+
+async def test_dual_head_light(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test dual head light entities."""
+    bulb, _ = await async_setup_integration(hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB)
+    entity_id = "light.mock_title_zone_a"
+    zone_b_entity_id = "light.mock_title_zone_b"
+
+    assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
+    assert entity_registry.async_get(zone_b_entity_id).unique_id == f"{FAKE_MAC}_1"
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Mock Title Zone A"
+    state = hass.states.get(zone_b_entity_id)
+    assert state.state == STATE_UNKNOWN
+    assert state.attributes[ATTR_FRIENDLY_NAME] == "Mock Title Zone B"
+
+    await async_push_update(
+        hass,
+        bulb,
+        {"mac": FAKE_MAC, "devices": 2, "state": False},
+    )
+    assert hass.states.get(zone_b_entity_id).state == STATE_OFF
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    bulb.turn_off.assert_called_once_with(device=1)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: zone_b_entity_id, ATTR_RGBWW_COLOR: (1, 2, 3, 4, 5)},
+        blocking=True,
+    )
+    pilot: PilotBuilder = bulb.turn_on.mock_calls[0][1][0]
+    assert pilot.pilot_params == {"b": 3, "c": 4, "g": 2, "r": 1, "w": 5}
+    assert bulb.turn_on.mock_calls[0][2] == {"device": 2}
+
+    await async_push_update(
+        hass,
+        bulb,
+        {
+            "mac": FAKE_MAC,
+            "devices": 2,
+            "state": True,
+            **pilot.pilot_params,
+        },
+    )
+    state = hass.states.get(zone_b_entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_RGBWW_COLOR] == (1, 2, 3, 4, 5)
+
+
+async def test_ratio_dual_head_uses_one_unsuffixed_light(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test a ratio-based dual-head device does not create zone lights."""
+    bulb = _mocked_wizlight(None, None, FAKE_DUAL_HEAD_RGBWW_BULB)
+    bulb.state = [PilotParser({**FAKE_STATE.pilotResult, "ratio": 50})]
+    bulb.updateState.return_value = bulb.state
+
+    await async_setup_integration(hass, wizlight=bulb)
+
+    entity_id = "light.mock_title"
+    assert entity_registry.async_get(entity_id).unique_id == FAKE_MAC
+    assert entity_registry.async_get("light.mock_title_zone_a") is None
+    assert entity_registry.async_get("light.mock_title_zone_b") is None
+    assert hass.states.get(entity_id).attributes[ATTR_FRIENDLY_NAME] == "Mock Title"
+
+    await async_push_update(
+        hass,
+        bulb,
+        {"mac": FAKE_MAC, "devices": 1, "state": True, "ratio": 50},
+    )
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    bulb.turn_off.assert_awaited_once_with()
 
 
 async def test_rgbww_light(hass: HomeAssistant) -> None:
@@ -120,6 +213,25 @@ async def test_rgbww_light(hass: HomeAssistant) -> None:
     )
     state = hass.states.get(entity_id)
     assert state.state == STATE_ON
+    assert state.attributes[ATTR_EFFECT] == "Ocean"
+    assert state.attributes[ATTR_COLOR_MODE] == "brightness"
+
+    await async_push_update(
+        hass,
+        bulb,
+        {
+            "mac": FAKE_MAC,
+            "state": True,
+            "sceneId": 1,
+            "dimming": 50,
+            "r": 1,
+            "g": 2,
+            "b": 3,
+            "c": 4,
+            "w": 5,
+        },
+    )
+    state = hass.states.get(entity_id)
     assert state.attributes[ATTR_EFFECT] == "Ocean"
     assert state.attributes[ATTR_COLOR_MODE] == "brightness"
 

--- a/tests/components/wiz/test_number.py
+++ b/tests/components/wiz/test_number.py
@@ -41,12 +41,12 @@ async def test_speed_operation(
 ) -> None:
     """Test changing a speed."""
     bulb, _ = await async_setup_integration(hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB)
-    await async_push_update(hass, bulb, {"mac": FAKE_MAC})
+    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "devices": 1})
     entity_id = "number.mock_title_effect_speed"
     assert entity_registry.async_get(entity_id).unique_id == f"{FAKE_MAC}_effect_speed"
     assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
 
-    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "speed": 50})
+    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "devices": 1, "speed": 50})
     assert hass.states.get(entity_id).state == "50.0"
 
     await hass.services.async_call(
@@ -56,23 +56,38 @@ async def test_speed_operation(
         blocking=True,
     )
     bulb.set_speed.assert_called_with(30)
-    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "speed": 30})
+    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "devices": 1, "speed": 30})
     assert hass.states.get(entity_id).state == "30.0"
+
+
+async def test_ratio_not_created_for_zoned_dual_head(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """Test the ratio entity is not created for a zoned dual-head light."""
+    await async_setup_integration(hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB)
+
+    assert (
+        entity_registry.async_get_entity_id(
+            NUMBER_DOMAIN, DOMAIN, f"{FAKE_MAC}_dual_head_ratio"
+        )
+        is None
+    )
 
 
 async def test_ratio_operation(
     hass: HomeAssistant, entity_registry: er.EntityRegistry
 ) -> None:
     """Test changing a dual head ratio."""
-    bulb, _ = await async_setup_integration(hass, bulb_type=FAKE_DUAL_HEAD_RGBWW_BULB)
-    await async_push_update(hass, bulb, {"mac": FAKE_MAC})
+    bulb = _mocked_wizlight(None, None, FAKE_DUAL_HEAD_RGBWW_BULB)
+    bulb.state = [PilotParser({"mac": FAKE_MAC, "ratio": 50})]
+    bulb.updateState.return_value = bulb.state
+
+    await async_setup_integration(hass, wizlight=bulb)
+
     entity_id = entity_registry.async_get_entity_id(
         NUMBER_DOMAIN, DOMAIN, f"{FAKE_MAC}_dual_head_ratio"
     )
     assert entity_id is not None
-    assert hass.states.get(entity_id).state == STATE_UNAVAILABLE
-
-    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "ratio": 50})
     assert hass.states.get(entity_id).state == "50.0"
 
     await hass.services.async_call(
@@ -91,10 +106,10 @@ async def test_ratio_operation_without_dual_head_feature(
 ) -> None:
     """Test changing a ratio reported by a light with an unadvertised dual head feature."""
     bulb = _mocked_wizlight(None, None, FAKE_TURNABLE_BULB)
-    bulb.state = None
+    bulb.state = []
 
-    async def _update_state() -> PilotParser:
-        bulb.state = PilotParser({"mac": FAKE_MAC, "ratio": 50})
+    async def _update_state() -> list[PilotParser]:
+        bulb.state = [PilotParser({"mac": FAKE_MAC, "ratio": 50})]
         return bulb.state
 
     bulb.updateState.side_effect = _update_state

--- a/tests/components/wiz/test_sensor.py
+++ b/tests/components/wiz/test_sensor.py
@@ -38,7 +38,10 @@ async def test_signal_strength(
 
     assert hass.states.get(entity_id).state == "-55"
 
-    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "rssi": -50})
+    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "devices": 1, "rssi": -50})
+    assert hass.states.get(entity_id).state == "-50"
+
+    await async_push_update(hass, bulb, {"mac": FAKE_MAC, "rssi": -40})
     assert hass.states.get(entity_id).state == "-50"
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

WiZ dual-zone lights now identify their primary light as Zone A. The existing primary entity keeps the same entity ID and unique ID, but its default displayed name changes from the device name to "<device name> Zone A". Custom entity names and automations are not changed.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add separate Zone A and Zone B light entities for WiZ devices that report independent dual-zone state. The primary entity retains the device MAC as its unique ID, while Zone B uses `<mac>_1`. Commands target the protocol's 1-based device indices.

Single-zone lights and ratio-based dual-head lights retain one unsuffixed light entity. The dual-head ratio number is created only when the device reports ratio support.

This change pins `pywizlight==0.6.6`, which includes runtime state handling for indexed zone responses, ratio-based devices, and per-head push updates.

The released dependency and integration have been validated on HALO (`ESP20_DHRGB_01`), Squire (`ESP20_DHRGB_01B`), and Mobile (`ESP20_DHRGB_01`) hardware running firmware `1.38.0`. HALO and Squire expose independently controllable zone states. After updating from firmware `1.29.1`, the Mobile exposes the same two-zone state shape, although its firmware still applies targeted color changes to the whole lamp, matching the WiZ app's behavior.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #121403
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 
- Upstream dual-head implementation: https://github.com/sbidy/pywizlight/pull/193
- Additional upstream changes: https://github.com/sbidy/pywizlight/pull/197
- Upstream state handling: https://github.com/sbidy/pywizlight/pull/209
- Dependency release: https://github.com/sbidy/pywizlight/releases/tag/v0.6.6
- Dependency diff: https://github.com/sbidy/pywizlight/compare/0.6.3...0.6.6
- Local validation: 61 WiZ tests and 5 snapshots pass.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr