### PR TITLE
Add UI config flow to Universal media player

### DIFF
--- a/homeassistant/components/universal/__init__.py
+++ b/homeassistant/components/universal/__init__.py
@@ -1,1 +1,19 @@
 """The universal component."""
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+
+DOMAIN = "universal"
+_PLATFORMS = (Platform.MEDIA_PLAYER,)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Set up Universal media player from a config entry."""
+    await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Unload a Universal media player config entry."""
+    return await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaConfigFlowHandler,
     SchemaFlowFormStep,
 )
+from homeassistant.helpers.template import Template
 
 from .media_player import (
     CONF_ACTIVE_CHILD_TEMPLATE,
@@ -136,6 +137,23 @@ OPTIONS_FLOW = {
 }
 
 
+def _flatten_templates(value: Any) -> Any:
+    """Recursively convert Template objects back to their raw template text.
+
+    CMD_SCHEMA (via cv.SERVICE_SCHEMA) compiles any templated `data`/`target`
+    values within a YAML command into Template objects, which config entry
+    storage (JSON) can't hold; media_player.async_setup_entry recompiles them
+    when constructing the entity.
+    """
+    if isinstance(value, Template):
+        return value.template
+    if isinstance(value, list):
+        return [_flatten_templates(item) for item in value]
+    if isinstance(value, dict):
+        return {key: _flatten_templates(item) for key, item in value.items()}
+    return value
+
+
 class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a Universal media player config and options flow."""
 
@@ -164,8 +182,12 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
             # Preserve JSON-serialisable advanced options so they survive the
             # round-trip through config entry storage unchanged.
             CONF_BROWSE_MEDIA_ENTITY: import_data.get(CONF_BROWSE_MEDIA_ENTITY),
-            CONF_DEVICE_CLASS: import_data.get(CONF_DEVICE_CLASS),
         }
+        # DEVICE_CLASSES_SCHEMA coerces this to a MediaPlayerDeviceClass
+        # (StrEnum); unwrap to a plain string since config entry storage is
+        # JSON and StrEnum members are not accepted by the JSON encoder.
+        if device_class := import_data.get(CONF_DEVICE_CLASS):
+            options[CONF_DEVICE_CLASS] = device_class.value
 
         # Templates are cv.template-validated Template objects at this point;
         # store the raw template text, matching what TemplateSelector returns.
@@ -182,7 +204,9 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
         options[CONF_ATTRS] = raw_attrs
 
         for cmd in EXPOSED_COMMANDS:
-            options[cmd] = [yaml_commands[cmd]] if cmd in yaml_commands else []
+            options[cmd] = (
+                [_flatten_templates(yaml_commands[cmd])] if cmd in yaml_commands else []
+            )
 
         _LOGGER.warning(
             (

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -222,10 +222,9 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
         _LOGGER.warning(
             (
-                "Universal media player '%s' is configured via YAML, which is "
-                "deprecated. Remove it from your configuration.yaml and recreate "
-                "it through the UI (Settings → Devices & services → Add integration "
-                "→ Universal media player)"
+                "Universal media player '%s' has been migrated from YAML to a "
+                "config entry. Remove it from your configuration.yaml; you can "
+                "now manage it from Settings → Devices & services"
             ),
             import_data[CONF_NAME],
         )

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -1,15 +1,13 @@
 """Config flow for the Universal media player integration."""
 
-from __future__ import annotations
-
-import logging
 from collections.abc import Mapping
-from typing import Any
+import logging
+from typing import Any, override
 
 import voluptuous as vol
 
 from homeassistant.components.media_player import SERVICE_SELECT_SOURCE
-from homeassistant.config_entries import ConfigFlowResult, SOURCE_IMPORT
+from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import (
     CONF_NAME,
     SERVICE_TURN_OFF,
@@ -25,7 +23,12 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaFlowFormStep,
 )
 
-from .media_player import CONF_ATTRS, CONF_BROWSE_MEDIA_ENTITY, CONF_CHILDREN, CONF_COMMANDS
+from .media_player import (
+    CONF_ATTRS,
+    CONF_BROWSE_MEDIA_ENTITY,
+    CONF_CHILDREN,
+    CONF_COMMANDS,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -98,15 +101,16 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
 
+    @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return options[CONF_NAME]
 
-    async def async_step_import(
-        self, import_data: dict[str, Any]
-    ) -> ConfigFlowResult:
+    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
         """Import a Universal media player from YAML configuration."""
-        unique_id: str = import_data.get("unique_id") or f"yaml_{import_data[CONF_NAME]}"
+        unique_id: str = (
+            import_data.get("unique_id") or f"yaml_{import_data[CONF_NAME]}"
+        )
         await self.async_set_unique_id(unique_id)
         self._abort_if_unique_id_configured()
 
@@ -137,7 +141,7 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
                 "Universal media player '%s' is configured via YAML, which is "
                 "deprecated. Remove it from your configuration.yaml and recreate "
                 "it through the UI (Settings → Devices & services → Add integration "
-                "→ Universal media player)."
+                "→ Universal media player)"
             ),
             import_data[CONF_NAME],
         )

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -6,16 +6,9 @@ from typing import Any, override
 
 import voluptuous as vol
 
-from homeassistant.components.media_player import SERVICE_SELECT_SOURCE
+from homeassistant.components.media_player import DEVICE_CLASSES
 from homeassistant.config_entries import ConfigFlowResult
-from homeassistant.const import (
-    CONF_NAME,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    SERVICE_VOLUME_DOWN,
-    SERVICE_VOLUME_MUTE,
-    SERVICE_VOLUME_UP,
-)
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_STATE_TEMPLATE
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
     SchemaCommonFlowHandler,
@@ -24,29 +17,24 @@ from homeassistant.helpers.schema_config_entry_flow import (
 )
 
 from .media_player import (
+    CONF_ACTIVE_CHILD_TEMPLATE,
     CONF_ATTRS,
     CONF_BROWSE_MEDIA_ENTITY,
     CONF_CHILDREN,
     CONF_COMMANDS,
+    EXPOSED_ATTRIBUTES,
+    EXPOSED_COMMANDS,
 )
 
 _LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "universal"
 
-EXPOSED_COMMANDS = (
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    SERVICE_VOLUME_UP,
-    SERVICE_VOLUME_DOWN,
-    SERVICE_VOLUME_MUTE,
-    SERVICE_SELECT_SOURCE,
-)
-
 _CHILDREN_SELECTOR = selector.EntitySelector(
     selector.EntitySelectorConfig(domain="media_player", multiple=True)
 )
 _ACTION_SELECTOR = selector.ActionSelector()
+_ATTRIBUTE_SELECTOR = selector.TextSelector()
 
 _CONFIG_BASIC_SCHEMA = vol.Schema(
     {
@@ -56,13 +44,28 @@ _CONFIG_BASIC_SCHEMA = vol.Schema(
 )
 
 _COMMANDS_SCHEMA = vol.Schema(
+    {vol.Optional(cmd): _ACTION_SELECTOR for cmd in EXPOSED_COMMANDS}
+)
+
+_ATTRIBUTES_SCHEMA = vol.Schema(
+    {vol.Optional(attr): _ATTRIBUTE_SELECTOR for attr in EXPOSED_ATTRIBUTES}
+)
+
+_ADVANCED_SCHEMA = vol.Schema(
     {
-        vol.Optional(SERVICE_TURN_ON): _ACTION_SELECTOR,
-        vol.Optional(SERVICE_TURN_OFF): _ACTION_SELECTOR,
-        vol.Optional(SERVICE_VOLUME_UP): _ACTION_SELECTOR,
-        vol.Optional(SERVICE_VOLUME_DOWN): _ACTION_SELECTOR,
-        vol.Optional(SERVICE_VOLUME_MUTE): _ACTION_SELECTOR,
-        vol.Optional(SERVICE_SELECT_SOURCE): _ACTION_SELECTOR,
+        vol.Optional(CONF_DEVICE_CLASS): selector.SelectSelector(
+            selector.SelectSelectorConfig(
+                options=DEVICE_CLASSES,
+                mode=selector.SelectSelectorMode.DROPDOWN,
+                translation_key="device_class",
+                sort=True,
+            )
+        ),
+        vol.Optional(CONF_BROWSE_MEDIA_ENTITY): selector.EntitySelector(
+            selector.EntitySelectorConfig(domain="media_player")
+        ),
+        vol.Optional(CONF_ACTIVE_CHILD_TEMPLATE): selector.TemplateSelector(),
+        vol.Optional(CONF_STATE_TEMPLATE): selector.TemplateSelector(),
     }
 )
 
@@ -80,18 +83,56 @@ async def _validate_commands(
     return {cmd: user_input.get(cmd, []) for cmd in EXPOSED_COMMANDS}
 
 
+async def _attributes_suggested_values(
+    handler: SchemaCommonFlowHandler,
+) -> dict[str, Any]:
+    """Flatten the stored attribute overrides for form pre-population."""
+    return dict(handler.options.get(CONF_ATTRS, {}))
+
+
+async def _validate_attributes(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Merge attribute overrides, preserving any YAML-only keys not exposed here."""
+    attrs: dict[str, Any] = dict(handler.options.get(CONF_ATTRS, {}))
+    for attr in EXPOSED_ATTRIBUTES:
+        if user_input.get(attr):
+            attrs[attr] = user_input[attr]
+        else:
+            attrs.pop(attr, None)
+    return {CONF_ATTRS: attrs}
+
+
 CONFIG_FLOW = {
     "user": SchemaFlowFormStep(_CONFIG_BASIC_SCHEMA, next_step="commands"),
     "commands": SchemaFlowFormStep(
-        _COMMANDS_SCHEMA, validate_user_input=_validate_commands
+        _COMMANDS_SCHEMA,
+        next_step="attributes",
+        validate_user_input=_validate_commands,
     ),
+    "attributes": SchemaFlowFormStep(
+        _ATTRIBUTES_SCHEMA,
+        next_step="advanced",
+        validate_user_input=_validate_attributes,
+        suggested_values=_attributes_suggested_values,
+    ),
+    "advanced": SchemaFlowFormStep(_ADVANCED_SCHEMA),
 }
 
 OPTIONS_FLOW = {
     "init": SchemaFlowFormStep(_OPTIONS_BASIC_SCHEMA, next_step="commands"),
     "commands": SchemaFlowFormStep(
-        _COMMANDS_SCHEMA, validate_user_input=_validate_commands
+        _COMMANDS_SCHEMA,
+        next_step="attributes",
+        validate_user_input=_validate_commands,
     ),
+    "attributes": SchemaFlowFormStep(
+        _ATTRIBUTES_SCHEMA,
+        next_step="advanced",
+        validate_user_input=_validate_attributes,
+        suggested_values=_attributes_suggested_values,
+    ),
+    "advanced": SchemaFlowFormStep(_ADVANCED_SCHEMA),
 }
 
 
@@ -123,7 +164,14 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
             # Preserve JSON-serialisable advanced options so they survive the
             # round-trip through config entry storage unchanged.
             CONF_BROWSE_MEDIA_ENTITY: import_data.get(CONF_BROWSE_MEDIA_ENTITY),
+            CONF_DEVICE_CLASS: import_data.get(CONF_DEVICE_CLASS),
         }
+
+        # Templates are cv.template-validated Template objects at this point;
+        # store the raw template text, matching what TemplateSelector returns.
+        for template_key in (CONF_ACTIVE_CHILD_TEMPLATE, CONF_STATE_TEMPLATE):
+            if template := import_data.get(template_key):
+                options[template_key] = template.template
 
         raw_attrs = import_data.get(CONF_ATTRS, {})
         if isinstance(raw_attrs, list):

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -1,13 +1,11 @@
 """Config flow for the Universal media player integration."""
 
 from collections.abc import Mapping
-import logging
 from typing import Any, override
 
 import voluptuous as vol
 
 from homeassistant.components.media_player import DEVICE_CLASSES
-from homeassistant.config_entries import ConfigFlowResult
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_STATE_TEMPLATE
 from homeassistant.helpers import selector
 from homeassistant.helpers.schema_config_entry_flow import (
@@ -15,19 +13,15 @@ from homeassistant.helpers.schema_config_entry_flow import (
     SchemaConfigFlowHandler,
     SchemaFlowFormStep,
 )
-from homeassistant.helpers.template import Template
 
 from .media_player import (
     CONF_ACTIVE_CHILD_TEMPLATE,
     CONF_ATTRS,
     CONF_BROWSE_MEDIA_ENTITY,
     CONF_CHILDREN,
-    CONF_COMMANDS,
     EXPOSED_ATTRIBUTES,
     EXPOSED_COMMANDS,
 )
-
-_LOGGER = logging.getLogger(__name__)
 
 DOMAIN = "universal"
 
@@ -94,14 +88,20 @@ async def _attributes_suggested_values(
 async def _validate_attributes(
     handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
 ) -> dict[str, Any]:
-    """Merge attribute overrides, preserving any YAML-only keys not exposed here."""
-    attrs: dict[str, Any] = dict(handler.options.get(CONF_ATTRS, {}))
-    for attr in EXPOSED_ATTRIBUTES:
-        if user_input.get(attr):
-            attrs[attr] = user_input[attr]
-        else:
-            attrs.pop(attr, None)
-    return {CONF_ATTRS: attrs}
+    """Normalise attribute inputs, omitting blank fields so clearing works.
+
+    Unlike commands (where an empty list cleanly means "not configured"),
+    an empty string can't be stored as a value here: media_player.py's
+    attrs parser does `value.split("|", 1)` unconditionally, so "" would be
+    treated as an override pointing at entity_id "" instead of being absent.
+    """
+    return {
+        CONF_ATTRS: {
+            attr: user_input[attr]
+            for attr in EXPOSED_ATTRIBUTES
+            if user_input.get(attr)
+        }
+    }
 
 
 CONFIG_FLOW = {
@@ -137,23 +137,6 @@ OPTIONS_FLOW = {
 }
 
 
-def _flatten_templates(value: Any) -> Any:
-    """Recursively convert Template objects back to their raw template text.
-
-    CMD_SCHEMA (via cv.SERVICE_SCHEMA) compiles any templated `data`/`target`
-    values within a YAML command into Template objects, which config entry
-    storage (JSON) can't hold; media_player.async_setup_entry recompiles them
-    when constructing the entity.
-    """
-    if isinstance(value, Template):
-        return value.template
-    if isinstance(value, list):
-        return [_flatten_templates(item) for item in value]
-    if isinstance(value, dict):
-        return {key: _flatten_templates(item) for key, item in value.items()}
-    return value
-
-
 class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     """Handle a Universal media player config and options flow."""
 
@@ -165,68 +148,3 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
         """Return config entry title."""
         return options[CONF_NAME]
-
-    async def async_step_import(self, import_data: dict[str, Any]) -> ConfigFlowResult:
-        """Import a Universal media player from YAML configuration."""
-        unique_id: str = (
-            import_data.get("unique_id") or f"yaml_{import_data[CONF_NAME]}"
-        )
-        await self.async_set_unique_id(unique_id)
-        self._abort_if_unique_id_configured()
-
-        # Commands in YAML are single service-call dicts; wrap in a list to
-        # match the ActionSelector storage format used by the UI flow.
-        yaml_commands: dict[str, Any] = import_data.get(CONF_COMMANDS, {})
-        options: dict[str, Any] = {
-            CONF_NAME: import_data[CONF_NAME],
-            CONF_CHILDREN: import_data.get(CONF_CHILDREN, []),
-            # Preserve JSON-serialisable advanced options so they survive the
-            # round-trip through config entry storage unchanged.
-            CONF_BROWSE_MEDIA_ENTITY: import_data.get(CONF_BROWSE_MEDIA_ENTITY),
-        }
-        # DEVICE_CLASSES_SCHEMA coerces this to a MediaPlayerDeviceClass
-        # (StrEnum); unwrap to a plain string since config entry storage is
-        # JSON and StrEnum members are not accepted by the JSON encoder.
-        if device_class := import_data.get(CONF_DEVICE_CLASS):
-            options[CONF_DEVICE_CLASS] = device_class.value
-
-        # Templates are cv.template-validated Template objects at this point;
-        # store the raw template text, matching what TemplateSelector returns.
-        for template_key in (CONF_ACTIVE_CHILD_TEMPLATE, CONF_STATE_TEMPLATE):
-            if template := import_data.get(template_key):
-                options[template_key] = template.template
-
-        raw_attrs = import_data.get(CONF_ATTRS, {})
-        if isinstance(raw_attrs, list):
-            merged: dict[str, str] = {}
-            for item in raw_attrs:
-                merged.update(item)
-            raw_attrs = merged
-        options[CONF_ATTRS] = raw_attrs
-
-        for cmd in EXPOSED_COMMANDS:
-            options[cmd] = (
-                [_flatten_templates(yaml_commands[cmd])] if cmd in yaml_commands else []
-            )
-
-        # YAML commands accept arbitrary slug keys (play_media, toggle,
-        # repeat_set, shuffle_set, clear_playlist, etc.), not just
-        # EXPOSED_COMMANDS; preserve anything outside that bounded list so
-        # migration doesn't silently turn them into delegation to the active
-        # child.
-        options[CONF_COMMANDS] = {
-            cmd: _flatten_templates(action)
-            for cmd, action in yaml_commands.items()
-            if cmd not in EXPOSED_COMMANDS
-        }
-
-        _LOGGER.warning(
-            (
-                "Universal media player '%s' has been migrated from YAML to a "
-                "config entry. Remove it from your configuration.yaml; you can "
-                "now manage it from Settings → Devices & services"
-            ),
-            import_data[CONF_NAME],
-        )
-
-        return self.async_create_entry(data=options)

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -159,6 +159,7 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
 
     config_flow = CONFIG_FLOW
     options_flow = OPTIONS_FLOW
+    options_flow_reloads = True
 
     @override
     def async_config_entry_title(self, options: Mapping[str, Any]) -> str:

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -1,0 +1,145 @@
+"""Config flow for the Universal media player integration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components.media_player import SERVICE_SELECT_SOURCE
+from homeassistant.config_entries import ConfigFlowResult, SOURCE_IMPORT
+from homeassistant.const import (
+    CONF_NAME,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_UP,
+)
+from homeassistant.helpers import selector
+from homeassistant.helpers.schema_config_entry_flow import (
+    SchemaCommonFlowHandler,
+    SchemaConfigFlowHandler,
+    SchemaFlowFormStep,
+)
+
+from .media_player import CONF_ATTRS, CONF_BROWSE_MEDIA_ENTITY, CONF_CHILDREN, CONF_COMMANDS
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "universal"
+
+EXPOSED_COMMANDS = (
+    SERVICE_TURN_ON,
+    SERVICE_TURN_OFF,
+    SERVICE_VOLUME_UP,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_SELECT_SOURCE,
+)
+
+_CHILDREN_SELECTOR = selector.EntitySelector(
+    selector.EntitySelectorConfig(domain="media_player", multiple=True)
+)
+_ACTION_SELECTOR = selector.ActionSelector()
+
+_CONFIG_BASIC_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_NAME): selector.TextSelector(),
+        vol.Optional(CONF_CHILDREN, default=[]): _CHILDREN_SELECTOR,
+    }
+)
+
+_COMMANDS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(SERVICE_TURN_ON): _ACTION_SELECTOR,
+        vol.Optional(SERVICE_TURN_OFF): _ACTION_SELECTOR,
+        vol.Optional(SERVICE_VOLUME_UP): _ACTION_SELECTOR,
+        vol.Optional(SERVICE_VOLUME_DOWN): _ACTION_SELECTOR,
+        vol.Optional(SERVICE_VOLUME_MUTE): _ACTION_SELECTOR,
+        vol.Optional(SERVICE_SELECT_SOURCE): _ACTION_SELECTOR,
+    }
+)
+
+_OPTIONS_BASIC_SCHEMA = vol.Schema(
+    {
+        vol.Optional(CONF_CHILDREN, default=[]): _CHILDREN_SELECTOR,
+    }
+)
+
+
+async def _validate_commands(
+    handler: SchemaCommonFlowHandler, user_input: dict[str, Any]
+) -> dict[str, Any]:
+    """Normalise command inputs; always write all keys so clearing works."""
+    return {cmd: user_input.get(cmd, []) for cmd in EXPOSED_COMMANDS}
+
+
+CONFIG_FLOW = {
+    "user": SchemaFlowFormStep(_CONFIG_BASIC_SCHEMA, next_step="commands"),
+    "commands": SchemaFlowFormStep(
+        _COMMANDS_SCHEMA, validate_user_input=_validate_commands
+    ),
+}
+
+OPTIONS_FLOW = {
+    "init": SchemaFlowFormStep(_OPTIONS_BASIC_SCHEMA, next_step="commands"),
+    "commands": SchemaFlowFormStep(
+        _COMMANDS_SCHEMA, validate_user_input=_validate_commands
+    ),
+}
+
+
+class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
+    """Handle a Universal media player config and options flow."""
+
+    config_flow = CONFIG_FLOW
+    options_flow = OPTIONS_FLOW
+
+    def async_config_entry_title(self, options: Mapping[str, Any]) -> str:
+        """Return config entry title."""
+        return options[CONF_NAME]
+
+    async def async_step_import(
+        self, import_data: dict[str, Any]
+    ) -> ConfigFlowResult:
+        """Import a Universal media player from YAML configuration."""
+        unique_id: str = import_data.get("unique_id") or f"yaml_{import_data[CONF_NAME]}"
+        await self.async_set_unique_id(unique_id)
+        self._abort_if_unique_id_configured()
+
+        # Commands in YAML are single service-call dicts; wrap in a list to
+        # match the ActionSelector storage format used by the UI flow.
+        yaml_commands: dict[str, Any] = import_data.get(CONF_COMMANDS, {})
+        options: dict[str, Any] = {
+            CONF_NAME: import_data[CONF_NAME],
+            CONF_CHILDREN: import_data.get(CONF_CHILDREN, []),
+            # Preserve JSON-serialisable advanced options so they survive the
+            # round-trip through config entry storage unchanged.
+            CONF_BROWSE_MEDIA_ENTITY: import_data.get(CONF_BROWSE_MEDIA_ENTITY),
+        }
+
+        raw_attrs = import_data.get(CONF_ATTRS, {})
+        if isinstance(raw_attrs, list):
+            merged: dict[str, str] = {}
+            for item in raw_attrs:
+                merged.update(item)
+            raw_attrs = merged
+        options[CONF_ATTRS] = raw_attrs
+
+        for cmd in EXPOSED_COMMANDS:
+            options[cmd] = [yaml_commands[cmd]] if cmd in yaml_commands else []
+
+        _LOGGER.warning(
+            (
+                "Universal media player '%s' is configured via YAML, which is "
+                "deprecated. Remove it from your configuration.yaml and recreate "
+                "it through the UI (Settings → Devices & services → Add integration "
+                "→ Universal media player)."
+            ),
+            import_data[CONF_NAME],
+        )
+
+        return self.async_create_entry(data=options)

--- a/homeassistant/components/universal/config_flow.py
+++ b/homeassistant/components/universal/config_flow.py
@@ -209,6 +209,17 @@ class UniversalFlowHandler(SchemaConfigFlowHandler, domain=DOMAIN):
                 [_flatten_templates(yaml_commands[cmd])] if cmd in yaml_commands else []
             )
 
+        # YAML commands accept arbitrary slug keys (play_media, toggle,
+        # repeat_set, shuffle_set, clear_playlist, etc.), not just
+        # EXPOSED_COMMANDS; preserve anything outside that bounded list so
+        # migration doesn't silently turn them into delegation to the active
+        # child.
+        options[CONF_COMMANDS] = {
+            cmd: _flatten_templates(action)
+            for cmd, action in yaml_commands.items()
+            if cmd not in EXPOSED_COMMANDS
+        }
+
         _LOGGER.warning(
             (
                 "Universal media player '%s' is configured via YAML, which is "

--- a/homeassistant/components/universal/manifest.json
+++ b/homeassistant/components/universal/manifest.json
@@ -2,6 +2,7 @@
   "domain": "universal",
   "name": "Universal media player",
   "codeowners": [],
+  "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/universal",
   "iot_class": "calculated",
   "quality_scale": "internal"

--- a/homeassistant/components/universal/manifest.json
+++ b/homeassistant/components/universal/manifest.json
@@ -4,6 +4,7 @@
   "codeowners": [],
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/universal",
+  "integration_type": "helper",
   "iot_class": "calculated",
   "quality_scale": "internal"
 }

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -1,6 +1,7 @@
 """Combination of multiple media players for a universal controller."""
 
 from copy import copy
+import logging
 from typing import Any, override
 
 import voluptuous as vol
@@ -33,6 +34,7 @@ from homeassistant.components.media_player import (
     MediaType,
     RepeatMode,
 )
+from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_CLASS,
@@ -67,7 +69,10 @@ from homeassistant.core import Event, EventStateChangedData, HomeAssistant, call
 from homeassistant.exceptions import TemplateError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity_component import EntityComponent
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    AddEntitiesCallback,
+)
 from homeassistant.helpers.event import (
     TrackTemplate,
     TrackTemplateResult,
@@ -77,6 +82,10 @@ from homeassistant.helpers.event import (
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.service import async_call_from_config
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
+
+_LOGGER = logging.getLogger(__name__)
+
+DOMAIN = "universal"
 
 ATTR_ACTIVE_CHILD = "active_child"
 
@@ -129,10 +138,70 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the universal media players."""
-    await async_setup_reload_service(hass, "universal", [Platform.MEDIA_PLAYER])
+    if config.get(CONF_UNIQUE_ID):
+        # Migrate YAML entries that carry a unique_id to a config entry so they
+        # become manageable via the UI.  The entity is created by async_setup_entry
+        # once the import flow completes; return early to avoid a duplicate.
+        hass.async_create_task(
+            hass.config_entries.flow.async_init(
+                DOMAIN,
+                context={"source": SOURCE_IMPORT},
+                data=config,
+            )
+        )
+        return
 
-    player = UniversalMediaPlayer(hass, config)
-    async_add_entities([player])
+    await async_setup_reload_service(hass, DOMAIN, [Platform.MEDIA_PLAYER])
+    async_add_entities([UniversalMediaPlayer(hass, config)])
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up Universal media player from a config entry."""
+    options = config_entry.options
+
+    # ActionSelector stores actions as lists; unwrap to the single service-call
+    # dict that async_call_from_config expects.  Empty lists mean the command
+    # was not configured and should be omitted from the commands dict entirely.
+    commands: dict[str, Any] = {}
+    for cmd in (
+        SERVICE_TURN_ON,
+        SERVICE_TURN_OFF,
+        SERVICE_VOLUME_UP,
+        SERVICE_VOLUME_DOWN,
+        SERVICE_VOLUME_MUTE,
+        SERVICE_SELECT_SOURCE,
+    ):
+        actions = options.get(cmd, [])
+        if isinstance(actions, list) and actions:
+            commands[cmd] = actions[0]
+        elif isinstance(actions, dict):
+            # Preserved from a YAML import that stored a raw service-call dict.
+            commands[cmd] = actions
+
+    raw_attrs = options.get(CONF_ATTRS, {})
+    if isinstance(raw_attrs, list):
+        merged: dict[str, str] = {}
+        for item in raw_attrs:
+            merged.update(item)
+        raw_attrs = merged
+
+    config: ConfigType = {
+        CONF_NAME: config_entry.title,
+        CONF_CHILDREN: options.get(CONF_CHILDREN, []),
+        CONF_COMMANDS: commands,
+        CONF_ATTRS: raw_attrs,
+        CONF_UNIQUE_ID: config_entry.entry_id,
+        CONF_BROWSE_MEDIA_ENTITY: options.get(CONF_BROWSE_MEDIA_ENTITY),
+        CONF_DEVICE_CLASS: options.get(CONF_DEVICE_CLASS),
+        CONF_ACTIVE_CHILD_TEMPLATE: options.get(CONF_ACTIVE_CHILD_TEMPLATE),
+        CONF_STATE_TEMPLATE: options.get(CONF_STATE_TEMPLATE),
+    }
+
+    async_add_entities([UniversalMediaPlayer(hass, config)])
 
 
 class UniversalMediaPlayer(MediaPlayerEntity):

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -81,6 +81,7 @@ from homeassistant.helpers.event import (
 )
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.service import async_call_from_config
+from homeassistant.helpers.template import Template
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 _LOGGER = logging.getLogger(__name__)
@@ -94,6 +95,35 @@ CONF_ATTRS = "attributes"
 CONF_CHILDREN = "children"
 CONF_COMMANDS = "commands"
 CONF_BROWSE_MEDIA_ENTITY = "browse_media_entity"
+
+# Config/options flow commands and attributes exposed via ActionSelector/
+# TextSelector fields; kept here (rather than in config_flow.py) so
+# async_setup_entry can share the same list without a circular import.
+EXPOSED_COMMANDS = (
+    SERVICE_TURN_ON,
+    SERVICE_TURN_OFF,
+    SERVICE_VOLUME_UP,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_SET,
+    SERVICE_SELECT_SOURCE,
+    SERVICE_SELECT_SOUND_MODE,
+    SERVICE_MEDIA_PLAY,
+    SERVICE_MEDIA_PAUSE,
+    SERVICE_MEDIA_STOP,
+    SERVICE_MEDIA_NEXT_TRACK,
+    SERVICE_MEDIA_PREVIOUS_TRACK,
+)
+
+EXPOSED_ATTRIBUTES = (
+    "state",
+    "is_volume_muted",
+    "volume_level",
+    "source",
+    "source_list",
+    "sound_mode",
+    "sound_mode_list",
+)
 
 STATES_ORDER = [
     STATE_UNKNOWN,
@@ -167,14 +197,7 @@ async def async_setup_entry(
     # dict that async_call_from_config expects.  Empty lists mean the command
     # was not configured and should be omitted from the commands dict entirely.
     commands: dict[str, Any] = {}
-    for cmd in (
-        SERVICE_TURN_ON,
-        SERVICE_TURN_OFF,
-        SERVICE_VOLUME_UP,
-        SERVICE_VOLUME_DOWN,
-        SERVICE_VOLUME_MUTE,
-        SERVICE_SELECT_SOURCE,
-    ):
+    for cmd in EXPOSED_COMMANDS:
         actions = options.get(cmd, [])
         if isinstance(actions, list) and actions:
             commands[cmd] = actions[0]
@@ -189,6 +212,15 @@ async def async_setup_entry(
             merged.update(item)
         raw_attrs = merged
 
+    # TemplateSelector (and YAML import) store templates as raw strings;
+    # compile them here since UniversalMediaPlayer expects Template objects.
+    active_child_template = None
+    if raw_template := options.get(CONF_ACTIVE_CHILD_TEMPLATE):
+        active_child_template = Template(raw_template, hass)
+    state_template = None
+    if raw_template := options.get(CONF_STATE_TEMPLATE):
+        state_template = Template(raw_template, hass)
+
     config: ConfigType = {
         CONF_NAME: config_entry.title,
         CONF_CHILDREN: options.get(CONF_CHILDREN, []),
@@ -200,8 +232,8 @@ async def async_setup_entry(
         CONF_UNIQUE_ID: config_entry.unique_id or config_entry.entry_id,
         CONF_BROWSE_MEDIA_ENTITY: options.get(CONF_BROWSE_MEDIA_ENTITY),
         CONF_DEVICE_CLASS: options.get(CONF_DEVICE_CLASS),
-        CONF_ACTIVE_CHILD_TEMPLATE: options.get(CONF_ACTIVE_CHILD_TEMPLATE),
-        CONF_STATE_TEMPLATE: options.get(CONF_STATE_TEMPLATE),
+        CONF_ACTIVE_CHILD_TEMPLATE: active_child_template,
+        CONF_STATE_TEMPLATE: state_template,
     }
 
     async_add_entities([UniversalMediaPlayer(hass, config)])

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -34,7 +34,7 @@ from homeassistant.components.media_player import (
     MediaType,
     RepeatMode,
 )
-from homeassistant.config_entries import SOURCE_IMPORT, ConfigEntry
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     CONF_DEVICE_CLASS,
@@ -168,19 +168,6 @@ async def async_setup_platform(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> None:
     """Set up the universal media players."""
-    if config.get(CONF_UNIQUE_ID):
-        # Migrate YAML entries that carry a unique_id to a config entry so they
-        # become manageable via the UI.  The entity is created by async_setup_entry
-        # once the import flow completes; return early to avoid a duplicate.
-        hass.async_create_task(
-            hass.config_entries.flow.async_init(
-                DOMAIN,
-                context={"source": SOURCE_IMPORT},
-                data=config,
-            )
-        )
-        return
-
     await async_setup_reload_service(hass, DOMAIN, [Platform.MEDIA_PLAYER])
     async_add_entities([UniversalMediaPlayer(hass, config)])
 
@@ -197,34 +184,18 @@ async def async_setup_entry(
     # dict that async_call_from_config expects.  Empty lists mean the command
     # was not configured and should be omitted from the commands dict entirely.
     # Re-validate through SERVICE_SCHEMA to compile any templated data/target
-    # values back into Template objects: config entry storage is JSON, so
-    # both the UI and YAML-import paths only ever persist raw strings, but
-    # _async_call_service calls async_call_from_config with
-    # validate_config=False and expects templates pre-compiled.
+    # values back into Template objects: config entry storage is JSON and can
+    # only ever hold raw strings, but _async_call_service calls
+    # async_call_from_config with validate_config=False and expects templates
+    # pre-compiled.
     commands: dict[str, Any] = {}
     for cmd in EXPOSED_COMMANDS:
         actions = options.get(cmd, [])
         if isinstance(actions, list) and actions:
             commands[cmd] = cv.SERVICE_SCHEMA(actions[0])
-        elif isinstance(actions, dict):
-            # Preserved from a YAML import that stored a raw service-call dict.
-            commands[cmd] = cv.SERVICE_SCHEMA(actions)
 
-    # Commands outside EXPOSED_COMMANDS (play_media, toggle, repeat_set, etc.)
-    # are preserved by the YAML import under CONF_COMMANDS instead of a flat
-    # per-command key, since they don't have a UI field of their own.
-    for cmd, action in options.get(CONF_COMMANDS, {}).items():
-        commands[cmd] = cv.SERVICE_SCHEMA(action)
-
-    raw_attrs = options.get(CONF_ATTRS, {})
-    if isinstance(raw_attrs, list):
-        merged: dict[str, str] = {}
-        for item in raw_attrs:
-            merged.update(item)
-        raw_attrs = merged
-
-    # TemplateSelector (and YAML import) store templates as raw strings;
-    # compile them here since UniversalMediaPlayer expects Template objects.
+    # TemplateSelector stores templates as raw strings; compile them here
+    # since UniversalMediaPlayer expects Template objects.
     active_child_template = None
     if raw_template := options.get(CONF_ACTIVE_CHILD_TEMPLATE):
         active_child_template = Template(raw_template, hass)
@@ -236,11 +207,8 @@ async def async_setup_entry(
         CONF_NAME: config_entry.title,
         CONF_CHILDREN: options.get(CONF_CHILDREN, []),
         CONF_COMMANDS: commands,
-        CONF_ATTRS: raw_attrs,
-        # Entries imported from YAML keep their original unique_id so the
-        # entity registry entry (and any user customisations) survive the
-        # migration; UI-created entries fall back to the entry_id.
-        CONF_UNIQUE_ID: config_entry.unique_id or config_entry.entry_id,
+        CONF_ATTRS: options.get(CONF_ATTRS, {}),
+        CONF_UNIQUE_ID: config_entry.entry_id,
         CONF_BROWSE_MEDIA_ENTITY: options.get(CONF_BROWSE_MEDIA_ENTITY),
         CONF_DEVICE_CLASS: options.get(CONF_DEVICE_CLASS),
         CONF_ACTIVE_CHILD_TEMPLATE: active_child_template,

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -194,7 +194,10 @@ async def async_setup_entry(
         CONF_CHILDREN: options.get(CONF_CHILDREN, []),
         CONF_COMMANDS: commands,
         CONF_ATTRS: raw_attrs,
-        CONF_UNIQUE_ID: config_entry.entry_id,
+        # Entries imported from YAML keep their original unique_id so the
+        # entity registry entry (and any user customisations) survive the
+        # migration; UI-created entries fall back to the entry_id.
+        CONF_UNIQUE_ID: config_entry.unique_id or config_entry.entry_id,
         CONF_BROWSE_MEDIA_ENTITY: options.get(CONF_BROWSE_MEDIA_ENTITY),
         CONF_DEVICE_CLASS: options.get(CONF_DEVICE_CLASS),
         CONF_ACTIVE_CHILD_TEMPLATE: options.get(CONF_ACTIVE_CHILD_TEMPLATE),

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -210,6 +210,12 @@ async def async_setup_entry(
             # Preserved from a YAML import that stored a raw service-call dict.
             commands[cmd] = cv.SERVICE_SCHEMA(actions)
 
+    # Commands outside EXPOSED_COMMANDS (play_media, toggle, repeat_set, etc.)
+    # are preserved by the YAML import under CONF_COMMANDS instead of a flat
+    # per-command key, since they don't have a UI field of their own.
+    for cmd, action in options.get(CONF_COMMANDS, {}).items():
+        commands[cmd] = cv.SERVICE_SCHEMA(action)
+
     raw_attrs = options.get(CONF_ATTRS, {})
     if isinstance(raw_attrs, list):
         merged: dict[str, str] = {}

--- a/homeassistant/components/universal/media_player.py
+++ b/homeassistant/components/universal/media_player.py
@@ -196,14 +196,19 @@ async def async_setup_entry(
     # ActionSelector stores actions as lists; unwrap to the single service-call
     # dict that async_call_from_config expects.  Empty lists mean the command
     # was not configured and should be omitted from the commands dict entirely.
+    # Re-validate through SERVICE_SCHEMA to compile any templated data/target
+    # values back into Template objects: config entry storage is JSON, so
+    # both the UI and YAML-import paths only ever persist raw strings, but
+    # _async_call_service calls async_call_from_config with
+    # validate_config=False and expects templates pre-compiled.
     commands: dict[str, Any] = {}
     for cmd in EXPOSED_COMMANDS:
         actions = options.get(cmd, [])
         if isinstance(actions, list) and actions:
-            commands[cmd] = actions[0]
+            commands[cmd] = cv.SERVICE_SCHEMA(actions[0])
         elif isinstance(actions, dict):
             # Preserved from a YAML import that stored a raw service-call dict.
-            commands[cmd] = actions
+            commands[cmd] = cv.SERVICE_SCHEMA(actions)
 
     raw_attrs = options.get(CONF_ATTRS, {})
     if isinstance(raw_attrs, list):

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -46,6 +46,7 @@
         "data": {
           "media_next_track": "Next track",
           "media_pause": "Pause",
+          "media_play": "Play",
           "media_previous_track": "Previous track",
           "media_stop": "Stop",
           "select_sound_mode": "Select sound mode",
@@ -60,6 +61,7 @@
         "data_description": {
           "media_next_track": "Action to run when skipping to the next track.",
           "media_pause": "Action to run when playback is paused.",
+          "media_play": "Action to run when playback is started.",
           "media_previous_track": "Action to run when skipping to the previous track.",
           "media_stop": "Action to run when playback is stopped.",
           "select_sound_mode": "Action to run when a sound mode is selected. Receives variable `sound_mode`.",
@@ -131,6 +133,7 @@
         "data": {
           "media_next_track": "[%key:component::universal::config::step::commands::data::media_next_track%]",
           "media_pause": "[%key:component::universal::config::step::commands::data::media_pause%]",
+          "media_play": "[%key:component::universal::config::step::commands::data::media_play%]",
           "media_previous_track": "[%key:component::universal::config::step::commands::data::media_previous_track%]",
           "media_stop": "[%key:component::universal::config::step::commands::data::media_stop%]",
           "select_sound_mode": "[%key:component::universal::config::step::commands::data::select_sound_mode%]",
@@ -145,6 +148,7 @@
         "data_description": {
           "media_next_track": "[%key:component::universal::config::step::commands::data_description::media_next_track%]",
           "media_pause": "[%key:component::universal::config::step::commands::data_description::media_pause%]",
+          "media_play": "[%key:component::universal::config::step::commands::data_description::media_play%]",
           "media_previous_track": "[%key:component::universal::config::step::commands::data_description::media_previous_track%]",
           "media_stop": "[%key:component::universal::config::step::commands::data_description::media_stop%]",
           "select_sound_mode": "[%key:component::universal::config::step::commands::data_description::select_sound_mode%]",

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -69,7 +69,7 @@
           "turn_off": "Action to run when the player is turned off.",
           "turn_on": "Action to run when the player is turned on (e.g. power on an AV receiver or run a script).",
           "volume_down": "Action to run when volume down is pressed.",
-          "volume_mute": "Action to run when muting or unmuting. Receives variable `media_player_volume_muted` (boolean).",
+          "volume_mute": "Action to run when muting or unmuting. Receives variable `is_volume_muted` (boolean).",
           "volume_set": "Action to run when the volume is set to a specific level. Receives variable `volume_level`.",
           "volume_up": "Action to run when volume up is pressed (e.g. route to a dedicated amplifier)."
         },

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -1,71 +1,72 @@
 {
   "config": {
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    },
     "step": {
-      "user": {
-        "title": "Universal media player",
+      "commands": {
         "data": {
-          "name": "[%key:common::config_flow::data::name%]",
-          "children": "Child media players"
+          "select_source": "Select source",
+          "turn_off": "Turn off",
+          "turn_on": "Turn on",
+          "volume_down": "Volume down",
+          "volume_mute": "Volume mute",
+          "volume_up": "Volume up"
+        },
+        "data_description": {
+          "select_source": "Action to run when a source is selected. Receives variable `source`.",
+          "turn_off": "Action to run when the player is turned off.",
+          "turn_on": "Action to run when the player is turned on (e.g. power on an AV receiver or run a script).",
+          "volume_down": "Action to run when volume down is pressed.",
+          "volume_mute": "Action to run when muting or unmuting. Receives variable `media_player_volume_muted` (boolean).",
+          "volume_up": "Action to run when volume up is pressed (e.g. route to a dedicated amplifier)."
+        },
+        "description": "Map each media command to an action on a specific device. Leave empty to delegate the command to the active child player.",
+        "title": "Command routing"
+      },
+      "user": {
+        "data": {
+          "children": "Child media players",
+          "name": "[%key:common::config_flow::data::name%]"
         },
         "data_description": {
           "children": "Media player entities whose state and playback commands this player will aggregate."
-        }
-      },
-      "commands": {
-        "title": "Command routing",
-        "description": "Map each media command to an action on a specific device. Leave empty to delegate the command to the active child player.",
-        "data": {
-          "turn_on": "Turn on",
-          "turn_off": "Turn off",
-          "volume_up": "Volume up",
-          "volume_down": "Volume down",
-          "volume_mute": "Volume mute",
-          "select_source": "Select source"
         },
-        "data_description": {
-          "turn_on": "Action to run when the player is turned on (e.g. power on an AV receiver or run a script).",
-          "turn_off": "Action to run when the player is turned off.",
-          "volume_up": "Action to run when volume up is pressed (e.g. route to a dedicated amplifier).",
-          "volume_down": "Action to run when volume down is pressed.",
-          "volume_mute": "Action to run when muting or unmuting. Receives variable `media_player_volume_muted` (boolean).",
-          "select_source": "Action to run when a source is selected. Receives variable `source`."
-        }
+        "description": "Combine one or more media players into a single media player entity.",
+        "title": "Universal media player"
       }
-    },
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     }
   },
   "options": {
     "step": {
+      "commands": {
+        "data": {
+          "select_source": "[%key:component::universal::config::step::commands::data::select_source%]",
+          "turn_off": "[%key:component::universal::config::step::commands::data::turn_off%]",
+          "turn_on": "[%key:component::universal::config::step::commands::data::turn_on%]",
+          "volume_down": "[%key:component::universal::config::step::commands::data::volume_down%]",
+          "volume_mute": "[%key:component::universal::config::step::commands::data::volume_mute%]",
+          "volume_up": "[%key:component::universal::config::step::commands::data::volume_up%]"
+        },
+        "data_description": {
+          "select_source": "[%key:component::universal::config::step::commands::data_description::select_source%]",
+          "turn_off": "[%key:component::universal::config::step::commands::data_description::turn_off%]",
+          "turn_on": "[%key:component::universal::config::step::commands::data_description::turn_on%]",
+          "volume_down": "[%key:component::universal::config::step::commands::data_description::volume_down%]",
+          "volume_mute": "[%key:component::universal::config::step::commands::data_description::volume_mute%]",
+          "volume_up": "[%key:component::universal::config::step::commands::data_description::volume_up%]"
+        },
+        "description": "[%key:component::universal::config::step::commands::description%]",
+        "title": "[%key:component::universal::config::step::commands::title%]"
+      },
       "init": {
-        "title": "Universal media player",
         "data": {
           "children": "[%key:component::universal::config::step::user::data::children%]"
         },
         "data_description": {
           "children": "[%key:component::universal::config::step::user::data_description::children%]"
-        }
-      },
-      "commands": {
-        "title": "[%key:component::universal::config::step::commands::title%]",
-        "description": "[%key:component::universal::config::step::commands::description%]",
-        "data": {
-          "turn_on": "[%key:component::universal::config::step::commands::data::turn_on%]",
-          "turn_off": "[%key:component::universal::config::step::commands::data::turn_off%]",
-          "volume_up": "[%key:component::universal::config::step::commands::data::volume_up%]",
-          "volume_down": "[%key:component::universal::config::step::commands::data::volume_down%]",
-          "volume_mute": "[%key:component::universal::config::step::commands::data::volume_mute%]",
-          "select_source": "[%key:component::universal::config::step::commands::data::select_source%]"
         },
-        "data_description": {
-          "turn_on": "[%key:component::universal::config::step::commands::data_description::turn_on%]",
-          "turn_off": "[%key:component::universal::config::step::commands::data_description::turn_off%]",
-          "volume_up": "[%key:component::universal::config::step::commands::data_description::volume_up%]",
-          "volume_down": "[%key:component::universal::config::step::commands::data_description::volume_down%]",
-          "volume_mute": "[%key:component::universal::config::step::commands::data_description::volume_mute%]",
-          "select_source": "[%key:component::universal::config::step::commands::data_description::select_source%]"
-        }
+        "title": "Universal media player"
       }
     }
   },

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -1,8 +1,5 @@
 {
   "config": {
-    "abort": {
-      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-    },
     "step": {
       "advanced": {
         "data": {

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -39,7 +39,7 @@
           "state": "Entity used to override the reported state, taking precedence over the active child's state.",
           "volume_level": "Entity used to override the reported volume level."
         },
-        "description": "Override specific attributes using another entity's state. Use the format `entity_id|attribute`, or just `entity_id` to use its state. Leave a field blank to use the active child's value.",
+        "description": "Override specific attributes using another entity's state. Use the format `entity_id|attribute` to use a specific attribute (for example, `media_player.receiver|volume_level`), or just `entity_id` to use its state (for example, `switch.tv_power`). Leave a field blank to use the active child's value.",
         "title": "Attribute overrides"
       },
       "commands": {

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -4,21 +4,71 @@
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
     },
     "step": {
+      "advanced": {
+        "data": {
+          "active_child_template": "Active child template",
+          "browse_media_entity": "Browse media entity",
+          "device_class": "Device class",
+          "state_template": "State template"
+        },
+        "data_description": {
+          "active_child_template": "A template that returns the entity ID of the child to treat as active, or `None` to use the default behavior (the first child that is on).",
+          "browse_media_entity": "Media player entity to use when browsing media, if different from the active child.",
+          "device_class": "The type of device this entity represents.",
+          "state_template": "A template used to render the state of this player. Useful when the state should depend on entities that are not themselves media players, like switches or input booleans."
+        },
+        "description": "Optional advanced overrides for this player.",
+        "title": "Advanced options"
+      },
+      "attributes": {
+        "data": {
+          "is_volume_muted": "Muted",
+          "sound_mode": "Sound mode",
+          "sound_mode_list": "Sound mode list",
+          "source": "Source",
+          "source_list": "Source list",
+          "state": "State",
+          "volume_level": "Volume level"
+        },
+        "data_description": {
+          "is_volume_muted": "Entity used to override whether the player is reported as muted.",
+          "sound_mode": "Entity used to override the currently selected sound mode.",
+          "sound_mode_list": "Entity used to override the list of available sound modes.",
+          "source": "Entity used to override the currently selected source.",
+          "source_list": "Entity used to override the list of available sources.",
+          "state": "Entity used to override the reported state, taking precedence over the active child's state.",
+          "volume_level": "Entity used to override the reported volume level."
+        },
+        "description": "Override specific attributes using another entity's state. Use the format `entity_id|attribute`, or just `entity_id` to use its state. Leave a field blank to use the active child's value.",
+        "title": "Attribute overrides"
+      },
       "commands": {
         "data": {
+          "media_next_track": "Next track",
+          "media_pause": "Pause",
+          "media_previous_track": "Previous track",
+          "media_stop": "Stop",
+          "select_sound_mode": "Select sound mode",
           "select_source": "Select source",
           "turn_off": "Turn off",
           "turn_on": "Turn on",
           "volume_down": "Volume down",
           "volume_mute": "Volume mute",
+          "volume_set": "Volume set",
           "volume_up": "Volume up"
         },
         "data_description": {
+          "media_next_track": "Action to run when skipping to the next track.",
+          "media_pause": "Action to run when playback is paused.",
+          "media_previous_track": "Action to run when skipping to the previous track.",
+          "media_stop": "Action to run when playback is stopped.",
+          "select_sound_mode": "Action to run when a sound mode is selected. Receives variable `sound_mode`.",
           "select_source": "Action to run when a source is selected. Receives variable `source`.",
           "turn_off": "Action to run when the player is turned off.",
           "turn_on": "Action to run when the player is turned on (e.g. power on an AV receiver or run a script).",
           "volume_down": "Action to run when volume down is pressed.",
           "volume_mute": "Action to run when muting or unmuting. Receives variable `media_player_volume_muted` (boolean).",
+          "volume_set": "Action to run when the volume is set to a specific level. Receives variable `volume_level`.",
           "volume_up": "Action to run when volume up is pressed (e.g. route to a dedicated amplifier)."
         },
         "description": "Map each media command to an action on a specific device. Leave empty to delegate the command to the active child player.",
@@ -39,21 +89,71 @@
   },
   "options": {
     "step": {
+      "advanced": {
+        "data": {
+          "active_child_template": "[%key:component::universal::config::step::advanced::data::active_child_template%]",
+          "browse_media_entity": "[%key:component::universal::config::step::advanced::data::browse_media_entity%]",
+          "device_class": "[%key:component::universal::config::step::advanced::data::device_class%]",
+          "state_template": "[%key:component::universal::config::step::advanced::data::state_template%]"
+        },
+        "data_description": {
+          "active_child_template": "[%key:component::universal::config::step::advanced::data_description::active_child_template%]",
+          "browse_media_entity": "[%key:component::universal::config::step::advanced::data_description::browse_media_entity%]",
+          "device_class": "[%key:component::universal::config::step::advanced::data_description::device_class%]",
+          "state_template": "[%key:component::universal::config::step::advanced::data_description::state_template%]"
+        },
+        "description": "[%key:component::universal::config::step::advanced::description%]",
+        "title": "[%key:component::universal::config::step::advanced::title%]"
+      },
+      "attributes": {
+        "data": {
+          "is_volume_muted": "[%key:component::universal::config::step::attributes::data::is_volume_muted%]",
+          "sound_mode": "[%key:component::universal::config::step::attributes::data::sound_mode%]",
+          "sound_mode_list": "[%key:component::universal::config::step::attributes::data::sound_mode_list%]",
+          "source": "[%key:component::universal::config::step::attributes::data::source%]",
+          "source_list": "[%key:component::universal::config::step::attributes::data::source_list%]",
+          "state": "[%key:component::universal::config::step::attributes::data::state%]",
+          "volume_level": "[%key:component::universal::config::step::attributes::data::volume_level%]"
+        },
+        "data_description": {
+          "is_volume_muted": "[%key:component::universal::config::step::attributes::data_description::is_volume_muted%]",
+          "sound_mode": "[%key:component::universal::config::step::attributes::data_description::sound_mode%]",
+          "sound_mode_list": "[%key:component::universal::config::step::attributes::data_description::sound_mode_list%]",
+          "source": "[%key:component::universal::config::step::attributes::data_description::source%]",
+          "source_list": "[%key:component::universal::config::step::attributes::data_description::source_list%]",
+          "state": "[%key:component::universal::config::step::attributes::data_description::state%]",
+          "volume_level": "[%key:component::universal::config::step::attributes::data_description::volume_level%]"
+        },
+        "description": "[%key:component::universal::config::step::attributes::description%]",
+        "title": "[%key:component::universal::config::step::attributes::title%]"
+      },
       "commands": {
         "data": {
+          "media_next_track": "[%key:component::universal::config::step::commands::data::media_next_track%]",
+          "media_pause": "[%key:component::universal::config::step::commands::data::media_pause%]",
+          "media_previous_track": "[%key:component::universal::config::step::commands::data::media_previous_track%]",
+          "media_stop": "[%key:component::universal::config::step::commands::data::media_stop%]",
+          "select_sound_mode": "[%key:component::universal::config::step::commands::data::select_sound_mode%]",
           "select_source": "[%key:component::universal::config::step::commands::data::select_source%]",
           "turn_off": "[%key:component::universal::config::step::commands::data::turn_off%]",
           "turn_on": "[%key:component::universal::config::step::commands::data::turn_on%]",
           "volume_down": "[%key:component::universal::config::step::commands::data::volume_down%]",
           "volume_mute": "[%key:component::universal::config::step::commands::data::volume_mute%]",
+          "volume_set": "[%key:component::universal::config::step::commands::data::volume_set%]",
           "volume_up": "[%key:component::universal::config::step::commands::data::volume_up%]"
         },
         "data_description": {
+          "media_next_track": "[%key:component::universal::config::step::commands::data_description::media_next_track%]",
+          "media_pause": "[%key:component::universal::config::step::commands::data_description::media_pause%]",
+          "media_previous_track": "[%key:component::universal::config::step::commands::data_description::media_previous_track%]",
+          "media_stop": "[%key:component::universal::config::step::commands::data_description::media_stop%]",
+          "select_sound_mode": "[%key:component::universal::config::step::commands::data_description::select_sound_mode%]",
           "select_source": "[%key:component::universal::config::step::commands::data_description::select_source%]",
           "turn_off": "[%key:component::universal::config::step::commands::data_description::turn_off%]",
           "turn_on": "[%key:component::universal::config::step::commands::data_description::turn_on%]",
           "volume_down": "[%key:component::universal::config::step::commands::data_description::volume_down%]",
           "volume_mute": "[%key:component::universal::config::step::commands::data_description::volume_mute%]",
+          "volume_set": "[%key:component::universal::config::step::commands::data_description::volume_set%]",
           "volume_up": "[%key:component::universal::config::step::commands::data_description::volume_up%]"
         },
         "description": "[%key:component::universal::config::step::commands::description%]",
@@ -67,6 +167,16 @@
           "children": "[%key:component::universal::config::step::user::data_description::children%]"
         },
         "title": "Universal media player"
+      }
+    }
+  },
+  "selector": {
+    "device_class": {
+      "options": {
+        "projector": "Projector",
+        "receiver": "Receiver",
+        "speaker": "Speaker",
+        "tv": "TV"
       }
     }
   },

--- a/homeassistant/components/universal/strings.json
+++ b/homeassistant/components/universal/strings.json
@@ -1,4 +1,74 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "title": "Universal media player",
+        "data": {
+          "name": "[%key:common::config_flow::data::name%]",
+          "children": "Child media players"
+        },
+        "data_description": {
+          "children": "Media player entities whose state and playback commands this player will aggregate."
+        }
+      },
+      "commands": {
+        "title": "Command routing",
+        "description": "Map each media command to an action on a specific device. Leave empty to delegate the command to the active child player.",
+        "data": {
+          "turn_on": "Turn on",
+          "turn_off": "Turn off",
+          "volume_up": "Volume up",
+          "volume_down": "Volume down",
+          "volume_mute": "Volume mute",
+          "select_source": "Select source"
+        },
+        "data_description": {
+          "turn_on": "Action to run when the player is turned on (e.g. power on an AV receiver or run a script).",
+          "turn_off": "Action to run when the player is turned off.",
+          "volume_up": "Action to run when volume up is pressed (e.g. route to a dedicated amplifier).",
+          "volume_down": "Action to run when volume down is pressed.",
+          "volume_mute": "Action to run when muting or unmuting. Receives variable `media_player_volume_muted` (boolean).",
+          "select_source": "Action to run when a source is selected. Receives variable `source`."
+        }
+      }
+    },
+    "abort": {
+      "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Universal media player",
+        "data": {
+          "children": "[%key:component::universal::config::step::user::data::children%]"
+        },
+        "data_description": {
+          "children": "[%key:component::universal::config::step::user::data_description::children%]"
+        }
+      },
+      "commands": {
+        "title": "[%key:component::universal::config::step::commands::title%]",
+        "description": "[%key:component::universal::config::step::commands::description%]",
+        "data": {
+          "turn_on": "[%key:component::universal::config::step::commands::data::turn_on%]",
+          "turn_off": "[%key:component::universal::config::step::commands::data::turn_off%]",
+          "volume_up": "[%key:component::universal::config::step::commands::data::volume_up%]",
+          "volume_down": "[%key:component::universal::config::step::commands::data::volume_down%]",
+          "volume_mute": "[%key:component::universal::config::step::commands::data::volume_mute%]",
+          "select_source": "[%key:component::universal::config::step::commands::data::select_source%]"
+        },
+        "data_description": {
+          "turn_on": "[%key:component::universal::config::step::commands::data_description::turn_on%]",
+          "turn_off": "[%key:component::universal::config::step::commands::data_description::turn_off%]",
+          "volume_up": "[%key:component::universal::config::step::commands::data_description::volume_up%]",
+          "volume_down": "[%key:component::universal::config::step::commands::data_description::volume_down%]",
+          "volume_mute": "[%key:component::universal::config::step::commands::data_description::volume_mute%]",
+          "select_source": "[%key:component::universal::config::step::commands::data_description::select_source%]"
+        }
+      }
+    }
+  },
   "services": {
     "reload": {
       "description": "Reloads universal media players from the YAML-configuration.",

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -22,6 +22,7 @@ FLOWS = {
         "threshold",
         "tod",
         "trend",
+        "universal",
         "utility_meter",
     ],
     "integration": [

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -7650,12 +7650,6 @@
       "config_flow": true,
       "iot_class": "cloud_polling"
     },
-    "universal": {
-      "name": "Universal media player",
-      "integration_type": "hub",
-      "config_flow": false,
-      "iot_class": "calculated"
-    },
     "upb": {
       "name": "Universal Powerline Bus (UPB)",
       "integration_type": "hub",
@@ -8526,6 +8520,12 @@
       "iot_class": "calculated"
     },
     "trend": {
+      "integration_type": "helper",
+      "config_flow": true,
+      "iot_class": "calculated"
+    },
+    "universal": {
+      "name": "Universal media player",
       "integration_type": "helper",
       "config_flow": true,
       "iot_class": "calculated"

--- a/tests/components/universal/test_config_flow.py
+++ b/tests/components/universal/test_config_flow.py
@@ -12,11 +12,12 @@ from homeassistant.components.universal.media_player import (
     CONF_CHILDREN,
     CONF_COMMANDS,
     EXPOSED_COMMANDS,
+    PLATFORM_SCHEMA,
 )
 from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_STATE_TEMPLATE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.template import Template
+from homeassistant.helpers.json import json_bytes_sorted
 
 from tests.common import MockConfigEntry
 
@@ -168,23 +169,38 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
 
 
 async def test_import_with_unique_id(hass: HomeAssistant) -> None:
-    """Test importing a YAML config that has a unique_id."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={
+    """Test importing a YAML config that has a unique_id.
+
+    The raw config is run through PLATFORM_SCHEMA first, like a real YAML
+    config would be, so device_class and the templates arrive as the coerced
+    types (a MediaPlayerDeviceClass StrEnum and Template objects) rather than
+    plain strings; this is what previously caused the config entry storage
+    write to fail (StrEnum members are not accepted by the JSON encoder).
+    """
+    raw_config = PLATFORM_SCHEMA(
+        {
+            "platform": "universal",
             CONF_NAME: "Master bed TV",
             "unique_id": "master_bed_tv",
             CONF_CHILDREN: ["media_player.mock1"],
             CONF_COMMANDS: {
-                "turn_on": {"action": "test.turn_on", "data": {}},
+                "turn_on": {
+                    "action": "test.turn_on",
+                    "data": {"level": "{{ volume_level }}"},
+                },
             },
             CONF_ATTRS: {"state": "switch.state"},
             CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
             CONF_DEVICE_CLASS: "tv",
-            CONF_ACTIVE_CHILD_TEMPLATE: Template("{{ 'media_player.mock1' }}", hass),
-            CONF_STATE_TEMPLATE: Template("{{ states('media_player.mock1') }}", hass),
-        },
+            CONF_ACTIVE_CHILD_TEMPLATE: "{{ 'media_player.mock1' }}",
+            CONF_STATE_TEMPLATE: "{{ states('media_player.mock1') }}",
+        }
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=raw_config,
     )
     await hass.async_block_till_done()
 
@@ -199,10 +215,22 @@ async def test_import_with_unique_id(hass: HomeAssistant) -> None:
         CONF_ACTIVE_CHILD_TEMPLATE: "{{ 'media_player.mock1' }}",
         CONF_STATE_TEMPLATE: "{{ states('media_player.mock1') }}",
         **{
-            cmd: [{"action": "test.turn_on", "data": {}}] if cmd == "turn_on" else []
+            cmd: [{"action": "test.turn_on", "data": {"level": "{{ volume_level }}"}}]
+            if cmd == "turn_on"
+            else []
             for cmd in EXPOSED_COMMANDS
         },
     }
+    # Dict equality alone doesn't catch a StrEnum smuggled in for
+    # device_class, since MediaPlayerDeviceClass.TV == "tv"; config entry
+    # options must be plain, JSON-serialisable types. Likewise, CMD_SCHEMA
+    # compiles a templated command "data" value into a Template object, which
+    # must be flattened back to its raw text for the same reason.
+    assert type(result["options"][CONF_DEVICE_CLASS]) is str
+    assert type(result["options"][CONF_ACTIVE_CHILD_TEMPLATE]) is str
+    assert type(result["options"][CONF_STATE_TEMPLATE]) is str
+    assert type(result["options"]["turn_on"][0]["data"]["level"]) is str
+    json_bytes_sorted(hass.config_entries.async_entries(DOMAIN)[0].as_dict())
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]
     assert config_entry.unique_id == "master_bed_tv"

--- a/tests/components/universal/test_config_flow.py
+++ b/tests/components/universal/test_config_flow.py
@@ -6,18 +6,14 @@ from homeassistant import config_entries
 from homeassistant.components.media_player import SERVICE_SELECT_SOURCE
 from homeassistant.components.universal import DOMAIN
 from homeassistant.components.universal.media_player import (
-    CONF_ACTIVE_CHILD_TEMPLATE,
     CONF_ATTRS,
     CONF_BROWSE_MEDIA_ENTITY,
     CONF_CHILDREN,
-    CONF_COMMANDS,
     EXPOSED_COMMANDS,
-    PLATFORM_SCHEMA,
 )
-from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_STATE_TEMPLATE
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers.json import json_bytes_sorted
 
 from tests.common import MockConfigEntry
 
@@ -101,7 +97,7 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
         options={
             CONF_NAME: "Living room",
             CONF_CHILDREN: ["media_player.mock1"],
-            CONF_ATTRS: {"state": "switch.old_state", "legacy_attr": "sensor.legacy"},
+            CONF_ATTRS: {"state": "switch.old_state"},
             **{cmd: [] for cmd in EXPOSED_COMMANDS},
         },
     )
@@ -127,8 +123,7 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "attributes"
 
-    # Clearing "state" (leaving it blank) should remove the override, while
-    # the "legacy_attr" key (not exposed in the UI) should be preserved.
+    # Clearing "state" (leaving it blank) should remove the override.
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         user_input={"source": "input_select.living_room_source"},
@@ -146,10 +141,7 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
     assert result["data"] == {
         CONF_NAME: "Living room",
         CONF_CHILDREN: ["media_player.mock2"],
-        CONF_ATTRS: {
-            "source": "input_select.living_room_source",
-            "legacy_attr": "sensor.legacy",
-        },
+        CONF_ATTRS: {"source": "input_select.living_room_source"},
         CONF_DEVICE_CLASS: "speaker",
         **{
             cmd: [{"action": "test.select_source"}]
@@ -160,124 +152,8 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
     }
     assert config_entry.options[CONF_CHILDREN] == ["media_player.mock2"]
     assert config_entry.options[CONF_ATTRS] == {
-        "source": "input_select.living_room_source",
-        "legacy_attr": "sensor.legacy",
+        "source": "input_select.living_room_source"
     }
     assert config_entry.options[SERVICE_SELECT_SOURCE] == [
         {"action": "test.select_source"}
     ]
-
-
-async def test_import_with_unique_id(hass: HomeAssistant) -> None:
-    """Test importing a YAML config that has a unique_id.
-
-    The raw config is run through PLATFORM_SCHEMA first, like a real YAML
-    config would be, so device_class and the templates arrive as the coerced
-    types (a MediaPlayerDeviceClass StrEnum and Template objects) rather than
-    plain strings; this is what previously caused the config entry storage
-    write to fail (StrEnum members are not accepted by the JSON encoder).
-    """
-    raw_config = PLATFORM_SCHEMA(
-        {
-            "platform": "universal",
-            CONF_NAME: "Master bed TV",
-            "unique_id": "master_bed_tv",
-            CONF_CHILDREN: ["media_player.mock1"],
-            CONF_COMMANDS: {
-                "turn_on": {
-                    "action": "test.turn_on",
-                    "data": {"level": "{{ volume_level }}"},
-                },
-                "play_media": {"action": "test.play_media"},
-            },
-            CONF_ATTRS: {"state": "switch.state"},
-            CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
-            CONF_DEVICE_CLASS: "tv",
-            CONF_ACTIVE_CHILD_TEMPLATE: "{{ 'media_player.mock1' }}",
-            CONF_STATE_TEMPLATE: "{{ states('media_player.mock1') }}",
-        }
-    )
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=raw_config,
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Master bed TV"
-    assert result["options"] == {
-        CONF_NAME: "Master bed TV",
-        CONF_CHILDREN: ["media_player.mock1"],
-        CONF_ATTRS: {"state": "switch.state"},
-        CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
-        CONF_DEVICE_CLASS: "tv",
-        CONF_ACTIVE_CHILD_TEMPLATE: "{{ 'media_player.mock1' }}",
-        CONF_STATE_TEMPLATE: "{{ states('media_player.mock1') }}",
-        # play_media isn't in EXPOSED_COMMANDS (no UI field for it), so it's
-        # preserved separately rather than dropped.
-        CONF_COMMANDS: {"play_media": {"action": "test.play_media"}},
-        **{
-            cmd: [{"action": "test.turn_on", "data": {"level": "{{ volume_level }}"}}]
-            if cmd == "turn_on"
-            else []
-            for cmd in EXPOSED_COMMANDS
-        },
-    }
-    # Dict equality alone doesn't catch a StrEnum smuggled in for
-    # device_class, since MediaPlayerDeviceClass.TV == "tv"; config entry
-    # options must be plain, JSON-serialisable types. Likewise, CMD_SCHEMA
-    # compiles a templated command "data" value into a Template object, which
-    # must be flattened back to its raw text for the same reason.
-    assert type(result["options"][CONF_DEVICE_CLASS]) is str
-    assert type(result["options"][CONF_ACTIVE_CHILD_TEMPLATE]) is str
-    assert type(result["options"][CONF_STATE_TEMPLATE]) is str
-    assert type(result["options"]["turn_on"][0]["data"]["level"]) is str
-    json_bytes_sorted(hass.config_entries.async_entries(DOMAIN)[0].as_dict())
-
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert config_entry.unique_id == "master_bed_tv"
-
-
-async def test_import_abort_if_already_configured(hass: HomeAssistant) -> None:
-    """Test importing the same unique_id twice aborts the second time."""
-    import_data = {
-        CONF_NAME: "Master bed TV",
-        "unique_id": "master_bed_tv",
-    }
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=import_data,
-    )
-    await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data=import_data,
-    )
-    await hass.async_block_till_done()
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "already_configured"
-
-    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
-
-
-async def test_import_without_unique_id(hass: HomeAssistant) -> None:
-    """Test importing a YAML config without a unique_id still creates an entry."""
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_IMPORT},
-        data={CONF_NAME: "Kitchen TV"},
-    )
-    await hass.async_block_till_done()
-
-    assert result["type"] is FlowResultType.CREATE_ENTRY
-    assert result["title"] == "Kitchen TV"
-
-    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
-    assert config_entry.unique_id == "yaml_Kitchen TV"

--- a/tests/components/universal/test_config_flow.py
+++ b/tests/components/universal/test_config_flow.py
@@ -1,0 +1,214 @@
+"""Test the Universal media player config flow."""
+
+from unittest.mock import patch
+
+from homeassistant import config_entries
+from homeassistant.components.media_player import SERVICE_SELECT_SOURCE
+from homeassistant.components.universal import DOMAIN
+from homeassistant.components.universal.media_player import (
+    CONF_ATTRS,
+    CONF_BROWSE_MEDIA_ENTITY,
+    CONF_CHILDREN,
+    CONF_COMMANDS,
+)
+from homeassistant.const import (
+    CONF_NAME,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_VOLUME_UP,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from tests.common import MockConfigEntry
+
+ALL_COMMANDS = (
+    SERVICE_TURN_ON,
+    SERVICE_TURN_OFF,
+    SERVICE_VOLUME_UP,
+    SERVICE_VOLUME_DOWN,
+    SERVICE_VOLUME_MUTE,
+    SERVICE_SELECT_SOURCE,
+)
+
+
+async def test_user_flow_commands(hass: HomeAssistant) -> None:
+    """Test the user config flow through to command routing."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_NAME: "Living room",
+            CONF_CHILDREN: ["media_player.mock1", "media_player.mock2"],
+        },
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "commands"
+
+    with patch(
+        "homeassistant.components.universal.async_setup_entry",
+        return_value=True,
+    ) as mock_setup_entry:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {SERVICE_TURN_ON: [{"action": "test.turn_on", "data": {}}]},
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Living room"
+    assert result["data"] == {}
+    assert result["options"] == {
+        CONF_NAME: "Living room",
+        CONF_CHILDREN: ["media_player.mock1", "media_player.mock2"],
+        SERVICE_TURN_ON: [{"action": "test.turn_on", "data": {}}],
+        SERVICE_TURN_OFF: [],
+        SERVICE_VOLUME_UP: [],
+        SERVICE_VOLUME_DOWN: [],
+        SERVICE_VOLUME_MUTE: [],
+        SERVICE_SELECT_SOURCE: [],
+    }
+    assert len(mock_setup_entry.mock_calls) == 1
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.title == "Living room"
+    assert config_entry.options[CONF_CHILDREN] == [
+        "media_player.mock1",
+        "media_player.mock2",
+    ]
+
+
+async def test_options_flow_edit(hass: HomeAssistant) -> None:
+    """Test editing an existing entry through the options flow."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Living room",
+        options={
+            CONF_NAME: "Living room",
+            CONF_CHILDREN: ["media_player.mock1"],
+            **{cmd: [] for cmd in ALL_COMMANDS},
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_CHILDREN: ["media_player.mock2"]},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "commands"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={SERVICE_SELECT_SOURCE: [{"action": "test.select_source"}]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {
+        CONF_NAME: "Living room",
+        CONF_CHILDREN: ["media_player.mock2"],
+        SERVICE_TURN_ON: [],
+        SERVICE_TURN_OFF: [],
+        SERVICE_VOLUME_UP: [],
+        SERVICE_VOLUME_DOWN: [],
+        SERVICE_VOLUME_MUTE: [],
+        SERVICE_SELECT_SOURCE: [{"action": "test.select_source"}],
+    }
+    assert config_entry.options[CONF_CHILDREN] == ["media_player.mock2"]
+    assert config_entry.options[SERVICE_SELECT_SOURCE] == [
+        {"action": "test.select_source"}
+    ]
+
+
+async def test_import_with_unique_id(hass: HomeAssistant) -> None:
+    """Test importing a YAML config that has a unique_id."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={
+            CONF_NAME: "Master bed TV",
+            "unique_id": "master_bed_tv",
+            CONF_CHILDREN: ["media_player.mock1"],
+            CONF_COMMANDS: {
+                SERVICE_TURN_ON: {"action": "test.turn_on", "data": {}},
+            },
+            CONF_ATTRS: {"state": "switch.state"},
+            CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
+        },
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Master bed TV"
+    assert result["options"] == {
+        CONF_NAME: "Master bed TV",
+        CONF_CHILDREN: ["media_player.mock1"],
+        CONF_ATTRS: {"state": "switch.state"},
+        CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
+        SERVICE_TURN_ON: [{"action": "test.turn_on", "data": {}}],
+        SERVICE_TURN_OFF: [],
+        SERVICE_VOLUME_UP: [],
+        SERVICE_VOLUME_DOWN: [],
+        SERVICE_VOLUME_MUTE: [],
+        SERVICE_SELECT_SOURCE: [],
+    }
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.unique_id == "master_bed_tv"
+
+
+async def test_import_abort_if_already_configured(hass: HomeAssistant) -> None:
+    """Test importing the same unique_id twice aborts the second time."""
+    import_data = {
+        CONF_NAME: "Master bed TV",
+        "unique_id": "master_bed_tv",
+    }
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=import_data,
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data=import_data,
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+async def test_import_without_unique_id(hass: HomeAssistant) -> None:
+    """Test importing a YAML config without a unique_id still creates an entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_IMPORT},
+        data={CONF_NAME: "Kitchen TV"},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Kitchen TV"
+
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert config_entry.unique_id == "yaml_Kitchen TV"

--- a/tests/components/universal/test_config_flow.py
+++ b/tests/components/universal/test_config_flow.py
@@ -6,36 +6,23 @@ from homeassistant import config_entries
 from homeassistant.components.media_player import SERVICE_SELECT_SOURCE
 from homeassistant.components.universal import DOMAIN
 from homeassistant.components.universal.media_player import (
+    CONF_ACTIVE_CHILD_TEMPLATE,
     CONF_ATTRS,
     CONF_BROWSE_MEDIA_ENTITY,
     CONF_CHILDREN,
     CONF_COMMANDS,
+    EXPOSED_COMMANDS,
 )
-from homeassistant.const import (
-    CONF_NAME,
-    SERVICE_TURN_OFF,
-    SERVICE_TURN_ON,
-    SERVICE_VOLUME_DOWN,
-    SERVICE_VOLUME_MUTE,
-    SERVICE_VOLUME_UP,
-)
+from homeassistant.const import CONF_DEVICE_CLASS, CONF_NAME, CONF_STATE_TEMPLATE
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.template import Template
 
 from tests.common import MockConfigEntry
 
-ALL_COMMANDS = (
-    SERVICE_TURN_ON,
-    SERVICE_TURN_OFF,
-    SERVICE_VOLUME_UP,
-    SERVICE_VOLUME_DOWN,
-    SERVICE_VOLUME_MUTE,
-    SERVICE_SELECT_SOURCE,
-)
-
 
 async def test_user_flow_commands(hass: HomeAssistant) -> None:
-    """Test the user config flow through to command routing."""
+    """Test the user config flow through to command routing, attributes and advanced."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
     )
@@ -52,13 +39,30 @@ async def test_user_flow_commands(hass: HomeAssistant) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "commands"
 
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {SERVICE_SELECT_SOURCE: [{"action": "test.select_source"}]},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "attributes"
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {"state": "switch.living_room_tv"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "advanced"
+
     with patch(
         "homeassistant.components.universal.async_setup_entry",
         return_value=True,
     ) as mock_setup_entry:
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
-            {SERVICE_TURN_ON: [{"action": "test.turn_on", "data": {}}]},
+            {
+                CONF_DEVICE_CLASS: "tv",
+                CONF_BROWSE_MEDIA_ENTITY: "media_player.mock2",
+            },
         )
         await hass.async_block_till_done()
 
@@ -68,12 +72,15 @@ async def test_user_flow_commands(hass: HomeAssistant) -> None:
     assert result["options"] == {
         CONF_NAME: "Living room",
         CONF_CHILDREN: ["media_player.mock1", "media_player.mock2"],
-        SERVICE_TURN_ON: [{"action": "test.turn_on", "data": {}}],
-        SERVICE_TURN_OFF: [],
-        SERVICE_VOLUME_UP: [],
-        SERVICE_VOLUME_DOWN: [],
-        SERVICE_VOLUME_MUTE: [],
-        SERVICE_SELECT_SOURCE: [],
+        CONF_ATTRS: {"state": "switch.living_room_tv"},
+        CONF_DEVICE_CLASS: "tv",
+        CONF_BROWSE_MEDIA_ENTITY: "media_player.mock2",
+        **{
+            cmd: [{"action": "test.select_source"}]
+            if cmd == SERVICE_SELECT_SOURCE
+            else []
+            for cmd in EXPOSED_COMMANDS
+        },
     }
     assert len(mock_setup_entry.mock_calls) == 1
 
@@ -93,7 +100,8 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
         options={
             CONF_NAME: "Living room",
             CONF_CHILDREN: ["media_player.mock1"],
-            **{cmd: [] for cmd in ALL_COMMANDS},
+            CONF_ATTRS: {"state": "switch.old_state", "legacy_attr": "sensor.legacy"},
+            **{cmd: [] for cmd in EXPOSED_COMMANDS},
         },
     )
     config_entry.add_to_hass(hass)
@@ -115,20 +123,45 @@ async def test_options_flow_edit(hass: HomeAssistant) -> None:
         result["flow_id"],
         user_input={SERVICE_SELECT_SOURCE: [{"action": "test.select_source"}]},
     )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "attributes"
+
+    # Clearing "state" (leaving it blank) should remove the override, while
+    # the "legacy_attr" key (not exposed in the UI) should be preserved.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"source": "input_select.living_room_source"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "advanced"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={CONF_DEVICE_CLASS: "speaker"},
+    )
     await hass.async_block_till_done()
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         CONF_NAME: "Living room",
         CONF_CHILDREN: ["media_player.mock2"],
-        SERVICE_TURN_ON: [],
-        SERVICE_TURN_OFF: [],
-        SERVICE_VOLUME_UP: [],
-        SERVICE_VOLUME_DOWN: [],
-        SERVICE_VOLUME_MUTE: [],
-        SERVICE_SELECT_SOURCE: [{"action": "test.select_source"}],
+        CONF_ATTRS: {
+            "source": "input_select.living_room_source",
+            "legacy_attr": "sensor.legacy",
+        },
+        CONF_DEVICE_CLASS: "speaker",
+        **{
+            cmd: [{"action": "test.select_source"}]
+            if cmd == SERVICE_SELECT_SOURCE
+            else []
+            for cmd in EXPOSED_COMMANDS
+        },
     }
     assert config_entry.options[CONF_CHILDREN] == ["media_player.mock2"]
+    assert config_entry.options[CONF_ATTRS] == {
+        "source": "input_select.living_room_source",
+        "legacy_attr": "sensor.legacy",
+    }
     assert config_entry.options[SERVICE_SELECT_SOURCE] == [
         {"action": "test.select_source"}
     ]
@@ -144,10 +177,13 @@ async def test_import_with_unique_id(hass: HomeAssistant) -> None:
             "unique_id": "master_bed_tv",
             CONF_CHILDREN: ["media_player.mock1"],
             CONF_COMMANDS: {
-                SERVICE_TURN_ON: {"action": "test.turn_on", "data": {}},
+                "turn_on": {"action": "test.turn_on", "data": {}},
             },
             CONF_ATTRS: {"state": "switch.state"},
             CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
+            CONF_DEVICE_CLASS: "tv",
+            CONF_ACTIVE_CHILD_TEMPLATE: Template("{{ 'media_player.mock1' }}", hass),
+            CONF_STATE_TEMPLATE: Template("{{ states('media_player.mock1') }}", hass),
         },
     )
     await hass.async_block_till_done()
@@ -159,12 +195,13 @@ async def test_import_with_unique_id(hass: HomeAssistant) -> None:
         CONF_CHILDREN: ["media_player.mock1"],
         CONF_ATTRS: {"state": "switch.state"},
         CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
-        SERVICE_TURN_ON: [{"action": "test.turn_on", "data": {}}],
-        SERVICE_TURN_OFF: [],
-        SERVICE_VOLUME_UP: [],
-        SERVICE_VOLUME_DOWN: [],
-        SERVICE_VOLUME_MUTE: [],
-        SERVICE_SELECT_SOURCE: [],
+        CONF_DEVICE_CLASS: "tv",
+        CONF_ACTIVE_CHILD_TEMPLATE: "{{ 'media_player.mock1' }}",
+        CONF_STATE_TEMPLATE: "{{ states('media_player.mock1') }}",
+        **{
+            cmd: [{"action": "test.turn_on", "data": {}}] if cmd == "turn_on" else []
+            for cmd in EXPOSED_COMMANDS
+        },
     }
 
     config_entry = hass.config_entries.async_entries(DOMAIN)[0]

--- a/tests/components/universal/test_config_flow.py
+++ b/tests/components/universal/test_config_flow.py
@@ -188,6 +188,7 @@ async def test_import_with_unique_id(hass: HomeAssistant) -> None:
                     "action": "test.turn_on",
                     "data": {"level": "{{ volume_level }}"},
                 },
+                "play_media": {"action": "test.play_media"},
             },
             CONF_ATTRS: {"state": "switch.state"},
             CONF_BROWSE_MEDIA_ENTITY: "media_player.mock1",
@@ -214,6 +215,9 @@ async def test_import_with_unique_id(hass: HomeAssistant) -> None:
         CONF_DEVICE_CLASS: "tv",
         CONF_ACTIVE_CHILD_TEMPLATE: "{{ 'media_player.mock1' }}",
         CONF_STATE_TEMPLATE: "{{ states('media_player.mock1') }}",
+        # play_media isn't in EXPOSED_COMMANDS (no UI field for it), so it's
+        # preserved separately rather than dropped.
+        CONF_COMMANDS: {"play_media": {"action": "test.play_media"}},
         **{
             cmd: [{"action": "test.turn_on", "data": {"level": "{{ volume_level }}"}}]
             if cmd == "turn_on"

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -16,6 +16,7 @@ from homeassistant.components.media_player import (
 from homeassistant.components.universal import media_player as universal
 from homeassistant.const import (
     SERVICE_RELOAD,
+    STATE_IDLE,
     STATE_OFF,
     STATE_ON,
     STATE_PAUSED,
@@ -23,6 +24,7 @@ from homeassistant.const import (
     STATE_UNKNOWN,
 )
 from homeassistant.core import Context, HomeAssistant, callback
+from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import EntityPlatformState
 from homeassistant.helpers.event import async_track_state_change_event
@@ -1568,3 +1570,55 @@ async def test_async_setup_entry_command_data_template(hass: HomeAssistant) -> N
     )
     assert len(service) == 1
     assert service[0].data["level"] == 0.42
+
+
+async def test_options_flow_reloads_entity(hass: HomeAssistant) -> None:
+    """Test that completing the options flow reloads the entity.
+
+    Without options_flow_reloads set on the flow handler, the config entry's
+    options are updated in storage but the running entity keeps its old
+    in-memory configuration until Home Assistant restarts.
+    """
+    hass.states.async_set("media_player.mock1", STATE_IDLE)
+    hass.states.async_set("media_player.mock2", STATE_IDLE)
+
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Reload test",
+        options={
+            "name": "Reload test",
+            "children": ["media_player.mock1"],
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    # _child_state is only populated by state-change events, not an initial
+    # read, so the child must actually change after setup for the entity to
+    # pick it up.
+    hass.states.async_set("media_player.mock1", STATE_PLAYING)
+    await hass.async_block_till_done()
+    assert hass.states.get("media_player.reload_test").state == STATE_PLAYING
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={"children": ["media_player.mock2"]}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    await hass.async_block_till_done()
+
+    # If the entity didn't reload, it would still be watching mock1 (stuck on
+    # "playing") and never react to mock2 changing at all.
+    hass.states.async_set("media_player.mock2", STATE_PAUSED)
+    await hass.async_block_till_done()
+    assert hass.states.get("media_player.reload_test").state == STATE_PAUSED

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1476,3 +1476,56 @@ async def test_async_setup_entry_commands(hass: HomeAssistant) -> None:
         blocking=True,
     )
     assert len(service) == 1
+
+
+async def test_async_setup_entry_device_class_and_attributes(
+    hass: HomeAssistant,
+) -> None:
+    """Test device_class and attribute overrides configured through a config entry."""
+    hass.states.async_set("switch.tv_state", STATE_ON)
+
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Entry advanced",
+        options={
+            "name": "Entry advanced",
+            "children": [],
+            "device_class": "speaker",
+            "attributes": {"state": "switch.tv_state"},
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.entry_advanced")
+    assert state.attributes["device_class"] == "speaker"
+    assert state.state == STATE_ON
+
+
+async def test_async_setup_entry_templates(hass: HomeAssistant) -> None:
+    """Test active_child_template and state_template configured through a config entry."""
+    hass.states.async_set("media_player.mock1", STATE_OFF)
+    hass.states.async_set("media_player.mock2", STATE_PLAYING)
+
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Entry templates",
+        options={
+            "name": "Entry templates",
+            "children": [
+                media_player.ENTITY_ID_FORMAT.format("mock1"),
+                media_player.ENTITY_ID_FORMAT.format("mock2"),
+            ],
+            "active_child_template": "{{ 'media_player.mock1' }}",
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    await hass.async_start()
+    await hass.async_block_till_done()
+
+    # active_child_template forces mock1 (off) to be treated as active,
+    # overriding the default of picking mock2 (playing).
+    assert hass.states.get("media_player.entry_templates").state == STATE_OFF

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -28,7 +28,12 @@ from homeassistant.helpers.entity import EntityPlatformState
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.setup import async_setup_component
 
-from tests.common import MockEntityPlatform, async_mock_service, get_fixture_path
+from tests.common import (
+    MockConfigEntry,
+    MockEntityPlatform,
+    async_mock_service,
+    get_fixture_path,
+)
 
 CONFIG_CHILDREN_ONLY = {
     "name": "test",
@@ -1414,3 +1419,60 @@ async def test_reload(hass: HomeAssistant) -> None:
         "device_class" not in hass.states.get("media_player.master_bed_tv").attributes
     )
     assert "unique_id" not in hass.states.get("media_player.master_bed_tv").attributes
+
+
+async def test_async_setup_entry(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry, mock_states: Mock
+) -> None:
+    """Test setting up the platform from a config entry."""
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Config entry TV",
+        options={
+            "name": "Config entry TV",
+            "children": [
+                media_player.ENTITY_ID_FORMAT.format("mock1"),
+                media_player.ENTITY_ID_FORMAT.format("mock2"),
+            ],
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        media_player.DOMAIN, universal.DOMAIN, config_entry.entry_id
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id).state == STATE_OFF
+
+    mock_states.mock_mp_1._state = STATE_PLAYING
+    mock_states.mock_mp_1.async_schedule_update_ha_state()
+    await hass.async_block_till_done()
+    assert hass.states.get(entity_id).state == STATE_PLAYING
+
+
+async def test_async_setup_entry_commands(hass: HomeAssistant) -> None:
+    """Test commands configured through a config entry are routed correctly."""
+    service = async_mock_service(hass, "test", "turn_off")
+
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Entry commands",
+        options={
+            "name": "Entry commands",
+            "children": [],
+            "turn_off": [{"action": "test.turn_off", "data": {}}],
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        media_player.SERVICE_TURN_OFF,
+        {"entity_id": "media_player.entry_commands"},
+        blocking=True,
+    )
+    assert len(service) == 1

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1480,6 +1480,41 @@ async def test_async_setup_entry_commands(hass: HomeAssistant) -> None:
     assert len(service) == 1
 
 
+async def test_async_setup_entry_extra_command(hass: HomeAssistant) -> None:
+    """Test a command preserved outside EXPOSED_COMMANDS via a config entry.
+
+    Commands like play_media don't have a UI field of their own, so
+    async_step_import preserves them under CONF_COMMANDS instead of a flat
+    per-command key; this verifies async_setup_entry still wires them up.
+    """
+    service = async_mock_service(hass, "test", "play_media")
+
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Entry extra command",
+        options={
+            "name": "Entry extra command",
+            "children": [],
+            "commands": {"play_media": {"action": "test.play_media"}},
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        media_player.SERVICE_PLAY_MEDIA,
+        {
+            "entity_id": "media_player.entry_extra_command",
+            "media_content_id": "some_id",
+            "media_content_type": "movie",
+        },
+        blocking=True,
+    )
+    assert len(service) == 1
+
+
 async def test_async_setup_entry_device_class_and_attributes(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1480,41 +1480,6 @@ async def test_async_setup_entry_commands(hass: HomeAssistant) -> None:
     assert len(service) == 1
 
 
-async def test_async_setup_entry_extra_command(hass: HomeAssistant) -> None:
-    """Test a command preserved outside EXPOSED_COMMANDS via a config entry.
-
-    Commands like play_media don't have a UI field of their own, so
-    async_step_import preserves them under CONF_COMMANDS instead of a flat
-    per-command key; this verifies async_setup_entry still wires them up.
-    """
-    service = async_mock_service(hass, "test", "play_media")
-
-    config_entry = MockConfigEntry(
-        domain=universal.DOMAIN,
-        title="Entry extra command",
-        options={
-            "name": "Entry extra command",
-            "children": [],
-            "commands": {"play_media": {"action": "test.play_media"}},
-        },
-    )
-    config_entry.add_to_hass(hass)
-    assert await hass.config_entries.async_setup(config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    await hass.services.async_call(
-        media_player.DOMAIN,
-        media_player.SERVICE_PLAY_MEDIA,
-        {
-            "entity_id": "media_player.entry_extra_command",
-            "media_content_id": "some_id",
-            "media_content_type": "movie",
-        },
-        blocking=True,
-    )
-    assert len(service) == 1
-
-
 async def test_async_setup_entry_device_class_and_attributes(
     hass: HomeAssistant,
 ) -> None:

--- a/tests/components/universal/test_media_player.py
+++ b/tests/components/universal/test_media_player.py
@@ -1529,3 +1529,42 @@ async def test_async_setup_entry_templates(hass: HomeAssistant) -> None:
     # active_child_template forces mock1 (off) to be treated as active,
     # overriding the default of picking mock2 (playing).
     assert hass.states.get("media_player.entry_templates").state == STATE_OFF
+
+
+async def test_async_setup_entry_command_data_template(hass: HomeAssistant) -> None:
+    """Test a templated value in a command's data configured through a config entry.
+
+    Config entry options are JSON, so command data can only ever be stored as
+    a plain template string, never a compiled Template object; this verifies
+    async_setup_entry recompiles it so the template still renders correctly
+    when the command runs (regression test: the recompiled command must also
+    remain usable with async_call_from_config's validate_config=False).
+    """
+    service = async_mock_service(hass, "test", "set_volume")
+
+    config_entry = MockConfigEntry(
+        domain=universal.DOMAIN,
+        title="Entry volume template",
+        options={
+            "name": "Entry volume template",
+            "children": [],
+            "volume_set": [
+                {"action": "test.set_volume", "data": {"level": "{{ volume_level }}"}}
+            ],
+        },
+    )
+    config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    await hass.services.async_call(
+        media_player.DOMAIN,
+        media_player.SERVICE_VOLUME_SET,
+        {
+            "entity_id": "media_player.entry_volume_template",
+            "volume_level": 0.42,
+        },
+        blocking=True,
+    )
+    assert len(service) == 1
+    assert service[0].data["level"] == 0.42


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a UI config flow to the Universal media player integration, which was previously YAML-only. YAML configuration continues to work unchanged; the config flow is an additional way to create new Universal media players through the UI, consistent with how every other comparable helper integration (`filter`, `generic_thermostat`, `threshold`, `min_max`, `derivative`, `statistics`) keeps YAML and the config flow as independent, parallel paths rather than migrating one into the other.

- Adds `async_setup_entry`/`async_unload_entry` and a 4-step config flow: name + children, command routing (13 commands via `ActionSelector`: `turn_on`, `turn_off`, `volume_up`, `volume_down`, `volume_mute`, `volume_set`, `select_source`, `select_sound_mode`, `media_play`, `media_pause`, `media_stop`, `media_next_track`, `media_previous_track`), attribute overrides (`state`, `is_volume_muted`, `volume_level`, `source`, `source_list`, `sound_mode`, `sound_mode_list`), and advanced options (`device_class`, `browse_media_entity`, `active_child_template`, `state_template`).
- Adds a matching options flow so existing UI-created entries can be reconfigured, with `options_flow_reloads = True` so edits take effect immediately instead of requiring a restart.
- The UI intentionally covers the common/documented cases; fully arbitrary command/attribute overrides (beyond the above) remain YAML-only, consistent with how `filter` and `generic_thermostat` split UI vs. YAML configuration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47157
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


