### PR TITLE
Fix Hue MotionAware motion sensors not reporting motion

### DIFF
--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -211,18 +211,16 @@ class HueMotionAwareSensor(HueMotionSensor):
         # so the zone is the only reliable signal that it stopped reporting motion
         if not zone.enabled or zone.health == MotionAreaHealth.NOT_RUNNING:
             return None
-        # a zone that is bound to lights enables its convenience service, and that
-        # service is then the only one reporting: the security service goes on
-        # advertising a valid reading that never changes again
-        convenience = self._convenience_service
-        source = (
-            convenience
-            if convenience is not None and convenience.enabled
-            else self.resource
-        )
-        if not source.enabled or source.motion is None:
-            return None
-        return source.motion.value
+        # either service can be the one reporting a zone, with the other left holding
+        # a reading that no longer changes, so take the first that has a valid one.
+        # The convenience service comes first because a zone that is bound to lights
+        # reports on that service.
+        for source in (self._convenience_service, self.resource):
+            if source is None or not source.enabled or source.motion is None:
+                continue
+            if (value := source.motion.value) is not None:
+                return value
+        return None
 
     def __init__(
         self,
@@ -253,25 +251,31 @@ class HueMotionAwareSensor(HueMotionSensor):
             )
         )
         # zones that are bound to lights report their motion on the convenience service
-        if (convenience := self._convenience_service) is not None:
+        if (service_id := self._convenience_service_id) is not None:
             self.async_on_remove(
                 self.bridge.api.sensors.convenience_area_motion.subscribe(
-                    self._handle_event, convenience.id
+                    self._handle_event, service_id
                 )
             )
 
     @property
-    def _convenience_service(self) -> ConvenienceAreaMotion | None:
-        """Return the ConvenienceAreaMotion service of this zone, if it has one."""
-        controller = self.bridge.api.sensors.convenience_area_motion
+    def _convenience_service_id(self) -> str | None:
+        """Return the id of this zone's ConvenienceAreaMotion service, if it has one."""
         return next(
             (
-                resource
+                service.rid
                 for service in self._motion_area_configuration.services
-                if (resource := controller.get(service.rid)) is not None
+                if service.rtype == ResourceTypes.CONVENIENCE_AREA_MOTION
             ),
             None,
         )
+
+    @property
+    def _convenience_service(self) -> ConvenienceAreaMotion | None:
+        """Return this zone's ConvenienceAreaMotion resource, if the bridge has it."""
+        if (service_id := self._convenience_service_id) is None:
+            return None
+        return self.bridge.api.sensors.convenience_area_motion.get(service_id)
 
 
 # pylint: disable-next=home-assistant-enforce-class-module

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -186,7 +186,7 @@ class HueMotionAwareSensor(HueMotionSensor):
     A MotionAware zone owns both a ConvenienceAreaMotion and a SecurityAreaMotion
     service, and which of the two carries the motion state depends on how the zone
     is set up in the Hue app. The source is therefore resolved from the zone, and
-    the sensor is unavailable while neither service reports a valid state.
+    the state is unknown while neither service reports a valid one.
     """
 
     controller: SecurityAreaMotionController
@@ -204,15 +204,25 @@ class HueMotionAwareSensor(HueMotionSensor):
 
     @property
     @override
-    def available(self) -> bool:
-        """Return entity availability."""
-        return super().available and self._motion_value is not None
-
-    @property
-    @override
     def is_on(self) -> bool | None:
         """Return true if the binary sensor is on."""
-        return self._motion_value
+        zone = self._motion_area_configuration
+        # switching a zone off leaves the `enabled` flag of its services untouched,
+        # so the zone is the only reliable signal that it stopped reporting motion
+        if not zone.enabled or zone.health == MotionAreaHealth.NOT_RUNNING:
+            return None
+        # a zone that is bound to lights enables its convenience service, and that
+        # service is then the only one reporting: the security service goes on
+        # advertising a valid reading that never changes again
+        convenience = self._convenience_service
+        source = (
+            convenience
+            if convenience is not None and convenience.enabled
+            else self.resource
+        )
+        if not source.enabled or source.motion is None:
+            return None
+        return source.motion.value
 
     def __init__(
         self,
@@ -262,24 +272,6 @@ class HueMotionAwareSensor(HueMotionSensor):
             ),
             None,
         )
-
-    @property
-    def _motion_value(self) -> bool | None:
-        """Return the motion state of this zone, or None if it reports none."""
-        zone = self._motion_area_configuration
-        # switching a zone off leaves the `enabled` flag of its services untouched,
-        # so the zone is the only reliable signal that it stopped reporting motion
-        if not zone.enabled or zone.health == MotionAreaHealth.NOT_RUNNING:
-            return None
-        # the convenience service comes first: a zone that is bound to lights enables it
-        # and it is then the only one still reporting, while the security service keeps
-        # advertising a valid reading that never changes again
-        for source in (self._convenience_service, self.resource):
-            if source is None or not source.enabled or source.motion is None:
-                continue
-            if (value := source.motion.value) is not None:
-                return value
-        return None
 
 
 # pylint: disable-next=home-assistant-enforce-class-module

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -19,9 +19,11 @@ from aiohue.v2.controllers.sensors import (
 )
 from aiohue.v2.models.camera_motion import CameraMotion
 from aiohue.v2.models.contact import Contact, ContactState
+from aiohue.v2.models.convenience_area_motion import ConvenienceAreaMotion
 from aiohue.v2.models.entertainment_configuration import EntertainmentStatus
 from aiohue.v2.models.grouped_motion import GroupedMotion
 from aiohue.v2.models.motion import Motion
+from aiohue.v2.models.motion_area_configuration import MotionAreaHealth
 from aiohue.v2.models.resource import ResourceTypes
 from aiohue.v2.models.security_area_motion import SecurityAreaMotion
 from aiohue.v2.models.tamper import Tamper, TamperState
@@ -181,11 +183,10 @@ class HueGroupedMotionSensor(HueMotionSensor):
 class HueMotionAwareSensor(HueMotionSensor):
     """Representation of a Motion sensor based on Hue Motion Aware.
 
-    Note that we only create sensors for the SecurityAreaMotion resource
-    and not for the ConvenienceAreaMotion resource, because the latter
-    does not have a state when it's not directly controlling lights.
-    The SecurityAreaMotion resource is always available with a state, allowing
-    Home Assistant users to actually use it as a motion sensor in their HA automations.
+    A MotionAware zone owns both a ConvenienceAreaMotion and a SecurityAreaMotion
+    service, and which of the two carries the motion state depends on how the zone
+    is set up in the Hue app. The source is therefore resolved from the zone, and
+    the sensor is unavailable while neither service reports a valid state.
     """
 
     controller: SecurityAreaMotionController
@@ -200,6 +201,18 @@ class HueMotionAwareSensor(HueMotionSensor):
     def name(self) -> str:
         """Return sensor name."""
         return self.controller.get_motion_area_configuration(self.resource.id).name
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return entity availability."""
+        return super().available and self._motion_value is not None
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return true if the binary sensor is on."""
+        return self._motion_value
 
     def __init__(
         self,
@@ -229,6 +242,44 @@ class HueMotionAwareSensor(HueMotionSensor):
                 self._handle_event, self._motion_area_configuration.id
             )
         )
+        # zones that are bound to lights report their motion on the convenience service
+        if (convenience := self._convenience_service) is not None:
+            self.async_on_remove(
+                self.bridge.api.sensors.convenience_area_motion.subscribe(
+                    self._handle_event, convenience.id
+                )
+            )
+
+    @property
+    def _convenience_service(self) -> ConvenienceAreaMotion | None:
+        """Return the ConvenienceAreaMotion service of this zone, if it has one."""
+        controller = self.bridge.api.sensors.convenience_area_motion
+        return next(
+            (
+                resource
+                for service in self._motion_area_configuration.services
+                if (resource := controller.get(service.rid)) is not None
+            ),
+            None,
+        )
+
+    @property
+    def _motion_value(self) -> bool | None:
+        """Return the motion state of this zone, or None if it reports none."""
+        zone = self._motion_area_configuration
+        # switching a zone off leaves the `enabled` flag of its services untouched,
+        # so the zone is the only reliable signal that it stopped reporting motion
+        if not zone.enabled or zone.health == MotionAreaHealth.NOT_RUNNING:
+            return None
+        # the convenience service comes first: a zone that is bound to lights enables it
+        # and it is then the only one still reporting, while the security service keeps
+        # advertising a valid reading that never changes again
+        for source in (self._convenience_service, self.resource):
+            if source is None or not source.enabled or source.motion is None:
+                continue
+            if (value := source.motion.value) is not None:
+                return value
+        return None
 
 
 # pylint: disable-next=home-assistant-enforce-class-module

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -62,6 +62,8 @@ def replace_resources(
 ) -> JsonArrayType:
     """Return the test data with each resource of the same id replaced."""
     replacements = {resource["id"]: resource for resource in resources}
+    missing = replacements.keys() - {resource["id"] for resource in data}
+    assert not missing, f"resource id(s) not present in the test data: {missing}"
     return [replacements.get(resource["id"], resource) for resource in data]
 
 
@@ -326,13 +328,15 @@ async def test_motion_aware_sensor(
             "unknown",
             id="not_bound_to_lights_without_valid_reading",
         ),
+        # a real zone can have its convenience service enabled while only the security
+        # service reports, so an enabled service without a reading must not win
         pytest.param(
             [
                 area_motion_service("security_area_motion", motion=MOTION_DETECTED),
                 area_motion_service("convenience_area_motion", motion=MOTION_INVALID),
             ],
-            "unknown",
-            id="bound_to_lights_does_not_fall_back_to_security",
+            "on",
+            id="falls_back_to_security_when_convenience_has_no_reading",
         ),
     ],
 )
@@ -379,23 +383,80 @@ async def test_motion_aware_sensor_follows_convenience_service(
     assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "on"
 
 
-async def test_motion_aware_sensor_zone_disabled(
+async def test_motion_aware_sensor_follows_security_service(
     hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
 ) -> None:
-    """Test the MotionAware sensor reports unknown while its zone is switched off."""
+    """Test the MotionAware sensor updates on events of the security service."""
+    await mock_bridge_v2.api.load_test_data(
+        replace_resources(
+            v2_resources_test_data,
+            [
+                area_motion_service("security_area_motion", motion=MOTION_CLEARED),
+                area_motion_service(
+                    "convenience_area_motion", enabled=False, motion=MOTION_CLEARED
+                ),
+            ],
+        )
+    )
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "off"
+
+    mock_bridge_v2.api.emit_event(
+        "update",
+        area_motion_service("security_area_motion", motion=MOTION_DETECTED),
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "on"
+
+
+async def test_motion_aware_sensor_without_convenience_resource(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test the MotionAware sensor works when the convenience service is missing."""
+    # the zone still lists the service, but the bridge never delivered the resource
+    data = replace_resources(
+        v2_resources_test_data,
+        [area_motion_service("security_area_motion", motion=MOTION_DETECTED)],
+    )
+    convenience_id = AREA_MOTION_SERVICE_IDS["convenience_area_motion"]
+    await mock_bridge_v2.api.load_test_data(
+        [resource for resource in data if resource["id"] != convenience_id]
+    )
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "on"
+
+
+@pytest.mark.parametrize(
+    ("zone_update", "zone_restore"),
+    [
+        pytest.param({"enabled": False}, {"enabled": True}, id="zone_switched_off"),
+        pytest.param(
+            {"health": "not_running"}, {"health": "healthy"}, id="zone_not_running"
+        ),
+    ],
+)
+async def test_motion_aware_sensor_zone_not_reporting(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    zone_update: dict[str, Any],
+    zone_restore: dict[str, Any],
+) -> None:
+    """Test the MotionAware sensor reports unknown while its zone is not reporting."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
 
     assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "off"
 
-    # the services keep reporting a valid state while the zone is switched off
+    # the services keep reporting a valid state while the zone itself does not
     mock_bridge_v2.api.emit_event(
         "update",
         {
             "id": MOTION_AREA_CONFIGURATION_ID,
             "type": "motion_area_configuration",
-            "enabled": False,
-            "health": "not_running",
+            **zone_update,
         },
     )
     await hass.async_block_till_done()
@@ -406,8 +467,7 @@ async def test_motion_aware_sensor_zone_disabled(
         {
             "id": MOTION_AREA_CONFIGURATION_ID,
             "type": "motion_area_configuration",
-            "enabled": True,
-            "health": "healthy",
+            **zone_restore,
         },
     )
     await hass.async_block_till_done()

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -1,6 +1,9 @@
 """Philips Hue binary_sensor platform tests for V2 bridge/api."""
 
+from typing import Any
 from unittest.mock import Mock
+
+import pytest
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -8,6 +11,58 @@ from homeassistant.util.json import JsonArrayType
 
 from .conftest import setup_platform
 from .const import FAKE_BINARY_SENSOR, FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY
+
+MOTION_AWARE_ENTITY_ID = "binary_sensor.test_room_test_room_motion_aware_sensor_1"
+MOTION_AREA_CONFIGURATION_ID = "5e6f7a8b-9c1d-4e2f-b3a4-5c6d7e8f9a0b"
+AREA_MOTION_SERVICE_IDS = {
+    "convenience_area_motion": "4f317b69-9da0-4b4f-84f2-7ca07b9fe345",
+    "security_area_motion": "8b7e4f82-9c3d-4e1a-a5f6-8d9c7b2a3e4f",
+}
+
+MOTION_DETECTED = {
+    "motion": True,
+    "motion_valid": True,
+    "motion_report": {"changed": "2023-09-23T08:20:51.384Z", "motion": True},
+}
+MOTION_CLEARED = {
+    "motion": False,
+    "motion_valid": True,
+    "motion_report": {"changed": "2023-09-23T08:13:42.394Z", "motion": False},
+}
+MOTION_INVALID = {
+    "motion": False,
+    "motion_valid": False,
+    "motion_report": {"changed": "2023-09-23T05:54:08.166Z", "motion": False},
+}
+
+
+def area_motion_service(
+    service_type: str,
+    *,
+    enabled: bool = True,
+    motion: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a service of the MotionAware zone, without `motion` when none is given."""
+    service = {
+        "id": AREA_MOTION_SERVICE_IDS[service_type],
+        "owner": {
+            "rid": MOTION_AREA_CONFIGURATION_ID,
+            "rtype": "motion_area_configuration",
+        },
+        "enabled": enabled,
+        "type": service_type,
+    }
+    if motion is not None:
+        service["motion"] = motion
+    return service
+
+
+def replace_resources(
+    data: JsonArrayType, resources: list[dict[str, Any]]
+) -> JsonArrayType:
+    """Return the test data with each resource of the same id replaced."""
+    replacements = {resource["id"]: resource for resource in resources}
+    return [replacements.get(resource["id"], resource) for resource in data]
 
 
 async def test_binary_sensors(
@@ -88,7 +143,7 @@ async def test_binary_sensors(
     assert sensor.attributes["device_class"] == "motion"
 
     # test motion aware sensor
-    sensor = hass.states.get("binary_sensor.test_room_test_room_motion_aware_sensor_1")
+    sensor = hass.states.get(MOTION_AWARE_ENTITY_ID)
     assert sensor is not None
     assert sensor.state == "off"
     assert sensor.name == "Test Room Motion Aware Sensor 1"
@@ -195,15 +250,17 @@ async def test_motion_aware_sensor(
     await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
 
     # test motion aware sensor exists and has correct state
-    sensor = hass.states.get("binary_sensor.test_room_test_room_motion_aware_sensor_1")
+    sensor = hass.states.get(MOTION_AWARE_ENTITY_ID)
     assert sensor is not None
     assert sensor.state == "off"
     assert sensor.attributes["device_class"] == "motion"
 
     # test update of motion aware sensor works on incoming event
+    # the zone in the test data has its convenience service enabled, so that is the
+    # service reporting its motion
     updated_sensor = {
-        "id": "8b7e4f82-9c3d-4e1a-a5f6-8d9c7b2a3e4f",
-        "type": "security_area_motion",
+        "id": "4f317b69-9da0-4b4f-84f2-7ca07b9fe345",
+        "type": "convenience_area_motion",
         "motion": {
             "motion": True,
             "motion_valid": True,
@@ -212,7 +269,7 @@ async def test_motion_aware_sensor(
     }
     mock_bridge_v2.api.emit_event("update", updated_sensor)
     await hass.async_block_till_done()
-    sensor = hass.states.get("binary_sensor.test_room_test_room_motion_aware_sensor_1")
+    sensor = hass.states.get(MOTION_AWARE_ENTITY_ID)
     assert sensor.state == "on"
 
     # test name update when motion area configuration name changes
@@ -225,6 +282,123 @@ async def test_motion_aware_sensor(
     await hass.async_block_till_done()
     # The entity name is derived from the motion area configuration name
     # but the entity ID doesn't change - we just verify the sensor still exists
-    sensor = hass.states.get("binary_sensor.test_room_test_room_motion_aware_sensor_1")
+    sensor = hass.states.get(MOTION_AWARE_ENTITY_ID)
     assert sensor is not None
     assert sensor.name == "Test Room Updated Motion Area"
+
+
+@pytest.mark.parametrize(
+    ("services", "expected_state"),
+    [
+        pytest.param(
+            [
+                area_motion_service("security_area_motion", motion=MOTION_CLEARED),
+                area_motion_service("convenience_area_motion", motion=MOTION_DETECTED),
+            ],
+            "on",
+            id="bound_to_lights_reads_convenience",
+        ),
+        pytest.param(
+            [
+                area_motion_service("security_area_motion", motion=MOTION_CLEARED),
+                area_motion_service(
+                    "convenience_area_motion", enabled=False, motion=MOTION_DETECTED
+                ),
+            ],
+            "off",
+            id="not_bound_to_lights_reads_security",
+        ),
+        pytest.param(
+            [
+                area_motion_service("security_area_motion"),
+                area_motion_service("convenience_area_motion", motion=MOTION_DETECTED),
+            ],
+            "on",
+            id="hue_secure_security_without_motion_reads_convenience",
+        ),
+        pytest.param(
+            [
+                area_motion_service("security_area_motion", motion=MOTION_INVALID),
+                area_motion_service("convenience_area_motion", motion=MOTION_INVALID),
+            ],
+            "unavailable",
+            id="no_service_reports_motion",
+        ),
+    ],
+)
+async def test_motion_aware_sensor_motion_source(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    services: list[dict[str, Any]],
+    expected_state: str,
+) -> None:
+    """Test the MotionAware sensor reads the zone service that reports motion."""
+    # every case gives the service that must be ignored the opposite state, so
+    # reading the wrong one results in a state other than the asserted one
+    await mock_bridge_v2.api.load_test_data(
+        replace_resources(v2_resources_test_data, services)
+    )
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == expected_state
+
+
+async def test_motion_aware_sensor_follows_convenience_service(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test the MotionAware sensor updates on events of the convenience service."""
+    await mock_bridge_v2.api.load_test_data(
+        replace_resources(
+            v2_resources_test_data,
+            [
+                area_motion_service("security_area_motion"),
+                area_motion_service("convenience_area_motion", motion=MOTION_CLEARED),
+            ],
+        )
+    )
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "off"
+
+    mock_bridge_v2.api.emit_event(
+        "update",
+        area_motion_service("convenience_area_motion", motion=MOTION_DETECTED),
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "on"
+
+
+async def test_motion_aware_sensor_zone_disabled(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test the MotionAware sensor is unavailable while its zone is switched off."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "off"
+
+    # the services keep reporting a valid state while the zone is switched off
+    mock_bridge_v2.api.emit_event(
+        "update",
+        {
+            "id": MOTION_AREA_CONFIGURATION_ID,
+            "type": "motion_area_configuration",
+            "enabled": False,
+            "health": "not_running",
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "unavailable"
+
+    mock_bridge_v2.api.emit_event(
+        "update",
+        {
+            "id": MOTION_AREA_CONFIGURATION_ID,
+            "type": "motion_area_configuration",
+            "enabled": True,
+            "health": "healthy",
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "off"

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -319,10 +319,20 @@ async def test_motion_aware_sensor(
         pytest.param(
             [
                 area_motion_service("security_area_motion", motion=MOTION_INVALID),
+                area_motion_service(
+                    "convenience_area_motion", enabled=False, motion=MOTION_DETECTED
+                ),
+            ],
+            "unknown",
+            id="not_bound_to_lights_without_valid_reading",
+        ),
+        pytest.param(
+            [
+                area_motion_service("security_area_motion", motion=MOTION_DETECTED),
                 area_motion_service("convenience_area_motion", motion=MOTION_INVALID),
             ],
-            "unavailable",
-            id="no_service_reports_motion",
+            "unknown",
+            id="bound_to_lights_does_not_fall_back_to_security",
         ),
     ],
 )
@@ -372,7 +382,7 @@ async def test_motion_aware_sensor_follows_convenience_service(
 async def test_motion_aware_sensor_zone_disabled(
     hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
 ) -> None:
-    """Test the MotionAware sensor is unavailable while its zone is switched off."""
+    """Test the MotionAware sensor reports unknown while its zone is switched off."""
     await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
     await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
 
@@ -389,7 +399,7 @@ async def test_motion_aware_sensor_zone_disabled(
         },
     )
     await hass.async_block_till_done()
-    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "unavailable"
+    assert hass.states.get(MOTION_AWARE_ENTITY_ID).state == "unknown"
 
     mock_bridge_v2.api.emit_event(
         "update",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Motion sensors for Hue MotionAware zones could stay stuck on "Clear" and never report motion. A zone that is set up to switch on lights publishes its motion in a different place than Home Assistant was reading, so nothing ever arrived.

- Read each MotionAware zone's motion from the right place, based on how the zone is set up in the Hue app
- Leave the state unknown when the bridge is not reporting motion for the zone, so it can be told apart from "no motion"
- Do the same while the zone is switched off in the Hue app
- Add tests covering the different zone setups

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168297
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

