### PR TITLE
Add missing icons and rename night light options for SwitchBot standing fan

### DIFF
--- a/homeassistant/components/switchbot/icons.json
+++ b/homeassistant/components/switchbot/icons.json
@@ -144,6 +144,27 @@
         }
       }
     },
+    "number": {
+      "horizontal_oscillation_angle": {
+        "default": "mdi:pan-horizontal"
+      },
+      "vertical_oscillation_angle": {
+        "default": "mdi:pan-vertical"
+      }
+    },
+    "select": {
+      "night_light": {
+        "default": "mdi:lightbulb",
+        "state": {
+          "bright": "mdi:lightbulb-on-70",
+          "off": "mdi:lightbulb-off",
+          "soft": "mdi:lightbulb-on-30"
+        }
+      },
+      "time_format": {
+        "default": "mdi:clock-outline"
+      }
+    },
     "sensor": {
       "aqi_quality_level": {
         "default": "mdi:air-filter",
@@ -194,6 +215,12 @@
           "off": "mdi:lock-open",
           "on": "mdi:lock"
         }
+      },
+      "horizontal_oscillation": {
+        "default": "mdi:arrow-left-right"
+      },
+      "vertical_oscillation": {
+        "default": "mdi:arrow-up-down"
       },
       "wireless_charging": {
         "state": {

--- a/homeassistant/components/switchbot/quality_scale.yaml
+++ b/homeassistant/components/switchbot/quality_scale.yaml
@@ -73,10 +73,7 @@ rules:
   entity-disabled-by-default: done
   entity-translations: done
   exception-translations: done
-  icon-translations:
-    status: exempt
-    comment: |
-      No custom icons.
+  icon-translations: done
   reconfiguration-flow:
     status: exempt
     comment: |

--- a/homeassistant/components/switchbot/select.py
+++ b/homeassistant/components/switchbot/select.py
@@ -79,13 +79,13 @@ class SwitchBotMeterProCO2TimeFormatSelect(SwitchbotEntity, SelectEntity):
 
 
 NIGHT_LIGHT_OFF = "off"
-NIGHT_LIGHT_LEVEL_1 = "level_1"
-NIGHT_LIGHT_LEVEL_2 = "level_2"
-NIGHT_LIGHT_OPTIONS = [NIGHT_LIGHT_OFF, NIGHT_LIGHT_LEVEL_1, NIGHT_LIGHT_LEVEL_2]
+NIGHT_LIGHT_BRIGHT = "bright"
+NIGHT_LIGHT_SOFT = "soft"
+NIGHT_LIGHT_OPTIONS = [NIGHT_LIGHT_OFF, NIGHT_LIGHT_SOFT, NIGHT_LIGHT_BRIGHT]
 NIGHT_LIGHT_TO_STATE: dict[str, NightLightState] = {
     NIGHT_LIGHT_OFF: NightLightState.OFF,
-    NIGHT_LIGHT_LEVEL_1: NightLightState.LEVEL_1,
-    NIGHT_LIGHT_LEVEL_2: NightLightState.LEVEL_2,
+    NIGHT_LIGHT_SOFT: NightLightState.LEVEL_2,
+    NIGHT_LIGHT_BRIGHT: NightLightState.LEVEL_1,
 }
 NIGHT_LIGHT_FROM_STATE: dict[int, str] = {
     state.value: option for option, state in NIGHT_LIGHT_TO_STATE.items()

--- a/homeassistant/components/switchbot/strings.json
+++ b/homeassistant/components/switchbot/strings.json
@@ -312,9 +312,9 @@
       "night_light": {
         "name": "Night light",
         "state": {
-          "level_1": "Level 1",
-          "level_2": "Level 2",
-          "off": "[%key:common::state::off%]"
+          "bright": "Bright",
+          "off": "[%key:common::state::off%]",
+          "soft": "Soft"
         }
       },
       "time_format": {

--- a/tests/components/switchbot/test_select.py
+++ b/tests/components/switchbot/test_select.py
@@ -129,8 +129,8 @@ async def test_set_time_format(
 @pytest.mark.parametrize(
     ("device_state", "option", "expected_state"),
     [
-        (NightLightState.OFF.value, "level_1", NightLightState.LEVEL_1),
-        (NightLightState.LEVEL_1.value, "level_2", NightLightState.LEVEL_2),
+        (NightLightState.OFF.value, "bright", NightLightState.LEVEL_1),
+        (NightLightState.LEVEL_1.value, "soft", NightLightState.LEVEL_2),
         (NightLightState.LEVEL_2.value, "off", NightLightState.OFF),
     ],
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

The SwitchBot standing fan has several entities that were missing icons: 
- the `Horizontal/Vertical oscillation` switches
- the `Horizontal/Vertical oscillation angle` numbers
- `Night light` select. 

This PR:
- Adds icons for all of the above.
- Renames the night light select options from "Level 1"/"Level 2" to "Bright"/"Soft", matching the wording used in the official SwitchBot app instead of two labels that don't say what they actually do. Also level 1 is bright and level 2 is soft which was counter-intuitive.

Changing the option value are not really a problem are we are still in beta.

<img width="463" height="604" alt="CleanShot 2026-07-30 at 12 46 37" src="https://github.com/user-attachments/assets/17aca39b-8a25-4cf0-8599-697a2d0f4542" />

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
