### PR TITLE
Fix asking Music Assistant for music searching only radio

### DIFF
--- a/homeassistant/components/music_assistant/media_browser.py
+++ b/homeassistant/components/music_assistant/media_browser.py
@@ -76,14 +76,24 @@ LIBRARY_MASS_MEDIA_TYPE_MAP = {
     LIBRARY_AUDIOBOOKS: MASSMediaType.AUDIOBOOK,
 }
 
+MUSIC_MASS_MEDIA_TYPES = [
+    MASSMediaType.ARTIST,
+    MASSMediaType.ALBUM,
+    MASSMediaType.TRACK,
+    MASSMediaType.PLAYLIST,
+]
+
 MEDIA_CLASS_MASS_MEDIA_TYPE_MAP = {
-    MediaClass.ARTIST: MASSMediaType.ARTIST,
-    MediaClass.ALBUM: MASSMediaType.ALBUM,
-    MediaClass.TRACK: MASSMediaType.TRACK,
-    MediaClass.PLAYLIST: MASSMediaType.PLAYLIST,
-    MediaClass.MUSIC: MASSMediaType.RADIO,
-    MediaClass.DIRECTORY: MASSMediaType.AUDIOBOOK,
-    MediaClass.PODCAST: MASSMediaType.PODCAST,
+    MediaClass.ARTIST: [MASSMediaType.ARTIST],
+    MediaClass.ALBUM: [MASSMediaType.ALBUM],
+    MediaClass.TRACK: [MASSMediaType.TRACK],
+    MediaClass.PLAYLIST: [MASSMediaType.PLAYLIST],
+    # music is the class a voice assistant picks for a plain "play something"
+    # request, so it has to mean music rather than the radio stations we
+    # happen to hand back to HA under the same class
+    MediaClass.MUSIC: MUSIC_MASS_MEDIA_TYPES,
+    MediaClass.DIRECTORY: [MASSMediaType.AUDIOBOOK],
+    MediaClass.PODCAST: [MASSMediaType.PODCAST],
 }
 
 SEARCHABLE_MASS_MEDIA_TYPES = [
@@ -548,11 +558,12 @@ def _get_media_types_from_query(query: SearchMediaQuery) -> list[MASSMediaType]:
     # wins from the media type that merely surrounds the search, and asking
     # for something unsearchable leaves nothing rather than everything
     if query.media_filter_classes:
-        return [
-            MEDIA_CLASS_MASS_MEDIA_TYPE_MAP[cls]
+        requested = {
+            media_type
             for cls in query.media_filter_classes
-            if MEDIA_CLASS_MASS_MEDIA_TYPE_MAP.get(cls) in allowed
-        ]
+            for media_type in MEDIA_CLASS_MASS_MEDIA_TYPE_MAP.get(cls, ())
+        }
+        return [media_type for media_type in allowed if media_type in requested]
 
     match query.media_content_type:
         case MediaType.ARTIST:

--- a/tests/components/music_assistant/test_media_browser.py
+++ b/tests/components/music_assistant/test_media_browser.py
@@ -550,6 +550,68 @@ async def test_search_within_artist_with_filter_classes(
 
 
 @pytest.mark.parametrize(
+    ("media_content_id", "expected_media_types"),
+    [
+        (
+            None,
+            [
+                MASSMediaType.ARTIST,
+                MASSMediaType.ALBUM,
+                MASSMediaType.TRACK,
+                MASSMediaType.PLAYLIST,
+            ],
+        ),
+        # inside an artist there is no more music to be had than their own
+        ("library://artist/127", [MASSMediaType.ALBUM, MASSMediaType.TRACK]),
+    ],
+)
+async def test_search_media_music_class_searches_music(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+    media_content_id: str | None,
+    expected_media_types: list[MASSMediaType],
+) -> None:
+    """Test that asking for music searches music instead of radio.
+
+    A voice assistant sends this class for a plain "play something" request,
+    and we hand radio stations back to HA under the same class, which is why
+    it used to end up searching radio only.
+    """
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+
+    artist = MagicMock()
+    artist.name = "Test Artist"
+    mock = MockSearchResults(["artist", "album", "track", "playlist"])
+
+    with (
+        patch.object(
+            music_assistant_client.music, "get_item_by_uri", return_value=artist
+        ),
+        patch.object(
+            music_assistant_client.music,
+            "search",
+            return_value=SearchResults(
+                artists=mock.artists,
+                albums=mock.albums,
+                tracks=mock.tracks,
+                playlists=mock.playlists,
+            ),
+        ) as mock_search,
+    ):
+        search_results = await async_search_media(
+            music_assistant_client,
+            SearchMediaQuery(
+                search_query="some artist",
+                media_content_id=media_content_id,
+                media_filter_classes={MediaClass.MUSIC},
+            ),
+        )
+
+    assert mock_search.call_args.kwargs["media_types"] == expected_media_types
+    assert search_results.result
+
+
+@pytest.mark.parametrize(
     ("media_content_id", "media_filter_classes"),
     [
         # an artist holds no playlists, so there is nothing to find


### PR DESCRIPTION
## Proposed change

Asking a voice assistant to "play some music" or "play songs by <artist>" did nothing on Music Assistant, while the assistant still said it was playing.

HA has no media class for radio, so we hand radio stations back under the music class. That same class was then read back as radio when searching, and a voice assistant picks music for any plain play request, so those searches only ever looked at radio stations and came back empty.

Music now means music, and radio keeps the class it is shown with.

- Search artists, albums, tracks and playlists when asked for music
- Allow a media class to stand for more than one kind of media

Stacked on #177673, which touches the same mapping. Only the last commit belongs to this one.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #173602
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
