### PR TITLE
Fix via_device race in advantage_air

### DIFF
--- a/homeassistant/components/advantage_air/__init__.py
+++ b/homeassistant/components/advantage_air/__init__.py
@@ -4,7 +4,7 @@ from advantage_air import advantage_air
 
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
@@ -49,6 +49,18 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register the system device so child devices can resolve it as their
+    # via_device parent regardless of platform setup order.
+    system = coordinator.data["system"]
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, system["rid"])},
+        manufacturer="Advantage Air",
+        model=system["sysType"],
+        name=system["name"],
+        sw_version=system["myAppRev"],
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/advantage_air/entity.py
+++ b/homeassistant/components/advantage_air/entity.py
@@ -5,6 +5,7 @@ from typing import Any
 from advantage_air import ApiError
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -49,7 +50,11 @@ class AdvantageAirAcEntity(AdvantageAirEntity):
         self._attr_unique_id += f"-{ac_key}"
 
         self._attr_device_info = DeviceInfo(
-            via_device=(DOMAIN, self.coordinator.data["system"]["rid"]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, self.coordinator.data["system"]["rid"]),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Advantage Air",
             model=self.coordinator.data["system"]["sysType"],
@@ -105,7 +110,11 @@ class AdvantageAirThingEntity(AdvantageAirEntity):
         self._attr_unique_id += f"-{self._id}"
 
         self._attr_device_info = DeviceInfo(
-            via_device=(DOMAIN, self.coordinator.data["system"]["rid"]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, self.coordinator.data["system"]["rid"]),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             identifiers={(DOMAIN, self._attr_unique_id)},
             manufacturer="Advantage Air",
             model="MyPlace",

--- a/homeassistant/components/advantage_air/light.py
+++ b/homeassistant/components/advantage_air/light.py
@@ -4,6 +4,7 @@ from typing import Any, override
 
 from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -55,7 +56,11 @@ class AdvantageAirLight(AdvantageAirEntity, LightEntity):
         self._attr_unique_id += f"-{self._id}"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._attr_unique_id)},
-            via_device=(DOMAIN, self.coordinator.data["system"]["rid"]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, self.coordinator.data["system"]["rid"]),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             manufacturer="Advantage Air",
             model=light.get("moduleType"),
             name=light["name"],

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -3,9 +3,12 @@
 from unittest.mock import AsyncMock
 
 from advantage_air import ApiError
+import pytest
 
+from homeassistant.components.advantage_air.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from . import add_mock_config, patch_get
 
@@ -19,6 +22,32 @@ async def test_async_setup_entry(hass: HomeAssistant, mock_get: AsyncMock) -> No
     assert await hass.config_entries.async_unload(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("mock_get")
+@pytest.mark.parametrize(
+    "child_identifier",
+    [
+        "uniqueid-ac1",  # AC device
+        "uniqueid-100",  # myLights light device
+        "uniqueid-203",  # myThings device
+    ],
+)
+async def test_child_devices_via_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    child_identifier: str,
+) -> None:
+    """Test child devices link to the system device via via_device_id."""
+
+    await add_mock_config(hass)
+
+    parent = device_registry.async_get_device(identifiers={(DOMAIN, "uniqueid")})
+    assert parent is not None
+
+    child = device_registry.async_get_device(identifiers={(DOMAIN, child_identifier)})
+    assert child is not None
+    assert child.via_device_id == parent.id
 
 
 async def test_async_setup_entry_failure(hass: HomeAssistant) -> None:

--- a/tests/components/advantage_air/test_init.py
+++ b/tests/components/advantage_air/test_init.py
@@ -40,12 +40,16 @@ async def test_child_devices_via_device(
 ) -> None:
     """Test child devices link to the system device via via_device_id."""
 
-    await add_mock_config(hass)
+    entry = await add_mock_config(hass)
 
-    parent = device_registry.async_get_device(identifiers={(DOMAIN, "uniqueid")})
+    parent = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "uniqueid"), entry.entry_id
+    )
     assert parent is not None
 
-    child = device_registry.async_get_device(identifiers={(DOMAIN, child_identifier)})
+    child = device_registry.async_get_device_by_identifier(
+        (DOMAIN, child_identifier), entry.entry_id
+    )
     assert child is not None
     assert child.via_device_id == parent.id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `advantage_air`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
