### PR TITLE
Clear stale restored entity names in bluetooth passive update processor

### DIFF
--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -165,6 +165,15 @@ class PassiveBluetoothDataUpdate[_T]:
                 if current.get(key, UNDEFINED) != data:
                     changed_entity_keys.add(key)
                     current[key] = data  # type: ignore[assignment]
+        # A key present in the update without a name means the integration
+        # does not name that entity; clear any stale name restored from storage.
+        for key in new_data.entity_data.keys() | new_data.entity_descriptions.keys():
+            if (
+                key not in new_data.entity_names
+                and self.entity_names.get(key) is not None
+            ):
+                changed_entity_keys.add(key)
+                self.entity_names[key] = None
         # If the device changed we don't need to return the changed
         # entity keys as all entities will be updated
         return None if device_change else changed_entity_keys

--- a/homeassistant/components/bluetooth/passive_update_processor.py
+++ b/homeassistant/components/bluetooth/passive_update_processor.py
@@ -165,15 +165,17 @@ class PassiveBluetoothDataUpdate[_T]:
                 if current.get(key, UNDEFINED) != data:
                     changed_entity_keys.add(key)
                     current[key] = data  # type: ignore[assignment]
-        # A key present in the update without a name means the integration
-        # does not name that entity; clear any stale name restored from storage.
-        for key in new_data.entity_data.keys() | new_data.entity_descriptions.keys():
-            if (
-                key not in new_data.entity_names
-                and self.entity_names.get(key) is not None
+        # An update without any names means the integration does not name its
+        # entities; clear stale names restored from storage for the updated keys.
+        # Updates that provide names for only some keys are left untouched since
+        # the missing names may be provided by other partial updates.
+        if not new_data.entity_names:
+            for key in (
+                new_data.entity_data.keys() | new_data.entity_descriptions.keys()
             ):
-                changed_entity_keys.add(key)
-                self.entity_names[key] = None
+                if self.entity_names.get(key) is not None:
+                    changed_entity_keys.add(key)
+                    self.entity_names[key] = None
         # If the device changed we don't need to return the changed
         # entity keys as all entities will be updated
         return None if device_change else changed_entity_keys

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -1982,3 +1982,50 @@ def test_deserialize_entity_description(
     """Test deserializing an entity description."""
     description = deserialize_entity_description(description_type, description_dict)
     assert description == expected_description
+
+
+def test_update_clears_names_missing_from_the_update() -> None:
+    """Test stored entity names are cleared when an update stops providing them.
+
+    Names restored from storage must not stick around once the integration
+    stops naming its entities, else entities keep stale names forever.
+    """
+    temperature_key = PassiveBluetoothEntityKey("temperature", None)
+    pressure_key = PassiveBluetoothEntityKey("pressure", None)
+    temperature_description = SensorEntityDescription(
+        key="temperature",
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        device_class=SensorDeviceClass.TEMPERATURE,
+    )
+    data = PassiveBluetoothDataUpdate(
+        devices={None: DeviceInfo(name="Test Device")},
+        entity_descriptions={temperature_key: temperature_description},
+        entity_names={temperature_key: "Temperature", pressure_key: "Pressure"},
+        entity_data={temperature_key: 14.5, pressure_key: 1234},
+    )
+    update_without_names = PassiveBluetoothDataUpdate(
+        devices={None: DeviceInfo(name="Test Device")},
+        entity_descriptions={temperature_key: temperature_description},
+        entity_names={},
+        entity_data={temperature_key: 15.5},
+    )
+
+    # The pressure name is untouched since the update does not include the key
+    assert data.update(update_without_names) == {temperature_key}
+    assert data.entity_names == {temperature_key: None, pressure_key: "Pressure"}
+
+    # A repeated update reports no changes
+    assert data.update(update_without_names) == set()
+
+    update_with_name = PassiveBluetoothDataUpdate(
+        devices={None: DeviceInfo(name="Test Device")},
+        entity_descriptions={temperature_key: temperature_description},
+        entity_names={temperature_key: "Custom name"},
+        entity_data={temperature_key: 15.5},
+    )
+
+    assert data.update(update_with_name) == {temperature_key}
+    assert data.entity_names == {
+        temperature_key: "Custom name",
+        pressure_key: "Pressure",
+    }

--- a/tests/components/bluetooth/test_passive_update_processor.py
+++ b/tests/components/bluetooth/test_passive_update_processor.py
@@ -2029,3 +2029,17 @@ def test_update_clears_names_missing_from_the_update() -> None:
         temperature_key: "Custom name",
         pressure_key: "Pressure",
     }
+
+    update_with_partial_names = PassiveBluetoothDataUpdate(
+        devices={None: DeviceInfo(name="Test Device")},
+        entity_descriptions={temperature_key: temperature_description},
+        entity_names={pressure_key: "Pressure"},
+        entity_data={temperature_key: 15.5, pressure_key: 1234},
+    )
+
+    # An update naming only some keys does not clear the other names
+    assert data.update(update_with_partial_names) == set()
+    assert data.entity_names == {
+        temperature_key: "Custom name",
+        pressure_key: "Pressure",
+    }


### PR DESCRIPTION
## Proposed change

Integrations that migrated to translated entity names pass `entity_names={}` (BTHome #156060, OralB #97402, Bluemaestro #102424). However, names persisted before the migration are restored from storage at startup, and `PassiveBluetoothDataUpdate.update()` only merges incoming mappings, so those entities keep the old hardcoded English names forever on existing installations.

Clear the stored name for updated keys when an update provides no names at all, which is the signature of the `entity_names={}` pattern. Updates that name some entities keep the current merge behavior, so partial updates (multi-packet devices) and integrations that rely on previously sent names are unaffected. The cleared names are persisted, and entities pick up the translated names on the next restart.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177644
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
