### PR TITLE
Raise `HomeAssistantError` for ZHA action / WS API failures

### DIFF
--- a/homeassistant/components/zha/strings.json
+++ b/homeassistant/components/zha/strings.json
@@ -2292,6 +2292,17 @@
       }
     }
   },
+  "exceptions": {
+    "device_not_found": {
+      "message": "Device with IEEE address {ieee} not found"
+    },
+    "group_not_found": {
+      "message": "Group with ID {group_id} not found"
+    },
+    "no_warning_device": {
+      "message": "Device with IEEE address {ieee} is not an IAS warning device"
+    }
+  },
   "issues": {
     "inconsistent_network_settings": {
       "fix_flow": {

--- a/homeassistant/components/zha/websocket_api.py
+++ b/homeassistant/components/zha/websocket_api.py
@@ -46,7 +46,8 @@ from zha.application.platforms.siren import (
     StrobeLevel,
     WarningMode,
 )
-from zha.zigbee.group import GroupMemberReference
+from zha.zigbee.device import Device
+from zha.zigbee.group import Group, GroupMemberReference
 import zigpy.backups
 from zigpy.config import CONF_DEVICE
 from zigpy.config.validators import cv_boolean
@@ -62,6 +63,7 @@ from homeassistant.components import websocket_api
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import ATTR_COMMAND, ATTR_ID, ATTR_NAME, Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.service import async_register_admin_service
@@ -91,6 +93,7 @@ from .helpers import (
     ZHAGatewayProxy,
     async_cluster_exists,
     cluster_command_schema_to_vol_schema,
+    convert_zha_error_to_ha_error,
     get_config_entry,
     get_zha_gateway,
     get_zha_gateway_proxy,
@@ -314,6 +317,41 @@ CLUSTER_BINDING_SCHEMA = vol.All(
 )
 
 
+def _get_device(zha_gateway: Gateway, ieee: EUI64) -> Device:
+    """Return the device for an IEEE address, raising if it is unknown."""
+    if (device := zha_gateway.get_device(ieee)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={"ieee": str(ieee)},
+        )
+    return device
+
+
+def _get_warning_device(zha_gateway: Gateway, ieee: EUI64) -> BaseSiren:
+    """Return the IAS warning device entity of a device, raising if it has none."""
+    device = _get_device(zha_gateway, ieee)
+    try:
+        return device.get_entity(Platform.SIREN, pick_first=True)
+    except LookupError as err:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="no_warning_device",
+            translation_placeholders={"ieee": str(ieee)},
+        ) from err
+
+
+def _get_group(zha_gateway: Gateway, group_id: int) -> Group:
+    """Return the group for a group ID, raising if it is unknown."""
+    if (group := zha_gateway.get_group(group_id)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="group_not_found",
+            translation_placeholders={"group_id": str(group_id)},
+        )
+    return group
+
+
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
@@ -348,23 +386,25 @@ async def websocket_permit_devices(
     zha_gateway_proxy.async_enable_debug_mode()
     src_ieee: EUI64
     link_key: KeyData
+    application_controller = zha_gateway_proxy.gateway.application_controller
     if ATTR_SOURCE_IEEE in msg:
         src_ieee = msg[ATTR_SOURCE_IEEE]
         link_key = msg[ATTR_INSTALL_CODE]
         _LOGGER.debug("Allowing join for %s device with link key", src_ieee)
-        await zha_gateway_proxy.gateway.application_controller.permit_with_link_key(
-            time_s=duration, node=src_ieee, link_key=link_key
-        )
+        async with convert_zha_error_to_ha_error():
+            await application_controller.permit_with_link_key(
+                time_s=duration, node=src_ieee, link_key=link_key
+            )
     elif ATTR_QR_CODE in msg:
         src_ieee, link_key = msg[ATTR_QR_CODE]
         _LOGGER.debug("Allowing join for %s device with link key", src_ieee)
-        await zha_gateway_proxy.gateway.application_controller.permit_with_link_key(
-            time_s=duration, node=src_ieee, link_key=link_key
-        )
+        async with convert_zha_error_to_ha_error():
+            await application_controller.permit_with_link_key(
+                time_s=duration, node=src_ieee, link_key=link_key
+            )
     else:
-        await zha_gateway_proxy.gateway.application_controller.permit(
-            time_s=duration, node=ieee
-        )
+        async with convert_zha_error_to_ha_error():
+            await application_controller.permit(time_s=duration, node=ieee)
     connection.send_result(msg[ID])
 
 
@@ -858,13 +898,11 @@ async def websocket_read_zigbee_cluster_attributes(
     cluster_type: str = msg[ATTR_CLUSTER_TYPE]
     attribute: int = msg[ATTR_ATTRIBUTE]
     manufacturer: int | ZigpyUndefinedType = msg.get(ATTR_MANUFACTURER, ZIGPY_UNDEFINED)
-    zha_device = zha_gateway.get_device(ieee)
-    success = {}
-    failure = {}
-    if zha_device is not None:
-        cluster = zha_device.async_get_cluster(
-            endpoint_id, cluster_id, cluster_type=cluster_type
-        )
+    zha_device = _get_device(zha_gateway, ieee)
+    cluster = zha_device.async_get_cluster(
+        endpoint_id, cluster_id, cluster_type=cluster_type
+    )
+    async with convert_zha_error_to_ha_error():
         success, failure = await cluster.read_attributes(
             [attribute], allow_cache=False, only_cache=False, manufacturer=manufacturer
         )
@@ -905,8 +943,12 @@ async def websocket_get_bindable_devices(
     """Directly bind devices."""
     zha_gateway_proxy = get_zha_gateway_proxy(hass)
     source_ieee: EUI64 = msg[ATTR_IEEE]
-    source_device = zha_gateway_proxy.device_proxies.get(source_ieee)
-    assert source_device is not None
+    if (source_device := zha_gateway_proxy.device_proxies.get(source_ieee)) is None:
+        raise ServiceValidationError(
+            translation_domain=DOMAIN,
+            translation_key="device_not_found",
+            translation_placeholders={"ieee": str(source_ieee)},
+        )
 
     devices = [
         device.zha_device_info
@@ -1001,8 +1043,7 @@ async def websocket_bind_group(
     source_ieee: EUI64 = msg[ATTR_SOURCE_IEEE]
     group_id: int = msg[GROUP_ID]
     bindings: list[ClusterBinding] = msg[BINDINGS]
-    source_device = zha_gateway.get_device(source_ieee)
-    assert source_device
+    source_device = _get_device(zha_gateway, source_ieee)
     await source_device.async_bind_to_group(group_id, bindings)
     connection.send_result(msg[ID])
 
@@ -1025,8 +1066,7 @@ async def websocket_unbind_group(
     source_ieee: EUI64 = msg[ATTR_SOURCE_IEEE]
     group_id: int = msg[GROUP_ID]
     bindings: list[ClusterBinding] = msg[BINDINGS]
-    source_device = zha_gateway.get_device(source_ieee)
-    assert source_device
+    source_device = _get_device(zha_gateway, source_ieee)
     await source_device.async_unbind_from_group(group_id, bindings)
     connection.send_result(msg[ID])
 
@@ -1039,11 +1079,9 @@ async def async_binding_operation(
 ) -> None:
     """Create or remove a direct zigbee binding between 2 devices."""
 
-    source_device = zha_gateway.get_device(source_ieee)
-    target_device = zha_gateway.get_device(target_ieee)
+    source_device = _get_device(zha_gateway, source_ieee)
+    target_device = _get_device(zha_gateway, target_ieee)
 
-    assert source_device
-    assert target_device
     clusters_to_bind = await get_matched_clusters(source_device, target_device)
 
     zdo = source_device.device.zdo
@@ -1291,24 +1329,27 @@ def async_load_api(hass: HomeAssistant) -> None:
             src_ieee = service.data[ATTR_SOURCE_IEEE]
             link_key = service.data[ATTR_INSTALL_CODE]
             _LOGGER.info("Allowing join for %s device with link key", src_ieee)
-            await application_controller.permit_with_link_key(
-                time_s=duration, node=src_ieee, link_key=link_key
-            )
+            async with convert_zha_error_to_ha_error():
+                await application_controller.permit_with_link_key(
+                    time_s=duration, node=src_ieee, link_key=link_key
+                )
             return
 
         if ATTR_QR_CODE in service.data:
             src_ieee, link_key = service.data[ATTR_QR_CODE]
             _LOGGER.info("Allowing join for %s device with link key", src_ieee)
-            await application_controller.permit_with_link_key(
-                time_s=duration, node=src_ieee, link_key=link_key
-            )
+            async with convert_zha_error_to_ha_error():
+                await application_controller.permit_with_link_key(
+                    time_s=duration, node=src_ieee, link_key=link_key
+                )
             return
 
         if ieee:
             _LOGGER.info("Permitting joins for %ss on %s device", duration, ieee)
         else:
             _LOGGER.info("Permitting joins for %ss", duration)
-        await application_controller.permit(time_s=duration, node=ieee)
+        async with convert_zha_error_to_ha_error():
+            await application_controller.permit(time_s=duration, node=ieee)
 
     async_register_admin_service(
         hass, DOMAIN, SERVICE_PERMIT, permit, schema=SERVICE_SCHEMAS[SERVICE_PERMIT]
@@ -1319,7 +1360,8 @@ def async_load_api(hass: HomeAssistant) -> None:
         zha_gateway = get_zha_gateway(hass)
         ieee: EUI64 = service.data[ATTR_IEEE]
         _LOGGER.info("Removing node %s", ieee)
-        await zha_gateway.async_remove_device(ieee)
+        async with convert_zha_error_to_ha_error():
+            await zha_gateway.async_remove_device(ieee)
 
     async_register_admin_service(
         hass, DOMAIN, SERVICE_REMOVE, remove, schema=SERVICE_SCHEMAS[IEEE_SERVICE]
@@ -1336,9 +1378,8 @@ def async_load_api(hass: HomeAssistant) -> None:
         manufacturer: int | ZigpyUndefinedType = service.data.get(
             ATTR_MANUFACTURER, ZIGPY_UNDEFINED
         )
-        zha_device = zha_gateway.get_device(ieee)
-        response = None
-        if zha_device is not None:
+        zha_device = _get_device(zha_gateway, ieee)
+        async with convert_zha_error_to_ha_error():
             response = await zha_device.write_zigbee_attribute(
                 endpoint_id,
                 cluster_id,
@@ -1347,8 +1388,6 @@ def async_load_api(hass: HomeAssistant) -> None:
                 cluster_type=cluster_type,
                 manufacturer=manufacturer,
             )
-        else:
-            raise ValueError(f"Device with IEEE {ieee!s} not found")
 
         _LOGGER.debug(
             (
@@ -1392,11 +1431,11 @@ def async_load_api(hass: HomeAssistant) -> None:
         manufacturer: int | ZigpyUndefinedType = service.data.get(
             ATTR_MANUFACTURER, ZIGPY_UNDEFINED
         )
-        zha_device = zha_gateway.get_device(ieee)
-        if zha_device is not None:
-            if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
-                manufacturer = zha_device.manufacturer_code
+        zha_device = _get_device(zha_gateway, ieee)
+        if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
+            manufacturer = zha_device.manufacturer_code
 
+        async with convert_zha_error_to_ha_error():
             await zha_device.issue_cluster_command(
                 endpoint_id,
                 cluster_id,
@@ -1407,30 +1446,28 @@ def async_load_api(hass: HomeAssistant) -> None:
                 cluster_type=cluster_type,
                 manufacturer=manufacturer,
             )
-            _LOGGER.debug(
-                (
-                    "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s]"
-                    " %s: [%s] %s: [%s] %s: [%s]"
-                ),
-                ATTR_CLUSTER_ID,
-                cluster_id,
-                ATTR_CLUSTER_TYPE,
-                cluster_type,
-                ATTR_ENDPOINT_ID,
-                endpoint_id,
-                ATTR_COMMAND,
-                command,
-                ATTR_COMMAND_TYPE,
-                command_type,
-                ATTR_ARGS,
-                args,
-                ATTR_PARAMS,
-                params,
-                ATTR_MANUFACTURER,
-                manufacturer,
-            )
-        else:
-            raise ValueError(f"Device with IEEE {ieee!s} not found")
+        _LOGGER.debug(
+            (
+                "Issued command for: %s: [%s] %s: [%s] %s: [%s] %s: [%s] %s: [%s]"
+                " %s: [%s] %s: [%s] %s: [%s]"
+            ),
+            ATTR_CLUSTER_ID,
+            cluster_id,
+            ATTR_CLUSTER_TYPE,
+            cluster_type,
+            ATTR_ENDPOINT_ID,
+            endpoint_id,
+            ATTR_COMMAND,
+            command,
+            ATTR_COMMAND_TYPE,
+            command_type,
+            ATTR_ARGS,
+            args,
+            ATTR_PARAMS,
+            params,
+            ATTR_MANUFACTURER,
+            manufacturer,
+        )
 
     async_register_admin_service(
         hass,
@@ -1449,12 +1486,11 @@ def async_load_api(hass: HomeAssistant) -> None:
         manufacturer: int | ZigpyUndefinedType = service.data.get(
             ATTR_MANUFACTURER, ZIGPY_UNDEFINED
         )
-        group = zha_gateway.get_group(group_id)
+        group = _get_group(zha_gateway, group_id)
         if cluster_id >= MFG_CLUSTER_ID_START and manufacturer is None:
             _LOGGER.error("Missing manufacturer attribute for cluster: %d", cluster_id)
-        response = None
-        if group is not None:
-            cluster = group.endpoint[cluster_id]
+        cluster = group.endpoint[cluster_id]
+        async with convert_zha_error_to_ha_error():
             response = await cluster.command(
                 command, *args, manufacturer=manufacturer, expect_reply=True
             )
@@ -1487,10 +1523,10 @@ def async_load_api(hass: HomeAssistant) -> None:
         strobe: int = service.data[ATTR_WARNING_DEVICE_STROBE]
         level: int = service.data[ATTR_LEVEL]
 
-        device = zha_gateway.get_device(ieee)
-        siren: BaseSiren = device.get_entity(Platform.SIREN, pick_first=True)
+        siren = _get_warning_device(zha_gateway, ieee)
 
-        await siren.async_squawk(mode=mode, strobe=strobe, squawk_level=level)
+        async with convert_zha_error_to_ha_error():
+            await siren.async_squawk(mode=mode, strobe=strobe, squawk_level=level)
 
     async_register_admin_service(
         hass,
@@ -1510,17 +1546,17 @@ def async_load_api(hass: HomeAssistant) -> None:
         duty_mode: int = service.data[ATTR_WARNING_DEVICE_STROBE_DUTY_CYCLE]
         intensity: int = service.data[ATTR_WARNING_DEVICE_STROBE_INTENSITY]
 
-        device = zha_gateway.get_device(ieee)
-        siren: BaseSiren = device.get_entity(Platform.SIREN, pick_first=True)
+        siren = _get_warning_device(zha_gateway, ieee)
 
-        await siren.async_turn_on(
-            tone=mode,
-            volume_level=level,
-            duration=duration,
-            strobe=strobe,
-            strobe_duty_cycle=duty_mode,
-            strobe_intensity=intensity,
-        )
+        async with convert_zha_error_to_ha_error():
+            await siren.async_turn_on(
+                tone=mode,
+                volume_level=level,
+                duration=duration,
+                strobe=strobe,
+                strobe_duty_cycle=duty_mode,
+                strobe_intensity=intensity,
+            )
 
     async_register_admin_service(
         hass,

--- a/tests/components/zha/test_websocket_api.py
+++ b/tests/components/zha/test_websocket_api.py
@@ -3,21 +3,27 @@
 from binascii import unhexlify
 from collections.abc import Callable, Coroutine
 from copy import deepcopy
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Any
 from unittest.mock import ANY, AsyncMock, MagicMock, call, patch
 
 import pytest
 import voluptuous as vol
 from zha.application.const import (
+    ATTR_ATTRIBUTE,
     ATTR_CLUSTER_ID,
     ATTR_CLUSTER_TYPE,
+    ATTR_COMMAND_TYPE,
     ATTR_ENDPOINT_ID,
     ATTR_ENDPOINT_NAMES,
     ATTR_IEEE,
     ATTR_MANUFACTURER,
     ATTR_NEIGHBORS,
+    ATTR_PARAMS,
     ATTR_QUIRK_APPLIED,
     ATTR_TYPE,
+    ATTR_VALUE,
+    CLUSTER_COMMAND_SERVER,
     CLUSTER_TYPE_IN,
 )
 from zha.zigbee.device import (
@@ -28,6 +34,7 @@ from zha.zigbee.device import (
 )
 import zigpy.backups
 from zigpy.const import SIG_EP_INPUT, SIG_EP_OUTPUT, SIG_EP_PROFILE, SIG_EP_TYPE
+import zigpy.exceptions
 import zigpy.profiles.zha
 import zigpy.types
 from zigpy.types.named import EUI64
@@ -37,6 +44,7 @@ from zigpy.zcl.clusters.general import Groups
 import zigpy.zdo.types as zdo_types
 
 from homeassistant.components.websocket_api import (
+    ERR_HOME_ASSISTANT_ERROR,
     ERR_INVALID_FORMAT,
     ERR_NOT_FOUND,
     TYPE_RESULT,
@@ -51,6 +59,7 @@ from homeassistant.components.zha.helpers import (
 )
 from homeassistant.components.zha.websocket_api import (
     ATTR_DURATION,
+    ATTR_GROUP,
     ATTR_INSTALL_CODE,
     ATTR_QR_CODE,
     ATTR_SOURCE_IEEE,
@@ -60,12 +69,18 @@ from homeassistant.components.zha.websocket_api import (
     GROUP_IDS,
     GROUP_NAME,
     ID,
+    SERVICE_ISSUE_ZIGBEE_CLUSTER_COMMAND,
+    SERVICE_ISSUE_ZIGBEE_GROUP_COMMAND,
     SERVICE_PERMIT,
+    SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE,
+    SERVICE_WARNING_DEVICE_SQUAWK,
+    SERVICE_WARNING_DEVICE_WARN,
     TYPE,
     async_load_api,
 )
-from homeassistant.const import ATTR_MODEL, ATTR_NAME, Platform
+from homeassistant.const import ATTR_COMMAND, ATTR_MODEL, ATTR_NAME, Platform
 from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .conftest import FIXTURE_GRP_ID, FIXTURE_GRP_NAME
 from .data import BASE_CUSTOM_CONFIGURATION, CONFIG_WITH_ALARM_OPTIONS
@@ -75,6 +90,7 @@ from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 IEEE_SWITCH_DEVICE = "01:2d:6f:00:0a:90:69:e7"
 IEEE_GROUPABLE_DEVICE = "01:2d:6f:00:0a:90:69:e8"
+IEEE_UNKNOWN_DEVICE = "01:2d:6f:00:0a:90:69:ff"
 
 if TYPE_CHECKING:
     from zigpy.application import ControllerApplication
@@ -1271,3 +1287,232 @@ async def test_websocket_reconfigure_device_not_found(
     assert msg["type"] == TYPE_RESULT
     assert not msg["success"]
     assert msg["error"]["code"] == ERR_NOT_FOUND
+
+
+ISSUE_CLUSTER_COMMAND_DATA = {
+    ATTR_ENDPOINT_ID: 1,
+    ATTR_CLUSTER_ID: general.OnOff.cluster_id,
+    ATTR_COMMAND: general.OnOff.ServerCommandDefs.on.id,
+    ATTR_COMMAND_TYPE: CLUSTER_COMMAND_SERVER,
+    ATTR_PARAMS: {},
+}
+SET_CLUSTER_ATTRIBUTE_DATA = {
+    ATTR_ENDPOINT_ID: 1,
+    ATTR_CLUSTER_ID: general.OnOff.cluster_id,
+    ATTR_ATTRIBUTE: general.OnOff.AttributeDefs.start_up_on_off.id,
+    ATTR_VALUE: 1,
+}
+
+
+@pytest.mark.parametrize(
+    ("service", "data", "method", "side_effect", "message"),
+    [
+        pytest.param(
+            SERVICE_ISSUE_ZIGBEE_CLUSTER_COMMAND,
+            ISSUE_CLUSTER_COMMAND_DATA,
+            "issue_cluster_command",
+            zigpy.exceptions.DeliveryError(
+                "Failed to deliver packet: <TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>",
+                225,
+            ),
+            (
+                "Failed to send request: Failed to deliver packet: "
+                "<TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>"
+            ),
+            id="issue_cluster_command_delivery_error",
+        ),
+        pytest.param(
+            SERVICE_ISSUE_ZIGBEE_CLUSTER_COMMAND,
+            ISSUE_CLUSTER_COMMAND_DATA,
+            "issue_cluster_command",
+            TimeoutError(),
+            "Failed to send request: device did not respond",
+            id="issue_cluster_command_timeout",
+        ),
+        pytest.param(
+            SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE,
+            SET_CLUSTER_ATTRIBUTE_DATA,
+            "write_zigbee_attribute",
+            zigpy.exceptions.DeliveryError("Failed to deliver packet", 225),
+            "Failed to send request: Failed to deliver packet",
+            id="write_attribute_delivery_error",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("zha_client")
+async def test_service_radio_failure(
+    service: str,
+    data: dict[str, Any],
+    method: str,
+    side_effect: Exception,
+    message: str,
+    hass: HomeAssistant,
+) -> None:
+    """Test that a radio failure surfaces as a readable HomeAssistantError."""
+    gateway = get_zha_gateway(hass)
+    device = gateway.get_device(EUI64.convert(IEEE_SWITCH_DEVICE))
+
+    with (
+        patch.object(device, method, side_effect=side_effect),
+        pytest.raises(HomeAssistantError, match=re.escape(message)),
+    ):
+        await hass.services.async_call(
+            DOMAIN, service, {ATTR_IEEE: IEEE_SWITCH_DEVICE} | data, blocking=True
+        )
+
+
+@pytest.mark.usefixtures("zha_client")
+async def test_permit_radio_failure(
+    hass: HomeAssistant, app_controller: ControllerApplication
+) -> None:
+    """Test that a failed permit surfaces as a readable HomeAssistantError."""
+    app_controller.permit.side_effect = zigpy.exceptions.DeliveryError(
+        "Failed to deliver packet", 225
+    )
+
+    with pytest.raises(
+        HomeAssistantError, match="Failed to send request: Failed to deliver packet"
+    ):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_PERMIT, {ATTR_DURATION: 30}, blocking=True
+        )
+
+
+@pytest.mark.parametrize(
+    ("service", "data"),
+    [
+        pytest.param(
+            SERVICE_SET_ZIGBEE_CLUSTER_ATTRIBUTE,
+            SET_CLUSTER_ATTRIBUTE_DATA,
+            id="set_zigbee_cluster_attribute",
+        ),
+        pytest.param(
+            SERVICE_ISSUE_ZIGBEE_CLUSTER_COMMAND,
+            ISSUE_CLUSTER_COMMAND_DATA,
+            id="issue_zigbee_cluster_command",
+        ),
+        pytest.param(SERVICE_WARNING_DEVICE_SQUAWK, {}, id="warning_device_squawk"),
+        pytest.param(SERVICE_WARNING_DEVICE_WARN, {}, id="warning_device_warn"),
+    ],
+)
+@pytest.mark.usefixtures("zha_client")
+async def test_service_device_not_found(
+    service: str, data: dict[str, Any], hass: HomeAssistant
+) -> None:
+    """Test that an unknown IEEE raises a validation error instead of crashing."""
+    with pytest.raises(
+        ServiceValidationError,
+        match=f"Device with IEEE address {IEEE_UNKNOWN_DEVICE} not found",
+    ):
+        await hass.services.async_call(
+            DOMAIN, service, {ATTR_IEEE: IEEE_UNKNOWN_DEVICE} | data, blocking=True
+        )
+
+
+@pytest.mark.parametrize(
+    "service", [SERVICE_WARNING_DEVICE_SQUAWK, SERVICE_WARNING_DEVICE_WARN]
+)
+@pytest.mark.usefixtures("zha_client")
+async def test_warning_device_service_without_siren(
+    service: str, hass: HomeAssistant
+) -> None:
+    """Test that a device without a siren entity raises a validation error."""
+    with pytest.raises(
+        ServiceValidationError,
+        match=(
+            f"Device with IEEE address {IEEE_SWITCH_DEVICE} "
+            "is not an IAS warning device"
+        ),
+    ):
+        await hass.services.async_call(
+            DOMAIN, service, {ATTR_IEEE: IEEE_SWITCH_DEVICE}, blocking=True
+        )
+
+
+@pytest.mark.usefixtures("zha_client")
+async def test_issue_zigbee_group_command_group_not_found(hass: HomeAssistant) -> None:
+    """Test that an unknown group raises a validation error instead of doing nothing."""
+    with pytest.raises(ServiceValidationError, match="Group with ID 1234 not found"):
+        await hass.services.async_call(
+            DOMAIN,
+            SERVICE_ISSUE_ZIGBEE_GROUP_COMMAND,
+            {
+                ATTR_GROUP: 1234,
+                ATTR_CLUSTER_ID: general.OnOff.cluster_id,
+                ATTR_COMMAND: general.OnOff.ServerCommandDefs.on.id,
+            },
+            blocking=True,
+        )
+
+
+async def test_websocket_read_cluster_attribute_radio_failure(
+    hass: HomeAssistant, zha_client: MockHAClientWebSocket
+) -> None:
+    """Test that a failed attribute read is reported to the frontend, not swallowed."""
+    gateway = get_zha_gateway(hass)
+    device = gateway.get_device(EUI64.convert(IEEE_SWITCH_DEVICE))
+    cluster = device.async_get_cluster(1, general.OnOff.cluster_id)
+
+    with patch.object(
+        cluster,
+        "read_attributes",
+        side_effect=zigpy.exceptions.DeliveryError("Failed to deliver packet", 225),
+    ):
+        await zha_client.send_json(
+            {
+                ID: 31,
+                TYPE: "zha/devices/clusters/attributes/value",
+                ATTR_IEEE: IEEE_SWITCH_DEVICE,
+                ATTR_ENDPOINT_ID: 1,
+                ATTR_CLUSTER_ID: general.OnOff.cluster_id,
+                ATTR_CLUSTER_TYPE: CLUSTER_TYPE_IN,
+                ATTR_ATTRIBUTE: general.OnOff.AttributeDefs.on_off.id,
+            }
+        )
+        msg = await zha_client.receive_json()
+
+    assert msg["id"] == 31
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_HOME_ASSISTANT_ERROR
+    assert msg["error"]["message"] == "Failed to send request: Failed to deliver packet"
+
+
+BIND_PAYLOAD = {
+    ATTR_SOURCE_IEEE: IEEE_UNKNOWN_DEVICE,
+    ATTR_TARGET_IEEE: IEEE_GROUPABLE_DEVICE,
+}
+GROUP_BIND_PAYLOAD = {
+    ATTR_SOURCE_IEEE: IEEE_UNKNOWN_DEVICE,
+    GROUP_ID: 0x0001,
+    BINDINGS: [{ATTR_ENDPOINT_ID: 1, ID: 6, ATTR_NAME: "OnOff", ATTR_TYPE: "out"}],
+}
+
+
+@pytest.mark.parametrize(
+    ("command", "payload"),
+    [
+        pytest.param("zha/devices/bind", BIND_PAYLOAD, id="devices_bind"),
+        pytest.param("zha/devices/unbind", BIND_PAYLOAD, id="devices_unbind"),
+        pytest.param("zha/groups/bind", GROUP_BIND_PAYLOAD, id="groups_bind"),
+        pytest.param("zha/groups/unbind", GROUP_BIND_PAYLOAD, id="groups_unbind"),
+        pytest.param(
+            "zha/devices/bindable",
+            {ATTR_IEEE: IEEE_UNKNOWN_DEVICE},
+            id="devices_bindable",
+        ),
+    ],
+)
+async def test_websocket_bind_device_not_found(
+    command: str, payload: dict[str, Any], zha_client: MockHAClientWebSocket
+) -> None:
+    """Test that an unknown IEEE is reported to the frontend instead of asserting."""
+    await zha_client.send_json({ID: 32, TYPE: command} | payload)
+    msg = await zha_client.receive_json()
+
+    assert msg["id"] == 32
+    assert not msg["success"]
+    assert msg["error"]["code"] == ERR_HOME_ASSISTANT_ERROR
+    assert (
+        msg["error"]["message"]
+        == f"Device with IEEE address {IEEE_UNKNOWN_DEVICE} not found"
+    )


### PR DESCRIPTION
## Proposed change

Radio failures (e.g. a zigpy `DeliveryError`) propagated out of the `zha.*` actions unwrapped, so the script engine logged them as "Unexpected error" with a full traceback, and the WebSocket API reported them as "Unknown error".

Wrap the calls that reach the radio in `convert_zha_error_to_ha_error`, which the entity platforms and device actions already use, and raise `ServiceValidationError` for an unknown IEEE address or group ID, and for a device that has no IAS warning device entity, instead of `ValueError`, an `assert`, a `LookupError`, or silently doing nothing.

Tests for the failure paths are also added, as coverage was lacking before. Though we're apparently still missing test coverage for a lot of other parts...

### Future note

Binding is deliberately left unwrapped: `async_binding_operation` and zha's `Device._async_group_binding_operation` both gather their ZDO requests with `return_exceptions=True` and only log failures, so no zigpy exception can escape them today. This should be addressed differently in another PR.

### Original report

The issue was noticed in the following comment https://github.com/home-assistant/core/issues/175890#issuecomment-4975930898, though it's unrelated to the actual (fixed) issue the original report is about.

### More detailed AI description

<details><summary>Detailed LLM-generated PR description</summary>
<p>

When a Zigbee device can't be reached, ZHA's actions dump a full traceback into the log instead of a readable error. Calling `zha.issue_zigbee_cluster_command` from an automation against an out-of-range device (or on a congested channel) produces this:

```
<Automation>: Error executing script. Unexpected error for call_service at pos 1: Failed to deliver packet: <TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>
Traceback (most recent call last):
  ...40 lines...
zigpy.exceptions.DeliveryError: Failed to deliver packet: <TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>
```

The cause is that `websocket_api.py` — which registers all seven `zha.*` actions and every `zha/...` WebSocket command — never used the `convert_zha_error_to_ha_error()` helper from `helpers.py`, even though every ZHA entity platform and `device_action.py` already does. Because the raw `zigpy.exceptions.DeliveryError` isn't a `HomeAssistantError`, `script.py` classifies it as "Unexpected error" and logs it at `_LOG_EXCEPTION` with the traceback, and the WebSocket API reports it to the frontend as `unknown_error` / "Unknown error" with nothing useful in it.

This is purely about how the failure is *presented* — a `MAC_CHANNEL_ACCESS_FAILURE` is the radio failing CSMA/CA, so the underlying delivery problem is real and unchanged. But it currently reads like a Home Assistant crash rather than "your device didn't get the packet".

**What this changes:**

- All seven `zha.*` actions (`permit`, `remove`, `set_zigbee_cluster_attribute`, `issue_zigbee_cluster_command`, `issue_zigbee_group_command`, `warning_device_squawk`, `warning_device_warn`) now wrap their radio call in `convert_zha_error_to_ha_error()`, as do the two WebSocket commands that propagate radio errors (`zha/devices/permit` and `zha/devices/clusters/attributes/value`). The example above becomes a single line: `Error for call_service at pos 1: Failed to send request: Failed to deliver packet: <TXStatus.MAC_CHANNEL_ACCESS_FAILURE: 225>`, and the frontend gets `home_assistant_error` with that message instead of "Unknown error".
- Unknown IEEE address or group ID now raises a translated `ServiceValidationError`, replacing two `raise ValueError`, three bare `assert`s (which surfaced as `AssertionError` → "Unknown error"), and — in `issue_zigbee_group_command` — a silent no-op that reported success for a group that doesn't exist.
- `zha.warning_device_squawk` / `warning_device_warn` against a device with no siren entity raised a raw `LookupError` from `device.get_entity(...)`, i.e. exactly the "Unexpected error" traceback this PR is about. That's now a `ServiceValidationError` too.

**Deliberately not changed:** device and group binding are left unwrapped. Both `async_binding_operation` here and zha's `Device._async_group_binding_operation` gather their ZDO requests with `return_exceptions=True` and only log failures at debug level, so no zigpy exception can escape them and a wrapper there would be dead code. That does mean bind/unbind still reports success to the frontend when every request failed on-air — a real bug, but fixing it is a behaviour change (partial-failure binds would start erroring) and the group half needs an upstream `zha` change, so it seems better suited to its own PR. I'm happy to do that separately if you'd prefer it here.

Also left as follow-ups: `zha/network/backups/create`, `zha/network/backups/restore` and `zha/network/change_channel` can still leak raw zigpy exceptions to the frontend as `unknown_error`.

These actions had no test coverage at all, so this adds tests for the error paths (81 tests in `test_websocket_api.py`, up from 64).

</p>
</details> 

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
