### PR TITLE
Fix: Silently ignore empty JSON string object for MQTT IR signal payload

### DIFF
--- a/homeassistant/components/mqtt/infrared.py
+++ b/homeassistant/components/mqtt/infrared.py
@@ -220,7 +220,7 @@ class MqttInfraredReceiverEntity(MqttEntity, InfraredReceiverEntity):
             _LOGGER.debug("Ignoring retained infrared signal on topic %s", msg.topic)
             return
         payload = self._value_template(msg.payload)
-        if not payload or payload in (PAYLOAD_NONE, "null"):
+        if not payload or payload in (PAYLOAD_NONE, "null", '""'):
             _LOGGER.debug(
                 "Ignoring payload for %s on topic %s, with template %s",
                 self.entity_id,

--- a/tests/components/mqtt/test_infrared.py
+++ b/tests/components/mqtt/test_infrared.py
@@ -184,6 +184,12 @@ async def test_receiving_command_success_using_value_template(
             False,
         ),
         (
+            '""',
+            "Ignoring payload for infrared.test on topic test-topic, with template None",
+            logging.DEBUG,
+            False,
+        ),
+        (
             "None",
             "Ignoring payload for infrared.test on topic test-topic, with template None",
             logging.DEBUG,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix: Silently ignore empty JSON string object for MQTT IR signal payload. When the infrared MQTT entity receives timings, these are often extracted using a valuetemplate. While a dict is expected we should ignore an empty JSON string `""`.
This fix wil no longer log warnings when the value is an empty string, like:

Invalid message received for infrared.irhub_learned_ir_timings on topic zigbee2mqtt/irhub, with template Template<template=({{ value_json.learned_ir_timings | tojson }}) renders=1>. Message is not a valid signal JSON message. Got
```json
{"ir_code_to_send":null,"ir_emitter":null,"learn_ir_code":null,"learned_ir_code":"Some code...","learned_ir_timings":"","linkquality":120}
```

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
