### PR TITLE
Add light platform for Electrolux integration

### DIFF
--- a/homeassistant/components/electrolux/__init__.py
+++ b/homeassistant/components/electrolux/__init__.py
@@ -41,6 +41,7 @@ _LOGGER: logging.Logger = logging.getLogger(__name__)
 PLATFORMS = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
+    Platform.LIGHT,
     Platform.SENSOR,
 ]
 

--- a/homeassistant/components/electrolux/light.py
+++ b/homeassistant/components/electrolux/light.py
@@ -48,10 +48,10 @@ class ElectroluxLightBaseDescription[T: ApplianceData, **P = []](
     color_mode: ColorMode
     supported_color_modes: set[ColorMode]
     exists_fn: Callable[Concatenate[T, P], bool]
-    min_color_fn: Callable[Concatenate[T, P], int | None] | None
-    max_color_fn: Callable[Concatenate[T, P], int | None] | None
-    color_fn: Callable[Concatenate[T, P], int | None] | None
-    brightness_fn: Callable[Concatenate[T, P], int | None] | None
+    min_color_fn: Callable[Concatenate[T, P], int | None] | None = None
+    max_color_fn: Callable[Concatenate[T, P], int | None] | None = None
+    color_fn: Callable[Concatenate[T, P], int | None] | None = None
+    brightness_fn: Callable[Concatenate[T, P], int | None] | None = None
     is_on_fn: Callable[Concatenate[T, P], bool]
     turn_on_command_fn: Callable[
         Concatenate[T, int | None, int | None, P], list[dict[str, Any]]
@@ -156,20 +156,6 @@ HOOD_LIGHTS: tuple[ElectroluxLightDescription[HDAppliance], ...] = (
 )
 
 
-def oven_cavity_light_turn_on_command_fn(
-    appliance: OVAppliance, brightness: int | None, color_temp: int | None
-) -> list[dict[str, Any]]:
-    """Generate the commands to turn on the cavity light of an oven."""
-    return [appliance.get_cavity_light_command(True)]
-
-
-def oven_cavity_light_turn_off_command_fn(
-    appliance: OVAppliance,
-) -> list[dict[str, Any]]:
-    """Generate the commands to turn off the cavity light of an oven."""
-    return [appliance.get_cavity_light_command(False)]
-
-
 OVEN_LIGHTS: tuple[ElectroluxLightDescription[OVAppliance], ...] = (
     ElectroluxLightDescription(
         key="cavity_light",
@@ -177,29 +163,15 @@ OVEN_LIGHTS: tuple[ElectroluxLightDescription[OVAppliance], ...] = (
         supported_color_modes={ColorMode.ONOFF},
         color_mode=ColorMode.ONOFF,
         exists_fn=lambda appliance: appliance.is_feature_supported(CAVITY_LIGHT),
-        min_color_fn=None,
-        max_color_fn=None,
-        color_fn=None,
-        brightness_fn=None,
         is_on_fn=lambda appliance: appliance.get_current_cavity_light(),
-        turn_on_command_fn=oven_cavity_light_turn_on_command_fn,
-        turn_off_command_fn=oven_cavity_light_turn_off_command_fn,
+        turn_on_command_fn=lambda appliance, brightness, color_temp: [
+            appliance.get_cavity_light_command(True)
+        ],
+        turn_off_command_fn=lambda appliance: [
+            appliance.get_cavity_light_command(False)
+        ],
     ),
 )
-
-
-def structured_oven_cavity_light_turn_on_command_fn(
-    appliance: SOAppliance, brightness: int | None, color_temp: int | None, cavity: str
-) -> list[dict[str, Any]]:
-    """Generate the commands to turn on the cavity light of an oven."""
-    return [appliance.get_cavity_light_command(cavity, True)]
-
-
-def structured_oven_cavity_light_turn_off_command_fn(
-    appliance: SOAppliance, cavity: str
-) -> list[dict[str, Any]]:
-    """Generate the commands to turn off the cavity light of an oven."""
-    return [appliance.get_cavity_light_command(cavity, False)]
 
 
 STRUCTURED_OVEN_LIGHTS: tuple[ElectroluxSubmoduleLightDescription[SOAppliance], ...] = (
@@ -211,15 +183,15 @@ STRUCTURED_OVEN_LIGHTS: tuple[ElectroluxSubmoduleLightDescription[SOAppliance], 
         exists_fn=lambda appliance, cavity: appliance.is_cavity_feature_supported(
             cavity, CAVITY_LIGHT
         ),
-        min_color_fn=None,
-        max_color_fn=None,
-        color_fn=None,
-        brightness_fn=None,
         is_on_fn=lambda appliance, cavity: appliance.get_current_cavity_cavity_light(
             cavity
         ),
-        turn_on_command_fn=structured_oven_cavity_light_turn_on_command_fn,
-        turn_off_command_fn=structured_oven_cavity_light_turn_off_command_fn,
+        turn_on_command_fn=lambda appliance, brightness, color_temp, cavity: [
+            appliance.get_cavity_light_command(cavity, True)
+        ],
+        turn_off_command_fn=lambda appliance, cavity: [
+            appliance.get_cavity_light_command(cavity, False)
+        ],
     ),
 )
 
@@ -385,8 +357,6 @@ class ElectroluxLight[T: ApplianceData](ElectroluxBaseLight[T]):
     @override
     def _is_on(self) -> bool | None:
         description = self.entity_description
-        if description.is_on_fn is None:
-            return None
 
         return description.is_on_fn(self._appliance_data)
 
@@ -476,8 +446,6 @@ class ElectroluxSubmoduleLight[T: ApplianceData](ElectroluxBaseLight[T]):
     @override
     def _is_on(self) -> bool | None:
         description = self.entity_description
-        if description.is_on_fn is None:
-            return None
 
         return description.is_on_fn(self._appliance_data, self._submodule)
 

--- a/homeassistant/components/electrolux/light.py
+++ b/homeassistant/components/electrolux/light.py
@@ -1,0 +1,536 @@
+"""Light entity for Electrolux Integration."""
+
+from abc import abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Concatenate, override
+
+from electrolux_group_developer_sdk.client.appliances.appliance_data import (
+    ApplianceData,
+)
+from electrolux_group_developer_sdk.client.appliances.hd_appliance import HDAppliance
+from electrolux_group_developer_sdk.client.appliances.ov_appliance import OVAppliance
+from electrolux_group_developer_sdk.client.appliances.so_appliance import SOAppliance
+from electrolux_group_developer_sdk.feature_constants import (
+    CAVITY_LIGHT,
+    LIGHT_COLOR_TEMPERATURE,
+    LIGHT_INTENSITY,
+)
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    ColorMode,
+    LightEntity,
+    LightEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util.color import brightness_to_value, value_to_brightness
+
+from .coordinator import ElectroluxConfigEntry, ElectroluxDataUpdateCoordinator
+from .entity import ElectroluxBaseEntity
+from .entity_helper import async_setup_entities_helper
+from .util import convert_to_snake_case, round_to_valid_step_int
+
+COLOR_RANGE = (0, 100)
+COLOR_KELVIN_RANGE = (2200, 6500)
+
+BRIGHTNESS_SCALE = (1, 100)
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElectroluxLightBaseDescription[T: ApplianceData, **P = []](
+    LightEntityDescription
+):
+    """Custom light description for Electrolux lights."""
+
+    color_mode: ColorMode
+    supported_color_modes: set[ColorMode]
+    exists_fn: Callable[Concatenate[T, P], bool]
+    min_color_fn: Callable[Concatenate[T, P], int | None] | None
+    max_color_fn: Callable[Concatenate[T, P], int | None] | None
+    color_fn: Callable[Concatenate[T, P], int | None] | None
+    brightness_fn: Callable[Concatenate[T, P], int | None] | None
+    is_on_fn: Callable[Concatenate[T, P], bool]
+    turn_on_command_fn: Callable[
+        Concatenate[T, int | None, int | None, P], list[dict[str, Any]]
+    ]
+    turn_off_command_fn: Callable[Concatenate[T, P], list[dict[str, Any]]]
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElectroluxLightDescription[T: ApplianceData](
+    ElectroluxLightBaseDescription[T, []]
+):
+    """Custom light description for Electrolux lights."""
+
+
+@dataclass(frozen=True, kw_only=True)
+class ElectroluxSubmoduleLightDescription[T: ApplianceData](
+    ElectroluxLightBaseDescription[T, [str]]
+):
+    """Custom light description for Electrolux appliance submodule lights."""
+
+
+def hood_light_is_on_fn(appliance: HDAppliance) -> bool:
+    """Determine if the hood light is on."""
+    current_light_intensity = appliance.get_current_light_intensity()
+    return current_light_intensity > 0
+
+
+def hood_light_turn_on_command_fn(
+    appliance: HDAppliance, brightness: int | None, color_temp: int | None
+) -> list[dict[str, Any]]:
+    """Generate the commands to turn on the hood light with the specified brightness and color."""
+    commands = []
+
+    is_on = hood_light_is_on_fn(appliance)
+    current_light_intensity = appliance.get_current_light_intensity()
+    light_intensity: float | None = None
+    if brightness is not None:
+        light_intensity = _map_from_brightness(brightness)
+    elif not is_on:
+        light_intensity = 70
+
+    if light_intensity is not None:
+        rounded_light_intensity = round_to_valid_step_int(
+            light_intensity,
+            appliance.get_min_light_intensity(),
+            appliance.get_step_light_intensity(),
+        )
+        if rounded_light_intensity != current_light_intensity:
+            commands.append(
+                appliance.get_set_light_intensity_command(rounded_light_intensity)
+            )
+
+    current_color_temperature = appliance.get_current_light_color_temperature()
+    color_temperature: float | None = _map_from_kelvin(color_temp)
+
+    if color_temperature is not None:
+        rounded_color_temperature = round_to_valid_step_int(
+            color_temperature,
+            appliance.get_min_light_color_temperature_range(),
+            appliance.get_step_light_color_temperature_range(),
+        )
+        if rounded_color_temperature != current_color_temperature:
+            commands.append(
+                appliance.get_set_light_color_temperature_command(
+                    rounded_color_temperature
+                )
+            )
+
+    return commands
+
+
+def hood_light_turn_off_command_fn(appliance: HDAppliance) -> list[dict[str, Any]]:
+    """Generate the commands to turn off the hood light."""
+    return [appliance.get_set_light_intensity_command(0)]
+
+
+HOOD_LIGHTS: tuple[ElectroluxLightDescription[HDAppliance], ...] = (
+    ElectroluxLightDescription(
+        key="hood_light",
+        translation_key="hood_light",
+        supported_color_modes={ColorMode.COLOR_TEMP},
+        color_mode=ColorMode.COLOR_TEMP,
+        exists_fn=lambda appliance: appliance.is_feature_supported(
+            [LIGHT_INTENSITY, LIGHT_COLOR_TEMPERATURE]
+        ),
+        min_color_fn=lambda appliance: _map_to_kelvin(
+            appliance.get_min_light_color_temperature_range()
+        ),
+        max_color_fn=lambda appliance: _map_to_kelvin(
+            appliance.get_max_light_color_temperature_range()
+        ),
+        color_fn=lambda appliance: _map_to_kelvin(
+            appliance.get_current_light_color_temperature()
+        ),
+        brightness_fn=lambda appliance: _map_to_brightness(
+            appliance.get_current_light_intensity()
+        ),
+        is_on_fn=hood_light_is_on_fn,
+        turn_on_command_fn=hood_light_turn_on_command_fn,
+        turn_off_command_fn=hood_light_turn_off_command_fn,
+    ),
+)
+
+
+def oven_cavity_light_turn_on_command_fn(
+    appliance: OVAppliance, brightness: int | None, color_temp: int | None
+) -> list[dict[str, Any]]:
+    """Generate the commands to turn on the cavity light of an oven."""
+    return [appliance.get_cavity_light_command(True)]
+
+
+def oven_cavity_light_turn_off_command_fn(
+    appliance: OVAppliance,
+) -> list[dict[str, Any]]:
+    """Generate the commands to turn off the cavity light of an oven."""
+    return [appliance.get_cavity_light_command(False)]
+
+
+OVEN_LIGHTS: tuple[ElectroluxLightDescription[OVAppliance], ...] = (
+    ElectroluxLightDescription(
+        key="cavity_light",
+        translation_key="cavity_light",
+        supported_color_modes={ColorMode.ONOFF},
+        color_mode=ColorMode.ONOFF,
+        exists_fn=lambda appliance: appliance.is_feature_supported(CAVITY_LIGHT),
+        min_color_fn=None,
+        max_color_fn=None,
+        color_fn=None,
+        brightness_fn=None,
+        is_on_fn=lambda appliance: appliance.get_current_cavity_light(),
+        turn_on_command_fn=oven_cavity_light_turn_on_command_fn,
+        turn_off_command_fn=oven_cavity_light_turn_off_command_fn,
+    ),
+)
+
+
+def structured_oven_cavity_light_turn_on_command_fn(
+    appliance: SOAppliance, brightness: int | None, color_temp: int | None, cavity: str
+) -> list[dict[str, Any]]:
+    """Generate the commands to turn on the cavity light of an oven."""
+    return [appliance.get_cavity_light_command(cavity, True)]
+
+
+def structured_oven_cavity_light_turn_off_command_fn(
+    appliance: SOAppliance, cavity: str
+) -> list[dict[str, Any]]:
+    """Generate the commands to turn off the cavity light of an oven."""
+    return [appliance.get_cavity_light_command(cavity, False)]
+
+
+STRUCTURED_OVEN_LIGHTS: tuple[ElectroluxSubmoduleLightDescription[SOAppliance], ...] = (
+    ElectroluxSubmoduleLightDescription(
+        key="cavity_light",
+        translation_key="cavity_light",
+        supported_color_modes={ColorMode.ONOFF},
+        color_mode=ColorMode.ONOFF,
+        exists_fn=lambda appliance, cavity: appliance.is_cavity_feature_supported(
+            cavity, CAVITY_LIGHT
+        ),
+        min_color_fn=None,
+        max_color_fn=None,
+        color_fn=None,
+        brightness_fn=None,
+        is_on_fn=lambda appliance, cavity: appliance.get_current_cavity_cavity_light(
+            cavity
+        ),
+        turn_on_command_fn=structured_oven_cavity_light_turn_on_command_fn,
+        turn_off_command_fn=structured_oven_cavity_light_turn_off_command_fn,
+    ),
+)
+
+
+def build_entities_for_appliance(
+    appliance_data: ApplianceData,
+    coordinators: dict[str, ElectroluxDataUpdateCoordinator],
+) -> list[ElectroluxBaseEntity]:
+    """Return all entities for a single appliance."""
+    appliance = appliance_data.appliance
+    coordinator = coordinators[appliance.applianceId]
+    entities: list[ElectroluxBaseEntity] = []
+
+    if isinstance(appliance_data, HDAppliance):
+        entities.extend(
+            ElectroluxLight(appliance_data, coordinator, description)
+            for description in HOOD_LIGHTS
+            if description.exists_fn(appliance_data)
+        )
+
+    if isinstance(appliance_data, OVAppliance):
+        entities.extend(
+            ElectroluxLight(appliance_data, coordinator, description)
+            for description in OVEN_LIGHTS
+            if description.exists_fn(appliance_data)
+        )
+
+    if isinstance(appliance_data, SOAppliance):
+        entities.extend(
+            ElectroluxSubmoduleLight(appliance_data, coordinator, description, cavity)
+            for cavity in appliance_data.get_supported_cavities()
+            for description in STRUCTURED_OVEN_LIGHTS
+            if description.exists_fn(appliance_data, cavity)
+        )
+
+    return entities
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ElectroluxConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up lights for Electrolux Integration."""
+    await async_setup_entities_helper(
+        hass, entry, async_add_entities, build_entities_for_appliance
+    )
+
+
+class ElectroluxBaseLight[T: ApplianceData](ElectroluxBaseEntity[T], LightEntity):
+    """Representation of a generic light for Electrolux appliances."""
+
+    @override
+    def _update_attr_state(self) -> bool:
+        state_changed = False
+
+        if (new_color_temp := self._get_color()) != self._attr_color_temp_kelvin:
+            self._attr_color_temp_kelvin = new_color_temp
+            state_changed = True
+
+        if (new_brightness := self._get_brightness()) != self._attr_brightness:
+            self._attr_brightness = new_brightness
+            state_changed = True
+
+        if (new_is_on := self._is_on()) != self._attr_is_on:
+            self._attr_is_on = new_is_on
+            state_changed = True
+
+        return state_changed
+
+    @abstractmethod
+    def _get_color(self) -> int | None: ...
+
+    @abstractmethod
+    def _get_brightness(self) -> int | None: ...
+
+    @abstractmethod
+    def _is_on(self) -> bool | None: ...
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the light on."""
+        brightness: int | None = kwargs.get(ATTR_BRIGHTNESS)
+        color_temp: int | None = kwargs.get(ATTR_COLOR_TEMP_KELVIN)
+
+        await self._execute_commands(self._get_turn_on_commands(brightness, color_temp))
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the light off."""
+        await self._execute_commands(self._get_turn_off_commands())
+
+    @abstractmethod
+    def _get_turn_on_commands(
+        self, brightness: int | None, color_temp: int | None
+    ) -> list[dict[str, Any]]: ...
+
+    @abstractmethod
+    def _get_turn_off_commands(self) -> list[dict[str, Any]]: ...
+
+    async def _execute_commands(self, commands: list[dict[str, Any]]) -> None:
+        """Execute a list of commands for the appliance."""
+        if commands:
+            for command in commands:
+                await self.coordinator.client.send_command(
+                    self._appliance_data.appliance.applianceId, command
+                )
+            await self.coordinator.async_request_refresh()
+
+
+class ElectroluxLight[T: ApplianceData](ElectroluxBaseLight[T]):
+    """Representation of a generic light for Electrolux appliances."""
+
+    entity_description: ElectroluxLightDescription[T]
+
+    def __init__(
+        self,
+        appliance_data: T,
+        coordinator: ElectroluxDataUpdateCoordinator,
+        description: ElectroluxLightDescription[T],
+    ) -> None:
+        """Initialize the light."""
+        super().__init__(appliance_data, coordinator, description.key)
+        self.entity_description = description
+
+        self._attr_supported_color_modes = description.supported_color_modes
+        self._attr_color_mode = description.color_mode
+        if (
+            description.min_color_fn is not None
+            and (min_color := description.min_color_fn(appliance_data)) is not None
+        ):
+            self._attr_min_color_temp_kelvin = min_color
+        if (
+            description.max_color_fn is not None
+            and (max_color := description.max_color_fn(appliance_data)) is not None
+        ):
+            self._attr_max_color_temp_kelvin = max_color
+
+    @override
+    def _get_color(self) -> int | None:
+        description = self.entity_description
+        if description.color_fn is None:
+            return None
+
+        color_temp = description.color_fn(self._appliance_data)
+        if color_temp is None or not (0 <= color_temp <= 100):
+            return None
+
+        return color_temp
+
+    @override
+    def _get_brightness(self) -> int | None:
+        description = self.entity_description
+        if description.brightness_fn is None:
+            return None
+
+        brightness = description.brightness_fn(self._appliance_data)
+        if brightness is None or not (0 < brightness <= 100):
+            return None
+
+        return brightness
+
+    @override
+    def _is_on(self) -> bool | None:
+        description = self.entity_description
+        if description.is_on_fn is None:
+            return None
+
+        return description.is_on_fn(self._appliance_data)
+
+    @override
+    def _get_turn_on_commands(
+        self, brightness: int | None, color_temp: int | None
+    ) -> list[dict[str, Any]]:
+        description = self.entity_description
+        if description.turn_on_command_fn is None:
+            return []
+
+        return description.turn_on_command_fn(
+            self._appliance_data, brightness, color_temp
+        )
+
+    @override
+    def _get_turn_off_commands(self) -> list[dict[str, Any]]:
+        description = self.entity_description
+        if description.turn_off_command_fn is None:
+            return []
+
+        return description.turn_off_command_fn(self._appliance_data)
+
+
+class ElectroluxSubmoduleLight[T: ApplianceData](ElectroluxBaseLight[T]):
+    """Representation of a generic light for Electrolux appliances."""
+
+    entity_description: ElectroluxSubmoduleLightDescription[T]
+
+    def __init__(
+        self,
+        appliance_data: T,
+        coordinator: ElectroluxDataUpdateCoordinator,
+        description: ElectroluxSubmoduleLightDescription[T],
+        submodule: str,
+    ) -> None:
+        """Initialize the light."""
+        entity_key = f"{convert_to_snake_case(submodule)}_{description.key}"
+        translation_key = (
+            f"{convert_to_snake_case(submodule)}_{description.translation_key}"
+        )
+        super().__init__(appliance_data, coordinator, entity_key)
+
+        self._submodule = submodule
+        self.entity_description = description
+        self._attr_translation_key = translation_key
+
+        self._attr_supported_color_modes = description.supported_color_modes
+        self._attr_color_mode = description.color_mode
+        if (
+            description.min_color_fn is not None
+            and (min_color := description.min_color_fn(appliance_data, submodule))
+            is not None
+        ):
+            self._attr_min_color_temp_kelvin = min_color
+        if (
+            description.max_color_fn is not None
+            and (max_color := description.max_color_fn(appliance_data, submodule))
+            is not None
+        ):
+            self._attr_max_color_temp_kelvin = max_color
+
+    @override
+    def _get_color(self) -> int | None:
+        description = self.entity_description
+        if description.color_fn is None:
+            return None
+
+        color_temp = description.color_fn(self._appliance_data, self._submodule)
+        if color_temp is None or not (0 <= color_temp <= 100):
+            return None
+
+        return color_temp
+
+    @override
+    def _get_brightness(self) -> int | None:
+        description = self.entity_description
+        if description.brightness_fn is None:
+            return None
+
+        brightness = description.brightness_fn(self._appliance_data, self._submodule)
+        if brightness is None or not (0 < brightness <= 100):
+            return None
+
+        return brightness
+
+    @override
+    def _is_on(self) -> bool | None:
+        description = self.entity_description
+        if description.is_on_fn is None:
+            return None
+
+        return description.is_on_fn(self._appliance_data, self._submodule)
+
+    @override
+    def _get_turn_on_commands(
+        self, brightness: int | None, color_temp: int | None
+    ) -> list[dict[str, Any]]:
+        description = self.entity_description
+        if description.turn_on_command_fn is None:
+            return []
+
+        return description.turn_on_command_fn(
+            self._appliance_data, brightness, color_temp, self._submodule
+        )
+
+    @override
+    def _get_turn_off_commands(self) -> list[dict[str, Any]]:
+        description = self.entity_description
+        if description.turn_off_command_fn is None:
+            return []
+
+        return description.turn_off_command_fn(self._appliance_data, self._submodule)
+
+
+def _map_to_kelvin(color_temp: int | None) -> int | None:
+    if color_temp is None:
+        return None
+    kelvin_scale_size = COLOR_KELVIN_RANGE[1] - COLOR_KELVIN_RANGE[0]
+    color_scale_size = COLOR_RANGE[1] - COLOR_RANGE[0]
+    return round(
+        COLOR_KELVIN_RANGE[0]
+        + ((color_temp - COLOR_RANGE[0]) / color_scale_size) * kelvin_scale_size
+    )
+
+
+def _map_from_kelvin(kelvin_temp: int | None) -> float | None:
+    if kelvin_temp is None:
+        return None
+    kelvin_scale_size = COLOR_KELVIN_RANGE[1] - COLOR_KELVIN_RANGE[0]
+    color_scale_size = COLOR_RANGE[1] - COLOR_RANGE[0]
+    return round(
+        COLOR_RANGE[0]
+        + ((kelvin_temp - COLOR_KELVIN_RANGE[0]) / kelvin_scale_size) * color_scale_size
+    )
+
+
+def _map_to_brightness(brightness: int | None) -> int | None:
+    if brightness is None:
+        return None
+    return value_to_brightness(BRIGHTNESS_SCALE, brightness)
+
+
+def _map_from_brightness(brightness: int | None) -> float | None:
+    if brightness is None:
+        return None
+    return brightness_to_value(BRIGHTNESS_SCALE, brightness)

--- a/homeassistant/components/electrolux/strings.json
+++ b/homeassistant/components/electrolux/strings.json
@@ -141,6 +141,20 @@
         "name": "Upper oven stop"
       }
     },
+    "light": {
+      "bottomoven_cavity_light": {
+        "name": "Lower cavity light"
+      },
+      "cavity_light": {
+        "name": "Cavity light"
+      },
+      "hood_light": {
+        "name": "Light"
+      },
+      "upperoven_cavity_light": {
+        "name": "Upper cavity light"
+      }
+    },
     "sensor": {
       "appliance_state": {
         "name": "Appliance state",

--- a/homeassistant/components/electrolux/strings.json
+++ b/homeassistant/components/electrolux/strings.json
@@ -149,7 +149,7 @@
         "name": "Cavity light"
       },
       "hood_light": {
-        "name": "Light"
+        "name": "[%key:component::light::title%]"
       },
       "upperoven_cavity_light": {
         "name": "Upper cavity light"

--- a/homeassistant/components/electrolux/util.py
+++ b/homeassistant/components/electrolux/util.py
@@ -1,6 +1,11 @@
 """Utility functions used by the Electrolux integration."""
 
 
+def round_to_valid_step_int(value: float, minimum: int, step: int) -> int:
+    """Utility function for rounding a value to the closest multiple of a step."""
+    return round((value - minimum) / step) * step + minimum
+
+
 def convert_to_snake_case(x: str) -> str:
     """Converts a string to snake case."""
     lower_case = x.lower()

--- a/tests/components/electrolux/snapshots/test_light.ambr
+++ b/tests/components/electrolux/snapshots/test_light.ambr
@@ -1,0 +1,246 @@
+# serializer version: 1
+# name: test_light[light.ceiling_hood_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.MAX_COLOR_TEMP_KELVIN: 'max_color_temp_kelvin'>: 6500,
+      <LightEntityCapabilityAttribute.MIN_COLOR_TEMP_KELVIN: 'min_color_temp_kelvin'>: 2200,
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.ceiling_hood_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Light',
+    'platform': 'electrolux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'hood_light',
+    'unique_id': '999008105_00:99010299-443E074B7A6E_hood_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light[light.ceiling_hood_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.BRIGHTNESS: 'brightness'>: None,
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
+      <LightEntityStateAttribute.COLOR_TEMP_KELVIN: 'color_temp_kelvin'>: None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Ceiling Hood Light',
+      <LightEntityStateAttribute.HS_COLOR: 'hs_color'>: None,
+      <LightEntityCapabilityAttribute.MAX_COLOR_TEMP_KELVIN: 'max_color_temp_kelvin'>: 6500,
+      <LightEntityCapabilityAttribute.MIN_COLOR_TEMP_KELVIN: 'min_color_temp_kelvin'>: 2200,
+      <LightEntityStateAttribute.RGB_COLOR: 'rgb_color'>: None,
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.COLOR_TEMP: 'color_temp'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+      <LightEntityStateAttribute.XY_COLOR: 'xy_color'>: None,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.ceiling_hood_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_light[light.fenix_cavity_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.fenix_cavity_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cavity light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cavity light',
+    'platform': 'electrolux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'cavity_light',
+    'unique_id': '900412569_00:43319382-443E0748CCD4_cavity_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light[light.fenix_cavity_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Fenix Cavity light',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.fenix_cavity_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_light[light.pux_pizza_oven_cavity_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.pux_pizza_oven_cavity_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Cavity light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Cavity light',
+    'platform': 'electrolux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'cavity_light',
+    'unique_id': '949288049_00:11112225-443E076A37D6_cavity_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light[light.pux_pizza_oven_cavity_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'PUX pizza oven Cavity light',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.pux_pizza_oven_cavity_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_light[light.supex_oven_upper_cavity_light-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'light',
+    'entity_category': None,
+    'entity_id': 'light.supex_oven_upper_cavity_light',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Upper cavity light',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Upper cavity light',
+    'platform': 'electrolux',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'upperoven_cavity_light',
+    'unique_id': '944035064_00:27032025-443E073D97B2_upperoven_cavity_light',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_light[light.supex_oven_upper_cavity_light-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <LightEntityStateAttribute.COLOR_MODE: 'color_mode'>: None,
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Supex oven Upper cavity light',
+      <LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES: 'supported_color_modes'>: list([
+        <ColorMode.ONOFF: 'onoff'>,
+      ]),
+      <EntityStateAttribute.SUPPORTED_FEATURES: 'supported_features'>: <LightEntityFeature: 0>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'light.supex_oven_upper_cavity_light',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---

--- a/tests/components/electrolux/test_light.py
+++ b/tests/components/electrolux/test_light.py
@@ -1,0 +1,193 @@
+"""Binary sensor tests of Electrolux integration."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, call, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_COLOR_TEMP_KELVIN,
+    DOMAIN as LIGHT_DOMAIN,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    Platform,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import get_appliance_id, setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+@pytest.fixture(autouse=True)
+def override_platforms() -> Generator[None]:
+    """Override PLATFORMS."""
+    with patch("homeassistant.components.electrolux.PLATFORMS", [Platform.LIGHT]):
+        yield
+
+
+@pytest.mark.usefixtures("appliances")
+async def test_light(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test states of the sensor."""
+    await setup_integration(hass, mock_config_entry)
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("appliance_fixture", "entity_id", "appliance_state", "data", "commands"),
+    [
+        (
+            "hood",
+            "light.ceiling_hood_light",
+            {"lightIntensity": 0},
+            {},
+            [{"lightIntensity": 70}],
+        ),
+        (
+            "hood",
+            "light.ceiling_hood_light",
+            {"lightIntensity": 0},
+            {ATTR_BRIGHTNESS: 50},
+            [{"lightIntensity": 20}],
+        ),
+        (
+            "hood",
+            "light.ceiling_hood_light",
+            {"lightIntensity": 70},
+            {ATTR_BRIGHTNESS: 50},
+            [{"lightIntensity": 20}],
+        ),
+        (
+            "hood",
+            "light.ceiling_hood_light",
+            {"lightIntensity": 70},
+            {ATTR_COLOR_TEMP_KELVIN: 4000},
+            [{"lightColorTemperature": 42}],
+        ),
+        (
+            "hood",
+            "light.ceiling_hood_light",
+            {"lightIntensity": 0},
+            {ATTR_COLOR_TEMP_KELVIN: 4000},
+            [{"lightIntensity": 70}, {"lightColorTemperature": 42}],
+        ),
+        (
+            "fenix_oven",
+            "light.fenix_cavity_light",
+            {},
+            {},
+            [{"cavityLight": True}],
+        ),
+        (
+            "supex_structured_oven",
+            "light.supex_oven_upper_cavity_light",
+            {},
+            {},
+            [{"upperOven": {"cavityLight": True}}],
+        ),
+    ],
+)
+async def test_turn_on(
+    hass: HomeAssistant,
+    appliances: AsyncMock,
+    appliance_fixture: str,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    appliance_state: dict[str, Any],
+    data: dict[str, Any],
+    commands: list[dict[str, Any]],
+) -> None:
+    """Test light turn on command."""
+
+    appliance_id = get_appliance_id(appliance_fixture)
+
+    state = await appliances.get_appliance_state(appliance_id)
+    for state_property, state_value in appliance_state.items():
+        state.properties["reported"][state_property] = state_value
+
+    appliances.get_appliance_state.side_effect = None
+    appliances.get_appliance_state.return_value = state
+
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id} | data,
+        blocking=True,
+    )
+    assert appliances.send_command.mock_calls == [
+        call(appliance_id, command) for command in commands
+    ]
+
+
+@pytest.mark.parametrize(
+    ("appliance_fixture", "entity_id", "appliance_state", "data", "commands"),
+    [
+        (
+            "hood",
+            "light.ceiling_hood_light",
+            {"lightIntensity": 70},
+            {},
+            [{"lightIntensity": 0}],
+        ),
+        (
+            "fenix_oven",
+            "light.fenix_cavity_light",
+            {},
+            {},
+            [{"cavityLight": False}],
+        ),
+        (
+            "supex_structured_oven",
+            "light.supex_oven_upper_cavity_light",
+            {},
+            {},
+            [{"upperOven": {"cavityLight": False}}],
+        ),
+    ],
+)
+async def test_turn_off(
+    hass: HomeAssistant,
+    appliances: AsyncMock,
+    appliance_fixture: str,
+    mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    appliance_state: dict[str, Any],
+    data: dict[str, Any],
+    commands: list[dict[str, Any]],
+) -> None:
+    """Test light turn off command."""
+
+    appliance_id = get_appliance_id(appliance_fixture)
+
+    state = await appliances.get_appliance_state(appliance_id)
+    for state_property, state_value in appliance_state.items():
+        state.properties["reported"][state_property] = state_value
+
+    appliances.get_appliance_state.side_effect = None
+    appliances.get_appliance_state.return_value = state
+
+    await setup_integration(hass, mock_config_entry)
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id} | data,
+        blocking=True,
+    )
+    assert appliances.send_command.mock_calls == [
+        call(appliance_id, command) for command in commands
+    ]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This PR adds support for the Light platform for the Electrolux integration, allowing to control the cavity light(s) of ovens and the overhead light of hoods.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47346
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
