### PR TITLE
Fix via_device race in airzone

### DIFF
--- a/homeassistant/components/airzone/__init__.py
+++ b/homeassistant/components/airzone/__init__.py
@@ -6,9 +6,11 @@ from typing import Any
 from aioairzone.const import (
     AZD_FIRMWARE,
     AZD_FULL_NAME,
+    AZD_HOT_WATER,
     AZD_ID,
     AZD_MAC,
     AZD_MODEL,
+    AZD_NAME,
     AZD_SYSTEMS,
     AZD_WEBSERVER,
     DEFAULT_SYSTEM_ID,
@@ -97,11 +99,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirzoneConfigEntry) -> b
 
     @callback
     def _async_register_devices() -> None:
-        """Register the WebServer and System via_device parents.
+        """Register the WebServer, System, and DHW via_device parents.
 
-        The WebServer and Systems can appear on later coordinator updates, so
-        this runs on every update (before the platform listeners) to keep the
-        via_device parents registered before their child entities are added.
+        The WebServer, Systems, and DHW can appear on later coordinator
+        updates, so this runs on every update (before the platform
+        listeners) to keep the via_device parents registered before their
+        child entities are added.
         """
         ws_device_id: str | None = None
         ws_data: dict[str, Any] | None = coordinator.data.get(AZD_WEBSERVER)
@@ -128,6 +131,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirzoneConfigEntry) -> b
                 model=system_data.get(AZD_MODEL),
                 name=f"System {system_id}",
                 sw_version=system_data.get(AZD_FIRMWARE),
+                via_device_id=ws_device_id,
+            )
+
+        dhw_data: dict[str, Any] | None = coordinator.data.get(AZD_HOT_WATER)
+        if dhw_data is not None:
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={(DOMAIN, f"{entry.entry_id}_dhw")},
+                manufacturer=MANUFACTURER,
+                model="DHW",
+                name=dhw_data.get(AZD_NAME),
                 via_device_id=ws_device_id,
             )
 

--- a/homeassistant/components/airzone/__init__.py
+++ b/homeassistant/components/airzone/__init__.py
@@ -6,8 +6,10 @@ from typing import Any
 from aioairzone.const import (
     AZD_FIRMWARE,
     AZD_FULL_NAME,
+    AZD_ID,
     AZD_MAC,
     AZD_MODEL,
+    AZD_SYSTEMS,
     AZD_WEBSERVER,
     DEFAULT_SYSTEM_ID,
 )
@@ -93,19 +95,46 @@ async def async_setup_entry(hass: HomeAssistant, entry: AirzoneConfigEntry) -> b
 
     device_registry = dr.async_get(hass)
 
-    ws_data: dict[str, Any] | None = coordinator.data.get(AZD_WEBSERVER)
-    if ws_data is not None:
-        mac = ws_data.get(AZD_MAC, "")
+    @callback
+    def _async_register_devices() -> None:
+        """Register the WebServer and System via_device parents.
 
-        device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            connections={(dr.CONNECTION_NETWORK_MAC, mac)},
-            identifiers={(DOMAIN, f"{entry.entry_id}_ws")},
-            manufacturer=MANUFACTURER,
-            model=ws_data.get(AZD_MODEL),
-            name=ws_data.get(AZD_FULL_NAME),
-            sw_version=ws_data.get(AZD_FIRMWARE),
-        )
+        The WebServer and Systems can appear on later coordinator updates, so
+        this runs on every update (before the platform listeners) to keep the
+        via_device parents registered before their child entities are added.
+        """
+        ws_device_id: str | None = None
+        ws_data: dict[str, Any] | None = coordinator.data.get(AZD_WEBSERVER)
+        if ws_data is not None:
+            mac = ws_data.get(AZD_MAC, "")
+
+            ws_device = device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+                identifiers={(DOMAIN, f"{entry.entry_id}_ws")},
+                manufacturer=MANUFACTURER,
+                model=ws_data.get(AZD_MODEL),
+                name=ws_data.get(AZD_FULL_NAME),
+                sw_version=ws_data.get(AZD_FIRMWARE),
+            )
+            ws_device_id = ws_device.id
+
+        for system_data in coordinator.data.get(AZD_SYSTEMS, {}).values():
+            system_id = system_data[AZD_ID]
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={(DOMAIN, f"{entry.entry_id}_{system_id}")},
+                manufacturer=MANUFACTURER,
+                model=system_data.get(AZD_MODEL),
+                name=f"System {system_id}",
+                sw_version=system_data.get(AZD_FIRMWARE),
+                via_device_id=ws_device_id,
+            )
+
+    # Register the parents before forwarding platforms, and keep them registered
+    # as new devices appear so child entities can resolve their via_device_id.
+    _async_register_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_async_register_devices))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/airzone/entity.py
+++ b/homeassistant/components/airzone/entity.py
@@ -67,7 +67,13 @@ class AirzoneSystemEntity(AirzoneEntity):
             sw_version=self.get_airzone_value(AZD_FIRMWARE),
         )
         if AZD_WEBSERVER in self.coordinator.data:
-            self._attr_device_info["via_device"] = (DOMAIN, f"{entry.entry_id}_ws")
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, f"{entry.entry_id}_ws"),
+                    config_entry_id=entry.entry_id,
+                )
+            )
         self._attr_unique_id = entry.unique_id or entry.entry_id
 
     @property
@@ -120,7 +126,13 @@ class AirzoneHotWaterEntity(AirzoneEntity):
             name=self.get_airzone_value(AZD_NAME),
         )
         if AZD_WEBSERVER in self.coordinator.data:
-            self._attr_device_info["via_device"] = (DOMAIN, f"{entry.entry_id}_ws")
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, f"{entry.entry_id}_ws"),
+                    config_entry_id=entry.entry_id,
+                )
+            )
         self._attr_unique_id = entry.unique_id or entry.entry_id
 
     @override
@@ -195,7 +207,11 @@ class AirzoneZoneEntity(AirzoneEntity):
             model=self.get_airzone_value(AZD_THERMOSTAT_MODEL),
             name=zone_data[AZD_NAME],
             sw_version=self.get_airzone_value(AZD_THERMOSTAT_FW),
-            via_device=(DOMAIN, f"{entry.entry_id}_{self.system_id}"),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, f"{entry.entry_id}_{self.system_id}"),
+                config_entry_id=entry.entry_id,
+            ),
         )
         self._attr_unique_id = entry.unique_id or entry.entry_id
 

--- a/tests/components/airzone/test_init.py
+++ b/tests/components/airzone/test_init.py
@@ -9,9 +9,16 @@ from homeassistant.components.airzone.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_ID
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
-from .util import CONFIG, HVAC_MOCK, HVAC_VERSION_MOCK, HVAC_WEBSERVER_MOCK, USER_INPUT
+from .util import (
+    CONFIG,
+    HVAC_MOCK,
+    HVAC_VERSION_MOCK,
+    HVAC_WEBSERVER_MOCK,
+    USER_INPUT,
+    async_init_integration,
+)
 
 from tests.common import MockConfigEntry
 
@@ -119,6 +126,31 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_device_via_device_links(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that child devices link to their registered parent via via_device_id."""
+
+    config_entry = await async_init_integration(hass)
+
+    ws_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{config_entry.entry_id}_ws")}
+    )
+    assert ws_device is not None
+
+    system_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{config_entry.entry_id}_1")}
+    )
+    assert system_device is not None
+    assert system_device.via_device_id == ws_device.id
+
+    zone_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{config_entry.entry_id}_1:1")}
+    )
+    assert zone_device is not None
+    assert zone_device.via_device_id == system_device.id
 
 
 async def test_migrate_entry_v2(hass: HomeAssistant) -> None:

--- a/tests/components/airzone/test_init.py
+++ b/tests/components/airzone/test_init.py
@@ -135,19 +135,19 @@ async def test_device_via_device_links(
 
     config_entry = await async_init_integration(hass)
 
-    ws_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{config_entry.entry_id}_ws")}
+    ws_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{config_entry.entry_id}_ws"), config_entry.entry_id
     )
     assert ws_device is not None
 
-    system_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{config_entry.entry_id}_1")}
+    system_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{config_entry.entry_id}_1"), config_entry.entry_id
     )
     assert system_device is not None
     assert system_device.via_device_id == ws_device.id
 
-    zone_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{config_entry.entry_id}_1:1")}
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{config_entry.entry_id}_1:1"), config_entry.entry_id
     )
     assert zone_device is not None
     assert zone_device.via_device_id == system_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `airzone`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
