### PR TITLE
Fix Hue Mimic Presence automations switch

### DIFF
--- a/homeassistant/components/hue/switch.py
+++ b/homeassistant/components/hue/switch.py
@@ -12,6 +12,7 @@ from aiohue.v2.controllers.sensors import (
     Motion,
     MotionController,
 )
+from aiohue.v2.models.behavior_instance import PresenceMimickingState
 from aiohue.v2.models.behavior_script import BehaviorScriptCategory
 
 from homeassistant.components.switch import (
@@ -143,8 +144,13 @@ class HueResourceEnabledEntity(HueBaseEntity, SwitchEntity):
 
 
 class HueBehaviorInstanceEnabledEntity(HueResourceEnabledEntity):
-    """Representation of a Switch entity to enable/disable a Hue Behavior Instance."""
+    """Representation of a Switch entity to enable/disable a Hue Behavior Instance.
 
+    Automations that the Hue app runs with a play button, such as mimic
+    presence, are started and stopped. All others are enabled and disabled.
+    """
+
+    controller: BehaviorInstanceController
     resource: BehaviorInstance
 
     entity_description = SwitchEntityDescription(
@@ -158,6 +164,30 @@ class HueBehaviorInstanceEnabledEntity(HueResourceEnabledEntity):
     def name(self) -> str:
         """Return name for this entity."""
         return f"Automation: {self.resource.metadata.name}"
+
+    @property
+    @override
+    def is_on(self) -> bool:
+        """Return true if the switch is on."""
+        if (run_state := self.resource.presence_mimicking_state) is not None:
+            return run_state is PresenceMimickingState.STARTED
+        return self.resource.enabled
+
+    @override
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Turn the entity on."""
+        if self.resource.presence_mimicking_state is None:
+            await super().async_turn_on(**kwargs)
+            return
+        await self.bridge.async_request_call(self.controller.start, self.resource.id)
+
+    @override
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn the entity off."""
+        if self.resource.presence_mimicking_state is None:
+            await super().async_turn_off(**kwargs)
+            return
+        await self.bridge.async_request_call(self.controller.stop, self.resource.id)
 
 
 class HueMotionSensorEnabledEntity(HueResourceEnabledEntity):

--- a/tests/components/hue/const.py
+++ b/tests/components/hue/const.py
@@ -162,3 +162,28 @@ FAKE_BEHAVIOR_INSTANCE = {
     "status": "running",
     "type": "behavior_instance",
 }
+
+FAKE_PRESENCE_MIMICKING_SCRIPT = {
+    "configuration_schema": {},
+    "description": "PM Automation",
+    "id": "fake_behavior_script_id_2",
+    "metadata": {"category": "automation", "name": "PM"},
+    "state_schema": {},
+    "supported_features": [],
+    "trigger_schema": {},
+    "type": "behavior_script",
+    "version": "0.0.1",
+}
+
+FAKE_PRESENCE_MIMICKING_INSTANCE = {
+    "configuration": {},
+    "dependees": [],  # codespell:ignore dependees
+    "enabled": True,
+    "id": "fake_behavior_instance_id_2",
+    "last_error": "",
+    "metadata": {"name": "Mimic presence"},
+    "script_id": "fake_behavior_script_id_2",
+    "state": {"pm_state": "stopped"},
+    "status": "running",
+    "type": "behavior_instance",
+}

--- a/tests/components/hue/test_switch.py
+++ b/tests/components/hue/test_switch.py
@@ -16,6 +16,8 @@ from .const import (
     FAKE_BEHAVIOR_SCRIPT,
     FAKE_BINARY_SENSOR,
     FAKE_DEVICE,
+    FAKE_PRESENCE_MIMICKING_INSTANCE,
+    FAKE_PRESENCE_MIMICKING_SCRIPT,
     FAKE_ZIGBEE_CONNECTIVITY,
 )
 
@@ -198,3 +200,79 @@ async def test_internal_behavior_instance_entity_removed(
     await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
 
     assert entity_registry.async_get(stale_entity.entity_id) is None
+
+
+@pytest.mark.parametrize(
+    ("pm_state", "expected_state"), [("started", "on"), ("stopped", "off")]
+)
+async def test_presence_mimicking_switch_state(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    pm_state: str,
+    expected_state: str,
+) -> None:
+    """Test the switch follows the run state instead of enabled."""
+    instance = {**FAKE_PRESENCE_MIMICKING_INSTANCE, "state": {"pm_state": pm_state}}
+    await mock_bridge_v2.api.load_test_data(
+        [*v2_resources_test_data, FAKE_PRESENCE_MIMICKING_SCRIPT, instance]
+    )
+
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
+
+    test_entity = hass.states.get("switch.philips_hue_automation_mimic_presence")
+    assert test_entity is not None
+    assert test_entity.state == expected_state
+
+
+@pytest.mark.parametrize(
+    ("service", "expected_trigger"),
+    [("turn_on", {"start": {}}), ("turn_off", {"stop": {}})],
+)
+async def test_presence_mimicking_switch_services(
+    hass: HomeAssistant,
+    mock_bridge_v2: Mock,
+    v2_resources_test_data: JsonArrayType,
+    service: str,
+    expected_trigger: dict,
+) -> None:
+    """Test the switch starts and stops instead of touching enabled."""
+    await mock_bridge_v2.api.load_test_data(
+        [
+            *v2_resources_test_data,
+            FAKE_PRESENCE_MIMICKING_SCRIPT,
+            FAKE_PRESENCE_MIMICKING_INSTANCE,
+        ]
+    )
+
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
+
+    await hass.services.async_call(
+        "switch",
+        service,
+        {"entity_id": "switch.philips_hue_automation_mimic_presence"},
+        blocking=True,
+    )
+
+    assert len(mock_bridge_v2.mock_requests) == 1
+    assert mock_bridge_v2.mock_requests[0]["method"] == "put"
+    assert mock_bridge_v2.mock_requests[0]["json"] == {"trigger": expected_trigger}
+
+
+async def test_regular_automation_switch_uses_enabled(
+    hass: HomeAssistant, mock_bridge_v2: Mock, v2_resources_test_data: JsonArrayType
+) -> None:
+    """Test an automation without a run state still toggles enabled."""
+    await mock_bridge_v2.api.load_test_data(v2_resources_test_data)
+
+    await setup_platform(hass, mock_bridge_v2, Platform.SWITCH)
+
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": "switch.philips_hue_automation_timer_test"},
+        blocking=True,
+    )
+
+    assert len(mock_bridge_v2.mock_requests) == 1
+    assert mock_bridge_v2.mock_requests[0]["json"] == {"enabled": False}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Some Hue automations, like mimic presence, are not switched on and off in the
Hue app but run with a play and stop button. Their switch in Home Assistant was
wired to the enabled flag instead, which is a different setting that the Hue app
does not even show, so turning the switch on never started the automation.

- The switch for these automations now starts and stops them
- Its state follows whether the automation is actually running
- Automations that do have an on/off toggle in the Hue app keep working as before
- Added tests

Stacked on top of https://github.com/home-assistant/core/pull/177671 (so that needs to be merged first, before this one)

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #131983
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
