### PR TITLE
Add Coordinator to LG WebOS TV

### DIFF
--- a/homeassistant/components/webostv/__init__.py
+++ b/homeassistant/components/webostv/__init__.py
@@ -20,7 +20,11 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, PLATFORMS, WEBOSTV_EXCEPTIONS
-from .helpers import WebOsTvConfigEntry, update_client_key
+from .coordinator import (
+    WebOsTvConfigEntry,
+    WebOsTvDataUpdateCoordinator,
+    update_client_key,
+)
 from .services import async_setup_services
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
@@ -39,9 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebOsTvConfigEntry) -> b
     key = entry.data[CONF_CLIENT_SECRET]
 
     # Attempt a connection, but fail gracefully if tv is off for example.
-    entry.runtime_data = client = WebOsClient(
-        host, key, client_session=async_get_clientsession(hass)
-    )
+    client = WebOsClient(host, key, client_session=async_get_clientsession(hass))
     with suppress(*WEBOSTV_EXCEPTIONS):
         try:
             await client.connect()
@@ -49,11 +51,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebOsTvConfigEntry) -> b
             raise ConfigEntryAuthFailed(
                 translation_domain=DOMAIN,
                 translation_key="auth_failed",
+                translation_placeholders={"device": entry.title},
             ) from err
 
     # If pairing request accepted there will be no error
     # Update the stored key without triggering reauth
-    update_client_key(hass, entry)
+    update_client_key(hass, entry, client)
+
+    entry.runtime_data = coordinator = WebOsTvDataUpdateCoordinator(hass, entry, client)
+    await client.register_state_update_callback(coordinator.async_handle_update)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -86,7 +92,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: WebOsTvConfigEntry) -> b
 async def async_unload_entry(hass: HomeAssistant, entry: WebOsTvConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        client = entry.runtime_data
+        client = entry.runtime_data.client
         await hass_notify.async_reload(hass, DOMAIN)
         client.clear_state_update_callbacks()
         await client.disconnect()

--- a/homeassistant/components/webostv/const.py
+++ b/homeassistant/components/webostv/const.py
@@ -1,6 +1,7 @@
 """Constants for the LG webOS TV integration."""
 
 import asyncio
+import logging
 
 import aiohttp
 from aiowebostv import WebOsTvCommandError
@@ -8,6 +9,7 @@ from aiowebostv import WebOsTvCommandError
 from homeassistant.const import Platform
 
 DOMAIN = "webostv"
+LOGGER = logging.getLogger(__package__)
 PLATFORMS = [Platform.MEDIA_PLAYER]
 DEFAULT_NAME = "LG webOS TV"
 

--- a/homeassistant/components/webostv/coordinator.py
+++ b/homeassistant/components/webostv/coordinator.py
@@ -1,0 +1,86 @@
+"""Coordinator for the LG webOS TV integration."""
+
+from datetime import timedelta
+from typing import override
+
+from aiowebostv import WebOsClient, WebOsTvPairError, WebOsTvState
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.trigger import PluggableAction
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, LOGGER, WEBOSTV_EXCEPTIONS
+
+SCAN_INTERVAL = timedelta(seconds=10)
+
+type WebOsTvConfigEntry = ConfigEntry[WebOsTvDataUpdateCoordinator]
+
+
+class WebOsTvDataUpdateCoordinator(DataUpdateCoordinator[None]):
+    """Coordinator for the LG webOS TV integration."""
+
+    config_entry: WebOsTvConfigEntry
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: WebOsTvConfigEntry,
+        client: WebOsClient,
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=config_entry.title,
+            update_interval=SCAN_INTERVAL,
+        )
+
+        self.client = client
+        self.turn_on = PluggableAction(self.async_update_listeners)
+
+    @override
+    async def _async_update_data(self) -> None:
+        """Connect to LG webOS TV if not connected."""
+        if self.client.is_connected():
+            return
+
+        try:
+            await self.client.connect()
+        except WEBOSTV_EXCEPTIONS as error:
+            if not self.turn_on:
+                # can't recover if the TV is disconnected and no turn_on action
+                raise UpdateFailed(
+                    translation_domain=DOMAIN,
+                    translation_key="device_unavailable",
+                    translation_placeholders={"device": self.name},
+                ) from error
+        except WebOsTvPairError as error:
+            raise ConfigEntryAuthFailed(
+                translation_domain=DOMAIN,
+                translation_key="auth_failed",
+                translation_placeholders={"device": self.name},
+            ) from error
+        else:
+            update_client_key(self.hass, self.config_entry, self.client)
+
+    async def async_handle_update(self, tv_state: WebOsTvState) -> None:
+        """Handle state update from TV."""
+        if self.last_update_success:
+            # client.connect() trigger an update on failure,
+            # avoid marking the device as available
+            self.async_set_updated_data(None)
+
+
+def update_client_key(
+    hass: HomeAssistant, entry: WebOsTvConfigEntry, client: WebOsClient
+) -> None:
+    """Check and update stored client key if key has changed."""
+    if client.client_key != entry.data[CONF_CLIENT_SECRET]:
+        host = entry.data[CONF_HOST]
+        LOGGER.debug("Updating client key for host %s", host)
+        data = {CONF_HOST: host, CONF_CLIENT_SECRET: client.client_key}
+        hass.config_entries.async_update_entry(entry, data=data)

--- a/homeassistant/components/webostv/diagnostics.py
+++ b/homeassistant/components/webostv/diagnostics.py
@@ -26,7 +26,7 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: WebOsTvConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    client: WebOsClient = entry.runtime_data
+    client: WebOsClient = entry.runtime_data.client
 
     client_data = {
         "is_registered": client.is_registered(),

--- a/homeassistant/components/webostv/helpers.py
+++ b/homeassistant/components/webostv/helpers.py
@@ -1,21 +1,13 @@
 """Helper functions for LG webOS TV."""
 
-import logging
+from aiowebostv import WebOsTvState
 
-from aiowebostv import WebOsClient, WebOsTvState
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_CLIENT_SECRET, CONF_HOST
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN, LIVE_TV_APP_ID
-
-_LOGGER = logging.getLogger(__name__)
-
-type WebOsTvConfigEntry = ConfigEntry[WebOsClient]
 
 
 @callback
@@ -75,15 +67,3 @@ def get_sources(tv_state: WebOsTvState) -> list[str]:
 
     # Preserve order when filtering duplicates
     return list(dict.fromkeys(sources))
-
-
-def update_client_key(hass: HomeAssistant, entry: WebOsTvConfigEntry) -> None:
-    """Check and update stored client key if key has changed."""
-    client: WebOsClient = entry.runtime_data
-    host = entry.data[CONF_HOST]
-    key = entry.data[CONF_CLIENT_SECRET]
-
-    if client.client_key != key:
-        _LOGGER.debug("Updating client key for host %s", host)
-        data = {CONF_HOST: host, CONF_CLIENT_SECRET: client.client_key}
-        hass.config_entries.async_update_entry(entry, data=data)

--- a/homeassistant/components/webostv/media_player.py
+++ b/homeassistant/components/webostv/media_player.py
@@ -3,15 +3,10 @@
 import asyncio
 from collections.abc import Callable, Coroutine
 from contextlib import suppress
-from datetime import timedelta
 from functools import wraps
 from http import HTTPStatus
-import logging
 from typing import Any, Concatenate, cast, override
 
-from aiowebostv import WebOsTvPairError, WebOsTvState
-
-from homeassistant import util
 from homeassistant.components.media_player import (
     MediaPlayerDeviceClass,
     MediaPlayerEntity,
@@ -20,13 +15,13 @@ from homeassistant.components.media_player import (
     MediaType,
 )
 from homeassistant.const import EntityStateAttribute
-from homeassistant.core import HomeAssistant, ServiceResponse
+from homeassistant.core import HomeAssistant, ServiceResponse, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.trigger import PluggableAction
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     ATTR_PAYLOAD,
@@ -34,12 +29,11 @@ from .const import (
     CONF_SOURCES,
     DOMAIN,
     LIVE_TV_APP_ID,
+    LOGGER,
     WEBOSTV_EXCEPTIONS,
 )
-from .helpers import WebOsTvConfigEntry, update_client_key
+from .coordinator import WebOsTvConfigEntry, WebOsTvDataUpdateCoordinator
 from .triggers.turn_on import async_get_turn_on_trigger
-
-_LOGGER = logging.getLogger(__name__)
 
 SUPPORT_WEBOSTV = (
     MediaPlayerEntityFeature.TURN_OFF
@@ -56,10 +50,7 @@ SUPPORT_WEBOSTV_VOLUME = (
     MediaPlayerEntityFeature.VOLUME_MUTE | MediaPlayerEntityFeature.VOLUME_STEP
 )
 
-MIN_TIME_BETWEEN_SCANS = timedelta(seconds=10)
-MIN_TIME_BETWEEN_FORCED_SCANS = timedelta(seconds=1)
 PARALLEL_UPDATES = 0
-SCAN_INTERVAL = timedelta(seconds=10)
 
 
 async def async_setup_entry(
@@ -107,7 +98,9 @@ def cmd[_R, **_P](
     return cmd_wrapper
 
 
-class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
+class LgWebOSMediaPlayerEntity(
+    CoordinatorEntity[WebOsTvDataUpdateCoordinator], RestoreEntity, MediaPlayerEntity
+):
     """Representation of a LG webOS TV."""
 
     _attr_device_class = MediaPlayerDeviceClass.TV
@@ -116,17 +109,16 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
     def __init__(self, entry: WebOsTvConfigEntry) -> None:
         """Initialize the webos device."""
+        super().__init__(entry.runtime_data)
         self._entry = entry
-        self._client = entry.runtime_data
+        self._client = entry.runtime_data.client
         self._attr_assumed_state = True
-        self._unavailable_logged = False
         self._device_name = entry.title
         self._attr_unique_id = entry.unique_id
         self._sources = entry.options.get(CONF_SOURCES)
 
         # Assume that the TV is not paused
         self._paused = False
-        self._turn_on = PluggableAction(self.async_write_ha_state)
         self._current_source = None
         self._source_list: dict = {}
 
@@ -140,14 +132,10 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
 
         if (entry := self.registry_entry) and entry.device_id:
             self.async_on_remove(
-                self._turn_on.async_register(
+                self.coordinator.turn_on.async_register(
                     self.hass, async_get_turn_on_trigger(entry.device_id)
                 )
             )
-
-        await self._client.register_state_update_callback(
-            self.async_handle_state_update
-        )
 
         if (
             self.state == MediaPlayerState.OFF
@@ -161,12 +149,10 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                 & ~MediaPlayerEntityFeature.TURN_ON
             )
 
-    @override
-    async def async_will_remove_from_hass(self) -> None:
-        """Call disconnect on removal."""
-        self._client.unregister_state_update_callback(self.async_handle_state_update)
+        self.async_on_remove(self.coordinator.async_add_listener(self._update_callback))
 
-    async def async_handle_state_update(self, tv_state: WebOsTvState) -> None:
+    @callback
+    def _update_callback(self) -> None:
         """Update state from WebOsClient."""
         self._update_states()
         self.async_write_ha_state()
@@ -309,37 +295,11 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
             ):
                 self._source_list["Live TV"] = app
 
-    def _set_availability(self, available: bool) -> None:
-        """Set availability and log changes only once."""
-        self._attr_available = available
-        if not available and not self._unavailable_logged:
-            _LOGGER.info("LG webOS TV entity %s is unavailable", self.entity_id)
-            self._unavailable_logged = True
-        elif available and self._unavailable_logged:
-            _LOGGER.info("LG webOS TV entity %s is back online", self.entity_id)
-            self._unavailable_logged = False
-
-    @util.Throttle(MIN_TIME_BETWEEN_SCANS, MIN_TIME_BETWEEN_FORCED_SCANS)
-    async def async_update(self) -> None:
-        """Connect."""
-        if self._client.is_connected():
-            return
-
-        try:
-            await self._client.connect()
-        except WEBOSTV_EXCEPTIONS:
-            self._set_availability(bool(self._turn_on))
-        except WebOsTvPairError:
-            self._entry.async_start_reauth(self.hass)
-        else:
-            self._set_availability(True)
-            update_client_key(self.hass, self._entry)
-
     @property
     @override
     def supported_features(self) -> MediaPlayerEntityFeature:
         """Flag media player features that are supported."""
-        if self._turn_on:
+        if self.coordinator.turn_on:
             return self._supported_features | MediaPlayerEntityFeature.TURN_ON
 
         return self._supported_features
@@ -353,7 +313,7 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
     @override
     async def async_turn_on(self) -> None:
         """Turn on media player."""
-        await self._turn_on.async_run(self.hass, self._context)
+        await self.coordinator.turn_on.async_run(self.hass, self._context)
 
     @cmd
     @override
@@ -418,10 +378,10 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
         self, media_type: MediaType | str, media_id: str, **kwargs: Any
     ) -> None:
         """Play a piece of media."""
-        _LOGGER.debug("Call play media type <%s>, Id <%s>", media_type, media_id)
+        LOGGER.debug("Call play media type <%s>, Id <%s>", media_type, media_id)
 
         if media_type == MediaType.CHANNEL and self._client.tv_state.channels:
-            _LOGGER.debug("Searching channel")
+            LOGGER.debug("Searching channel")
             partial_match_channel_id = None
             perfect_match_channel_id = None
 
@@ -438,13 +398,13 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                     partial_match_channel_id = channel["channelId"]
 
             if perfect_match_channel_id is not None:
-                _LOGGER.debug(
+                LOGGER.debug(
                     "Switching to channel <%s> with perfect match",
                     perfect_match_channel_id,
                 )
                 await self._client.set_channel(perfect_match_channel_id)
             elif partial_match_channel_id is not None:
-                _LOGGER.debug(
+                LOGGER.debug(
                     "Switching to channel <%s> with partial match",
                     partial_match_channel_id,
                 )
@@ -515,6 +475,6 @@ class LgWebOSMediaPlayerEntity(RestoreEntity, MediaPlayerEntity):
                     content = await response.read()
 
         if content is None:
-            _LOGGER.warning("Error retrieving proxied image from %s", url)
+            LOGGER.warning("Error retrieving proxied image from %s", url)
 
         return content, None

--- a/homeassistant/components/webostv/notify.py
+++ b/homeassistant/components/webostv/notify.py
@@ -44,7 +44,7 @@ class LgWebOSNotificationService(BaseNotificationService):
     @override
     async def async_send_message(self, message: str = "", **kwargs: Any) -> None:
         """Send a message to the tv."""
-        client: WebOsClient = self._entry.runtime_data
+        client: WebOsClient = self._entry.runtime_data.client
         data = kwargs[ATTR_DATA]
         icon_path = data.get(ATTR_ICON) if data else None
 

--- a/homeassistant/components/webostv/strings.json
+++ b/homeassistant/components/webostv/strings.json
@@ -47,7 +47,7 @@
   },
   "exceptions": {
     "auth_failed": {
-      "message": "Pairing failed, make sure to accept the pairing request on your TV."
+      "message": "Pairing for {device} failed, make sure to accept the pairing request on your TV."
     },
     "communication_error": {
       "message": "Communication error while calling {func} for device {name}: {error}"
@@ -60,6 +60,9 @@
     },
     "device_off": {
       "message": "Error calling {func} for device {name}: Device is off and cannot be controlled."
+    },
+    "device_unavailable": {
+      "message": "Device {device} is unavailable"
     },
     "invalid_entity_id": {
       "message": "Entity {entity_id} is not a valid webOS TV entity."

--- a/tests/components/webostv/test_media_player.py
+++ b/tests/components/webostv/test_media_player.py
@@ -498,6 +498,30 @@ async def test_client_disconnected(
 ) -> None:
     """Test error not raised when client is disconnected."""
     await setup_webostv(hass)
+
+    # Support turn on
+    assert await async_setup_component(
+        hass,
+        automation.DOMAIN,
+        {
+            automation.DOMAIN: [
+                {
+                    "trigger": {
+                        "platform": "webostv.turn_on",
+                        "entity_id": ENTITY_ID,
+                    },
+                    "action": {
+                        "service": "test.automation",
+                        "data_template": {
+                            "some": ENTITY_ID,
+                            "id": "{{ trigger.id }}",
+                        },
+                    },
+                },
+            ],
+        },
+    )
+
     client.is_connected.return_value = False
     client.connect.side_effect = TimeoutError
 
@@ -520,6 +544,14 @@ async def test_client_key_update_on_connect(
     await mock_scan_interval(hass, freezer)
 
     assert config_entry.data[CONF_CLIENT_SECRET] == client.client_key
+
+    # validate that the key is not updated if the client is already connected
+    client.is_connected.return_value = True
+    client.client_key = "old_key"
+
+    await mock_scan_interval(hass, freezer)
+
+    assert config_entry.data[CONF_CLIENT_SECRET] == "new_key"
 
 
 @pytest.mark.parametrize(
@@ -916,7 +948,7 @@ async def test_availability(
     await mock_scan_interval(hass, freezer)
 
     assert hass.states.get(ENTITY_ID).state == STATE_UNAVAILABLE
-    unavailable_log = f"LG webOS TV entity {ENTITY_ID} is unavailable"
+    unavailable_log = f"Device {TV_NAME} is unavailable"
     assert unavailable_log in caplog.text
 
     # Clear logs and update the offline entity again - should NOT log again
@@ -930,7 +962,7 @@ async def test_availability(
     await mock_scan_interval(hass, freezer)
 
     assert hass.states.get(ENTITY_ID).state == MediaPlayerState.ON
-    available_log = f"LG webOS TV entity {ENTITY_ID} is back online"
+    available_log = f"Fetching {TV_NAME} data recovered"
     assert available_log in caplog.text
 
     # Clear logs and make update again - should NOT log again
@@ -973,5 +1005,5 @@ async def test_availability(
     await mock_scan_interval(hass, freezer)
 
     assert hass.states.get(ENTITY_ID).state == MediaPlayerState.ON
-    available_log = f"LG webOS TV entity {ENTITY_ID} is back online"
+    available_log = f"Fetching {TV_NAME} data recovered"
     assert available_log in caplog.text


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Data update and reconnecting to LG WebOS TV was implemented by the media player entity, this was implemented this way since it was a single entity and single platform.

There have being several contributions attempts to add additional entities/platforms to LG WebOS TV:
- https://github.com/home-assistant/core/pull/176824
- https://github.com/home-assistant/core/pull/162802
- https://github.com/home-assistant/core/pull/161557

In order to support it a central coordinator which is responsible both on data updates and reconnect logic is needed, because the media player entity can't be the entity which handle data for other platforms.

This PR only migrate the reconnect logic and data updates to a coordinator, I tried to limit the PR to the minimum possible to keep the same behavior, it can be seen that the tests had minimal adjustment and there is 100% coverage for the integration (including the new coordinator).

In future PRs I will move tests related to the coordinator to a dedicated test module and add a switch platform for controlling the screen on/off state.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
