### PR TITLE
Require UniFi Protect 7.1

### DIFF
--- a/homeassistant/components/unifiprotect/const.py
+++ b/homeassistant/components/unifiprotect/const.py
@@ -55,7 +55,7 @@ DEVICES_FOR_SUBSCRIBE = DEVICES_WITH_ENTITIES | {ModelType.EVENT}
 # the public API devices WebSocket.
 DEVICES_WS_SUBSCRIBED_MODELS: set[ModelType] = set()
 
-MIN_REQUIRED_PROTECT_V = Version("6.0.0")
+MIN_REQUIRED_PROTECT_V = Version("7.1.0")
 OUTDATED_LOG_MESSAGE = (
     "You are running v%s of UniFi Protect. Minimum required version is v%s. Please"
     " upgrade UniFi Protect and then retry"

--- a/homeassistant/components/unifiprotect/strings.json
+++ b/homeassistant/components/unifiprotect/strings.json
@@ -11,7 +11,7 @@
       "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
       "cloud_user": "Ubiquiti Cloud users are not supported. Please use a local user instead.",
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "protect_version": "Minimum required version is v6.0.0. Please upgrade UniFi Protect and then retry."
+      "protect_version": "Minimum required version is v7.1.0. Please upgrade UniFi Protect and then retry."
     },
     "flow_title": "{name} ({ip_address})",
     "step": {

--- a/tests/components/unifiprotect/fixtures/sample_nvr.json
+++ b/tests/components/unifiprotect/fixtures/sample_nvr.json
@@ -5,7 +5,7 @@
   "canAutoUpdate": true,
   "isStatsGatheringEnabled": true,
   "timezone": "America/New_York",
-  "version": "6.0.0",
+  "version": "7.1.0",
   "ucoreVersion": "2.3.26",
   "firmwareVersion": "2.3.10",
   "uiVersion": null,

--- a/tests/components/unifiprotect/snapshots/test_diagnostics.ambr
+++ b/tests/components/unifiprotect/snapshots/test_diagnostics.ambr
@@ -603,7 +603,7 @@
         'uptime': 1191516000,
         'vaultCameras': list([
         ]),
-        'version': '6.0.0',
+        'version': '7.1.0',
         'wanIp': None,
       }),
       'ringtones': list([

--- a/tests/components/unifiprotect/snapshots/test_init.ambr
+++ b/tests/components/unifiprotect/snapshots/test_init.ambr
@@ -29,7 +29,7 @@
     'name': 'UnifiProtect',
     'name_by_user': None,
     'serial_number': None,
-    'sw_version': '6.0.0',
+    'sw_version': '7.1.0',
     'via_device_id': None,
   })
 # ---

--- a/tests/components/unifiprotect/test_config_flow.py
+++ b/tests/components/unifiprotect/test_config_flow.py
@@ -149,14 +149,21 @@ async def test_user_flow(hass: HomeAssistant, bootstrap: Bootstrap, nvr: NVR) ->
     assert len(mock_setup.mock_calls) == 1
 
 
+@pytest.mark.parametrize("version", ["1.19.0", "7.0.107"])
 async def test_form_version_too_old(
-    hass: HomeAssistant, bootstrap: Bootstrap, old_nvr: NVR, nvr: NVR, mock_setup: None
+    hass: HomeAssistant,
+    bootstrap: Bootstrap,
+    old_nvr: NVR,
+    nvr: NVR,
+    version: str,
+    mock_setup: None,
 ) -> None:
     """Test we handle the version being too old and can recover."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
 
+    old_nvr.version = Version(version)
     bootstrap.nvr = old_nvr
     with (
         patch(
@@ -1619,7 +1626,7 @@ async def test_reconfigure_outdated_version(
 
     # Set up NVR with outdated version
     old_nvr = nvr.model_copy()
-    old_nvr.version = Version("5.0.0")  # Below MIN_REQUIRED_PROTECT_V (6.0.0)
+    old_nvr.version = Version("5.0.0")  # Below MIN_REQUIRED_PROTECT_V (7.1.0)
     bootstrap.nvr = old_nvr
 
     result = await hass.config_entries.flow.async_configure(

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -235,7 +235,6 @@ async def test_setup_too_old(
     await hass.config_entries.async_setup(ufp.entry.entry_id)
     await hass.async_block_till_done()
     assert ufp.entry.state is ConfigEntryState.SETUP_ERROR
-    # assert the version gate is what failed, not some later step
     assert ufp.entry.error_reason_translation_key == "protect_version"
 
 

--- a/tests/components/unifiprotect/test_init.py
+++ b/tests/components/unifiprotect/test_init.py
@@ -6,7 +6,7 @@ import pytest
 from syrupy.assertion import SnapshotAssertion
 from uiprotect import NvrError, ProtectApiClient
 from uiprotect.api import DEVICE_UPDATE_INTERVAL
-from uiprotect.data import NVR, Bootstrap, CloudAccount, Light
+from uiprotect.data import NVR, Bootstrap, CloudAccount, Light, Version
 from uiprotect.exceptions import BadRequest, NotAuthorized
 
 from homeassistant.components.unifiprotect.const import (
@@ -216,11 +216,17 @@ async def test_remove_entry_not_loaded_clear_session_fails(
         assert mock_api.clear_session.called
 
 
+@pytest.mark.parametrize("version", ["1.19.0", "7.0.107"])
 async def test_setup_too_old(
-    hass: HomeAssistant, ufp: MockUFPFixture, old_nvr: NVR
+    hass: HomeAssistant, ufp: MockUFPFixture, old_nvr: NVR, version: str
 ) -> None:
-    """Test setup of unifiprotect entry with too old of version of UniFi Protect."""
+    """Test setup of unifiprotect entry with too old of version of UniFi Protect.
 
+    7.0.107 is the last release before the public API gained the camera and
+    sensor fields the integration reads, so it has to be rejected too.
+    """
+
+    old_nvr.version = Version(version)
     old_bootstrap = ufp.api.bootstrap.model_copy()
     old_bootstrap.nvr = old_nvr
     ufp.api.update.return_value = old_bootstrap
@@ -229,6 +235,8 @@ async def test_setup_too_old(
     await hass.config_entries.async_setup(ufp.entry.entry_id)
     await hass.async_block_till_done()
     assert ufp.entry.state is ConfigEntryState.SETUP_ERROR
+    # assert the version gate is what failed, not some later step
+    assert ufp.entry.error_reason_translation_key == "protect_version"
 
 
 async def test_setup_cloud_account(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
UniFi Protect 7.1 or newer is now required. On an older console the integration
reports that the version is too old instead of setting up; update UniFi Protect
to 7.1 or newer to keep using it.

7.1 is already the de-facto minimum, this mainly writes it down: two fields the
integration reads only exist in the public API from 7.1 on, so on 7.0 and older
the camera entities already fail to load.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixes #177577, where all camera entities disappear with
`AttributeError: 'PublicCamera' object has no attribute 'has_package_camera'`.

`hasPackageCamera` is not part of the public camera object before 7.1, and
`wirelessConnectionState` not part of the public sensor object, which `battery_low`
reads; both are there on 7.1.87. uiprotect builds the public models with
`model_construct`, so defaults are filled in but a required field the console
omitted stays unset, and reading it raises instead of degrading.

Defaulting those fields in uiprotect is the obvious alternative, but it trades a
loud error for a silent wrong answer: the field is missing for *every* camera on
those consoles, so `False` would quietly drop the package-camera entity from
doorbells that do have one, and an empty `wirelessConnectionState` leaves the
battery sensor blank with nothing to point at. `PublicCamera` has twelve fields
that behave this way, and every further migration to the public API adds more, so
that is a growing set of plausible-looking wrong values. The finished migration is
expected to need something newer than 7.2 anyway, and I am not aware of a console
that runs 6.x but cannot update to 7.1 — so the floor costs no hardware and
replaces guesswork with a message users can act on.

The hardcoded v6.0.0 string and the test NVR fixture, which sat exactly on the old
floor, move along. The version tests now cover 7.0.107 and assert the entry failed
on `protect_version` instead of only landing in SETUP_ERROR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [x] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177577
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47129
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
