### PR TITLE
tplink: detect wrong e-mail case on auth failure and suggest the fix

### DIFF
--- a/homeassistant/components/tplink/_email_case.py
+++ b/homeassistant/components/tplink/_email_case.py
@@ -1,0 +1,81 @@
+"""Look up a TP-Link account's canonical e-mail capitalisation.
+
+KLAP/AES local authentication hashes the username (e-mail) case-sensitively,
+but TP-Link cloud login is case-insensitive. Devices are provisioned by the
+cloud with the account's *registered* e-mail case, so users who enter a
+different case (their credentials still work in the Kasa app, which is
+cloud-based) hit a confusing local ``AuthenticationError``.
+
+On auth failure the config flow can call the cloud with the same credentials
+(cloud login is case-insensitive, so it succeeds) and read back the canonical
+e-mail, then suggest the correct capitalisation to the user.
+"""
+
+import asyncio
+import logging
+import uuid
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+_LOGGER = logging.getLogger(__name__)
+
+_CLOUD_URL = "https://wap.tplinkcloud.com"
+_TIMEOUT = 15
+
+
+async def async_get_canonical_username(
+    hass: HomeAssistant, username: str, password: str
+) -> str | None:
+    """Return the account's canonical (registered-case) e-mail, or None.
+
+    Never raises: any failure (wrong password, MFA/2FA, network error,
+    unexpected payload) returns None so the caller falls back to the normal
+    error handling.
+    """
+    session = async_get_clientsession(hass)
+    payload = {
+        "method": "login",
+        "params": {
+            "appType": "Kasa_Android",
+            "cloudUserName": username,
+            "cloudPassword": password,
+            "terminalUUID": str(uuid.uuid4()),
+        },
+    }
+    try:
+        async with asyncio.timeout(_TIMEOUT):
+            resp = await session.post(_CLOUD_URL, json=payload)
+            data = await resp.json(content_type=None)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("TP-Link cloud e-mail-case lookup failed: %s", err)
+        return None
+
+    if not isinstance(data, dict) or data.get("error_code") != 0:
+        _LOGGER.debug(
+            "TP-Link cloud e-mail-case lookup returned error_code %s",
+            data.get("error_code") if isinstance(data, dict) else "?",
+        )
+        return None
+
+    result = data.get("result")
+    if isinstance(result, dict):
+        email = result.get("email")
+        if isinstance(email, str):
+            return email
+    return None
+
+
+def suggest_username_case(entered: str, canonical: str | None) -> str | None:
+    """Return the canonical username if it differs from ``entered`` only in case.
+
+    Returns None when there is nothing useful to suggest (no canonical value,
+    identical strings, or a genuinely different address).
+    """
+    if (
+        canonical
+        and canonical != entered
+        and canonical.casefold() == entered.casefold()
+    ):
+        return canonical
+    return None

--- a/homeassistant/components/tplink/config_flow.py
+++ b/homeassistant/components/tplink/config_flow.py
@@ -48,6 +48,7 @@ from . import (
     mac_alias,
     set_credentials,
 )
+from ._email_case import async_get_canonical_username, suggest_username_case
 from .const import (
     CONF_AES_KEYS,
     CONF_CAMERA_CREDENTIALS,
@@ -90,6 +91,39 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         """Initialize the config flow."""
         self._discovered_devices: dict[str, Device] = {}
         self._discovered_device: Device | None = None
+        self._suggested_username: str | None = None
+
+    async def _async_suggest_username_case(
+        self,
+        username: str,
+        password: str,
+        errors: dict[str, str],
+        placeholders: dict[str, str],
+    ) -> None:
+        """On auth failure, suggest the correct e-mail capitalisation.
+
+        The KLAP/AES local auth_hash is derived from the username
+        case-sensitively, but TP-Link cloud login is case-insensitive, so a
+        device is often provisioned with a different capitalisation than the
+        user types. Look the account's canonical e-mail up via the cloud and, if
+        it differs from the entered value only in case, switch to a translated
+        error that names it and pre-fill the username field. Best effort: on any
+        failure the existing error is left intact.
+        """
+        self._suggested_username = None
+        canonical = await async_get_canonical_username(self.hass, username, password)
+        if suggestion := suggest_username_case(username, canonical):
+            self._suggested_username = suggestion
+            errors[CONF_PASSWORD] = "invalid_auth_email_case"
+            placeholders["canonical"] = suggestion
+
+    def _auth_data_schema(self) -> vol.Schema:
+        """Auth schema, pre-filling a suggested username case if we have one."""
+        if self._suggested_username:
+            return self.add_suggested_values_to_schema(
+                STEP_AUTH_DATA_SCHEMA, {CONF_USERNAME: self._suggested_username}
+            )
+        return STEP_AUTH_DATA_SCHEMA
 
     @override
     async def async_step_dhcp(
@@ -236,6 +270,9 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             except AuthenticationError as ex:
                 errors[CONF_PASSWORD] = "invalid_auth"
                 placeholders["error"] = str(ex)
+                await self._async_suggest_username_case(
+                    username, password, errors, placeholders
+                )
             except KasaException as ex:
                 errors["base"] = "cannot_connect"
                 placeholders["error"] = str(ex)
@@ -255,7 +292,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = placeholders
         return self.async_show_form(
             step_id="discovery_auth_confirm",
-            data_schema=STEP_AUTH_DATA_SCHEMA,
+            data_schema=self._auth_data_schema(),
             errors=errors,
             description_placeholders=placeholders,
         )
@@ -403,6 +440,9 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             except AuthenticationError as ex:
                 errors[CONF_PASSWORD] = "invalid_auth"
                 placeholders["error"] = str(ex)
+                await self._async_suggest_username_case(
+                    username, password, errors, placeholders
+                )
             except KasaException as ex:
                 errors["base"] = "cannot_connect"
                 placeholders["error"] = str(ex)
@@ -422,7 +462,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="user_auth_confirm",
-            data_schema=STEP_AUTH_DATA_SCHEMA,
+            data_schema=self._auth_data_schema(),
             errors=errors,
             description_placeholders=placeholders,
         )
@@ -769,6 +809,9 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
             except AuthenticationError as ex:
                 errors[CONF_PASSWORD] = "invalid_auth"
                 placeholders["error"] = str(ex)
+                await self._async_suggest_username_case(
+                    username, password, errors, placeholders
+                )
             except KasaException as ex:
                 errors["base"] = "cannot_connect"
                 placeholders["error"] = str(ex)
@@ -800,7 +843,7 @@ class TPLinkConfigFlow(ConfigFlow, domain=DOMAIN):
         self.context["title_placeholders"] = placeholders
         return self.async_show_form(
             step_id="reauth_confirm",
-            data_schema=STEP_AUTH_DATA_SCHEMA,
+            data_schema=self._auth_data_schema(),
             errors=errors,
             description_placeholders=placeholders,
         )

--- a/homeassistant/components/tplink/strings.json
+++ b/homeassistant/components/tplink/strings.json
@@ -12,6 +12,7 @@
       "cannot_connect": "Connection error: {error}",
       "cannot_connect_camera": "Unable to access the camera stream, verify that you have set up the camera account: {error}",
       "invalid_auth": "Unable to authenticate: {error}",
+      "invalid_auth_email_case": "Unable to authenticate. Your TP-Link account email is registered with a different capitalization; try {canonical} (the email is case-sensitive for local control, unlike the Kasa app which ignores case).",
       "invalid_camera_auth": "Camera stream authentication failed"
     },
     "flow_title": "{name} {model} ({host})",

--- a/tests/components/tplink/test_config_flow.py
+++ b/tests/components/tplink/test_config_flow.py
@@ -1028,6 +1028,57 @@ async def test_manual_auth(
     assert result3["context"]["unique_id"] == MAC_ADDRESS
 
 
+@pytest.mark.usefixtures("mock_init")
+async def test_manual_auth_suggests_email_case(
+    hass: HomeAssistant,
+    mock_discovery: AsyncMock,
+    mock_connect: AsyncMock,
+) -> None:
+    """A wrong-case email auth failure suggests the registered case and pre-fills it."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["step_id"] == "user"
+
+    mock_discovery["mock_devices"][IP_ADDRESS].update.side_effect = AuthenticationError
+    result2 = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={CONF_HOST: IP_ADDRESS}
+    )
+    await hass.async_block_till_done()
+    assert result2["step_id"] == "user_auth_confirm"
+
+    # The entered credentials still fail locally (wrong case), but the cloud
+    # reports a canonical e-mail that differs only in case.
+    with (
+        override_side_effect(mock_connect["connect"], AuthenticationError),
+        patch(
+            "homeassistant.components.tplink.config_flow.async_get_canonical_username",
+            AsyncMock(return_value="Fake_Username"),
+        ),
+    ):
+        result3 = await hass.config_entries.flow.async_configure(
+            result2["flow_id"],
+            user_input={
+                CONF_USERNAME: "fake_username",
+                CONF_PASSWORD: "fake_password",
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result3["type"] is FlowResultType.FORM
+    assert result3["step_id"] == "user_auth_confirm"
+    assert result3["errors"] == {CONF_PASSWORD: "invalid_auth_email_case"}
+    assert result3["description_placeholders"]["canonical"] == "Fake_Username"
+
+    # The username field is pre-filled with the correct capitalisation.
+    suggested = {
+        str(marker.schema): marker.description.get("suggested_value")
+        for marker in result3["data_schema"].schema
+        if getattr(marker, "description", None)
+    }
+    assert suggested.get(CONF_USERNAME) == "Fake_Username"
+
+
 async def test_manual_auth_camera(
     hass: HomeAssistant,
     mock_discovery: AsyncMock,

--- a/tests/components/tplink/test_email_case.py
+++ b/tests/components/tplink/test_email_case.py
@@ -1,0 +1,58 @@
+"""Tests for the TP-Link e-mail case-detection helper."""
+
+import pytest
+
+from homeassistant.components.tplink._email_case import (
+    async_get_canonical_username,
+    suggest_username_case,
+)
+from homeassistant.core import HomeAssistant
+
+from tests.test_util.aiohttp import AiohttpClientMocker
+
+_CLOUD_URL = "https://wap.tplinkcloud.com"
+
+
+@pytest.mark.parametrize(
+    ("entered", "canonical", "expected"),
+    [
+        ("jdoe@example.com", "Jdoe@example.com", "Jdoe@example.com"),
+        ("JDOE@example.com", "jdoe@example.com", "jdoe@example.com"),
+        ("jdoe@example.com", "jdoe@example.com", None),
+        ("jdoe@example.com", None, None),
+        ("jdoe@example.com", "someone@else.com", None),
+    ],
+)
+def test_suggest_username_case(
+    entered: str, canonical: str | None, expected: str | None
+) -> None:
+    """Only a pure case-difference yields a suggestion."""
+    assert suggest_username_case(entered, canonical) == expected
+
+
+async def test_get_canonical_username_success(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """The canonical e-mail is read from the cloud login response."""
+    aioclient_mock.post(
+        _CLOUD_URL,
+        json={"error_code": 0, "result": {"email": "Jdoe@example.com"}},
+    )
+    result = await async_get_canonical_username(hass, "jdoe@example.com", "pw")
+    assert result == "Jdoe@example.com"
+
+
+async def test_get_canonical_username_cloud_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """A cloud error (e.g. wrong password / MFA) yields None, not a raise."""
+    aioclient_mock.post(_CLOUD_URL, json={"error_code": -20601})
+    assert await async_get_canonical_username(hass, "jdoe@example.com", "pw") is None
+
+
+async def test_get_canonical_username_network_error(
+    hass: HomeAssistant, aioclient_mock: AiohttpClientMocker
+) -> None:
+    """A network failure yields None, not a raise."""
+    aioclient_mock.post(_CLOUD_URL, exc=TimeoutError())
+    assert await async_get_canonical_username(hass, "jdoe@example.com", "pw") is None


### PR DESCRIPTION
## Proposed change

<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

The TP-Link/Kasa app and cloud login are **case-insensitive** for the account email, but
the local integration hashes the email **case-sensitively** for KLAP/AES authentication.
A user whose account is registered as `Jdoe@example.com` but who enters
`jdoe@example.com` — which works fine in the Kasa app and via SmartThings — fails local
authentication with `Unable to authenticate: … (both case-sensitive)`, and almost nobody
suspects the *email* case (everyone re-checks the password). This underlies a long tail
of reports (#164777, #132304); python-kasa#1700 has the root-cause detail.

On `AuthenticationError` in the credentials / discovery / reauth steps, the flow now
checks whether a case difference is the cause: it performs a (case-insensitive) TP-Link
cloud login with the entered credentials, reads back the account's canonical email, and
if it matches case-insensitively but differs in case, it shows a translated error naming
the correct casing and pre-fills the username field. Best-effort and failure-path only —
any problem (wrong password, MFA, no network) falls through to the existing error, so
there is no new behaviour in the normal path.

Includes a unit-tested helper (`_email_case.py`) and a config-flow test for the
case-suggestion path.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #164777, #132304
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

<!--
  Put an `x` in the boxes that apply.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
