### PR TITLE
Bump lyngdorf to 1.4.0

### DIFF
--- a/homeassistant/components/lyngdorf/__init__.py
+++ b/homeassistant/components/lyngdorf/__init__.py
@@ -71,25 +71,26 @@ async def async_setup_entry(
         model=lyngdorf_model.model_name,
     )
 
-    # Register the main device up front so Zone B can resolve its via_device_id.
-    device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
-        config_entry_id=config_entry.entry_id, **device_info
-    )
-
-    zone_b_device_info = DeviceInfo(
-        identifiers={(DOMAIN, f"{config_entry.unique_id}_zone_b")},
-        manufacturer=lyngdorf_model.manufacturer,
-        serial_number=serial,
-        model=lyngdorf_model.model_name,
-        translation_key="zone_b",
-        translation_placeholders={"device_name": config_entry.title},
-        via_device_id=async_get_device_id_by_identifier(
-            hass,
-            (DOMAIN, config_entry.unique_id),
-            config_entry_id=config_entry.entry_id,
-        ),
-    )
+    zone_b_device_info: DeviceInfo | None = None
+    if lyngdorf_model.has_zone_b_feature():
+        # Register the main device up front so Zone B can resolve its via_device_id.
+        device_registry = dr.async_get(hass)
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id, **device_info
+        )
+        zone_b_device_info = DeviceInfo(
+            identifiers={(DOMAIN, f"{config_entry.unique_id}_zone_b")},
+            manufacturer=lyngdorf_model.manufacturer,
+            serial_number=serial,
+            model=lyngdorf_model.model_name,
+            translation_key="zone_b",
+            translation_placeholders={"device_name": config_entry.title},
+            via_device_id=async_get_device_id_by_identifier(
+                hass,
+                (DOMAIN, config_entry.unique_id),
+                config_entry_id=config_entry.entry_id,
+            ),
+        )
 
     config_entry.runtime_data = LyngdorfRuntimeData(
         receiver=receiver,

--- a/homeassistant/components/lyngdorf/manifest.json
+++ b/homeassistant/components/lyngdorf/manifest.json
@@ -9,7 +9,7 @@
   "iot_class": "local_push",
   "loggers": ["lyngdorf", "async_upnp_client"],
   "quality_scale": "silver",
-  "requirements": ["lyngdorf==1.3.3"],
+  "requirements": ["lyngdorf==1.4.0"],
   "ssdp": [
     {
       "deviceType": "urn:schemas-upnp-org:device:MediaRenderer:2",

--- a/homeassistant/components/lyngdorf/media_player.py
+++ b/homeassistant/components/lyngdorf/media_player.py
@@ -51,16 +51,19 @@ async def async_setup_entry(
     """Set up the receiver from a config entry."""
     runtime_data = config_entry.runtime_data
 
-    async_add_entities(
-        [
-            LyngdorfMainDevice(
-                runtime_data.receiver, config_entry, runtime_data.device_info
-            ),
+    entities: list[LyngdorfDevice] = [
+        LyngdorfMainDevice(
+            runtime_data.receiver, config_entry, runtime_data.device_info
+        )
+    ]
+    if runtime_data.zone_b_device_info is not None:
+        entities.append(
             LyngdorfZoneBDevice(
                 runtime_data.receiver, config_entry, runtime_data.zone_b_device_info
-            ),
-        ]
-    )
+            )
+        )
+
+    async_add_entities(entities)
 
 
 def _to_ha_volume(volume_db: float) -> float:

--- a/homeassistant/components/lyngdorf/models.py
+++ b/homeassistant/components/lyngdorf/models.py
@@ -14,7 +14,7 @@ class LyngdorfRuntimeData:
 
     receiver: Receiver
     device_info: DeviceInfo
-    zone_b_device_info: DeviceInfo
+    zone_b_device_info: DeviceInfo | None
 
 
 type LyngdorfConfigEntry = ConfigEntry[LyngdorfRuntimeData]

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1531,7 +1531,7 @@ lw12==0.9.2
 lxml==6.1.1
 
 # homeassistant.components.lyngdorf
-lyngdorf==1.3.3
+lyngdorf==1.4.0
 
 # homeassistant.components.matrix
 matrix-nio==0.26.0

--- a/tests/components/lyngdorf/test_init.py
+++ b/tests/components/lyngdorf/test_init.py
@@ -127,3 +127,26 @@ async def test_mac_connection_registered_when_serial_is_mac(
         value for kind, value in device.connections if kind == dr.CONNECTION_NETWORK_MAC
     }
     assert mac_connections == expected_mac_connections
+
+
+@pytest.mark.usefixtures("mock_receiver")
+async def test_no_zone_b_device_for_model_without_zone_b(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test no Zone B device is created for a model without Zone B."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.lyngdorf.lookup_receiver_model",
+        return_value=LyngdorfModel.TDAI_3400,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{mock_config_entry.unique_id}_zone_b")}
+    )
+    assert device is None

--- a/tests/components/lyngdorf/test_media_player.py
+++ b/tests/components/lyngdorf/test_media_player.py
@@ -1,7 +1,8 @@
 """Tests for the Lyngdorf media player platform."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
+from lyngdorf.const import LyngdorfModel
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -44,6 +45,27 @@ async def test_entities(
 ) -> None:
     """Test the media player entities."""
     await snapshot_platform(hass, entity_registry, snapshot, init_integration.entry_id)
+
+
+@pytest.mark.usefixtures("mock_receiver")
+async def test_no_zone_b_entity_for_model_without_zone_b(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test no Zone B media player entity is created for a model without Zone B."""
+    mock_config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.lyngdorf.lookup_receiver_model",
+        return_value=LyngdorfModel.TDAI_3400,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert hass.states.get(ZONE_B) is None
+    assert entity_registry.async_get(ZONE_B) is None
+    assert hass.states.get(MAIN_ZONE) is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Breaking change


## Proposed change

Bumps the `lyngdorf` dependency from `1.3.3` to `1.4.0`:

- Adds support for the P100, P200, and P300 (Steinway & Lyngdorf-branded multichannel processors).
- Fixes `async_connect()` unconditionally registering Zone B message callbacks on models without Zone B (all TDAI-series), which raised `KeyError: <Msg.ZONE_B_VOLUME: 19>` and broke setup entirely. `async_connect` now guards each Zone B registration on `has_zone_b_feature()`. See [fishloa/lyngdorf#16](https://github.com/fishloa/lyngdorf/issues/16).

Since the library now lets Zone-B-less models (all TDAI-series) finish setup, this PR also gates the integration's own Zone B device/entity creation (`__init__.py`, `media_player.py`) on `has_zone_b_feature()` — otherwise those models would newly complete setup but expose a Zone B media_player entity for hardware that doesn't have one. Added a test covering setup with a Zone-B-less model.

Library diff (single commit): https://github.com/fishloa/lyngdorf/compare/42f8e507...v1.4.0

Rebased on `dev` now that #177732 (`via_device` race fix) merged — combines its `via_device_id` fix with the `has_zone_b_feature()` gating in this PR.

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177624
- This PR is related to issue: 
- Link to documentation pull request: home-assistant/home-assistant.io#47161
- Link to developer documentation pull request: 
- Link to frontend pull request: 

PyPI: https://pypi.org/project/lyngdorf/1.4.0/
GitHub release: https://github.com/fishloa/lyngdorf/releases/tag/v1.4.0

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


