### PR TITLE
Fix via_device race in actron_air

### DIFF
--- a/homeassistant/components/actron_air/__init__.py
+++ b/homeassistant/components/actron_air/__init__.py
@@ -6,6 +6,7 @@ from actron_neo_api.models.system import ActronAirSystemInfo
 from homeassistant.const import CONF_API_TOKEN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from .const import DOMAIN, LOGGER
 from .coordinator import (
@@ -37,12 +38,26 @@ async def async_setup_entry(hass: HomeAssistant, entry: ActronAirConfigEntry) ->
             translation_key="setup_connection_error",
         ) from err
 
+    device_registry = dr.async_get(hass)
     system_coordinators: dict[str, ActronAirSystemCoordinator] = {}
     for system in systems:
         coordinator = ActronAirSystemCoordinator(hass, entry, api, system)
         LOGGER.debug("Setting up coordinator for system: %s", system.serial)
         await coordinator.async_config_entry_first_refresh()
         system_coordinators[system.serial] = coordinator
+
+        # Register the AC system device so zone entities can link to it as their
+        # via device when they are set up.
+        ac_system = coordinator.data.ac_system
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, system.serial)},
+            name=ac_system.system_name,
+            manufacturer="Actron Air",
+            model_id=ac_system.master_wc_model,
+            sw_version=ac_system.master_wc_firmware_version,
+            serial_number=system.serial,
+        )
 
     entry.runtime_data = ActronAirRuntimeData(
         api=api,

--- a/homeassistant/components/actron_air/coordinator.py
+++ b/homeassistant/components/actron_air/coordinator.py
@@ -40,6 +40,8 @@ type ActronAirConfigEntry = ConfigEntry[ActronAirRuntimeData]
 class ActronAirSystemCoordinator(DataUpdateCoordinator[ActronAirStatus]):
     """System coordinator for Actron Air integration."""
 
+    config_entry: ActronAirConfigEntry
+
     def __init__(
         self,
         hass: HomeAssistant,

--- a/homeassistant/components/actron_air/entity.py
+++ b/homeassistant/components/actron_air/entity.py
@@ -7,6 +7,7 @@ from typing import Any, Concatenate, override
 from actron_neo_api import ActronAirAPIError, ActronAirZone
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -90,5 +91,9 @@ class ActronAirZoneEntity(ActronAirEntity):
             manufacturer="Actron Air",
             model="Zone",
             suggested_area=zone.title,
-            via_device=(DOMAIN, self._serial_number),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, self._serial_number),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )

--- a/tests/components/actron_air/test_init.py
+++ b/tests/components/actron_air/test_init.py
@@ -3,9 +3,12 @@
 from unittest.mock import AsyncMock
 
 from actron_neo_api import ActronAirAPIError, ActronAirAuthError
+import pytest
 
+from homeassistant.components.actron_air.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
@@ -36,3 +39,22 @@ async def test_setup_entry_api_error(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("init_integration_with_zone")
+async def test_zone_device_via_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the zone device links to the AC system device via via_device_id."""
+    system_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456"), mock_config_entry.entry_id
+    )
+    assert system_device is not None
+
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456_zone_0"), mock_config_entry.entry_id
+    )
+    assert zone_device is not None
+    assert zone_device.via_device_id == system_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `actron_air`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
