### PR TITLE
Fix searching within an artist returning no results in Music Assistant

### DIFF
--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -76,6 +76,9 @@ LIBRARY_MASS_MEDIA_TYPE_MAP = {
     LIBRARY_AUDIOBOOKS: MASSMediaType.AUDIOBOOK,
 }
 
+# an artist holds nothing else we can search or browse
+ARTIST_MASS_MEDIA_TYPES = [MASSMediaType.ALBUM, MASSMediaType.TRACK]
+
 MEDIA_CONTENT_TYPE_FLAC = "audio/flac"
 THUMB_SIZE = 200
 SORT_NAME = "sort_name"
@@ -490,14 +493,18 @@ async def _search_within_playlist(
 
 
 async def _search_within_artist(
-    mass: MusicAssistantClient, artist_uri: str, search_query: str, limit: int
+    mass: MusicAssistantClient,
+    artist_uri: str,
+    search_query: str,
+    limit: int,
+    media_types: list[MASSMediaType],
 ) -> SearchResults:
     """Search for content within an artist's catalog."""
     artist = await mass.music.get_item_by_uri(artist_uri)
     search_query = f"{artist.name} - {search_query}"
     return await mass.music.search(
         search_query,
-        media_types=[MASSMediaType.ALBUM, MASSMediaType.TRACK],
+        media_types=media_types,
         limit=limit,
     )
 
@@ -645,6 +652,9 @@ async def async_search_media(
         limit = 5  # Default limit per media type
         search_results: SearchResults | None = None
 
+        # Determine which media types to search
+        media_types = _get_media_types_from_query(query)
+
         # Handle media_content_id if provided (for contextual searches)
         if query.media_content_id:
             if "album/" in query.media_content_id:
@@ -656,13 +666,18 @@ async def async_search_media(
                     mass, query.media_content_id, search_query, limit
                 )
             if "artist/" in query.media_content_id:
+                # we can only make sense of what we asked for, so drop anything
+                # an artist cannot hold instead of searching for it and
+                # discarding the entire response
+                media_types = [
+                    media_type
+                    for media_type in media_types
+                    if media_type in ARTIST_MASS_MEDIA_TYPES
+                ] or ARTIST_MASS_MEDIA_TYPES
                 # For artists, we already run a search, so save the results
                 search_results = await _search_within_artist(
-                    mass, query.media_content_id, search_query, limit
+                    mass, query.media_content_id, search_query, limit, media_types
                 )
-
-        # Determine which media types to search
-        media_types = _get_media_types_from_query(query)
 
         # Execute search using the Music Assistant API if we haven't already done so
         if search_results is None:

--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -76,6 +76,26 @@ LIBRARY_MASS_MEDIA_TYPE_MAP = {
     LIBRARY_AUDIOBOOKS: MASSMediaType.AUDIOBOOK,
 }
 
+MEDIA_CLASS_MASS_MEDIA_TYPE_MAP = {
+    MediaClass.ARTIST: MASSMediaType.ARTIST,
+    MediaClass.ALBUM: MASSMediaType.ALBUM,
+    MediaClass.TRACK: MASSMediaType.TRACK,
+    MediaClass.PLAYLIST: MASSMediaType.PLAYLIST,
+    MediaClass.MUSIC: MASSMediaType.RADIO,
+    MediaClass.DIRECTORY: MASSMediaType.AUDIOBOOK,
+    MediaClass.PODCAST: MASSMediaType.PODCAST,
+}
+
+SEARCHABLE_MASS_MEDIA_TYPES = [
+    MASSMediaType.ARTIST,
+    MASSMediaType.ALBUM,
+    MASSMediaType.TRACK,
+    MASSMediaType.PLAYLIST,
+    MASSMediaType.RADIO,
+    MASSMediaType.AUDIOBOOK,
+    MASSMediaType.PODCAST,
+]
+
 # an artist holds nothing else we can search or browse
 ARTIST_MASS_MEDIA_TYPES = [MASSMediaType.ALBUM, MASSMediaType.TRACK]
 
@@ -513,6 +533,15 @@ def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
     """Map query to Music Assistant media types."""
     media_types: list[MASSMediaType] = []
 
+    # an explicit filter is the only thing the user picked themselves,
+    # so it wins from the media type that merely surrounds the search
+    if query.media_filter_classes:
+        return [
+            MEDIA_CLASS_MASS_MEDIA_TYPE_MAP[cls]
+            for cls in query.media_filter_classes
+            if cls in MEDIA_CLASS_MASS_MEDIA_TYPE_MAP
+        ] or SEARCHABLE_MASS_MEDIA_TYPES
+
     match query.media_content_type:
         case MediaType.ARTIST:
             media_types = [MASSMediaType.ARTIST]
@@ -530,21 +559,7 @@ def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
             media_types = [MASSMediaType.PODCAST]
         case _:
             # No specific type selected
-            if query.media_filter_classes:
-                # Map MediaClass to search types
-                mapping = {
-                    MediaClass.ARTIST: MASSMediaType.ARTIST,
-                    MediaClass.ALBUM: MASSMediaType.ALBUM,
-                    MediaClass.TRACK: MASSMediaType.TRACK,
-                    MediaClass.PLAYLIST: MASSMediaType.PLAYLIST,
-                    MediaClass.MUSIC: MASSMediaType.RADIO,
-                    MediaClass.DIRECTORY: MASSMediaType.AUDIOBOOK,
-                    MediaClass.PODCAST: MASSMediaType.PODCAST,
-                }
-                media_types = [
-                    mapping[cls] for cls in query.media_filter_classes if cls in mapping
-                ]
-            elif library_media_type := LIBRARY_MASS_MEDIA_TYPE_MAP.get(
+            if library_media_type := LIBRARY_MASS_MEDIA_TYPE_MAP.get(
                 query.media_content_id or ""
             ):
                 # Searching from a library listing scopes to that library,
@@ -553,18 +568,7 @@ def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
                 media_types = [library_media_type]
 
     # Default to all types if none specified
-    if not media_types:
-        media_types = [
-            MASSMediaType.ARTIST,
-            MASSMediaType.ALBUM,
-            MASSMediaType.TRACK,
-            MASSMediaType.PLAYLIST,
-            MASSMediaType.RADIO,
-            MASSMediaType.AUDIOBOOK,
-            MASSMediaType.PODCAST,
-        ]
-
-    return media_types
+    return media_types or SEARCHABLE_MASS_MEDIA_TYPES
 
 
 def _process_search_results(

--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -530,17 +530,29 @@ async def _search_within_artist(
 
 
 def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
-    """Map query to Music Assistant media types."""
+    """Map query to Music Assistant media types.
+
+    Returns nothing when the query rules out everything we could look for.
+    """
     media_types: list[MASSMediaType] = []
 
-    # an explicit filter is the only thing the user picked themselves,
-    # so it wins from the media type that merely surrounds the search
+    # searching inside an artist can never turn up more than their own
+    # albums and tracks, whatever the rest of the query asks for
+    allowed = (
+        ARTIST_MASS_MEDIA_TYPES
+        if "artist/" in (query.media_content_id or "")
+        else SEARCHABLE_MASS_MEDIA_TYPES
+    )
+
+    # an explicit filter is the only thing the user picked themselves, so it
+    # wins from the media type that merely surrounds the search, and asking
+    # for something unsearchable leaves nothing rather than everything
     if query.media_filter_classes:
         return [
             MEDIA_CLASS_MASS_MEDIA_TYPE_MAP[cls]
             for cls in query.media_filter_classes
-            if cls in MEDIA_CLASS_MASS_MEDIA_TYPE_MAP
-        ] or SEARCHABLE_MASS_MEDIA_TYPES
+            if MEDIA_CLASS_MASS_MEDIA_TYPE_MAP.get(cls) in allowed
+        ]
 
     match query.media_content_type:
         case MediaType.ARTIST:
@@ -567,8 +579,10 @@ def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
                 # rather than as a concrete media type.
                 media_types = [library_media_type]
 
-    # Default to all types if none specified
-    return media_types or SEARCHABLE_MASS_MEDIA_TYPES
+    # Default to everything we are allowed to look for if none specified
+    return [
+        media_type for media_type in media_types if media_type in allowed
+    ] or allowed
 
 
 def _process_search_results(
@@ -658,6 +672,9 @@ async def async_search_media(
 
         # Determine which media types to search
         media_types = _get_media_types_from_query(query)
+        if not media_types:
+            # the query ruled out everything we could have looked for
+            return SearchMedia(result=[])
 
         # Handle media_content_id if provided (for contextual searches)
         if query.media_content_id:
@@ -670,14 +687,6 @@ async def async_search_media(
                     mass, query.media_content_id, search_query, limit
                 )
             if "artist/" in query.media_content_id:
-                # we can only make sense of what we asked for, so drop anything
-                # an artist cannot hold instead of searching for it and
-                # discarding the entire response
-                media_types = [
-                    media_type
-                    for media_type in media_types
-                    if media_type in ARTIST_MASS_MEDIA_TYPES
-                ] or ARTIST_MASS_MEDIA_TYPES
                 # For artists, we already run a search, so save the results
                 search_results = await _search_within_artist(
                     mass, query.media_content_id, search_query, limit, media_types

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -438,17 +438,71 @@ async def test_browse_artist_search_media_classes(
 
 
 @pytest.mark.parametrize(
-    ("media_filter_classes", "expected_classes"),
+    "media_content_type",
+    [MediaType.MUSIC, MediaType.ARTIST, None],
+)
+async def test_search_within_artist_ignores_surrounding_media_type(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    media_content_type: str | None,
+) -> None:
+    """Test that an artist search returns its albums and tracks either way.
+
+    An artist holds no artists, so a surrounding artist media type must not be
+    taken as the thing to look for, or the whole response gets discarded.
+    """
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    artist = MagicMock()
+    artist.name = "Test Artist"
+    mock = MockSearchResults(["album", "track"])
+
+    with (
+        patch.object(
+            music_assistant_client.music, "get_item_by_uri", return_value=artist
+        ),
+        patch.object(
+            music_assistant_client.music,
+            "search",
+            return_value=SearchResults(albums=mock.albums, tracks=mock.tracks),
+        ) as mock_search,
+    ):
+        search_results = await async_search_media(
+            music_assistant_client,
+            SearchMediaQuery(
+                search_query="test",
+                media_content_type=media_content_type,
+                media_content_id="library://artist/127",
+            ),
+        )
+
+    assert mock_search.call_args.kwargs["media_types"] == [
+        MASSMediaType.ALBUM,
+        MASSMediaType.TRACK,
+    ]
+    assert {item.media_class for item in search_results.result} == {
+        MediaClass.ALBUM,
+        MediaClass.TRACK,
+    }
+
+
+@pytest.mark.parametrize(
+    ("media_filter_classes", "expected_media_types", "expected_classes"),
     [
-        (None, {MediaClass.ALBUM, MediaClass.TRACK}),
-        ({MediaClass.ALBUM}, {MediaClass.ALBUM}),
-        ({MediaClass.TRACK}, {MediaClass.TRACK}),
+        (
+            None,
+            [MASSMediaType.ALBUM, MASSMediaType.TRACK],
+            {MediaClass.ALBUM, MediaClass.TRACK},
+        ),
+        ({MediaClass.ALBUM}, [MASSMediaType.ALBUM], {MediaClass.ALBUM}),
+        ({MediaClass.TRACK}, [MASSMediaType.TRACK], {MediaClass.TRACK}),
     ],
 )
 async def test_search_within_artist_with_filter_classes(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,
     media_filter_classes: set[MediaClass] | None,
+    expected_media_types: list[MASSMediaType],
     expected_classes: set[MediaClass],
 ) -> None:
     """Test that the filters offered on an artist listing narrow its results."""
@@ -482,11 +536,9 @@ async def test_search_within_artist_with_filter_classes(
 
     # the artist name scopes the query that is sent to the search api
     assert mock_search.call_args.args[0] == "Test Artist - test"
-    # the response is only useful as long as it holds what we asked for
-    assert mock_search.call_args.kwargs["media_types"] == [
-        MASSMediaType.ALBUM,
-        MASSMediaType.TRACK,
-    ]
+    # a filter narrows what we ask for, instead of asking for everything
+    # an artist can hold and dropping most of the response again
+    assert mock_search.call_args.kwargs["media_types"] == expected_media_types
     assert {item.media_class for item in search_results.result} == expected_classes
 
 

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -549,6 +549,39 @@ async def test_search_within_artist_with_filter_classes(
     assert {item.media_class for item in search_results.result} == expected_classes
 
 
+@pytest.mark.parametrize(
+    ("media_content_id", "media_filter_classes"),
+    [
+        # an artist holds no playlists, so there is nothing to find
+        ("library://artist/127", {MediaClass.PLAYLIST}),
+        # nothing we can search for is an image
+        ("library://artist/127", {MediaClass.IMAGE}),
+        (None, {MediaClass.IMAGE}),
+    ],
+)
+async def test_search_media_with_unsearchable_filter(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    media_content_id: str | None,
+    media_filter_classes: set[MediaClass],
+) -> None:
+    """Test that a filter we cannot honour returns nothing, not everything."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    with patch.object(music_assistant_client.music, "search") as mock_search:
+        search_results = await async_search_media(
+            music_assistant_client,
+            SearchMediaQuery(
+                search_query="test",
+                media_content_id=media_content_id,
+                media_filter_classes=media_filter_classes,
+            ),
+        )
+
+    mock_search.assert_not_called()
+    assert search_results.result == []
+
+
 async def test_search_media_results_are_browsable(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -437,6 +437,51 @@ async def test_browse_artist_search_media_classes(
     assert browse_item.search_media_classes == [MediaClass.ALBUM, MediaClass.TRACK]
 
 
+@pytest.mark.parametrize(
+    ("media_filter_classes", "expected_classes"),
+    [
+        (None, {MediaClass.ALBUM, MediaClass.TRACK}),
+        ({MediaClass.ALBUM}, {MediaClass.ALBUM}),
+        ({MediaClass.TRACK}, {MediaClass.TRACK}),
+    ],
+)
+async def test_search_within_artist_with_filter_classes(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    media_filter_classes: set[MediaClass] | None,
+    expected_classes: set[MediaClass],
+) -> None:
+    """Test that the filters offered on an artist listing narrow its results."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    artist = MagicMock()
+    artist.name = "Test Artist"
+    mock = MockSearchResults(["album", "track"])
+
+    with (
+        patch.object(
+            music_assistant_client.music, "get_item_by_uri", return_value=artist
+        ),
+        patch.object(
+            music_assistant_client.music,
+            "search",
+            return_value=SearchResults(albums=mock.albums, tracks=mock.tracks),
+        ) as mock_search,
+    ):
+        search_results = await async_search_media(
+            music_assistant_client,
+            SearchMediaQuery(
+                search_query="test",
+                media_content_id="library://artist/127",
+                media_filter_classes=media_filter_classes,
+            ),
+        )
+
+    # the artist name scopes the query that is sent to the search api
+    assert mock_search.call_args.args[0] == "Test Artist - test"
+    assert {item.media_class for item in search_results.result} == expected_classes
+
+
 async def test_search_media_results_are_browsable(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -472,6 +472,9 @@ async def test_search_within_artist_with_filter_classes(
             music_assistant_client,
             SearchMediaQuery(
                 search_query="test",
+                # the media browser navigates using the item its parent listing
+                # built, and those are all reported as plain music
+                media_content_type=MediaType.MUSIC,
                 media_content_id="library://artist/127",
                 media_filter_classes=media_filter_classes,
             ),
@@ -479,6 +482,11 @@ async def test_search_within_artist_with_filter_classes(
 
     # the artist name scopes the query that is sent to the search api
     assert mock_search.call_args.args[0] == "Test Artist - test"
+    # the response is only useful as long as it holds what we asked for
+    assert mock_search.call_args.kwargs["media_types"] == [
+        MASSMediaType.ALBUM,
+        MASSMediaType.TRACK,
+    ]
     assert {item.media_class for item in search_results.result} == expected_classes
 
 

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -487,6 +487,10 @@ async def test_search_within_artist_ignores_surrounding_media_type(
 
 
 @pytest.mark.parametrize(
+    "media_content_type",
+    [MediaType.MUSIC, MediaType.ARTIST],
+)
+@pytest.mark.parametrize(
     ("media_filter_classes", "expected_media_types", "expected_classes"),
     [
         (
@@ -501,11 +505,16 @@ async def test_search_within_artist_ignores_surrounding_media_type(
 async def test_search_within_artist_with_filter_classes(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,
+    media_content_type: str,
     media_filter_classes: set[MediaClass] | None,
     expected_media_types: list[MASSMediaType],
     expected_classes: set[MediaClass],
 ) -> None:
-    """Test that the filters offered on an artist listing narrow its results."""
+    """Test that the filters offered on an artist listing narrow its results.
+
+    A filter is picked by the user, so it has to win from whatever media type
+    happens to surround the search.
+    """
     await setup_integration_from_fixtures(hass, music_assistant_client)
 
     artist = MagicMock()
@@ -526,9 +535,7 @@ async def test_search_within_artist_with_filter_classes(
             music_assistant_client,
             SearchMediaQuery(
                 search_query="test",
-                # the media browser navigates using the item its parent listing
-                # built, and those are all reported as plain music
-                media_content_type=MediaType.MUSIC,
+                media_content_type=media_content_type,
                 media_content_id="library://artist/127",
                 media_filter_classes=media_filter_classes,
             ),


### PR DESCRIPTION
## Proposed change

Searching within an artist in Music Assistant could come back empty even when the artist had matching albums and tracks. An artist search always asks the server for albums and tracks, but the media type surrounding the search decided what was kept from the answer. When that media type was the artist itself, we ended up looking for artists in a response that only held albums and tracks, so everything was dropped.

This is not reachable from the media browser, which reports items as plain music, but it is through the `music_assistant.search` and `media_player.search_media` actions.

A related one turned up next to it: a filter is the only part of a search the user picks themselves, but it was ignored whenever a media type came along with it, so narrowing an artist search down to tracks still returned albums.

- Keep only what an artist can actually hold when searching within one, and ask the server for just that
- Let a chosen filter win from the media type that merely surrounds the search
- Return nothing when a filter rules out everything we could look for, instead of quietly widening the search
- Add tests for searching an artist, with and without the album and track filters

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/177649
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
