### PR TITLE
Do not set a device on YAML mold_indicator entities

### DIFF
--- a/homeassistant/components/mold_indicator/config_flow.py
+++ b/homeassistant/components/mold_indicator/config_flow.py
@@ -162,7 +162,6 @@ def ws_start_preview(
         )
 
     preview_entity = MoldIndicator(
-        hass,
         name,
         hass.config.units is METRIC_SYSTEM,
         indoor_temp,

--- a/homeassistant/components/mold_indicator/sensor.py
+++ b/homeassistant/components/mold_indicator/sensor.py
@@ -34,6 +34,7 @@ from homeassistant.core import (
 )
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.device import async_entity_id_to_device
+from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
@@ -89,7 +90,6 @@ async def async_setup_platform(
     async_add_entities(
         [
             MoldIndicator(
-                hass,
                 name,
                 hass.config.units is METRIC_SYSTEM,
                 indoor_temp_sensor,
@@ -118,7 +118,6 @@ async def async_setup_entry(
     async_add_entities(
         [
             MoldIndicator(
-                hass,
                 name,
                 hass.config.units is METRIC_SYSTEM,
                 indoor_temp_sensor,
@@ -126,6 +125,7 @@ async def async_setup_entry(
                 indoor_humidity_sensor,
                 calib_factor,
                 entry.entry_id,
+                device=async_entity_id_to_device(hass, indoor_humidity_sensor),
             )
         ],
         False,
@@ -142,7 +142,6 @@ class MoldIndicator(SensorEntity):
 
     def __init__(
         self,
-        hass: HomeAssistant,
         name: str,
         is_metric: bool,
         indoor_temp_sensor: str,
@@ -150,6 +149,7 @@ class MoldIndicator(SensorEntity):
         indoor_humidity_sensor: str,
         calib_factor: float,
         unique_id: str | None,
+        device: DeviceEntry | None = None,
     ) -> None:
         """Initialize the sensor."""
         self._attr_name = name
@@ -168,11 +168,7 @@ class MoldIndicator(SensorEntity):
         self._outdoor_temp: float | None = None
         self._indoor_hum: float | None = None
         self._crit_temp: float | None = None
-        if indoor_humidity_sensor:
-            self.device_entry = async_entity_id_to_device(
-                hass,
-                indoor_humidity_sensor,
-            )
+        self.device_entry = device
         self._preview_callback: Callable[[str, Mapping[str, Any]], None] | None = None
 
     @callback

--- a/tests/components/mold_indicator/test_sensor.py
+++ b/tests/components/mold_indicator/test_sensor.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
@@ -53,6 +54,51 @@ async def test_setup(hass: HomeAssistant) -> None:
     moldind = hass.states.get("sensor.mold_indicator")
     assert moldind
     assert moldind.attributes.get("unit_of_measurement") == PERCENTAGE
+
+
+async def test_device_id_yaml(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test no device is set for a YAML-configured MoldIndicator."""
+    source_config_entry = MockConfigEntry()
+    source_config_entry.add_to_hass(hass)
+    source_device_entry = device_registry.async_get_or_create(
+        config_entry_id=source_config_entry.entry_id,
+        identifiers={("sensor", "identifier_test")},
+        connections={("mac", "30:31:32:33:34:35")},
+    )
+    entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "source",
+        config_entry=source_config_entry,
+        device_id=source_device_entry.id,
+    )
+    await hass.async_block_till_done()
+
+    assert await async_setup_component(
+        hass,
+        sensor.DOMAIN,
+        {
+            "sensor": {
+                "platform": "mold_indicator",
+                "indoor_temp_sensor": "test.indoortemp",
+                "outdoor_temp_sensor": "test.outdoortemp",
+                "indoor_humidity_sensor": "sensor.test_source",
+                "calibration_factor": 2.0,
+                "unique_id": "mold_indicator_yaml",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+    mold_indicator_entity = entity_registry.async_get("sensor.mold_indicator")
+    assert mold_indicator_entity is not None
+    assert mold_indicator_entity.device_id is None
+    assert "attempts to attach a device to an entity" not in caplog.text
 
 
 async def test_setup_from_config_entry(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Do not set a device on YAML `mold_indicator` entities.

Since #177459, `entity_platform` warns when an entity attempts to attach a device without a config entry. YAML-configured mold_indicator sensors trigger this warning, because the entity constructor unconditionally looks up the source entity's device and sets `device_entry`, also when set up from YAML.

The device link never worked for YAML setups anyway — without a config entry the link is not persisted to the entity registry — so this behavior is now made explicit: the device lookup moves out of the entity constructor into `async_setup_entry`, which passes the device to the entity. The YAML platform path no longer sets a device.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177568
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
