### PR TITLE
Improve naming of Hue entertainment area sensors

### DIFF
--- a/homeassistant/components/hue/strings.json
+++ b/homeassistant/components/hue/strings.json
@@ -76,6 +76,11 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "entertainment_area": {
+        "name": "Entertainment area {area_name}"
+      }
+    },
     "event": {
       "button": {
         "name": "Button {button_id}",

--- a/homeassistant/components/hue/v2/binary_sensor.py
+++ b/homeassistant/components/hue/v2/binary_sensor.py
@@ -239,8 +239,21 @@ class HueEntertainmentActiveSensor(HueBaseEntity, BinarySensorEntity):
     resource: EntertainmentConfiguration
 
     entity_description = BinarySensorEntityDescription(
-        key="entertainment_active_sensor", device_class=BinarySensorDeviceClass.RUNNING
+        key="entertainment_active_sensor",
+        device_class=BinarySensorDeviceClass.RUNNING,
+        has_entity_name=True,
+        translation_key="entertainment_area",
     )
+
+    def __init__(
+        self,
+        bridge: HueBridge,
+        controller: EntertainmentConfigurationController,
+        resource: EntertainmentConfiguration,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(bridge, controller, resource)
+        self._attr_translation_placeholders = {"area_name": resource.metadata.name}
 
     @property
     @override
@@ -248,11 +261,14 @@ class HueEntertainmentActiveSensor(HueBaseEntity, BinarySensorEntity):
         """Return true if the binary sensor is on."""
         return self.resource.status == EntertainmentStatus.ACTIVE
 
-    @property
+    @callback
     @override
-    def name(self) -> str:
-        """Return sensor name."""
-        return self.resource.metadata.name
+    def on_update(self) -> None:
+        """Call on update event."""
+        self._attr_translation_placeholders = {"area_name": self.resource.metadata.name}
+        # the entity name is cached, invalidate it so a rename
+        # of the entertainment area in the Hue app is picked up
+        self.__dict__.pop("name", None)
 
 
 # pylint: disable-next=home-assistant-enforce-class-module

--- a/tests/components/hue/test_binary_sensor.py
+++ b/tests/components/hue/test_binary_sensor.py
@@ -29,10 +29,12 @@ async def test_binary_sensors(
     assert sensor.attributes["device_class"] == "motion"
 
     # test entertainment room active sensor
-    sensor = hass.states.get("binary_sensor.philips_hue_entertainmentroom_1")
+    sensor = hass.states.get(
+        "binary_sensor.philips_hue_entertainment_area_entertainmentroom_1"
+    )
     assert sensor is not None
     assert sensor.state == "off"
-    assert sensor.name == "Philips hue Entertainmentroom 1"
+    assert sensor.name == "Philips hue Entertainment area Entertainmentroom 1"
     assert sensor.attributes["device_class"] == "running"
 
     # test contact sensor
@@ -185,6 +187,46 @@ async def test_grouped_motion_sensor(
     await hass.async_block_till_done()
     sensor = hass.states.get("binary_sensor.sensor_group_motion")
     assert sensor.state == "unknown"
+
+
+async def test_entertainment_active_sensor(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test HueEntertainmentActiveSensor functionality."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+    await setup_platform(hass, mock_bridge_v2, Platform.BINARY_SENSOR)
+
+    test_entity_id = "binary_sensor.philips_hue_entertainment_area_entertainmentroom_1"
+    sensor = hass.states.get(test_entity_id)
+    assert sensor is not None
+    assert sensor.state == "off"
+
+    # test the sensor turns on once the entertainment area becomes active
+    mock_bridge_v2.api.emit_event(
+        "update",
+        {
+            "id": "c14cf1cf-6c7a-4984-b8bb-c5b71aeb70fc",
+            "type": "entertainment_configuration",
+            "status": "active",
+        },
+    )
+    await hass.async_block_till_done()
+    assert hass.states.get(test_entity_id).state == "on"
+
+    # test the name follows a rename of the entertainment area in the Hue app
+    mock_bridge_v2.api.emit_event(
+        "update",
+        {
+            "id": "c14cf1cf-6c7a-4984-b8bb-c5b71aeb70fc",
+            "type": "entertainment_configuration",
+            "metadata": {"name": "Entertainmentroom 2"},
+        },
+    )
+    await hass.async_block_till_done()
+    assert (
+        hass.states.get(test_entity_id).name
+        == "Philips hue Entertainment area Entertainmentroom 2"
+    )
 
 
 async def test_motion_aware_sensor(


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Entertainment areas show up as sensors on the Hue Bridge device to tell you if
they are streaming. Those sensors were named after the area only, for example
"Bedroom", which gives no clue about what the sensor actually is. It gets even
more confusing when the entertainment area has the same name as a room or zone.

- Entertainment area sensors are now named "Entertainment area <name>"
- That name is now translatable
- Existing entity IDs stay the same, only the displayed name changes
- Added tests for the entertainment area sensor

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
