### PR TITLE
Cleanup broken switch entities for Hue automations

### DIFF
--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -1,5 +1,6 @@
 """Support for switch platform for Hue resources (V2 only)."""
 
+from collections.abc import Callable
 from typing import Any, override
 
 from aiohue.v2 import HueBridgeV2
@@ -11,18 +12,30 @@ from aiohue.v2.controllers.sensors import (
     Motion,
     MotionController,
 )
+from aiohue.v2.models.behavior_script import BehaviorScriptCategory
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
     SwitchEntity,
     SwitchEntityDescription,
 )
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .bridge import HueConfigEntry
+from .const import DOMAIN
 from .v2.entity import HueBaseEntity
+
+# Behavior instances of these script categories are internal device
+# configuration (button mappings, entertainment cleanup) rather than user
+# facing automations. The bridge accepts a change to their `enabled` flag but
+# keeps running them regardless, so exposing them as switches is misleading.
+INTERNAL_SCRIPT_CATEGORIES = {
+    BehaviorScriptCategory.ACCESSORY,
+    BehaviorScriptCategory.ENTERTAINMENT,
+}
 
 
 async def async_setup_entry(
@@ -48,12 +61,15 @@ async def async_setup_entry(
             | HueLightSensorEnabledEntity
             | HueMotionSensorEnabledEntity
         ],
+        resource_filter: Callable[[Any], bool] | None = None,
     ):
         @callback
         def async_add_entity(
             event_type: EventType, resource: BehaviorInstance | LightLevel | Motion
         ) -> None:
             """Add entity from Hue resource."""
+            if resource_filter is not None and not resource_filter(resource):
+                return
             async_add_entities([switch_class(bridge, controller, resource)])
 
         # add all current items in controller
@@ -67,10 +83,33 @@ async def async_setup_entry(
             )
         )
 
+    @callback
+    def is_user_automation(resource: BehaviorInstance) -> bool:
+        """Return if the behavior instance is a user facing automation."""
+        # older bridges do not report a category, keep the instance in that case
+        script = api.config.behavior_script.get(resource.script_id)
+        return (
+            script is None or script.metadata.category not in INTERNAL_SCRIPT_CATEGORIES
+        )
+
+    # clean up entities previously created for internal behavior instances
+    entity_registry = er.async_get(hass)
+    for resource in api.config.behavior_instance:
+        if is_user_automation(resource):
+            continue
+        if entity_id := entity_registry.async_get_entity_id(
+            Platform.SWITCH, DOMAIN, resource.id
+        ):
+            entity_registry.async_remove(entity_id)
+
     # setup for each switch-type hue resource
     register_items(api.sensors.motion, HueMotionSensorEnabledEntity)
     register_items(api.sensors.light_level, HueLightSensorEnabledEntity)
-    register_items(api.config.behavior_instance, HueBehaviorInstanceEnabledEntity)
+    register_items(
+        api.config.behavior_instance,
+        HueBehaviorInstanceEnabledEntity,
+        is_user_automation,
+    )
 
 
 class HueResourceEnabledEntity(HueBaseEntity, SwitchEntity):

--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -28,15 +28,6 @@ from .bridge import HueConfigEntry
 from .const import DOMAIN
 from .v2.entity import HueBaseEntity
 
-# Behavior instances of these script categories are internal device
-# configuration (button mappings, entertainment cleanup) rather than user
-# facing automations. The bridge accepts a change to their `enabled` flag but
-# keeps running them regardless, so exposing them as switches is misleading.
-INTERNAL_SCRIPT_CATEGORIES = {
-    BehaviorScriptCategory.ACCESSORY,
-    BehaviorScriptCategory.ENTERTAINMENT,
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -85,11 +76,16 @@ async def async_setup_entry(
 
     @callback
     def is_user_automation(resource: BehaviorInstance) -> bool:
-        """Return if the behavior instance is a user facing automation."""
-        # older bridges do not report a category, keep the instance in that case
+        """Return if the behavior instance is an automation from the Hue app.
+
+        Anything else is device configuration, which the bridge keeps running
+        even after it accepts switching it off. Categories we do not recognise
+        are skipped too, better no switch than one that does nothing.
+        """
         script = api.config.behavior_script.get(resource.script_id)
         return (
-            script is None or script.metadata.category not in INTERNAL_SCRIPT_CATEGORIES
+            script is not None
+            and script.metadata.category is BehaviorScriptCategory.AUTOMATION
         )
 
     # clean up entities previously created for internal behavior instances

--- a/tests/components/hue/const.py
+++ b/tests/components/hue/const.py
@@ -138,3 +138,27 @@ FAKE_ROTARY = {
     },
     "type": "relative_rotary",
 }
+
+FAKE_BEHAVIOR_SCRIPT = {
+    "configuration_schema": {},
+    "description": "Generic switches script",
+    "id": "fake_behavior_script_id_1",
+    "metadata": {"category": "accessory", "name": "Hue Accessories"},
+    "state_schema": {},
+    "supported_features": [],
+    "trigger_schema": {},
+    "type": "behavior_script",
+    "version": "0.0.1",
+}
+
+FAKE_BEHAVIOR_INSTANCE = {
+    "configuration": {},
+    "dependees": [],  # codespell:ignore dependees
+    "enabled": True,
+    "id": "fake_behavior_instance_id_1",
+    "last_error": "",
+    "metadata": {"name": "Wall switch Hallway"},
+    "script_id": "fake_behavior_script_id_1",
+    "status": "running",
+    "type": "behavior_instance",
+}

--- a/tests/components/hue/fixtures/v2_resources.json
+++ b/tests/components/hue/fixtures/v2_resources.json
@@ -2235,6 +2235,7 @@
     "description": "Countdown Timer",
     "id": "e73bc72d-96b1-46f8-aa57-729861f80c78",
     "metadata": {
+      "category": "automation",
       "name": "Timers"
     },
     "state_schema": {

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -2,12 +2,22 @@
 
 from unittest.mock import Mock
 
+import pytest
+
+from homeassistant.components.hue.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 from homeassistant.util.json import JsonArrayType
 
 from .conftest import setup_platform
-from .const import FAKE_BINARY_SENSOR, FAKE_DEVICE, FAKE_ZIGBEE_CONNECTIVITY
+from .const import (
+    FAKE_BEHAVIOR_INSTANCE,
+    FAKE_BEHAVIOR_SCRIPT,
+    FAKE_BINARY_SENSOR,
+    FAKE_DEVICE,
+    FAKE_ZIGBEE_CONNECTIVITY,
+)
 
 
 async def test_switch(
@@ -131,3 +141,52 @@ async def test_switch_added(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     test_entity = hass.states.get(test_entity_id)
     assert test_entity is not None
     assert test_entity.state == "off"
+
+
+@pytest.mark.parametrize("category", ["accessory", "entertainment"])
+async def test_internal_behavior_instance_not_added(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    category: str,
+) -> None:
+    """Test internal behavior instances are not exposed as switches.
+
+    The bridge accepts a change to `enabled` on these but keeps running them,
+    so a switch for them would silently do nothing.
+    """
+    internal_script = {
+        **FAKE_BEHAVIOR_SCRIPT,
+        "metadata": {**FAKE_BEHAVIOR_SCRIPT["metadata"], "category": category},
+    }
+    await mock_bridge_v2.api.load_test_data(
+        [*v2_resources_test_data, internal_script, FAKE_BEHAVIOR_INSTANCE]
+    )
+
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
+
+    # the internal instance is not exposed
+    assert hass.states.get("switch.philips_hue_automation_wall_switch_hallway") is None
+    # while a regular automation still is
+    assert hass.states.get("switch.philips_hue_automation_timer_test") is not None
+    assert len(hass.states.async_all()) == 4
+
+
+async def test_internal_behavior_instance_entity_removed(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test a previously created entity for an internal instance is removed."""
+    # simulate the entity a previous version of the integration created
+    stale_entity = entity_registry.async_get_or_create(
+        Platform.SWITCH, DOMAIN, FAKE_BEHAVIOR_INSTANCE["id"]
+    )
+    await mock_bridge_v2.api.load_test_data(
+        [*v2_resources_test_data, FAKE_BEHAVIOR_SCRIPT, FAKE_BEHAVIOR_INSTANCE]
+    )
+
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
+
+    assert entity_registry.async_get(stale_entity.entity_id) is None

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -175,9 +175,7 @@ async def test_internal_behavior_instance_not_added(
 
     await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
 
-    # the internal instance is not exposed
     assert hass.states.get("switch.philips_hue_automation_wall_switch_hallway") is None
-    # while a regular automation still is
     assert hass.states.get("switch.philips_hue_automation_timer_test") is not None
     assert len(hass.states.async_all()) == 4
 

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -187,7 +187,7 @@ async def test_internal_behavior_instance_entity_removed(
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test a previously created entity for an internal instance is removed."""
-    # simulate the entity a previous version of the integration created
+    # Simulate an entity created with a previous version of the integration
     stale_entity = entity_registry.async_get_or_create(
         Platform.SWITCH, DOMAIN, FAKE_BEHAVIOR_INSTANCE["id"]
     )

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -143,22 +143,32 @@ async def test_switch_added(hass: HomeAssistant, mock_bridge_v2: Mock) -> None:
     assert test_entity.state == "off"
 
 
-@pytest.mark.parametrize("category", ["accessory", "entertainment"])
+@pytest.mark.parametrize(
+    "metadata",
+    [
+        pytest.param(
+            {"name": "Hue Accessories", "category": "accessory"}, id="accessory"
+        ),
+        pytest.param(
+            {"name": "Light state after streaming", "category": "entertainment"},
+            id="entertainment",
+        ),
+        pytest.param({"name": "Old bridge script"}, id="no_category"),
+    ],
+)
 async def test_internal_behavior_instance_not_added(
     hass: HomeAssistant,
     mock_bridge_v2: Mock,
     v2_resources_test_data: JsonArrayType,
-    category: str,
+    metadata: dict,
 ) -> None:
     """Test internal behavior instances are not exposed as switches.
 
     The bridge accepts a change to `enabled` on these but keeps running them,
-    so a switch for them would silently do nothing.
+    so a switch for them would silently do nothing. Bridges that do not report
+    a category at all are skipped for the same reason.
     """
-    internal_script = {
-        **FAKE_BEHAVIOR_SCRIPT,
-        "metadata": {**FAKE_BEHAVIOR_SCRIPT["metadata"], "category": category},
-    }
+    internal_script = {**FAKE_BEHAVIOR_SCRIPT, "metadata": metadata}
     await mock_bridge_v2.api.load_test_data(
         [*v2_resources_test_data, internal_script, FAKE_BEHAVIOR_INSTANCE]
     )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Home Assistant adds an "Automation: <name>" switch for every automation stored
on the Hue bridge. Most of those are not automations you can find in the Hue
app, but the button settings of your dimmer switches, wall switches and tap
dials, plus some internal entertainment settings. The bridge refuses to switch
those off, and when it does accept the change the accessory simply keeps
working, so those switches never did anything.

- Only add automation switches for automations that also show up in the Hue app
- Remove the switches that were added earlier for accessories and entertainment
- Added tests

Note that I deliberatly did not mark this as a breaking change although we are removing entities because these entities were non functional anyways and deeply hidden behind the hue bridge device. It is a fix to cleanup some (long overdue) wrong state.
 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
