### PR TITLE
Fix stale HomeKit characteristic entities after config changes

### DIFF
--- a/homeassistant/components/homekit_controller/entity.py
+++ b/homeassistant/components/homekit_controller/entity.py
@@ -286,26 +286,23 @@ class BaseCharacteristicEntity(HomeKitEntity):
         self._entity_key = (self._aid, self._iid, char.iid)
 
     @callback
-    def _async_remove_entity_if_characteristics_disappeared(self) -> bool:
-        """Handle characteristic disappearance."""
-        if (
-            not self._accessory.entity_map.aid(self._aid)
-            .services.iid(self._iid)
-            .get_char_by_iid(self._char.iid)
-        ):
-            self._async_handle_entity_removed()
-            return True
-        return False
-
-    @callback
     @override
     def _async_config_changed(self) -> None:
         """Handle accessory discovery changes."""
-        if (
-            not self._async_remove_entity_if_accessory_or_service_disappeared()
-            and not self._async_remove_entity_if_characteristics_disappeared()
-        ):
-            super()._async_reconfigure()
+        if self._async_remove_entity_if_accessory_or_service_disappeared():
+            return
+
+        char = (
+            self._accessory.entity_map.aid(self._aid)
+            .services.iid(self._iid)
+            .get_char_by_iid(self._char.iid)
+        )
+        if char is None:
+            self._async_handle_entity_removed()
+            return
+
+        self._char = char
+        super()._async_reconfigure()
 
 
 class CharacteristicEntity(BaseCharacteristicEntity):

--- a/tests/components/homekit_controller/specific_devices/test_ecobee3.py
+++ b/tests/components/homekit_controller/specific_devices/test_ecobee3.py
@@ -7,6 +7,8 @@ from typing import Any
 from unittest import mock
 
 from aiohomekit import AccessoryNotFoundError
+from aiohomekit.model.characteristics import CharacteristicsTypes
+from aiohomekit.model.services import ServicesTypes
 from aiohomekit.testing import FakePairing
 
 from homeassistant.components.climate import ClimateEntityFeature
@@ -138,6 +140,37 @@ async def test_ecobee3_setup(hass: HomeAssistant) -> None:
             ],
         ),
     )
+
+
+async def test_ecobee3_current_temperature_after_config_change(
+    hass: HomeAssistant,
+) -> None:
+    """Test current temperature updates after the accessory map is replaced."""
+    accessories = await setup_accessories_from_file(hass, "ecobee3.json")
+    await setup_test_accessories(hass, accessories)
+
+    state = hass.states.get("sensor.homew_current_temperature")
+    assert state
+    assert state.state == "21.8"
+
+    accessories = await setup_accessories_from_file(hass, "ecobee3.json")
+    thermostat = next(
+        accessory.services.first(service_type=ServicesTypes.THERMOSTAT)
+        for accessory in accessories
+        if accessory.aid == 1
+    )
+    assert thermostat
+    current_temperature = thermostat.characteristics.first(
+        char_types=[CharacteristicsTypes.TEMPERATURE_CURRENT]
+    )
+    assert current_temperature
+    current_temperature.value = 22.4
+
+    await device_config_changed(hass, accessories)
+
+    state = hass.states.get("sensor.homew_current_temperature")
+    assert state
+    assert state.state == "22.4"
 
 
 async def test_ecobee3_setup_from_cache(

--- a/tests/components/homekit_controller/test_sensor.py
+++ b/tests/components/homekit_controller/test_sensor.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Callable
 
-from aiohomekit.model import Accessory
+from aiohomekit.model import Accessories, AccessoriesState, Accessory
 from aiohomekit.model.characteristics import CharacteristicsTypes
 from aiohomekit.model.characteristics.const import ThreadNodeCapabilities, ThreadStatus
 from aiohomekit.model.services import Service, ServicesTypes
@@ -10,12 +10,14 @@ from aiohomekit.protocol.statuscodes import HapStatusCode
 import pytest
 
 from homeassistant.components.homekit_controller.sensor import (
+    SimpleSensor,
     thread_node_capability_to_str,
     thread_status_to_str,
 )
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_component import DATA_INSTANCES
 
 from .common import TEST_DEVICE_SERVICE_INFO, Helper, setup_test_component
 
@@ -81,6 +83,20 @@ def create_humidifier_with_water_level_sensor(accessory: Accessory) -> Service:
     service.add_char(CharacteristicsTypes.RELATIVE_HUMIDITY_CURRENT).value = 30
 
     return service
+
+
+def create_accessory_without_humidifier(aid: int) -> Accessory:
+    """Create an accessory without the humidifier service."""
+    return Accessory.create_with_info(
+        aid, "TestDevice", "example.com", "Test", "0001", "0.1"
+    )
+
+
+def create_humidifier_without_water_level(aid: int) -> Accessory:
+    """Create a humidifier accessory without the water level characteristic."""
+    accessory = create_accessory_without_humidifier(aid)
+    accessory.add_service(ServicesTypes.HUMIDIFIER_DEHUMIDIFIER)
+    return accessory
 
 
 async def test_temperature_sensor_read_state(
@@ -326,6 +342,48 @@ async def test_water_level_sensor_read_state(
     assert state.state == "20"
 
     assert state.attributes["state_class"] == SensorStateClass.MEASUREMENT
+
+
+@pytest.mark.parametrize(
+    "replacement_accessory_factory",
+    [
+        pytest.param(
+            create_accessory_without_humidifier,
+            id="service-removed",
+        ),
+        pytest.param(
+            create_humidifier_without_water_level,
+            id="characteristic-removed",
+        ),
+    ],
+)
+async def test_characteristic_sensor_removed_after_config_change(
+    hass: HomeAssistant,
+    get_next_aid: Callable[[], int],
+    replacement_accessory_factory: Callable[[int], Accessory],
+) -> None:
+    """Test a characteristic sensor is removed when its source disappears."""
+    aid = get_next_aid()
+    helper = await setup_test_component(
+        hass, aid, create_humidifier_with_water_level_sensor
+    )
+
+    assert hass.states.get("sensor.testdevice_water_level") is not None
+    entity = hass.data[DATA_INSTANCES]["sensor"].get_entity(
+        "sensor.testdevice_water_level"
+    )
+    assert isinstance(entity, SimpleSensor)
+
+    accessory = replacement_accessory_factory(aid)
+    accessories = Accessories()
+    accessories.add_accessory(accessory)
+    helper.pairing._accessories_state = AccessoriesState(
+        accessories, helper.pairing.config_num + 1
+    )
+    entity._async_config_changed()
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.testdevice_water_level") is None
 
 
 def create_switch_with_sensor(accessory: Accessory) -> Service:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

### Context

HomeKit-over-IP climate accessories can stop updating characteristic-backed entities after a reconnect or configuration refresh, while reloading the integration temporarily restores updates. Similar symptoms were reported in #100331 and #102258. #116200 attempted to reduce HomeKit polling and #139550 later reverted those polling changes, but neither addresses stale characteristic references when aiohomekit replaces the accessory map. This fix has kept the affected current-temperature sensor updating for five days on a real AC controller.

### Issue

When aiohomekit reports a configuration-number change, it replaces the accessory, service, and characteristic object graph. `HomeKitEntity` rebinds its accessory and service during reconfiguration, but `BaseCharacteristicEntity` only checks that a characteristic with the same IID exists and then keeps its original `self._char` reference. Polling and events update the new characteristic object, while the entity continues reading the old object. It should rebind `self._char` to the characteristic in the current accessory map before reconfiguring.

### Fix

In `BaseCharacteristicEntity._async_config_changed`, replace the characteristic-disappearance helper with logic that resolves the characteristic by IID from the current accessory map. If the accessory, service, or characteristic no longer exists, remove the entity as before. Otherwise, assign the resolved characteristic to `self._char` and then run the existing reconfiguration logic to rebuild polling and event subscriptions against the replacement map.

### Unit test

The Ecobee regression test first creates the current-temperature sensor from an accessory map where the value is `21.8`. It then loads a fresh accessory map, changes that map's current-temperature value to `22.4`, and triggers the existing configuration-change flow that replaces the complete accessory map. The test verifies that the existing sensor now reports `22.4`; without the fix, it continues reading the old characteristic and remains at `21.8`.
## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #102258, #100331
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
