### PR TITLE
Ignore stale moving operational status for position aware Matter covers

### DIFF
--- a/homeassistant/components/matter/cover.py
+++ b/homeassistant/components/matter/cover.py
@@ -127,6 +127,37 @@ class MatterCover(MatterEntity, CoverEntity):
         )
 
     @callback
+    def _positions_at_target(self) -> bool | None:
+        """Return whether all supported positions match their target position.
+
+        Returns None if the positions cannot be compared, e.g. the device is
+        not position aware or a position is (still) unknown.
+        """
+        at_target: bool | None = None
+        for current_attribute, target_attribute in (
+            (
+                clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
+                clusters.WindowCovering.Attributes.TargetPositionLiftPercent100ths,
+            ),
+            (
+                clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
+                clusters.WindowCovering.Attributes.TargetPositionTiltPercent100ths,
+            ),
+        ):
+            if not self._entity_info.endpoint.has_attribute(
+                None, current_attribute
+            ) or not self._entity_info.endpoint.has_attribute(None, target_attribute):
+                continue
+            current_position = self.get_matter_attribute_value(current_attribute)
+            target_position = self.get_matter_attribute_value(target_attribute)
+            if current_position is None or target_position is None:
+                return None
+            if current_position != target_position:
+                return False
+            at_target = True
+        return at_target
+
+    @callback
     @override
     def _update_from_device(self) -> None:
         """Update from device."""
@@ -153,6 +184,29 @@ class MatterCover(MatterEntity, CoverEntity):
             case _:
                 self._attr_is_opening = False
                 self._attr_is_closing = False
+
+        # Some devices report a moving operational status together with the
+        # final position(s) without a subsequent report clearing the moving
+        # state, leaving the cover stuck in a moving state. For position aware
+        # covers, a covering whose position(s) match the target position(s) is
+        # not moving.
+        at_target = self._positions_at_target()
+        if at_target and (self._attr_is_opening or self._attr_is_closing):
+            LOGGER.debug(
+                "Ignoring moving operational status for %s, position(s) match target position(s)",
+                self.entity_id,
+            )
+            self._attr_is_opening = False
+            self._attr_is_closing = False
+        LOGGER.debug(
+            "Movement state for %s: opening=%s closing=%s (%s)",
+            self.entity_id,
+            self._attr_is_opening,
+            self._attr_is_closing,
+            "from operational status and target/current position"
+            if at_target is not None
+            else "from operational status only",
+        )
 
         if self._entity_info.endpoint.has_attribute(
             None, clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths
@@ -242,6 +296,9 @@ DISCOVERY_SCHEMAS = [
             clusters.WindowCovering.Attributes.Type,
             clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
         ),
+        optional_attributes=(
+            clusters.WindowCovering.Attributes.TargetPositionLiftPercent100ths,
+        ),
         absent_attributes=(
             clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
         ),
@@ -256,6 +313,9 @@ DISCOVERY_SCHEMAS = [
             clusters.WindowCovering.Attributes.OperationalStatus,
             clusters.WindowCovering.Attributes.Type,
             clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
+        ),
+        optional_attributes=(
+            clusters.WindowCovering.Attributes.TargetPositionTiltPercent100ths,
         ),
         absent_attributes=(
             clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
@@ -272,6 +332,10 @@ DISCOVERY_SCHEMAS = [
             clusters.WindowCovering.Attributes.Type,
             clusters.WindowCovering.Attributes.CurrentPositionLiftPercent100ths,
             clusters.WindowCovering.Attributes.CurrentPositionTiltPercent100ths,
+        ),
+        optional_attributes=(
+            clusters.WindowCovering.Attributes.TargetPositionLiftPercent100ths,
+            clusters.WindowCovering.Attributes.TargetPositionTiltPercent100ths,
         ),
     ),
 ]

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -150,6 +150,8 @@ async def test_cover_lift(
     )
     matter_client.send_device_command.reset_mock()
 
+    set_node_attribute(matter_node, 1, 258, 14, 5000)
+    set_node_attribute(matter_node, 1, 258, 11, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b001010)
     await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
@@ -157,6 +159,7 @@ async def test_cover_lift(
     assert state
     assert state.state == CoverState.CLOSING
 
+    set_node_attribute(matter_node, 1, 258, 11, 0)
     set_node_attribute(matter_node, 1, 258, 10, 0b000101)
     await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
@@ -293,6 +296,58 @@ async def test_cover_split_attribute_updates(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
+        ("mock_window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+    ],
+)
+async def test_cover_stale_moving_operational_status(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test moving operational status is ignored when the cover is at its target."""
+
+    # the device reports a moving operational status without ever
+    # reporting it stopped, while position reports show it reached the target
+    set_node_attribute(matter_node, 1, 258, 11, 10000)
+    set_node_attribute(matter_node, 1, 258, 14, 10000)
+    set_node_attribute(matter_node, 1, 258, 10, 0b001010)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
+        ("mock_window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+    ],
+)
+async def test_cover_moving_status_with_unknown_target(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test operational status is trusted when the target position is unknown."""
+
+    set_node_attribute(matter_node, 1, 258, 11, None)
+    set_node_attribute(matter_node, 1, 258, 14, 10000)
+    set_node_attribute(matter_node, 1, 258, 10, 0b001010)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == CoverState.CLOSING
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
         ("mock_window_covering_tilt", "cover.mock_tilt_window_covering"),
         ("mock_window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering"),
         ("mock_window_covering_full", "cover.mock_full_window_covering"),
@@ -327,12 +382,15 @@ async def test_cover_tilt(
 
     await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 
+    set_node_attribute(matter_node, 1, 258, 15, 5000)
+    set_node_attribute(matter_node, 1, 258, 12, 10000)
     set_node_attribute(matter_node, 1, 258, 10, 0b100010)
     await trigger_subscription_callback_debounced(hass, freezer, matter_client)
     state = hass.states.get(entity_id)
     assert state
     assert state.state == CoverState.CLOSING
 
+    set_node_attribute(matter_node, 1, 258, 12, 0)
     set_node_attribute(matter_node, 1, 258, 10, 0b010001)
     await trigger_subscription_callback_debounced(hass, freezer, matter_client)
 

--- a/tests/components/matter/test_cover.py
+++ b/tests/components/matter/test_cover.py
@@ -348,6 +348,41 @@ async def test_cover_moving_status_with_unknown_target(
 @pytest.mark.parametrize(
     ("node_fixture", "entity_id"),
     [
+        ("mock_window_covering_pa_lift", "cover.longan_link_wncv_da01"),
+    ],
+)
+async def test_cover_position_updates_without_operational_status(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    matter_node: MatterNode,
+    entity_id: str,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a device which only reports positions, never an operational status."""
+
+    # the device reports the new target and position updates while the
+    # operational status remains "not moving" the whole time
+    set_node_attribute(matter_node, 1, 258, 11, 10000)
+    set_node_attribute(matter_node, 1, 258, 14, 5000)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["current_position"] == 50
+    assert state.state == CoverState.OPEN
+
+    set_node_attribute(matter_node, 1, 258, 14, 10000)
+    await trigger_subscription_callback_debounced(hass, freezer, matter_client)
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes["current_position"] == 0
+    assert state.state == CoverState.CLOSED
+
+
+@pytest.mark.parametrize(
+    ("node_fixture", "entity_id"),
+    [
         ("mock_window_covering_tilt", "cover.mock_tilt_window_covering"),
         ("mock_window_covering_pa_tilt", "cover.mock_pa_tilt_window_covering"),
         ("mock_window_covering_full", "cover.mock_full_window_covering"),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
--> 


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Ignore a stale moving `OperationalStatus` for position aware Matter covers: a covering whose current position(s) match the target position(s) is not moving, regardless of what the operational status claims.

This builds on the state write debouncing from #177540 (merged): the debounce re-coalesces attribute updates split from a single Matter report, while this PR handles reports whose content leaves the cover stuck in a moving state.

Some devices deliver a single Matter report containing a moving `OperationalStatus` together with the final positions (current position already at target), without a subsequent report clearing the moving state. This has been observed with Rademacher shutters behind a Matter bridge (see home-assistant/addons#4724, server debug log analysis): the only `OperationalStatus` reports in a 2 hour debug log arrived together with `TargetPositionLiftPercent100ths` = `CurrentPositionLiftPercent100ths` = 10000, claiming "closing" while the device was provably stationary at its target. Since the integration derives `is_opening`/`is_closing` solely from `OperationalStatus`, the cover entity remained stuck in a closing state until the Matter Server was restarted.

The Matter specification provides the tools to detect this: for position aware covers the target position attributes are mandatory alongside the current position attributes (identical conformance, `LF & PA_LF` resp. `TL & PA_TL`), the target position "SHALL reflect the requested position" (set upon command receipt, and set to the current position by `StopMotion`), and the current position "SHALL always reflect the physical position" (section 5.3.4.3). A covering resting at its target is therefore not moving.

The check is deliberately asymmetric: position/target equality only ever forces the moving state **off**, a position/target mismatch never forces it **on**. Real-world target values cannot be fully trusted, e.g. the `mock_window_covering_pa_lift` fixture (a diagnostics dump of a real Eliteu/Longan Link WNCV-DA01) rests with `TargetPositionLiftPercent100ths` = 0 while `CurrentPositionLiftPercent100ths` = 4900. With this polarity a bogus target can at most fail to unstick a broken cover, but can never wedge a healthy one into a moving state.

When the positions cannot be compared (non position aware covers, null values, missing target attribute), the operational status remains authoritative, as before. Debug logging now states which movement detection mode is in use for each update.

Minor behavior change for spec-compliant devices: when the final position report (current = target) arrives before the report clearing the operational status, the cover now shows the final state immediately instead of remaining in a moving state until the status clears (observed up to ~800 ms with Eve MotionBlinds).

The target position attributes are added as `optional_attributes` to the position aware discovery schemas so the entities subscribe to their updates; discovery matching is unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/addons#4724
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

