### PR TITLE
Show artwork and a play button when opening a Sonos music library album

### DIFF
--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -303,7 +303,11 @@ def build_item_response(
         item = get_media(media_library, idstring, search_type)
 
         title = getattr(item, "title", None)
-        thumbnail = get_thumbnail_url(search_type, payload["idstring"])
+        # The browse image proxy round-trips this back to async_get_browse_image,
+        # which matches on MediaType, not on the Sonos search type.
+        thumbnail = get_thumbnail_url(
+            SONOS_TO_MEDIA_TYPES[search_type], payload["idstring"]
+        )
 
     if not title:
         title = _get_title(id_string=payload["idstring"])

--- a/homeassistant/components/sonos/media_browser.py
+++ b/homeassistant/components/sonos/media_browser.py
@@ -288,6 +288,9 @@ def build_item_response(
 
     thumbnail = None
     title = None
+    # Library listings such as Albums and Artists are browsed, not played; only a
+    # single album resolved below can be played as a whole.
+    playable = False
 
     # Fetch album info for titles and thumbnails
     # Can't be extracted from track info
@@ -308,6 +311,7 @@ def build_item_response(
         thumbnail = get_thumbnail_url(
             SONOS_TO_MEDIA_TYPES[search_type], payload["idstring"]
         )
+        playable = can_play(search_type)
 
     if not title:
         title = _get_title(id_string=payload["idstring"])
@@ -332,7 +336,7 @@ def build_item_response(
         media_content_id=payload["idstring"],
         media_content_type=payload["search_type"],
         children=children,
-        can_play=can_play(payload["search_type"]),
+        can_play=playable,
         can_expand=can_expand(payload["search_type"]),
     )
 

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -90,6 +90,48 @@ def test_build_item_response_container_art_uses_media_type(
     assert get_thumbnail_url.call_args.args[0] == expected_type
 
 
+@pytest.mark.parametrize(
+    ("idstring", "child_class", "expected_can_play"),
+    [
+        pytest.param(
+            "A:ALBUM/Abbey%20Road",
+            "object.item.audioItem.musicTrack",
+            True,
+            id="single_album",
+        ),
+        pytest.param(
+            "A:ALBUM",
+            "object.container.album.musicAlbum",
+            False,
+            id="album_listing",
+        ),
+    ],
+)
+def test_build_item_response_playable_only_for_a_single_album(
+    idstring: str, child_class: str, expected_can_play: bool
+) -> None:
+    """Test a resolved album is playable while the album listing is not.
+
+    can_play is passed a Sonos search type, which for the listing would otherwise
+    mark every library listing playable.
+    """
+    music_library = MagicMock()
+    music_library.browse_by_idstring.return_value = [
+        MockMusicServiceItem(
+            "Abbey Road", "A:ALBUM/Abbey%20Road", idstring, child_class
+        )
+    ]
+    music_library.get_music_library_information.return_value = []
+
+    response = build_item_response(
+        music_library,
+        {"search_type": MediaType.ALBUM, "idstring": idstring},
+        Mock(return_value="/thumb"),
+    )
+
+    assert response.can_play is expected_can_play
+
+
 async def test_build_item_response(
     hass: HomeAssistant,
     soco_factory: SoCoMockFactory,

--- a/tests/components/sonos/test_media_browser.py
+++ b/tests/components/sonos/test_media_browser.py
@@ -52,6 +52,44 @@ def mock_browse_by_idstring(
     return None
 
 
+@pytest.mark.parametrize(
+    ("idstring", "expected_type"),
+    [
+        pytest.param("A:ALBUM/Abbey%20Road", MediaType.ALBUM, id="album"),
+        pytest.param(
+            "A:ALBUMARTIST/The%20Beatles", MediaType.ARTIST, id="album_artist"
+        ),
+    ],
+)
+def test_build_item_response_container_art_uses_media_type(
+    idstring: str, expected_type: MediaType
+) -> None:
+    """Test container art is requested with a MediaType, not a Sonos search type.
+
+    async_get_browse_image matches on MediaType, so requesting the container art
+    with the Sonos search type makes the browse image proxy return no image.
+    """
+    music_library = MagicMock()
+    music_library.browse_by_idstring.return_value = [
+        MockMusicServiceItem(
+            "Come Together",
+            "x-file-cifs://192.168.42.10/music/01%20Come%20Together.mp3",
+            idstring,
+            "object.item.audioItem.musicTrack",
+        )
+    ]
+    music_library.get_music_library_information.return_value = []
+    get_thumbnail_url = Mock(return_value="/thumb")
+
+    build_item_response(
+        music_library,
+        {"search_type": MediaType.ALBUM, "idstring": idstring},
+        get_thumbnail_url,
+    )
+
+    assert get_thumbnail_url.call_args.args[0] == expected_type
+
+
 async def test_build_item_response(
     hass: HomeAssistant,
     soco_factory: SoCoMockFactory,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Opening a music library album in the Sonos media browser showed a bare track list: no cover art and no play button for the album itself, even though the same album shows both in the Music Library Albums list.

`build_item_response` filled in the container's own fields with values the helpers do not accept. `can_play` was passed a `MediaType`, which is never a key of `SONOS_TO_MEDIA_TYPES`, so it returned `False` and the frontend rendered no header, and the header is what carries the cover art and the play button. Separately the container thumbnail was requested with the Sonos search type, which `async_get_browse_image` does not match, so that image request returned 500.

Only a resolved album becomes playable. The library listings (Albums, Artists and so on) keep their existing behaviour, since marking every container playable would put a play button on each listing.

Verified against real Sonos hardware: opening an album now shows its cover art and a play button, and the container image returns HTTP 200 where it returned HTTP 500 on `dev`.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177504
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


