### PR TITLE
Coalesce concurrent statistics queries

### DIFF
--- a/homeassistant/components/recorder/websocket_api.py
+++ b/homeassistant/components/recorder/websocket_api.py
@@ -1,9 +1,10 @@
 """The Recorder websocket API."""
 
 import asyncio
+from collections.abc import Callable
 from datetime import datetime as dt
 import logging
-from typing import Any, Literal, cast
+from typing import Any, Literal, NamedTuple, cast
 
 import voluptuous as vol
 
@@ -15,6 +16,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.json import json_bytes
 from homeassistant.helpers.typing import UNDEFINED
 from homeassistant.util import dt as dt_util
+from homeassistant.util.hass_dict import HassKey
 from homeassistant.util.unit_conversion import (
     ApparentPowerConverter,
     AreaConverter,
@@ -69,6 +71,27 @@ _LOGGER = logging.getLogger(__name__)
 
 CLEAR_STATISTICS_TIME_OUT = 10
 UPDATE_STATISTICS_METADATA_TIME_OUT = 10
+
+type _StatisticsPeriod = Literal["5minute", "day", "hour", "week", "month", "year"]
+type _StatisticsType = Literal[
+    "change", "last_reset", "max", "mean", "min", "state", "sum"
+]
+
+
+class _StatisticsQueryKey(NamedTuple):
+    """Identify a statistics query whose result can be shared."""
+
+    start_time: dt
+    end_time: dt | None
+    statistic_ids: frozenset[str]
+    period: _StatisticsPeriod
+    units: frozenset[tuple[str, str]]
+    types: frozenset[_StatisticsType]
+
+
+_IN_FLIGHT_STATISTICS_QUERIES: HassKey[
+    dict[_StatisticsQueryKey, asyncio.Future[bytes]]
+] = HassKey("recorder_in_flight_statistics_queries")
 
 UNIT_SCHEMA = vol.Schema(
     {
@@ -198,13 +221,12 @@ async def ws_get_statistic_during_period(
 
 def _ws_get_statistics_during_period(
     hass: HomeAssistant,
-    msg_id: int,
     start_time: dt,
     end_time: dt | None,
     statistic_ids: set[str] | None,
-    period: Literal["5minute", "day", "hour", "week", "month", "year"],
-    units: dict[str, str],
-    types: set[Literal["change", "last_reset", "max", "mean", "min", "state", "sum"]],
+    period: _StatisticsPeriod,
+    units: dict[str, str] | None,
+    types: set[_StatisticsType],
 ) -> bytes:
     """Fetch statistics and convert them to json in the executor."""
     result = statistics_during_period(
@@ -223,7 +245,32 @@ def _ws_get_statistics_during_period(
             row["end"] = int(row["end"] * 1000)
             if include_last_reset and (last_reset := row["last_reset"]) is not None:
                 row["last_reset"] = int(last_reset * 1000)
-    return json_bytes(messages.result_message(msg_id, result))
+    return json_bytes(result)
+
+
+async def _async_get_or_create_statistics_result(
+    hass: HomeAssistant,
+    query_key: _StatisticsQueryKey,
+    create_result_future: Callable[[], asyncio.Future[bytes]],
+) -> bytes:
+    """Get an in-flight statistics result or start a new query."""
+    in_flight_queries = hass.data.setdefault(_IN_FLIGHT_STATISTICS_QUERIES, {})
+    if (
+        result_future := in_flight_queries.get(query_key)
+    ) is None or result_future.done():
+        result_future = create_result_future()
+        in_flight_queries[query_key] = result_future
+
+        def remove_completed_query(future: asyncio.Future[bytes]) -> None:
+            if in_flight_queries.get(query_key) is future:
+                del in_flight_queries[query_key]
+            if not future.cancelled():
+                future.exception()
+
+        result_future.add_done_callback(remove_completed_query)
+
+    # A disconnected requester must not cancel a query used by other requesters.
+    return await asyncio.shield(result_future)
 
 
 async def ws_handle_get_statistics_during_period(
@@ -250,19 +297,32 @@ async def ws_handle_get_statistics_during_period(
 
     if (types := msg.get("types")) is None:
         types = {"change", "last_reset", "max", "mean", "min", "state", "sum"}
-    connection.send_message(
-        await get_instance(hass).async_add_executor_job(
+    statistic_ids = set(msg["statistic_ids"])
+    period = msg["period"]
+    units = msg.get("units")
+    query_key = _StatisticsQueryKey(
+        start_time=start_time,
+        end_time=end_time,
+        statistic_ids=frozenset(statistic_ids),
+        period=period,
+        units=frozenset((units or {}).items()),
+        types=frozenset(types),
+    )
+    result = await _async_get_or_create_statistics_result(
+        hass,
+        query_key,
+        lambda: get_instance(hass).async_add_executor_job(
             _ws_get_statistics_during_period,
             hass,
-            msg["id"],
             start_time,
             end_time,
-            set(msg["statistic_ids"]),
-            msg.get("period"),
-            msg.get("units"),
+            statistic_ids,
+            period,
+            units,
             types,
-        )
+        ),
     )
+    connection.send_message(messages.construct_result_message(msg["id"], result))
 
 
 @websocket_api.websocket_command(

--- a/tests/components/recorder/test_websocket_api.py
+++ b/tests/components/recorder/test_websocket_api.py
@@ -1,6 +1,7 @@
 """The tests for sensor recorder platform."""
 
-from collections.abc import Iterable
+import asyncio
+from collections.abc import Callable, Iterable
 import datetime
 from datetime import timedelta
 import math
@@ -15,7 +16,10 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components import recorder
-from homeassistant.components.recorder import Recorder
+from homeassistant.components.recorder import (
+    Recorder,
+    websocket_api as recorder_websocket_api,
+)
 from homeassistant.components.recorder.db_schema import Statistics, StatisticsShortTerm
 from homeassistant.components.recorder.models import (
     StatisticData,
@@ -177,6 +181,193 @@ def test_converters_align_with_sensor() -> None:
 
     for unit_class in UNIT_SCHEMA.schema:
         assert any(c for c in UNIT_CONVERTERS.values() if unit_class == c.UNIT_CLASS)
+
+
+def statistics_query_key() -> recorder_websocket_api._StatisticsQueryKey:
+    """Return a statistics query key for tests."""
+    now = dt_util.utcnow()
+    return recorder_websocket_api._StatisticsQueryKey(
+        start_time=now - timedelta(hours=1),
+        end_time=now,
+        statistic_ids=frozenset(("sensor.power",)),
+        period="hour",
+        units=frozenset(),
+        types=frozenset(("mean", "sum")),
+    )
+
+
+async def test_coalesce_in_flight_statistics_queries(hass: HomeAssistant) -> None:
+    """Test identical in-flight statistics queries share their result."""
+    query_key = statistics_query_key()
+    result_future = hass.loop.create_future()
+    retry_future = hass.loop.create_future()
+    result_futures = iter((result_future, retry_future))
+    create_calls = 0
+
+    def create_result_future() -> asyncio.Future[bytes]:
+        nonlocal create_calls
+        create_calls += 1
+        return next(result_futures)
+
+    first_task = hass.async_create_task(
+        recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, create_result_future
+        )
+    )
+    await asyncio.sleep(0)
+    second_task = hass.async_create_task(
+        recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, create_result_future
+        )
+    )
+    await asyncio.sleep(0)
+
+    assert create_calls == 1
+    result_future.set_result(b'{"sensor.power":[]}')
+    assert await asyncio.gather(first_task, second_task) == [
+        b'{"sensor.power":[]}',
+        b'{"sensor.power":[]}',
+    ]
+    assert (
+        query_key not in hass.data[recorder_websocket_api._IN_FLIGHT_STATISTICS_QUERIES]
+    )
+
+    retry_future.set_result(b'{"sensor.power":[{"mean":1}]}')
+    assert (
+        await recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, create_result_future
+        )
+        == b'{"sensor.power":[{"mean":1}]}'
+    )
+    assert create_calls == 2
+
+
+async def test_cancelled_statistics_request_does_not_cancel_shared_query(
+    hass: HomeAssistant,
+) -> None:
+    """Test cancelling one waiter does not cancel the shared query."""
+    query_key = statistics_query_key()
+    result_future = hass.loop.create_future()
+
+    first_task = hass.async_create_task(
+        recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, lambda: result_future
+        )
+    )
+    await asyncio.sleep(0)
+    second_task = hass.async_create_task(
+        recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, lambda: result_future
+        )
+    )
+    await asyncio.sleep(0)
+
+    first_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+
+    assert not result_future.cancelled()
+    result_future.set_result(b'{"sensor.power":[]}')
+    assert await second_task == b'{"sensor.power":[]}'
+
+
+async def test_failed_statistics_query_is_retried(hass: HomeAssistant) -> None:
+    """Test a failed shared statistics query is removed."""
+    query_key = statistics_query_key()
+    failed_future = hass.loop.create_future()
+    failed_task = hass.async_create_task(
+        recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, lambda: failed_future
+        )
+    )
+    await asyncio.sleep(0)
+
+    failed_future.set_exception(RuntimeError("query failed"))
+    with pytest.raises(RuntimeError, match="query failed"):
+        await failed_task
+
+    retry_future = hass.loop.create_future()
+    retry_future.set_result(b'{"sensor.power":[]}')
+    assert (
+        await recorder_websocket_api._async_get_or_create_statistics_result(
+            hass, query_key, lambda: retry_future
+        )
+        == b'{"sensor.power":[]}'
+    )
+
+
+@pytest.mark.usefixtures("recorder_mock")
+async def test_coalesce_in_flight_statistics_queries_across_users(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test users can share an identical in-flight statistics query."""
+    first_client = await hass_ws_client()
+    second_client = await hass_ws_client(hass, hass_read_only_access_token)
+    now = dt_util.utcnow()
+    command = {
+        "type": "recorder/statistics_during_period",
+        "start_time": (now - timedelta(hours=1)).isoformat(),
+        "end_time": now.isoformat(),
+        "statistic_ids": ["sensor.power"],
+        "period": "hour",
+        "types": ["mean"],
+    }
+    result_future = hass.loop.create_future()
+    both_requests_started = asyncio.Event()
+    original_get_result = recorder_websocket_api._async_get_or_create_statistics_result
+    request_count = 0
+
+    async def track_get_result(
+        hass_: HomeAssistant,
+        query_key: recorder_websocket_api._StatisticsQueryKey,
+        create_result_future: Callable[[], asyncio.Future[bytes]],
+    ) -> bytes:
+        nonlocal request_count
+        request_count += 1
+        if request_count == 2:
+            both_requests_started.set()
+        return await original_get_result(hass_, query_key, create_result_future)
+
+    recorder_instance = recorder.get_instance(hass)
+    with (
+        patch.object(
+            recorder_instance,
+            "async_add_executor_job",
+            return_value=result_future,
+        ) as add_executor_job,
+        patch.object(
+            recorder_websocket_api,
+            "_async_get_or_create_statistics_result",
+            side_effect=track_get_result,
+        ),
+    ):
+        await first_client.send_json({**command, "id": 11})
+        await second_client.send_json({**command, "id": 22})
+        await asyncio.wait_for(both_requests_started.wait(), 1)
+
+        assert add_executor_job.call_count == 1
+        result_future.set_result(b'{"sensor.power":[{"mean":12.5}]}')
+        responses = await asyncio.gather(
+            first_client.receive_json(), second_client.receive_json()
+        )
+
+    assert responses == [
+        {
+            "id": 11,
+            "type": "result",
+            "success": True,
+            "result": {"sensor.power": [{"mean": 12.5}]},
+        },
+        {
+            "id": 22,
+            "type": "result",
+            "success": True,
+            "result": {"sensor.power": [{"mean": 12.5}]},
+        },
+    ]
+    assert not hass.data[recorder_websocket_api._IN_FLIGHT_STATISTICS_QUERIES]
 
 
 @pytest.mark.usefixtures("recorder_mock")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Coalesce identical in-flight `recorder/statistics_during_period` WebSocket
requests so concurrent callers await one Recorder executor query instead of
starting duplicate database work.

The query key contains the UTC start and end times, statistic IDs, period,
units, and requested statistic types. Matching requests can share work across
WebSocket connections and users. Each caller still receives a separate
response with its own message ID.

Only in-flight work is shared. Completed and failed queries are removed
immediately, so this does not introduce a response cache or stale data.
Shielding the shared future prevents one disconnected requester from
cancelling work awaited by another requester.

Live testing with two dashboard tabs and three loads per tab captured 18
statistics requests. Six were redundant exact requests, and all six overlapped
with an identical query that was still in flight. A controlled benchmark with
eight identical callers and four executor workers reduced database jobs from
eight to one and wall time from 117.0 ms to 60.9 ms.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: N/A
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
