### PR TITLE
Fix search not showing up in the Music Assistant media browser

### DIFF
--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -261,7 +261,6 @@ async def build_artist_items_listing(
         can_play=True,
         can_expand=True,
         can_search=True,
-        # searching an artist looks through their albums and tracks
         search_media_classes=[MediaClass.ALBUM, MediaClass.TRACK],
         children_media_class=MediaClass.ALBUM,
         children=[
@@ -617,7 +616,9 @@ def _process_search_results(
 
 def _should_expand_media_type(media_type: str) -> bool:
     """Determine if a media type should be expandable."""
-    return media_type in ("artist", "album", "playlist", "podcast")
+    # podcasts are left out because we cannot browse their episodes,
+    # which is also why the podcasts listing builds them non-expandable
+    return media_type in ("artist", "album", "playlist")
 
 
 def _get_media_class_for_type(media_type: str) -> MediaClass | None:

--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -66,6 +66,16 @@ LIBRARY_MEDIA_CLASS_MAP = {
     LIBRARY_AUDIOBOOKS: MediaClass.DIRECTORY,  # audiobook is not accepted by HA
 }
 
+LIBRARY_MASS_MEDIA_TYPE_MAP = {
+    LIBRARY_ARTISTS: MASSMediaType.ARTIST,
+    LIBRARY_ALBUMS: MASSMediaType.ALBUM,
+    LIBRARY_TRACKS: MASSMediaType.TRACK,
+    LIBRARY_PLAYLISTS: MASSMediaType.PLAYLIST,
+    LIBRARY_RADIO: MASSMediaType.RADIO,
+    LIBRARY_PODCASTS: MASSMediaType.PODCAST,
+    LIBRARY_AUDIOBOOKS: MASSMediaType.AUDIOBOOK,
+}
+
 MEDIA_CONTENT_TYPE_FLAC = "audio/flac"
 THUMB_SIZE = 200
 SORT_NAME = "sort_name"
@@ -165,6 +175,7 @@ async def build_playlists_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_PLAYLISTS],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, item, can_expand=True)
@@ -193,6 +204,7 @@ async def build_playlist_items_listing(
         title=playlist.name,
         can_play=True,
         can_expand=True,
+        can_search=True,
         children_media_class=MediaClass.TRACK,
         children=[
             build_item(mass, item, can_expand=False)
@@ -217,6 +229,7 @@ async def build_artists_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_ARTISTS],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, artist, can_expand=True)
@@ -247,6 +260,9 @@ async def build_artist_items_listing(
         title=artist.name,
         can_play=True,
         can_expand=True,
+        can_search=True,
+        # searching an artist looks through their albums and tracks
+        search_media_classes=[MediaClass.ALBUM, MediaClass.TRACK],
         children_media_class=MediaClass.ALBUM,
         children=[
             build_item(mass, album, can_expand=True)
@@ -267,6 +283,7 @@ async def build_albums_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_ALBUMS],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, album, can_expand=True)
@@ -297,6 +314,7 @@ async def build_album_items_listing(
         title=album.name,
         can_play=True,
         can_expand=True,
+        can_search=True,
         children_media_class=MediaClass.TRACK,
         children=[
             build_item(mass, track, False) for track in tracks if track.available
@@ -315,6 +333,7 @@ async def build_tracks_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_TRACKS],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, track, can_expand=False)
@@ -338,6 +357,7 @@ async def build_podcasts_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_PODCASTS],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, podcast, can_expand=False)
@@ -361,6 +381,7 @@ async def build_audiobooks_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_AUDIOBOOKS],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, audiobook, can_expand=False)
@@ -384,6 +405,7 @@ async def build_radio_listing(mass: MusicAssistantClient) -> BrowseMedia:
         title=LIBRARY_TITLE_MAP[LIBRARY_RADIO],
         can_play=False,
         can_expand=True,
+        can_search=True,
         children_media_class=media_class,
         children=[
             build_item(mass, track, can_expand=False, media_class=media_class)
@@ -430,6 +452,28 @@ async def _search_within_album(
     """Search for tracks within a specific album."""
     album = await mass.music.get_item_by_uri(album_uri)
     tracks = await mass.music.get_album_tracks(album.item_id, album.provider)
+
+    # Filter tracks by search query
+    filtered_tracks = [
+        track
+        for track in tracks
+        if search_query.lower() in track.name.lower() and track.available
+    ]
+
+    return SearchMedia(
+        result=[
+            build_item(mass, track, can_expand=False)
+            for track in filtered_tracks[:limit]
+        ]
+    )
+
+
+async def _search_within_playlist(
+    mass: MusicAssistantClient, playlist_uri: str, search_query: str, limit: int
+) -> SearchMedia:
+    """Search for tracks within a specific playlist."""
+    playlist = await mass.music.get_item_by_uri(playlist_uri)
+    tracks = await mass.music.get_playlist_tracks(playlist.item_id, playlist.provider)
 
     # Filter tracks by search query
     filtered_tracks = [
@@ -494,6 +538,13 @@ def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
                 media_types = [
                     mapping[cls] for cls in query.media_filter_classes if cls in mapping
                 ]
+            elif library_media_type := LIBRARY_MASS_MEDIA_TYPE_MAP.get(
+                query.media_content_id or ""
+            ):
+                # Searching from a library listing scopes to that library,
+                # because the browse tree reports those pages as our own domain
+                # rather than as a concrete media type.
+                media_types = [library_media_type]
 
     # Default to all types if none specified
     if not media_types:
@@ -597,6 +648,10 @@ async def async_search_media(
         if query.media_content_id:
             if "album/" in query.media_content_id:
                 return await _search_within_album(
+                    mass, query.media_content_id, search_query, limit
+                )
+            if "playlist/" in query.media_content_id:
+                return await _search_within_playlist(
                     mass, query.media_content_id, search_query, limit
                 )
             if "artist/" in query.media_content_id:

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -3,6 +3,7 @@
 from unittest.mock import MagicMock, patch
 
 from music_assistant_models.enums import MediaType as MASSMediaType
+from music_assistant_models.media_items import SearchResults
 import pytest
 
 from homeassistant.components.media_player import (
@@ -434,6 +435,38 @@ async def test_browse_artist_search_media_classes(
     )
 
     assert browse_item.search_media_classes == [MediaClass.ALBUM, MediaClass.TRACK]
+
+
+async def test_search_media_results_are_browsable(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that every expandable search result can actually be browsed."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    media_types = ["artist", "album", "track", "playlist", "radio", "podcast"]
+    mock = MockSearchResults(media_types)
+    results = SearchResults(
+        artists=mock.artists,
+        albums=mock.albums,
+        tracks=mock.tracks,
+        playlists=mock.playlists,
+        radio=mock.radio,
+        podcasts=mock.podcasts,
+    )
+
+    with patch.object(music_assistant_client.music, "search", return_value=results):
+        search_results = await async_search_media(
+            music_assistant_client, SearchMediaQuery(search_query="test")
+        )
+
+    expandable = [item for item in search_results.result if item.can_expand]
+    assert expandable
+    for item in expandable:
+        # raises BrowseError if the browse tree has no route for this item
+        await async_browse_media(
+            hass, music_assistant_client, item.media_content_id, item.media_content_type
+        )
 
 
 async def test_search_media_websocket_from_library_listing(

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import MagicMock, patch
 
+from music_assistant_models.enums import MediaType as MASSMediaType
 import pytest
 
 from homeassistant.components.media_player import (
@@ -30,6 +31,8 @@ from homeassistant.components.music_assistant.media_browser import (
 from homeassistant.core import HomeAssistant
 
 from .common import setup_integration_from_fixtures
+
+from tests.typing import WebSocketGenerator
 
 
 @pytest.mark.parametrize(
@@ -303,6 +306,181 @@ async def test_search_media_within_album(
         # Verify search results
         assert isinstance(search_results, SearchMedia)
         assert len(search_results.result) > 0  # Should have results
+
+
+async def test_search_media_within_playlist(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test searching within a playlist context."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    playlist = MagicMock()
+    playlist.item_id = "40"
+    playlist.provider = "library"
+
+    with (
+        patch.object(
+            music_assistant_client.music, "get_item_by_uri", return_value=playlist
+        ),
+        patch.object(music_assistant_client.music, "search") as mock_search,
+    ):
+        query = SearchMediaQuery(
+            search_query="fooled",
+            media_content_id="library://playlist/40",
+        )
+        search_results = await async_search_media(music_assistant_client, query)
+
+    # the playlist tracks are filtered locally, without hitting the search api
+    mock_search.assert_not_called()
+    assert [item.title for item in search_results.result] == [
+        "The Who - Won't Get Fooled Again"
+    ]
+
+
+@pytest.mark.parametrize(
+    ("media_content_id", "expected_media_type"),
+    [
+        (LIBRARY_ARTISTS, MASSMediaType.ARTIST),
+        (LIBRARY_ALBUMS, MASSMediaType.ALBUM),
+        (LIBRARY_TRACKS, MASSMediaType.TRACK),
+        (LIBRARY_PLAYLISTS, MASSMediaType.PLAYLIST),
+        (LIBRARY_RADIO, MASSMediaType.RADIO),
+        (LIBRARY_PODCASTS, MASSMediaType.PODCAST),
+        (LIBRARY_AUDIOBOOKS, MASSMediaType.AUDIOBOOK),
+    ],
+)
+async def test_search_media_scoped_to_library(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    media_content_id: str,
+    expected_media_type: MASSMediaType,
+) -> None:
+    """Test that searching from a library listing only searches that library.
+
+    The browse tree reports the library listings as our own domain instead of a
+    concrete media type, so the listing id is what scopes the search.
+    """
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    mock_results = MockSearchResults([expected_media_type.value])
+
+    with patch.object(
+        music_assistant_client.music, "search", return_value=mock_results
+    ) as mock_search:
+        query = SearchMediaQuery(
+            search_query="test",
+            media_content_type=DOMAIN,
+            media_content_id=media_content_id,
+        )
+        search_results = await async_search_media(music_assistant_client, query)
+
+    assert mock_search.call_args.kwargs["media_types"] == [expected_media_type]
+    assert len(search_results.result) == 5
+
+
+@pytest.mark.parametrize(
+    ("media_content_id", "media_content_type"),
+    [
+        (LIBRARY_ARTISTS, MediaType.ARTIST),
+        (LIBRARY_ALBUMS, MediaType.ALBUM),
+        (LIBRARY_TRACKS, MediaType.TRACK),
+        (LIBRARY_PLAYLISTS, MediaType.PLAYLIST),
+        (LIBRARY_RADIO, DOMAIN),
+        (LIBRARY_PODCASTS, MediaType.PODCAST),
+        (LIBRARY_AUDIOBOOKS, DOMAIN),
+        ("artist", MediaType.ARTIST),
+        ("album", MediaType.ALBUM),
+        ("playlist", DOMAIN),
+    ],
+)
+async def test_browse_media_can_search(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    media_content_id: str,
+    media_content_type: str,
+) -> None:
+    """Test that browse listings tell the media browser they can be searched."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    browse_item = await async_browse_media(
+        hass, music_assistant_client, media_content_id, media_content_type
+    )
+
+    assert browse_item.can_search is True
+
+
+async def test_browse_media_root_cannot_search(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that the root listing does not offer search."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    browse_item = await async_browse_media(hass, music_assistant_client, None, None)
+
+    assert browse_item.can_search is False
+
+
+async def test_browse_artist_search_media_classes(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test that an artist listing offers its searchable media classes."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    browse_item = await async_browse_media(
+        hass, music_assistant_client, "artist", MediaType.ARTIST
+    )
+
+    assert browse_item.search_media_classes == [MediaClass.ALBUM, MediaClass.TRACK]
+
+
+async def test_search_media_websocket_from_library_listing(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test searching a library listing the way the media browser does.
+
+    The media browser reports the listing as the child that its parent built, so
+    it sends our domain as the content type and the listing id as the content id.
+    """
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    root = await async_browse_media(hass, music_assistant_client, None, None)
+    artists_child = next(
+        child for child in root.children if child.media_content_id == LIBRARY_ARTISTS
+    )
+    listing = await async_browse_media(
+        hass,
+        music_assistant_client,
+        artists_child.media_content_id,
+        artists_child.media_content_type,
+    )
+    assert listing.can_search is True
+
+    client = await hass_ws_client(hass)
+    with patch.object(
+        music_assistant_client.music,
+        "search",
+        return_value=MockSearchResults(["artist"]),
+    ) as mock_search:
+        await client.send_json_auto_id(
+            {
+                "type": "media_player/search_media",
+                "entity_id": "media_player.test_player_1",
+                "search_query": "test",
+                "media_content_id": artists_child.media_content_id,
+                "media_content_type": artists_child.media_content_type,
+            }
+        )
+        msg = await client.receive_json()
+
+    assert msg["success"]
+    assert mock_search.call_args.kwargs["media_types"] == [MASSMediaType.ARTIST]
+    assert len(msg["result"]["result"]) == 5
+    assert all(item["media_class"] == "artist" for item in msg["result"]["result"])
 
 
 async def test_search_media_error(


### PR DESCRIPTION
## Proposed change

Music Assistant has been able to search since 2025.5, but its browse pages never told the media browser that, so the search box never appeared. Fixing that surfaced a few more things that were wrong in the search itself.

- Tell the media browser that the library, artist, album and playlist pages can be searched, so the search box shows up
- Scope a search to the page it was started from, so searching in Artists returns artists instead of a mix of everything
- Searching inside a playlist now looks through that playlist's tracks, instead of returning unrelated playlists
- Stop offering to open podcast search results, which ended in an error because podcast episodes cannot be browsed
- Offer albums and tracks as filters when searching an artist

Needs the linked frontend change to reach users.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: https://github.com/home-assistant/frontend/pull/53402

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
