### PR TITLE
Interpret absent YAML server_port as the historical default during HTTP migration

### DIFF
--- a/homeassistant/components/http/__init__.py
+++ b/homeassistant/components/http/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.setup import (
 )
 from homeassistant.util.async_ import create_eager_task
 
-from .config import async_get_and_load_store, async_load_config, default_server_port
+from .config import async_get_and_load_store, async_load_config
 from .const import (  # noqa: F401
     CONF_BASE_URL,
     CONF_CORS_ORIGINS,
@@ -77,7 +77,9 @@ HTTP_SCHEMA: Final = vol.All(
             vol.Optional(CONF_SERVER_HOST): vol.All(
                 cv.ensure_list, vol.Length(min=1), [cv.string]
             ),
-            vol.Optional(CONF_SERVER_PORT, default=default_server_port): cv.port,
+            # No default: an absent port is filled with the historical YAML
+            # default (8123) during the migration (see async_migrate_yaml).
+            vol.Optional(CONF_SERVER_PORT): cv.port,
             vol.Optional(CONF_BASE_URL): cv.string,
             vol.Optional(CONF_SSL_CERTIFICATE): cv.isfile,
             vol.Optional(CONF_SSL_PEER_CERTIFICATE): cv.isfile,

--- a/homeassistant/components/http/config.py
+++ b/homeassistant/components/http/config.py
@@ -477,6 +477,13 @@ class HTTPConfigStore:
     async def async_migrate_yaml(self, config: ConfData) -> None:
         """Migrate YAML config to storage as pending if not the same as the config used for recovery."""
         await self.async_load()
+        if CONF_SERVER_PORT not in config:
+            # An absent port in YAML has always meant SERVER_PORT (8123).
+            # Filling in the current default instead would reinterpret the
+            # config now that the default depends on the environment (port 80
+            # under Supervisor) and stage an unwanted port change as a
+            # pending trial.
+            config = cast(ConfData, {**config, CONF_SERVER_PORT: SERVER_PORT})
         validated_config = cast(ConfData, HTTP_STORAGE_SCHEMA(config))
         if self._stable_differs_only_by_lost_proxy_masks(validated_config):
             # Releases up to 2026.7.1 dropped the network mask when storing

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -1584,6 +1584,100 @@ async def test_upgrade_with_stored_old_default_config_keeps_port(
         assert len(restart_calls) == 0
 
 
+async def test_upgrade_yaml_without_port_keeps_stable_port(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+    issue_registry: ir.IssueRegistry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """A YAML config without an explicit port keeps its port on upgrade.
+
+    A YAML config without server_port (e.g. a reverse proxy setup) has been
+    running on the old default port 8123, which the v1 store recorded
+    explicitly. Migrating it with the port filled from the new Supervisor
+    default (80) instead of the historical YAML default would stage an
+    otherwise unchanged config as a pending trial: nothing promotes it, so
+    the trial would auto-revert with a restart five minutes later.
+    """
+    hass_storage[DOMAIN] = {
+        "version": 1,
+        "key": DOMAIN,
+        "data": {
+            "server_port": 8123,
+            "use_x_forwarded_for": True,
+            "trusted_proxies": ["10.0.0.0/24"],
+            "cors_allowed_origins": ["https://cast.home-assistant.io"],
+            "use_x_frame_options": True,
+            "ip_ban_enabled": True,
+            "login_attempts_threshold": -1,
+            "ssl_profile": "modern",
+        },
+    }
+    yaml_conf = {
+        "use_x_forwarded_for": True,
+        "trusted_proxies": ["10.0.0.0/24"],
+    }
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+
+    with _supervisor_default_config():
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: yaml_conf})
+        assert await async_setup_component(hass, "onboarding", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        assert hass.config.api.port == 8123
+        store = await async_get_and_load_store(hass)
+        assert store.active_config_type is ActiveConfigType.STABLE
+        assert store.revert_deadline is None
+        data = hass_storage[DOMAIN]["data"]
+        assert data["pending"] is None
+        assert data["stable"]["server_port"] == 8123
+        assert data["stable"]["trusted_proxies"] == ["10.0.0.0/24"]
+        assert data["yaml_migration_done"] is True
+        assert issue_registry.async_get_issue(DOMAIN, "deprecated_yaml") is not None
+
+        # Nothing was staged for trial: no auto-revert restart fires.
+        freezer.tick(AUTO_REVERT_DELAY)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        assert len(restart_calls) == 0
+
+
+@pytest.mark.usefixtures("freezer")
+async def test_yaml_without_port_means_historical_default_without_store(
+    hass: HomeAssistant,
+    hass_storage: dict[str, Any],
+) -> None:
+    """An absent YAML port means 8123 even when there is no store.
+
+    Without a store (e.g. a YAML-only backup restored to a fresh install),
+    stable is the built-in default config — port 80 under Supervisor. The
+    absent YAML port must still be interpreted as the historical YAML
+    default 8123, not as the environment-dependent default the YAML author
+    never expressed.
+    """
+    yaml_conf = {
+        "use_x_forwarded_for": True,
+        "trusted_proxies": ["10.0.0.0/24"],
+    }
+
+    with _supervisor_default_config():
+        assert await async_setup_component(hass, DOMAIN, {DOMAIN: yaml_conf})
+        assert await async_setup_component(hass, "onboarding", {})
+        await hass.async_start()
+        await hass.async_block_till_done()
+
+        # The YAML config differs from the default stable, so it is trialed
+        # as pending — on the port the YAML config always meant.
+        assert hass.config.api.port == 8123
+        store = await async_get_and_load_store(hass)
+        assert store.active_config_type is ActiveConfigType.PENDING
+        data = hass_storage[DOMAIN]["data"]
+        assert data["pending"]["server_port"] == 8123
+        assert data["pending"]["trusted_proxies"] == ["10.0.0.0/24"]
+        assert data["stable"]["server_port"] == 80
+
+
 @pytest.mark.usefixtures("freezer")
 async def test_setup_migrates_v2_1_storage_to_v2_2(
     hass: HomeAssistant,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
A YAML config without an explicit `server_port` (e.g. a reverse proxy setup with just `use_x_forwarded_for` + `trusted_proxies`) has been running on the old default port 8123, which the v1 store recorded explicitly. The YAML schema fills an absent port with the new environment-dependent default (`default_server_port()`, port 80 under Supervisor, #174278), so the otherwise unchanged YAML config no longer matched the stored stable config and was staged as a pending trial on the new default port: nothing promotes it, so five minutes later the trial auto-reverts with a restart and the port flips back — a spurious port change plus restart for every reverse-proxy-style YAML user upgrading under Supervisor.

Fix: drop the YAML schema default for `server_port` (absence must stay detectable; the storage schema remains authoritative for defaults) and fill an absent port with the historical YAML default (`SERVER_PORT`, 8123) during the migration — the meaning the YAML author expressed. This restores the invariant that an unchanged YAML config equals the migrated v1 store contents, so nothing is staged and no trial restart fires. Filling from the stable slot instead would be equivalent for upgrades (the v1 store always recorded the port explicitly), but would reintroduce the port-80 reinterpretation when no store exists, e.g. a YAML-only backup restored to a fresh install. Follow-up to #177622, which fixed the same reinterpretation for installs with no YAML at all.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
