### PR TITLE
Don't allow setting http config if HA is not running

### DIFF
--- a/homeassistant/components/http/websocket_api.py
+++ b/homeassistant/components/http/websocket_api.py
@@ -9,7 +9,7 @@ from homeassistant.components.homeassistant import (
     DOMAIN as HASS_DOMAIN,
     SERVICE_HOMEASSISTANT_RESTART,
 )
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import CoreState, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 from .config import HTTP_STORAGE_SCHEMA, ConfData, async_get_and_load_store
@@ -17,6 +17,7 @@ from .const import ATTR_CONFIG, CONF_SERVER_PORT
 from .server import async_verify_can_bind
 
 ERR_BIND_FAILED: Final = "bind_failed"
+ERR_NOT_RUNNING: Final = "not_running"
 
 
 @callback
@@ -74,6 +75,10 @@ async def websocket_set_config(
 ) -> None:
     """Store a new pending HTTP configuration and restart to apply it.
 
+    Only allowed while Home Assistant is running: applying a config means
+    restarting, and restarting a start that has not finished yet leaves
+    integrations that are still setting up in an undefined state.
+
     A new config is first verified to be applicable by binding its
     configured address, so an unusable config is rejected here instead of
     being discovered after the restart. The check is skipped when the port
@@ -85,6 +90,15 @@ async def websocket_set_config(
     refreshed. The result reports whether a restart was triggered via
     ``{"restart": bool}``.
     """
+    if hass.state is not CoreState.running:
+        connection.send_error(
+            msg["id"],
+            ERR_NOT_RUNNING,
+            "The HTTP configuration can only be changed while Home Assistant "
+            f"is running, current state: {hass.state.value}",
+        )
+        return
+
     config: ConfData | None = msg[ATTR_CONFIG]
     if config is not None and config[CONF_SERVER_PORT] != hass.http.server_port:
         try:

--- a/tests/components/http/test_init.py
+++ b/tests/components/http/test_init.py
@@ -33,7 +33,7 @@ from homeassistant.components.http.config import (
 )
 from homeassistant.components.http.const import ENV_SETUP_PORT, ENV_SUPERVISOR
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP, HASSIO_USER_NAME
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CoreState, HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.http import KEY_HASS
@@ -2260,6 +2260,58 @@ async def test_websocket_configure_same_port_skips_bind_check(
     assert response["success"]
     assert response["result"] == {"restart": True}
     assert hass_storage[DOMAIN]["data"]["pending"]["server_port"] == current_port
+
+    await hass.async_block_till_done()
+    assert len(restart_calls) == 1
+
+
+@pytest.mark.parametrize(
+    "core_state",
+    [CoreState.not_running, CoreState.starting],
+    ids=["not-running", "starting"],
+)
+async def test_websocket_configure_rejected_while_not_running(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_storage: dict[str, Any],
+    mock_create_server: Mock,
+    core_state: CoreState,
+) -> None:
+    """Staging a new config is rejected while Home Assistant is not running yet."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    await async_setup_component(hass, "websocket_api", {})
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    restart_calls = async_mock_service(hass, "homeassistant", "restart")
+    ws_client = await hass_ws_client(hass)
+
+    hass.set_state(core_state)
+    await ws_client.send_json_auto_id(
+        {"type": "http/config/configure", "config": {"server_port": 9123}}
+    )
+    response = await ws_client.receive_json()
+    assert not response["success"]
+    assert response["error"]["code"] == "not_running"
+    assert response["error"]["message"] == (
+        "The HTTP configuration can only be changed while Home Assistant is "
+        f"running, current state: {core_state.value}"
+    )
+
+    # The config is neither probed nor stored, and no restart is triggered.
+    assert mock_create_server.call_count == 1
+    assert hass_storage[DOMAIN]["data"]["pending"] is None
+    assert len(restart_calls) == 0
+
+    # Once the start finished, the same config is accepted.
+    hass.set_state(CoreState.running)
+    await ws_client.send_json_auto_id(
+        {"type": "http/config/configure", "config": {"server_port": 9123}}
+    )
+    response = await ws_client.receive_json()
+    assert response["success"]
+    assert response["result"] == {"restart": True}
+    assert hass_storage[DOMAIN]["data"]["pending"]["server_port"] == 9123
 
     await hass.async_block_till_done()
     assert len(restart_calls) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Prevent changing the http config if HA is not running. So we avoid setting a new config if HA is still booting

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
