### PR TITLE
Add shared base entity class to vizio

### DIFF
--- a/homeassistant/components/vizio/entity.py
+++ b/homeassistant/components/vizio/entity.py
@@ -1,0 +1,26 @@
+"""Base entity for Vizio SmartCast devices."""
+
+from typing import TYPE_CHECKING
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+from .coordinator import VizioConfigEntry, VizioDeviceCoordinator
+
+
+class VizioEntity(CoordinatorEntity[VizioDeviceCoordinator]):
+    """Base class for Vizio SmartCast entities."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, config_entry: VizioConfigEntry) -> None:
+        """Initialize the Vizio entity."""
+        coordinator = config_entry.runtime_data.device_coordinator
+        super().__init__(coordinator)
+        self._attr_unique_id = unique_id = config_entry.unique_id
+        # Guard against config entries missing unique_id, which should never happen
+        if TYPE_CHECKING:
+            assert unique_id is not None
+        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
+        self._device = coordinator.device

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -19,9 +19,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_EXCLUDE, CONF_INCLUDE
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import DATA_APPS
 from .const import (
@@ -33,7 +31,6 @@ from .const import (
     CONF_NAME_SPACE,
     CONF_VOLUME_STEP,
     DEFAULT_VOLUME_STEP,
-    DOMAIN,
     SUPPORTED_COMMANDS,
     VIZIO_AUDIO_SETTINGS,
     VIZIO_MUTE,
@@ -41,11 +38,8 @@ from .const import (
     VIZIO_SOUND_MODE,
     VIZIO_VOLUME,
 )
-from .coordinator import (
-    VizioAppsDataUpdateCoordinator,
-    VizioConfigEntry,
-    VizioDeviceCoordinator,
-)
+from .coordinator import VizioAppsDataUpdateCoordinator, VizioConfigEntry
+from .entity import VizioEntity
 from .helpers import async_device_command
 
 PARALLEL_UPDATES = 0
@@ -98,7 +92,6 @@ async def async_setup_entry(
     entity = VizioDevice(
         config_entry,
         device_class,
-        config_entry.runtime_data.device_coordinator,
         hass.data.get(DATA_APPS) if device_class == MediaPlayerDeviceClass.TV else None,
     )
 
@@ -114,10 +107,9 @@ def _app_config_from_conf(config: dict[str, Any]) -> AppConfig:
     )
 
 
-class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
+class VizioDevice(VizioEntity, MediaPlayerEntity):
     """Media Player implementation which performs REST requests to device."""
 
-    _attr_has_entity_name = True
     _attr_name = None
     _current_input: str | None = None
     _current_app_config: AppConfig | None = None
@@ -126,11 +118,10 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         self,
         config_entry: VizioConfigEntry,
         device_class: MediaPlayerDeviceClass,
-        coordinator: VizioDeviceCoordinator,
         apps_coordinator: VizioAppsDataUpdateCoordinator | None,
     ) -> None:
         """Initialize Vizio device."""
-        super().__init__(coordinator)
+        super().__init__(config_entry)
 
         self._config_entry = config_entry
         self._apps_coordinator = apps_coordinator
@@ -142,7 +133,6 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         self._additional_app_configs = config_entry.data.get(CONF_APPS, {}).get(
             CONF_ADDITIONAL_CONFIGS, []
         )
-        self._device = coordinator.device
         if apps_coordinator:
             self._device.set_app_catalog(apps_coordinator.data)
             self._device.set_app_availability(apps_coordinator.availability)
@@ -151,13 +141,7 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
         # Entity class attributes that will change with each update (we only include
         # the ones that are initialized differently from the defaults)
         self._attr_supported_features = SUPPORTED_COMMANDS[device_class]
-
-        # Entity class attributes that will not change
-        unique_id = config_entry.unique_id
-        assert unique_id
-        self._attr_unique_id = unique_id
         self._attr_device_class = device_class
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
 
     @property
     def _volume_step(self) -> int:

--- a/homeassistant/components/vizio/remote.py
+++ b/homeassistant/components/vizio/remote.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Any, override
+from typing import Any, override
 
 import voluptuous as vol
 
@@ -14,12 +14,11 @@ from homeassistant.components.remote import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import VizioConfigEntry, VizioDeviceCoordinator
+from .coordinator import VizioConfigEntry
+from .entity import VizioEntity
 from .helpers import async_device_command
 
 PARALLEL_UPDATES = 0
@@ -60,21 +59,12 @@ async def async_setup_entry(
     async_add_entities([VizioRemote(config_entry)])
 
 
-class VizioRemote(CoordinatorEntity[VizioDeviceCoordinator], RemoteEntity):
+class VizioRemote(VizioEntity, RemoteEntity):
     """Remote entity for Vizio SmartCast devices."""
-
-    _attr_has_entity_name = True
 
     def __init__(self, config_entry: VizioConfigEntry) -> None:
         """Initialize the remote entity."""
-        coordinator = config_entry.runtime_data.device_coordinator
-        super().__init__(coordinator)
-        self._attr_unique_id = unique_id = config_entry.unique_id
-        # Guard against config entries missing unique_id, which should never happen
-        if TYPE_CHECKING:
-            assert unique_id is not None
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, unique_id)})
-        self._device = coordinator.device
+        super().__init__(config_entry)
         valid_keys = set(self._device.available_keys)
         # Map lowercased native keys to their original uppercase vizaio names
         self._command_map: dict[str, str] = {key.lower(): key for key in valid_keys}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

One of a series of quality-scale cleanup PRs for the `vizio` integration. This one addresses the [`common-modules`](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/common-modules/) Bronze rule (entity base class belongs in `entity.py`).

- Add `homeassistant/components/vizio/entity.py` with a `VizioEntity` base class (a `CoordinatorEntity` subclass) that sets `_attr_has_entity_name`, the unique ID from the config entry, `DeviceInfo`, and the device reference from the coordinator.
- `media_player.py` and `remote.py` now inherit from `VizioEntity` instead of duplicating that setup. `VizioDevice`'s constructor no longer takes the coordinator parameter, since the base class pulls it from `config_entry.runtime_data`.

Pure refactor — no behavior change. All 82 existing vizio tests pass locally and all 8 snapshots are unchanged, so no new tests are needed.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr