### PR TITLE
Debounce Matter cover state writes to coalesce split attribute updates

### DIFF
--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -27,6 +27,12 @@ from .models import MatterDiscoverySchema
 # The MASK used for extracting bits 0 to 1 of the byte.
 OPERATIONAL_STATUS_MASK = 0b11
 
+# Cover state is derived from both the operational status and the current
+# position, which some devices report as separate attribute updates shortly
+# after each other (e.g. stopped before the final position). Debounce state
+# writes to avoid writing intermittent states.
+STATE_WRITE_DEBOUNCE_COOLDOWN = 0.1
+
 # map Matter window cover types to HA device class
 TYPE_MAP = {
     clusters.WindowCovering.Enums.Type.kRollerShade: CoverDeviceClass.SHADE,
@@ -69,6 +75,7 @@ class MatterCoverEntityDescription(CoverEntityDescription, MatterEntityDescripti
 class MatterCover(MatterEntity, CoverEntity):
     """Representation of a Matter Cover."""
 
+    _write_state_debounce_cooldown = STATE_WRITE_DEBOUNCE_COOLDOWN
     entity_description: MatterCoverEntityDescription
 
     @property

--- a/homeassistant/components/matter/entity.py
+++ b/homeassistant/components/matter/entity.py
@@ -19,6 +19,7 @@ from propcache.api import cached_property
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.typing import UndefinedType
@@ -94,6 +95,11 @@ class MatterEntity(Entity):
     _attr_should_poll = False
     _name_postfix: str | None = None
     _platform_translation_key: str | None = None
+    # Cooldown in seconds to debounce state writes on updates from the device.
+    # Platforms which derive their state from multiple attributes can set this
+    # to coalesce attribute updates which arrive as separate events.
+    _write_state_debounce_cooldown: float | None = None
+    _write_state_debouncer: Debouncer[None] | None = None
 
     def __init__(
         self,
@@ -188,6 +194,15 @@ class MatterEntity(Entity):
     async def async_added_to_hass(self) -> None:
         """Handle being added to Home Assistant."""
         await super().async_added_to_hass()
+
+        if self._write_state_debounce_cooldown is not None:
+            self._write_state_debouncer = Debouncer(
+                self.hass,
+                LOGGER,
+                cooldown=self._write_state_debounce_cooldown,
+                immediate=False,
+                function=self.async_write_ha_state,
+            )
 
         # Subscribe to attribute updates.
         sub_paths: list[str] = []
@@ -305,6 +320,14 @@ class MatterEntity(Entity):
             return True
         return bool(reachable)
 
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Handle being removed from Home Assistant."""
+        await super().async_will_remove_from_hass()
+        if self._write_state_debouncer is not None:
+            self._write_state_debouncer.async_shutdown()
+            self._write_state_debouncer = None
+
     @callback
     def _on_matter_event(self, event: EventType, data: Any = None) -> None:
         """Call on update from the device."""
@@ -312,7 +335,10 @@ class MatterEntity(Entity):
             self._endpoint.node.available and self._get_bridged_reachable()
         )
         self._update_from_device()
-        self.async_write_ha_state()
+        if self._write_state_debouncer is not None:
+            self._write_state_debouncer.async_schedule_call()
+        else:
+            self.async_write_ha_state()
 
     @callback
     def _on_featuremap_update(self, event: EventType, data: int | None) -> None:

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -4,11 +4,13 @@ from math import floor
 from unittest.mock import MagicMock, call
 
 from chip.clusters import Objects as clusters
+from freezegun.api import FrozenDateTimeFactory
 from matter_server.client.models.node import MatterNode
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.cover import CoverEntityFeature, CoverState
+from homeassistant.components.matter.cover import STATE_WRITE_DEBOUNCE_COOLDOWN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
@@ -18,6 +20,20 @@ from .common import (
     snapshot_matter_entities,
     trigger_subscription_callback,
 )
+
+from tests.common import async_fire_time_changed
+
+
+async def trigger_subscription_callback_debounced(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    client: MagicMock,
+) -> None:
+    """Trigger subscription callbacks and wait for the debounced state write."""
+    await trigger_subscription_callback(hass, client)
+    freezer.tick(STATE_WRITE_DEBOUNCE_COOLDOWN)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
 
 @pytest.mark.usefixtures("matter_devices")
@@ -113,6 +129,7 @@ async def test_cover_lift(
     matter_client: MagicMock,
     matter_node: MatterNode,
     entity_id: str,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering devices with lift and position aware lift features."""
     await hass.services.async_call(
@@ -134,14 +151,14 @@ async def test_cover_lift(
     matter_client.send_device_command.reset_mock()
 
     set_node_attribute(matter_node, 1, 258, 10, 0b001010)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
     assert state.state == CoverState.CLOSING
 
     set_node_attribute(matter_node, 1, 258, 10, 0b000101)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -159,26 +176,27 @@ async def test_cover_lift_only(
     matter_client: MagicMock,
     matter_node: MatterNode,
     entity_id: str,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering with lift but without position aware lift."""
 
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"
 
     set_node_attribute(matter_node, 1, 258, 65529, [0, 1, 2])
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
     assert state.attributes["supported_features"] & CoverEntityFeature.SET_POSITION == 0
 
     set_node_attribute(matter_node, 1, 258, 65529, [0, 1, 2, 5])
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -196,6 +214,7 @@ async def test_cover_position_aware_lift(
     matter_client: MagicMock,
     matter_node: MatterNode,
     entity_id: str,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering devices with position aware lift features."""
 
@@ -212,7 +231,7 @@ async def test_cover_position_aware_lift(
     for position in (0, 9999):
         set_node_attribute(matter_node, 1, 258, 14, position)
         set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-        await trigger_subscription_callback(hass, matter_client)
+        await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
         state = hass.states.get(entity_id)
         assert state
@@ -221,7 +240,49 @@ async def test_cover_position_aware_lift(
 
     set_node_attribute(matter_node, 1, 258, 14, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["current_position"] == 0
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
+        ("mock_window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+    ],
+)
+async def test_cover_split_attribute_updates(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test state writes are debounced to coalesce split attribute updates."""
+
+    set_node_attribute(matter_node, 1, 258, 14, 9900)
+    set_node_attribute(matter_node, 1, 258, 10, 0b001010)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == CoverState.CLOSING
+
+    # the device reports it stopped moving, while the final position
+    # arrives as a separate attribute update slightly later
+    set_node_attribute(matter_node, 1, 258, 10, 0b000000)
     await trigger_subscription_callback(hass, matter_client)
+
+    # the intermittent state (stopped at 1% open) is not written
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == CoverState.CLOSING
+
+    set_node_attribute(matter_node, 1, 258, 14, 10000)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -242,6 +303,7 @@ async def test_cover_tilt(
     matter_client: MagicMock,
     matter_node: MatterNode,
     entity_id: str,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering devices with tilt and position aware tilt features."""
 
@@ -263,16 +325,16 @@ async def test_cover_tilt(
     )
     matter_client.send_device_command.reset_mock()
 
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     set_node_attribute(matter_node, 1, 258, 10, 0b100010)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == CoverState.CLOSING
 
     set_node_attribute(matter_node, 1, 258, 10, 0b010001)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -290,11 +352,12 @@ async def test_cover_tilt_only(
     matter_client: MagicMock,
     matter_node: MatterNode,
     entity_id: str,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering with tilt but without position aware tilt."""
 
     set_node_attribute(matter_node, 1, 258, 65529, [0, 1, 2])
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -304,7 +367,7 @@ async def test_cover_tilt_only(
     )
 
     set_node_attribute(matter_node, 1, 258, 65529, [0, 1, 2, 8])
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -325,6 +388,7 @@ async def test_cover_position_aware_tilt(
     matter_client: MagicMock,
     matter_node: MatterNode,
     entity_id: str,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering devices with position aware tilt feature."""
 
@@ -341,7 +405,7 @@ async def test_cover_position_aware_tilt(
     for tilt_position in (0, 9999, 10000):
         set_node_attribute(matter_node, 1, 258, 15, tilt_position)
         set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-        await trigger_subscription_callback(hass, matter_client)
+        await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
         state = hass.states.get(entity_id)
         assert state
@@ -355,6 +419,7 @@ async def test_cover_full_features(
     hass: HomeAssistant,
     matter_client: MagicMock,
     matter_node: MatterNode,
+    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test window covering devices with all the features."""
     entity_id = "cover.mock_full_window_covering"
@@ -373,7 +438,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, 10000)
     set_node_attribute(matter_node, 1, 258, 15, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -382,7 +447,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, 5000)
     set_node_attribute(matter_node, 1, 258, 15, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -391,7 +456,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, 10000)
     set_node_attribute(matter_node, 1, 258, 15, 5000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -400,7 +465,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, 5000)
     set_node_attribute(matter_node, 1, 258, 15, 5000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
     state = hass.states.get(entity_id)
     assert state
@@ -409,7 +474,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, 5000)
     set_node_attribute(matter_node, 1, 258, 15, None)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == CoverState.OPEN
@@ -417,7 +482,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 15, 5000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"
@@ -425,7 +490,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, 10000)
     set_node_attribute(matter_node, 1, 258, 15, None)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == CoverState.CLOSED
@@ -433,7 +498,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 15, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"
@@ -441,7 +506,7 @@ async def test_cover_full_features(
     set_node_attribute(matter_node, 1, 258, 14, None)
     set_node_attribute(matter_node, 1, 258, 15, None)
     set_node_attribute(matter_node, 1, 258, 10, 0b000000)
-    await trigger_subscription_callback(hass, matter_client)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "unknown"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Debounce Matter cover state writes to avoid publishing intermittent states when the attributes making up a single logical state change arrive as separate attribute updates.

Some devices report the end of a cover movement as two attribute updates shortly after each other, e.g. Eve MotionBlinds (firmware 3.5.1, via Matter.js based Matter Server) report `OperationalStatus` stopped before the final `CurrentPositionLiftPercent100ths` value:

```
2026-07-29 09:44:27.843 DEBUG (MainThread) [matter_server.client] Attribute updated: Node: 103 - Attribute: 1/258/10 - New value: 0
2026-07-29 09:44:27.843 DEBUG (MainThread) [homeassistant.components.matter] Operational status 0b00000000 for cover.eve_motionblinds_20caa9901
2026-07-29 09:44:27.843 DEBUG (MainThread) [homeassistant.components.matter] Current position for cover.eve_motionblinds_20caa9901 - raw: 9900 - corrected: 1
2026-07-29 09:44:27.849 DEBUG (MainThread) [matter_server.client] Attribute updated: Node: 103 - Attribute: 1/258/14 - New value: 10000
2026-07-29 09:44:27.849 DEBUG (MainThread) [homeassistant.components.matter] Operational status 0b00000000 for cover.eve_motionblinds_20caa9901
2026-07-29 09:44:27.849 DEBUG (MainThread) [homeassistant.components.matter] Current position for cover.eve_motionblinds_20caa9901 - raw: 10000 - corrected: 0
```

These attribute updates typically originate from a single (atomic) Matter subscription report: the Matter Server WebSocket API splits such a report into separate per-attribute `attribute_updated` events, which the integration processes individually. Since the entity state was written on each individual event, this published an intermittent state (stopped at 1% open, i.e. `open`, followed by `closed` a few milliseconds later), causing state change automations to trigger twice.

This adds opt-in state write debouncing to the Matter entity base class and enables it for covers, which derive their state from both the operational status and the current position attributes. Attribute updates still get processed immediately, only the state write is deferred by 100 ms, so updates arriving shortly after each other coalesce into a single state write. Effectively this re-coalesces what the device sent as one report: attributes split from the same report arrive within milliseconds of each other, so the 100 ms window reliably covers the split.

This supersedes #164175: that PR was closed in favor of the ordering fix in matter-js/matter.js#3290, but preserving the attribute update order does not help here since the WebSocket events are delivered and processed separately regardless of order, and the batched `attributes_updated` event suggested back then has not been implemented in the Matter Server client. Compared to the original PR, the debounce machinery now lives in the entity base class (opt-in via a class attribute) instead of overriding `_on_matter_event()` in the cover platform, which avoids duplicating base class logic (the override from the original PR would meanwhile have silently dropped the newly added bridged device reachability handling).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
