### PR TITLE
Bump pyintelliclima to 0.4.0

### DIFF
--- a/homeassistant/components/intelliclima/manifest.json
+++ b/homeassistant/components/intelliclima/manifest.json
@@ -7,5 +7,5 @@
   "integration_type": "device",
   "iot_class": "cloud_polling",
   "quality_scale": "bronze",
-  "requirements": ["pyintelliclima==0.3.1"]
+  "requirements": ["pyintelliclima==0.4.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -2267,7 +2267,7 @@ pyimouapi==1.3.0
 pyinsteon==1.6.4
 
 # homeassistant.components.intelliclima
-pyintelliclima==0.3.1
+pyintelliclima==0.4.0
 
 # homeassistant.components.intesishome
 pyintesishome==2.0.3


### PR DESCRIPTION
## Proposed change

Bump the `pyintelliclima` dependency used by the `intelliclima` integration from 0.3.1 to 0.4.0.

This release adds new API surface (filter status, season, free cooling, calibration offsets, master/slave rotation), fixes a bug where only the first house on a multi-house account was scanned for devices, adds a `py.typed` marker, and refreshes dev-tool pins. None of the new API surface is consumed yet — this PR is purely the dependency bump so that follow-up PRs adding new entities can build on it independently.

- PyPI: https://pypi.org/project/pyintelliclima/0.4.0/
- Changelog: https://github.com/dvdinth/pyintelliclima/releases/tag/v0.4.0
- Diff: https://github.com/dvdinth/pyintelliclima/compare/v0.3.1...v0.4.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
