### PR TITLE
Update Google Health sensor units to be more reasonable

### DIFF
--- a/homeassistant/components/google_health/sensor.py
+++ b/homeassistant/components/google_health/sensor.py
@@ -27,6 +27,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
+from homeassistant.util.unit_system import US_CUSTOMARY_SYSTEM, UnitSystem
 
 from . import GoogleHealthConfigEntry
 from .const import DOMAIN
@@ -50,6 +51,7 @@ class GoogleHealthSensorEntityDescription[
     """Class describing Google Health sensor entities."""
 
     value_fn: Callable[[Any], _ValueT]
+    suggested_unit_fn: Callable[[UnitSystem], str | None] | None = None
 
 
 ACTIVITY_SENSORS: list[
@@ -68,6 +70,11 @@ ACTIVITY_SENSORS: list[
         state_class=SensorStateClass.TOTAL_INCREASING,
         value_fn=lambda data: (
             data.distance.millimeters_sum / 1000.0 if data and data.distance else 0.0
+        ),
+        suggested_unit_fn=lambda units: (
+            UnitOfLength.MILES
+            if units is US_CUSTOMARY_SYSTEM
+            else UnitOfLength.KILOMETERS
         ),
     ),
     GoogleHealthSensorEntityDescription[GoogleHealthActivityCoordinator, float](
@@ -108,6 +115,9 @@ BODY_SENSORS: list[
         state_class=SensorStateClass.MEASUREMENT,
         value_fn=lambda data: (
             data.weight.weight_grams / 1000.0 if data and data.weight else None
+        ),
+        suggested_unit_fn=lambda units: (
+            UnitOfMass.POUNDS if units is US_CUSTOMARY_SYSTEM else None
         ),
     ),
     GoogleHealthSensorEntityDescription[GoogleHealthBodyCoordinator, int | None](
@@ -211,6 +221,9 @@ NUTRITION_SENSORS: list[
             data.hydration.amount_consumed.milliliters_sum / 1000.0
             if data and data.hydration and data.hydration.amount_consumed
             else 0.0
+        ),
+        suggested_unit_fn=lambda units: (
+            UnitOfVolume.FLUID_OUNCES if units is US_CUSTOMARY_SYSTEM else None
         ),
     ),
     GoogleHealthSensorEntityDescription[GoogleHealthNutritionCoordinator, float](
@@ -344,6 +357,15 @@ class GoogleHealthSensor[_CoordinatorT: GoogleHealthDataUpdateCoordinator[Any]](
     def native_value(self) -> StateType:
         """Return the state of the sensor."""
         return cast(StateType, self.entity_description.value_fn(self.coordinator.data))
+
+    @property
+    @override
+    def suggested_unit_of_measurement(self) -> str | None:
+        """Return the suggested unit of measurement."""
+        if (suggested_unit_fn := self.entity_description.suggested_unit_fn) is not None:
+            return suggested_unit_fn(self.hass.config.units)
+
+        return super().suggested_unit_of_measurement
 
 
 class GoogleHealthDeviceSensor(

--- a/tests/components/google_health/snapshots/test_sensor.ambr
+++ b/tests/components/google_health/snapshots/test_sensor.ambr
@@ -402,6 +402,9 @@
       'sensor': dict({
         'suggested_display_precision': 2,
       }),
+      'sensor.private': dict({
+        'suggested_unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
+      }),
     }),
     'original_device_class': <SensorDeviceClass.DISTANCE: 'distance'>,
     'original_icon': None,
@@ -412,7 +415,7 @@
     'supported_features': 0,
     'translation_key': None,
     'unique_id': '01J0BC4QM2YBRP6H5G933CETT7_distance',
-    'unit_of_measurement': <UnitOfLength.METERS: 'm'>,
+    'unit_of_measurement': <UnitOfLength.KILOMETERS: 'km'>,
   })
 # ---
 # name: test_all_entities[sensor.google_health_distance-state]
@@ -421,14 +424,14 @@
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'distance',
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Google Health Distance',
       <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.TOTAL_INCREASING: 'total_increasing'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfLength.METERS: 'm'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfLength.KILOMETERS: 'km'>,
     }),
     'context': <ANY>,
     'entity_id': 'sensor.google_health_distance',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '5000.0',
+    'state': '5.0',
   })
 # ---
 # name: test_all_entities[sensor.google_health_floors-entry]

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -1,15 +1,20 @@
 """Tests for Google Health sensor platform."""
 
 from collections.abc import Awaitable, Callable
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from google_health_api.model import ListDataPointResult, _ListDataPointsModel
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util.unit_system import (
+    METRIC_SYSTEM,
+    US_CUSTOMARY_SYSTEM,
+    UnitSystem,
+)
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -80,12 +85,58 @@ async def test_sensor_empty_sleep(
     integration_setup: Callable[[], Awaitable[bool]],
 ) -> None:
     """Test sleep sensors when the sleep endpoint returns no data."""
-    mock_google_health_client.sleep.list.return_value = ListDataPointResult(
-        _ListDataPointsModel(data_points=[])
-    )
+    mock_google_health_client.sleep.list.return_value = MagicMock(data_points=[])
 
     assert await integration_setup()
 
     time_asleep_state = hass.states.get("sensor.google_health_time_asleep")
     assert time_asleep_state is not None
     assert time_asleep_state.state == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("unit_system", "expected_sensors"),
+    [
+        pytest.param(
+            METRIC_SYSTEM,
+            {
+                "sensor.google_health_weight": (pytest.approx(80.0), "kg"),
+                "sensor.google_health_distance": (pytest.approx(5.0), "km"),
+                "sensor.google_health_water_intake": (pytest.approx(2.5), "L"),
+            },
+            id="metric",
+        ),
+        pytest.param(
+            US_CUSTOMARY_SYSTEM,
+            {
+                "sensor.google_health_weight": (pytest.approx(176.37, abs=1e-2), "lb"),
+                "sensor.google_health_distance": (
+                    pytest.approx(3.11, abs=1e-2),
+                    "mi",
+                ),
+                "sensor.google_health_water_intake": (
+                    pytest.approx(84.54, abs=1e-1),
+                    "fl. oz.",
+                ),
+            },
+            id="us_customary",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_google_health_client")
+async def test_sensor_unit_conversions(
+    hass: HomeAssistant,
+    integration_setup: Callable[[], Awaitable[bool]],
+    unit_system: UnitSystem,
+    expected_sensors: dict[str, tuple[Any, str]],
+) -> None:
+    """Test sensors dynamically convert states and units under different unit systems."""
+    hass.config.units = unit_system
+
+    assert await integration_setup()
+
+    for entity_id, (expected_state, expected_unit) in expected_sensors.items():
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert float(state.state) == expected_state
+        assert state.attributes.get("unit_of_measurement") == expected_unit


### PR DESCRIPTION
## Proposed change

Add dynamic unit suggestion logic for Google Health sensors via a new `suggested_unit_fn` callback on `GoogleHealthSensorEntityDescription`. 

By default, Home Assistant does not convert weights/masses across unit systems automatically (to prevent body scales from defaulting to grams), and generic unit system mappings for distance and volume convert to architectural/utility defaults (`m` -> `ft`, `L` -> `gal`). 

This PR configures unit-system-aware defaults tailored for a fitness/health tracker:

- **Weight sensor**: Defaults to pounds (`lb`) for US Customary users and kilograms (`kg`) for Metric users.
- **Distance sensor**: Defaults to miles (`mi`) for US Customary users and kilometers (`km`) for Metric users (instead of feet or raw meters).
- **Hydration / Water intake sensor**: Defaults to fluid ounces (`fl. oz.`) for US Customary users (instead of gallons).
- **Parameterized unit testing**: Added `test_sensor_unit_conversions` with `pytest.approx()` to test unit system conversions across `METRIC_SYSTEM` and `US_CUSTOMARY_SYSTEM`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
