### PR TITLE
Log unrecognized SSDP model names for lyngdorf

### DIFF
--- a/homeassistant/components/lyngdorf/config_flow.py
+++ b/homeassistant/components/lyngdorf/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Lyngdorf integration."""
 
+import logging
 from typing import Any, override
 from urllib.parse import urlparse
 
@@ -22,6 +23,8 @@ from homeassistant.helpers.service_info.ssdp import (
 )
 
 from .const import CONF_SERIAL_NUMBER, DEFAULT_DEVICE_NAME, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
@@ -158,6 +161,11 @@ class LyngdorfFlowHandler(ConfigFlow, domain=DOMAIN):
 
         device_model_name = discovery_info.upnp.get(ATTR_UPNP_MODEL_NAME) or ""
         if not (model := lookup_receiver_model(device_model_name)):
+            _LOGGER.warning(
+                "SSDP discovered device with unrecognized model name %r at %s",
+                device_model_name,
+                self._host,
+            )
             raise AbortFlow("unsupported_model")
         self._device_model = model.model_name
         self._device_serial_number = (

--- a/tests/components/lyngdorf/test_config_flow.py
+++ b/tests/components/lyngdorf/test_config_flow.py
@@ -260,7 +260,9 @@ async def test_ssdp_discovery_no_serial(hass: HomeAssistant) -> None:
     assert result["reason"] == "cannot_determine_id"
 
 
-async def test_ssdp_discovery_unsupported_model(hass: HomeAssistant) -> None:
+async def test_ssdp_discovery_unsupported_model(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test SSDP discovery aborts when model is not supported."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -278,6 +280,7 @@ async def test_ssdp_discovery_unsupported_model(hass: HomeAssistant) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unsupported_model"
+    assert "UNKNOWN-MODEL" in caplog.text
 
 
 async def test_ssdp_discovery_missing_model(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Breaking change


## Proposed change

Adds a `_LOGGER.warning` in `LyngdorfFlowHandler._async_set_info_from_discovery` when SSDP discovers a device with a model name `lookup_receiver_model` doesn't recognize. Previously this silently aborted the config flow (`unsupported_model`) with no trace in `home-assistant.log`, so triaging such reports required asking the user for a debug-log reproduction.

Split out of #177685 per review feedback, to keep that dependency bump scoped to the version change.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #177685
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
