### PR TITLE
Report a failure when a media search finds nothing to play

### DIFF
--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -376,8 +376,10 @@ class MediaSearchAndPlayHandler(intent.IntentHandler):
             )
             or not (results := entity_response.result)
         ):
-            # No results found
-            return intent_obj.create_response()
+            # Nothing was found to play. Reporting that as done leaves the
+            # assistant telling the user it is playing something that was
+            # never found, because the response is a plain success otherwise.
+            raise intent.IntentHandleError(f"No results found for {search_query}")
 
         # 2. Play Media (first result)
         first_result = results[0]

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -376,8 +376,6 @@ class MediaSearchAndPlayHandler(intent.IntentHandler):
             )
             or not (results := entity_response.result)
         ):
-            # anything short of an error reads as a successful play, which is
-            # how this used to claim it was playing what it never found
             raise intent.IntentHandleError(f"No results found for {search_query}")
 
         # 2. Play Media (first result)

--- a/homeassistant/components/media_player/intent.py
+++ b/homeassistant/components/media_player/intent.py
@@ -376,9 +376,8 @@ class MediaSearchAndPlayHandler(intent.IntentHandler):
             )
             or not (results := entity_response.result)
         ):
-            # Nothing was found to play. Reporting that as done leaves the
-            # assistant telling the user it is playing something that was
-            # never found, because the response is a plain success otherwise.
+            # anything short of an error reads as a successful play, which is
+            # how this used to claim it was playing what it never found
             raise intent.IntentHandleError(f"No results found for {search_query}")
 
         # 2. Play Media (first result)

--- a/tests/components/media_player/test_intent.py
+++ b/tests/components/media_player/test_intent.py
@@ -804,19 +804,15 @@ async def test_search_and_play_media_player_intent(hass: HomeAssistant) -> None:
 
     # Test no search results
     search_results.clear()
-    response = await intent.async_handle(
-        hass,
-        "test",
-        media_player_intent.INTENT_MEDIA_SEARCH_AND_PLAY,
-        {"search_query": {"value": "another query"}},
-    )
+    with pytest.raises(intent.IntentHandleError, match="No results found"):
+        await intent.async_handle(
+            hass,
+            "test",
+            media_player_intent.INTENT_MEDIA_SEARCH_AND_PLAY,
+            {"search_query": {"value": "another query"}},
+        )
     await hass.async_block_till_done()
 
-    assert response.response_type is intent.IntentResponseType.ACTION_DONE
-
-    # A search failure is indicated by no "media" slot in the response.
-    assert not response.speech
-    assert "media" not in response.speech_slots
     assert len(search_calls) == 2  # Search was called again
     assert len(play_calls) == 1  # Play was not called again
 


### PR DESCRIPTION
## Proposed change

Asking a voice assistant to play something it cannot find ended with the assistant cheerfully saying it was playing it, while nothing happened.

The search and play intent handed back the same plain success whether it found something or not. Finding nothing was only signalled by leaving a detail out of the response, which is not something an assistant can act on, so it had no way to tell the two apart.

- Report a failure when a media search comes back with nothing to play

NOTE: this deliberately replaces that earlier signal, so the response now says a search found nothing instead of quietly looking like a success. The spoken reply falls back to the generic error sentence, as there is no response key for this yet.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/issues/173602
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
