### PR TITLE
Migrate integrations to setting via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/insteon/entity.py
+++ b/homeassistant/components/insteon/entity.py
@@ -7,6 +7,7 @@ from typing import Any, override
 from pyinsteon import devices
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -88,6 +89,8 @@ class InsteonEntity(Entity):
     @override
     def device_info(self) -> DeviceInfo:
         """Return device information."""
+        config_entry = self.platform.config_entry
+        assert config_entry
         return DeviceInfo(
             identifiers={(DOMAIN, str(self._insteon_device.address))},
             manufacturer="SmartLabs, Inc",
@@ -100,7 +103,11 @@ class InsteonEntity(Entity):
                 f"{self._insteon_device.firmware:02x} Engine Version:"
                 f" {self._insteon_device.engine_version}"
             ),
-            via_device=(DOMAIN, str(devices.modem.address)),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, str(devices.modem.address)),
+                config_entry_id=config_entry.entry_id,
+            ),
             configuration_url=f"homeassistant://insteon/device/config/{self._insteon_device.id}",
         )
 

--- a/homeassistant/components/iskra/entity.py
+++ b/homeassistant/components/iskra/entity.py
@@ -1,5 +1,6 @@
 """Base entity for Iskra devices."""
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -26,7 +27,11 @@ class IskraEntity(CoordinatorEntity[IskraDataUpdateCoordinator]):
                 name=self.device.model,
                 sw_version=self.device.fw_version,
                 serial_number=self.device.serial,
-                via_device=(DOMAIN, gateway.serial),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, gateway.serial),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                ),
             )
         else:
             self._attr_device_info = DeviceInfo(

--- a/homeassistant/components/jellyfin/entity.py
+++ b/homeassistant/components/jellyfin/entity.py
@@ -2,6 +2,7 @@
 
 from typing import Any, override
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -50,7 +51,11 @@ class JellyfinClientEntity(JellyfinEntity):
                 model=self.client_name,
                 name=self.device_name,
                 sw_version=self.app_version,
-                via_device=(DOMAIN, coordinator.server_id),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, coordinator.server_id),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                ),
             )
             self._attr_name = None
         else:

--- a/homeassistant/components/kitchen_sink/sensor.py
+++ b/homeassistant/components/kitchen_sink/sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import DEGREE, UnitOfPower
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import UNDEFINED, StateType, UndefinedType
@@ -31,6 +32,10 @@ async def async_setup_entry(
         "2_ch_power_strip",
     )
 
+    via_device_id = dr.async_get_device_id_by_identifier(
+        hass, (DOMAIN, "2_ch_power_strip"), config_entry_id=config_entry.entry_id
+    )
+
     async_add_entities(
         [
             DemoSensor(
@@ -42,7 +47,7 @@ async def async_setup_entry(
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 unit_of_measurement=UnitOfPower.WATT,
-                via_device="2_ch_power_strip",
+                via_device_id=via_device_id,
             ),
             DemoSensor(
                 device_unique_id="outlet_2",
@@ -53,7 +58,7 @@ async def async_setup_entry(
                 device_class=SensorDeviceClass.POWER,
                 state_class=SensorStateClass.MEASUREMENT,
                 unit_of_measurement=UnitOfPower.WATT,
-                via_device="2_ch_power_strip",
+                via_device_id=via_device_id,
             ),
             DemoSensor(
                 device_unique_id="statistics_issues",
@@ -135,7 +140,7 @@ class DemoSensor(SensorEntity):
         device_class: SensorDeviceClass | None,
         state_class: SensorStateClass | None,
         unit_of_measurement: str | None,
-        via_device: str | None = None,
+        via_device_id: str | None = None,
     ) -> None:
         """Initialize the sensor."""
         self._attr_device_class = device_class
@@ -150,5 +155,5 @@ class DemoSensor(SensorEntity):
             identifiers={(DOMAIN, device_unique_id)},
             name=device_name,
         )
-        if via_device:
-            self._attr_device_info["via_device"] = (DOMAIN, via_device)
+        if via_device_id:
+            self._attr_device_info["via_device_id"] = via_device_id

--- a/homeassistant/components/kitchen_sink/switch.py
+++ b/homeassistant/components/kitchen_sink/switch.py
@@ -5,6 +5,7 @@ from typing import Any, override
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -27,6 +28,10 @@ async def async_setup_entry(
         "2_ch_power_strip",
     )
 
+    via_device_id = dr.async_get_device_id_by_identifier(
+        hass, (DOMAIN, "2_ch_power_strip"), config_entry_id=config_entry.entry_id
+    )
+
     async_add_entities(
         [
             DemoSwitch(
@@ -35,7 +40,7 @@ async def async_setup_entry(
                 entity_name=None,
                 state=False,
                 assumed=False,
-                via_device="2_ch_power_strip",
+                via_device_id=via_device_id,
             ),
             DemoSwitch(
                 unique_id="outlet_2",
@@ -43,7 +48,7 @@ async def async_setup_entry(
                 entity_name=None,
                 state=True,
                 assumed=False,
-                via_device="2_ch_power_strip",
+                via_device_id=via_device_id,
             ),
         ]
     )
@@ -65,7 +70,7 @@ class DemoSwitch(SwitchEntity):
         assumed: bool,
         translation_key: str | None = None,
         device_class: SwitchDeviceClass | None = None,
-        via_device: str | None = None,
+        via_device_id: str | None = None,
     ) -> None:
         """Initialize the Demo switch."""
         self._attr_assumed_state = assumed
@@ -77,8 +82,8 @@ class DemoSwitch(SwitchEntity):
             identifiers={(DOMAIN, unique_id)},
             name=device_name,
         )
-        if via_device:
-            self._attr_device_info["via_device"] = (DOMAIN, via_device)
+        if via_device_id:
+            self._attr_device_info["via_device_id"] = via_device_id
         self._attr_name = entity_name
 
     @override

--- a/homeassistant/components/lcn/helpers.py
+++ b/homeassistant/components/lcn/helpers.py
@@ -211,7 +211,9 @@ def register_lcn_address_devices(
     """
     device_registry = dr.async_get(hass)
 
-    host_identifiers = (DOMAIN, config_entry.entry_id)
+    host_device_id = dr.async_get_device_id_by_identifier(
+        hass, (DOMAIN, config_entry.entry_id), config_entry_id=config_entry.entry_id
+    )
 
     for device_config in config_entry.data[CONF_DEVICES]:
         address = device_config[CONF_ADDRESS]
@@ -233,7 +235,7 @@ def register_lcn_address_devices(
         device_entry = device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             identifiers=identifiers,
-            via_device=host_identifiers,
+            via_device_id=host_device_id,
             manufacturer="Issendorff",
             sw_version=sw_version,
             name=device_name,

--- a/homeassistant/components/livisi/entity.py
+++ b/homeassistant/components/livisi/entity.py
@@ -6,6 +6,7 @@ from typing import Any, override
 from livisi.const import CAPABILITY_MAP
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -59,7 +60,11 @@ class LivisiEntity(CoordinatorEntity[LivisiDataUpdateCoordinator]):
             model=device["type"],
             name=device_name,
             suggested_area=room_name,
-            via_device=(DOMAIN, config_entry.entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, config_entry.entry_id),
+                config_entry_id=config_entry.entry_id,
+            ),
         )
         super().__init__(coordinator)
 

--- a/homeassistant/components/lunatone/light.py
+++ b/homeassistant/components/lunatone/light.py
@@ -15,6 +15,7 @@ from homeassistant.components.light import (
     brightness_supported,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -97,9 +98,13 @@ class LunatoneLight(
         return DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
             name=self._device.name,
-            via_device=(
-                DOMAIN,
-                f"{self._config_entry_unique_id}-line{self._device.data.line}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (
+                    DOMAIN,
+                    f"{self._config_entry_unique_id}-line{self._device.data.line}",
+                ),
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 
@@ -261,7 +266,11 @@ class LunatoneLineBroadcastLight(
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
             name=f"DALI Line {line}",
-            via_device=(DOMAIN, config_entry_unique_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, config_entry_unique_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             **extra_info,
         )
 

--- a/homeassistant/components/lunatone/sensor.py
+++ b/homeassistant/components/lunatone/sensor.py
@@ -18,6 +18,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -135,7 +136,11 @@ class LunatoneSensor(
                     f"DALI Line {self.sensor.data.dali_sensor_address.line}"
                     f" - A{self.sensor.data.dali_sensor_address.address}\u00b2"
                 ),
-                via_device=(DOMAIN, str(self._config_entry_unique_id)),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, str(self._config_entry_unique_id)),
+                    config_entry_id=self.coordinator.config_entry.entry_id,
+                ),
             )
         self._attr_device_info = device_info
 

--- a/homeassistant/components/lyric/entity.py
+++ b/homeassistant/components/lyric/entity.py
@@ -97,7 +97,11 @@ class LyricAccessoryEntity(LyricDeviceEntity):
             manufacturer="Honeywell",
             model="RCHTSENSOR",
             name=f"{self.room.room_name} Sensor",
-            via_device=(dr.CONNECTION_NETWORK_MAC, self._mac_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (dr.CONNECTION_NETWORK_MAC, self._mac_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
         )
 
     @property

--- a/homeassistant/components/lyric/entity.py
+++ b/homeassistant/components/lyric/entity.py
@@ -97,11 +97,7 @@ class LyricAccessoryEntity(LyricDeviceEntity):
             manufacturer="Honeywell",
             model="RCHTSENSOR",
             name=f"{self.room.room_name} Sensor",
-            via_device_id=dr.async_get_device_id_by_identifier(
-                self.hass,
-                (dr.CONNECTION_NETWORK_MAC, self._mac_id),
-                config_entry_id=self.coordinator.config_entry.entry_id,
-            ),
+            via_device=(dr.CONNECTION_NETWORK_MAC, self._mac_id),
         )
 
     @property

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -172,14 +172,20 @@ class MatterAdapter:
             or (device_type.__name__ if device_type else None)
         )
 
+        device_registry = dr.async_get(self.hass)
+
         # handle bridged devices
-        bridge_device_id = None
+        via_device_id: str | None = None
         if endpoint.is_bridged_device and endpoint.node.endpoints[0] != endpoint:
             bridge_device_id = get_device_id(
                 server_info,
                 endpoint.node.endpoints[0],
             )
-            bridge_device_id = f"{ID_TYPE_DEVICE_ID}_{bridge_device_id}"
+            via_device_id = dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{bridge_device_id}"),
+                config_entry_id=self.config_entry.entry_id,
+            )
 
         node_device_id = get_device_id(
             server_info,
@@ -214,7 +220,7 @@ class MatterAdapter:
         else:
             model_id = str(product_id) if (product_id := basic_info.productID) else None
 
-        dr.async_get(self.hass).async_get_or_create(
+        device_registry.async_get_or_create(
             name=name,
             config_entry_id=self.config_entry.entry_id,
             identifiers=identifiers,
@@ -224,7 +230,7 @@ class MatterAdapter:
             model=model_name,
             model_id=model_id,
             serial_number=serial_number,
-            via_device=(DOMAIN, bridge_device_id) if bridge_device_id else None,
+            via_device_id=via_device_id,
         )
 
     def _setup_endpoint(self, endpoint: MatterEndpoint) -> None:

--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -172,20 +172,14 @@ class MatterAdapter:
             or (device_type.__name__ if device_type else None)
         )
 
-        device_registry = dr.async_get(self.hass)
-
         # handle bridged devices
-        via_device_id: str | None = None
+        bridge_device_id = None
         if endpoint.is_bridged_device and endpoint.node.endpoints[0] != endpoint:
             bridge_device_id = get_device_id(
                 server_info,
                 endpoint.node.endpoints[0],
             )
-            via_device_id = dr.async_get_device_id_by_identifier(
-                self.hass,
-                (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{bridge_device_id}"),
-                config_entry_id=self.config_entry.entry_id,
-            )
+            bridge_device_id = f"{ID_TYPE_DEVICE_ID}_{bridge_device_id}"
 
         node_device_id = get_device_id(
             server_info,
@@ -220,7 +214,7 @@ class MatterAdapter:
         else:
             model_id = str(product_id) if (product_id := basic_info.productID) else None
 
-        device_registry.async_get_or_create(
+        dr.async_get(self.hass).async_get_or_create(
             name=name,
             config_entry_id=self.config_entry.entry_id,
             identifiers=identifiers,
@@ -230,7 +224,7 @@ class MatterAdapter:
             model=model_name,
             model_id=model_id,
             serial_number=serial_number,
-            via_device_id=via_device_id,
+            via_device=(DOMAIN, bridge_device_id) if bridge_device_id else None,
         )
 
     def _setup_endpoint(self, endpoint: MatterEndpoint) -> None:

--- a/homeassistant/components/melcloud/coordinator.py
+++ b/homeassistant/components/melcloud/coordinator.py
@@ -11,6 +11,7 @@ from pymelcloud.atw_device import Zone
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -37,6 +38,8 @@ type MelCloudConfigEntry = ConfigEntry[dict[str, list[MelCloudDeviceUpdateCoordi
 
 class MelCloudDeviceUpdateCoordinator(DataUpdateCoordinator[None]):
     """Per-device coordinator for MELCloud data updates."""
+
+    config_entry: MelCloudConfigEntry
 
     def __init__(
         self,
@@ -110,7 +113,11 @@ class MelCloudDeviceUpdateCoordinator(DataUpdateCoordinator[None]):
             manufacturer="Mitsubishi Electric",
             model="ATW zone device",
             name=f"{self.device.name} {zone.name}",
-            via_device=(DOMAIN, f"{dev.mac}-{dev.serial}"),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, f"{dev.mac}-{dev.serial}"),
+                config_entry_id=self.config_entry.entry_id,
+            ),
         )
 
     @override

--- a/homeassistant/components/nuki/entity.py
+++ b/homeassistant/components/nuki/entity.py
@@ -4,6 +4,7 @@ from typing import override
 
 from pynuki.device import NukiDevice
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -38,6 +39,10 @@ class NukiEntity[_NukiDeviceT: NukiDevice](CoordinatorEntity[NukiCoordinator]):
             manufacturer="Nuki Home Solutions GmbH",
             model=self._nuki_device.device_model_str.capitalize(),
             sw_version=self._nuki_device.firmware_version,
-            via_device=(DOMAIN, self.coordinator.bridge_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, self.coordinator.bridge_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             serial_number=parse_id(self._nuki_device.nuki_id),
         )

--- a/homeassistant/components/openrgb/light.py
+++ b/homeassistant/components/openrgb/light.py
@@ -17,6 +17,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -99,7 +100,11 @@ class OpenRGBLight(CoordinatorEntity[OpenRGBCoordinator], LightEntity):
             model=f"{self.device.metadata.description} ({self.device.type.name})",
             sw_version=self.device.metadata.version,
             serial_number=self.device.metadata.serial,
-            via_device=(DOMAIN, coordinator.entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.entry_id),
+                config_entry_id=coordinator.entry_id,
+            ),
         )
 
         modes = [mode.name for mode in self.device.modes]

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from functools import wraps
 import logging
-from typing import Any, Concatenate, cast, override
+from typing import TYPE_CHECKING, Any, Concatenate, cast, override
 
 from plexapi.client import PlexClient
 import plexapi.exceptions
@@ -557,6 +557,9 @@ class PlexMediaPlayer(MediaPlayerEntity):
                 entry_type=DeviceEntryType.SERVICE,
             )
 
+        config_entry = self.platform.config_entry
+        if TYPE_CHECKING:
+            assert config_entry
         return DeviceInfo(
             identifiers={(DOMAIN, self.machine_identifier)},
             manufacturer=self.device_platform or "Plex",
@@ -569,7 +572,7 @@ class PlexMediaPlayer(MediaPlayerEntity):
             via_device_id=dr.async_get_device_id_by_identifier(
                 self.hass,
                 (DOMAIN, self.plex_server.machine_identifier),
-                config_entry_id=self.plex_server.entry_id,
+                config_entry_id=config_entry.entry_id,
             ),
         )
 

--- a/homeassistant/components/plex/media_player.py
+++ b/homeassistant/components/plex/media_player.py
@@ -20,7 +20,7 @@ from homeassistant.components.media_player import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -566,7 +566,11 @@ class PlexMediaPlayer(MediaPlayerEntity):
             # name to None
             name=cast(str | None, self.name),
             sw_version=self.device_version,
-            via_device=(DOMAIN, self.plex_server.machine_identifier),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, self.plex_server.machine_identifier),
+                config_entry_id=self.plex_server.entry_id,
+            ),
         )
 
     @override

--- a/homeassistant/components/roon/event.py
+++ b/homeassistant/components/roon/event.py
@@ -5,6 +5,7 @@ from typing import cast, override
 
 from homeassistant.components.event import EventDeviceClass, EventEntity
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -70,7 +71,11 @@ class RoonEventEntity(EventEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
-            via_device=(DOMAIN, self._entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self._server.hass,
+                (DOMAIN, self._entry_id),
+                config_entry_id=self._entry_id,
+            ),
         )
 
     def _roonapi_volume_callback(

--- a/homeassistant/components/roon/media_player.py
+++ b/homeassistant/components/roon/media_player.py
@@ -15,6 +15,7 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.const import DEVICE_DEFAULT_NAME
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -154,7 +155,9 @@ class RoonDevice(MediaPlayerEntity):
             name=cast(str | None, self.name),
             manufacturer="RoonLabs",
             model=dev_model,
-            via_device=(DOMAIN, self._entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass, (DOMAIN, self._entry_id), config_entry_id=self._entry_id
+            ),
         )
 
     def update_data(self, player_data=None):

--- a/homeassistant/components/satel_integra/entity.py
+++ b/homeassistant/components/satel_integra/entity.py
@@ -6,6 +6,7 @@ from satel_integra import AsyncSatel
 
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_NAME
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -60,7 +61,11 @@ class SatelIntegraEntity[_CoordinatorT: SatelIntegraBaseCoordinator](
         self._attr_device_info = DeviceInfo(
             name=subentry.data[CONF_NAME],
             identifiers={(DOMAIN, self._attr_unique_id)},
-            via_device=(DOMAIN, config_entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, config_entry_id),
+                config_entry_id=config_entry_id,
+            ),
         )
 
     @property

--- a/homeassistant/components/simplisafe/entity.py
+++ b/homeassistant/components/simplisafe/entity.py
@@ -17,6 +17,7 @@ from simplipy.websocket import (
 )
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -101,7 +102,11 @@ class SimpliSafeEntity(CoordinatorEntity[SimpliSafeDataUpdateCoordinator]):
             manufacturer="SimpliSafe",
             model=model,
             name=device_name,
-            via_device=(DOMAIN, str(system.system_id)),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, str(system.system_id)),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
         )
 
         self._attr_unique_id = serial

--- a/homeassistant/components/squeezebox/media_player.py
+++ b/homeassistant/components/squeezebox/media_player.py
@@ -162,7 +162,7 @@ async def async_setup_entry(
             model_id=model_id,
             hw_version=str(player.firmware) if player.firmware is not None else None,
             sw_version=sw_version,
-            via_device=(DOMAIN, coordinator.server_uuid),
+            via_device_id=server_device.id if server_device else None,
         )
         _LOGGER.debug("Creating / Updating player device %s", device)
         async_add_entities([SqueezeBoxMediaPlayerEntity(coordinator)])

--- a/homeassistant/components/tailwind/coordinator.py
+++ b/homeassistant/components/tailwind/coordinator.py
@@ -26,6 +26,8 @@ type TailwindConfigEntry = ConfigEntry[TailwindDataUpdateCoordinator]
 class TailwindDataUpdateCoordinator(DataUpdateCoordinator[TailwindDeviceStatus]):
     """Class to manage fetching Tailwind data."""
 
+    config_entry: TailwindConfigEntry
+
     def __init__(self, hass: HomeAssistant, entry: TailwindConfigEntry) -> None:
         """Initialize the coordinator."""
         self.tailwind = Tailwind(

--- a/homeassistant/components/tailwind/entity.py
+++ b/homeassistant/components/tailwind/entity.py
@@ -1,5 +1,6 @@
 """Base entity for the Tailwind integration."""
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -55,7 +56,11 @@ class TailwindDoorEntity(CoordinatorEntity[TailwindDataUpdateCoordinator]):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{coordinator.data.device_id}-{door_id}")},
-            via_device=(DOMAIN, coordinator.data.device_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.data.device_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             name=f"Door {coordinator.data.doors[door_id].index + 1}",
             manufacturer="Tailwind",
             model=coordinator.data.product,

--- a/homeassistant/components/tedee/entity.py
+++ b/homeassistant/components/tedee/entity.py
@@ -5,6 +5,7 @@ from typing import override
 from aiotedee.models import TedeeLock
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -35,7 +36,11 @@ class TedeeEntity(CoordinatorEntity[TedeeApiCoordinator]):
             manufacturer="Tedee",
             model=lock.type_name,
             model_id=lock.type_name,
-            via_device=(DOMAIN, coordinator.bridge.serial),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.bridge.serial),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
 
     @property

--- a/homeassistant/components/tesla_fleet/entity.py
+++ b/homeassistant/components/tesla_fleet/entity.py
@@ -8,6 +8,7 @@ from tesla_fleet_api.tesla.energysite import EnergySite
 from tesla_fleet_api.tesla.vehicle.fleet import VehicleFleet
 
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -205,7 +206,11 @@ class TeslaFleetWallConnectorEntity(
             identifiers={(DOMAIN, din)},
             manufacturer="Tesla",
             name="Wall Connector",
-            via_device=(DOMAIN, str(data.id)),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                data.live_coordinator.hass,
+                (DOMAIN, str(data.id)),
+                config_entry_id=data.live_coordinator.config_entry.entry_id,
+            ),
             serial_number=din.rsplit("-", maxsplit=1)[-1],
             model=model,
         )

--- a/homeassistant/components/teslemetry/entity.py
+++ b/homeassistant/components/teslemetry/entity.py
@@ -7,6 +7,7 @@ from tesla_fleet_api.const import Scope
 from tesla_fleet_api.teslemetry import EnergySite, Vehicle
 
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.typing import StateType
@@ -224,7 +225,11 @@ class TeslemetryWallConnectorEntity(TeslemetryPollingEntity):
             manufacturer="Tesla",
             configuration_url="https://teslemetry.com/console",
             name="Wall Connector",
-            via_device=(DOMAIN, str(data.id)),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                data.live_coordinator.hass,
+                (DOMAIN, str(data.id)),
+                config_entry_id=data.live_coordinator.config_entry.entry_id,
+            ),
             serial_number=din.rsplit("-", maxsplit=1)[-1],
             model=model,
         )

--- a/homeassistant/components/togrill/coordinator.py
+++ b/homeassistant/components/togrill/coordinator.py
@@ -107,7 +107,11 @@ class ToGrillCoordinator(DataUpdateCoordinator[dict[tuple[int, int | None], Pack
                 "probe_number": str(probe_number),
             },
             identifiers={(DOMAIN, f"{self.address}_{probe_number}")},
-            via_device=(DOMAIN, self.address),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, self.address),
+                config_entry_id=self.config_entry.entry_id,
+            ),
         )
 
     @callback

--- a/homeassistant/components/touchline_sl/entity.py
+++ b/homeassistant/components/touchline_sl/entity.py
@@ -4,6 +4,7 @@ from typing import override
 
 from pytouchlinesl import Zone
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -24,7 +25,11 @@ class TouchlineSLZoneEntity(CoordinatorEntity[TouchlineSLModuleCoordinator]):
             identifiers={(DOMAIN, f"{coordinator.data.module.id}-{zone_id}")},
             name=self.zone.name,
             manufacturer="Roth",
-            via_device=(DOMAIN, coordinator.data.module.id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.data.module.id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             model="zone",
             suggested_area=self.zone.name,
         )

--- a/homeassistant/components/tradfri/entity.py
+++ b/homeassistant/components/tradfri/entity.py
@@ -10,6 +10,7 @@ from pytradfri.device import Device
 from pytradfri.error import RequestError
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -61,7 +62,11 @@ class TradfriBaseEntity(CoordinatorEntity[TradfriDeviceDataUpdateCoordinator]):
             model=info.model_number,
             name=self._device.name,
             sw_version=info.firmware_version,
-            via_device=(DOMAIN, gateway_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                device_coordinator.hass,
+                (DOMAIN, gateway_id),
+                config_entry_id=device_coordinator.config_entry.entry_id,
+            ),
         )
         self._attr_unique_id = f"{gateway_id}-{self._device_id}"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate integrations to setting via_device_id instead of via_device in DeviceInfo

Rationale: via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
