### PR TITLE
Enable strict typing for vizio

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -624,6 +624,7 @@ homeassistant.components.velux.*
 homeassistant.components.victron_gx.*
 homeassistant.components.vistapool.*
 homeassistant.components.vivotek.*
+homeassistant.components.vizio.*
 homeassistant.components.vlc_telnet.*
 homeassistant.components.vodafone_station.*
 homeassistant.components.volvo.*

--- a/homeassistant/components/vizio/media_player.py
+++ b/homeassistant/components/vizio/media_player.py
@@ -1,6 +1,6 @@
 """Vizio SmartCast Device support."""
 
-from typing import Any, override
+from typing import Any, cast, override
 
 from vizaio import AppConfig, AppRecord, RemoteKey
 from vizaio.apps import (
@@ -162,12 +162,12 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
     @property
     def _volume_step(self) -> int:
         """Return the configured volume step."""
-        return self._config_entry.options[CONF_VOLUME_STEP]
+        return cast(int, self._config_entry.options[CONF_VOLUME_STEP])
 
     @property
-    def _conf_apps(self) -> dict:
+    def _conf_apps(self) -> dict[str, Any]:
         """Return the configured app filter options."""
-        return self._config_entry.options.get(CONF_APPS, {})
+        return cast("dict[str, Any]", self._config_entry.options.get(CONF_APPS, {}))
 
     def _apps_list(self, apps: list[str]) -> list[str]:
         """Return process apps list based on configured filters."""
@@ -348,8 +348,13 @@ class VizioDevice(CoordinatorEntity[VizioDeviceCoordinator], MediaPlayerEntity):
 
     @property
     @override
-    def app_id(self):
-        """Return the ID of the current app if it is unknown by vizaio."""
+    # pylint: disable-next=home-assistant-return-type
+    def app_id(self) -> dict[str, Any] | None:  # type: ignore[override]
+        """Return the app config of the current app if it is unknown by vizaio.
+
+        Documented way for users to obtain app configs for additional_configs;
+        intentionally returns a dict instead of the app ID string.
+        """
         if self._current_app_config and self.source == UNKNOWN_APP:
             return {
                 CONF_APP_ID: self._current_app_config.app_id,

--- a/mypy.ini
+++ b/mypy.ini
@@ -6000,6 +6000,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.vizio.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.vlc_telnet.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

One of a series of quality-scale PRs for the vizio integration; this addresses the `strict-typing` Platinum rule. The `vizaio` dependency ships `py.typed` (PEP 561).

- Added `homeassistant.components.vizio.*` to `.strict-typing` and regenerated `mypy.ini` via `script.hassfest`.
- Fixed the resulting mypy errors in `media_player.py`: cast the two config entry options reads (`_volume_step`, `_conf_apps`) and annotated the `app_id` property.

Note for reviewers: `app_id` intentionally returns the current app's config dict when the app is unknown (the documented way for users to obtain app configs for the `additional_configs` option), which is incompatible with the base class's `str | None` — suppressed with `type: ignore[override]` and a pylint disable, with an explanatory docstring. Changing that behavior to a properly-typed attribute is possible but is a user-facing change out of scope for this PR — happy to discuss.

Tests: all 82 vizio tests pass locally; mypy reports no issues in 8 vizio source files; pylint clean.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr