### PR TITLE
Fix via_device race in airzone_cloud

### DIFF
--- a/homeassistant/components/airzone_cloud/__init__.py
+++ b/homeassistant/components/airzone_cloud/__init__.py
@@ -2,11 +2,20 @@
 
 from aioairzone_cloud.cloudapi import AirzoneCloudApi
 from aioairzone_cloud.common import ConnectionOptions
+from aioairzone_cloud.const import (
+    AZD_FIRMWARE,
+    AZD_MODEL,
+    AZD_NAME,
+    AZD_SYSTEMS,
+    AZD_WEBSERVER,
+    AZD_WEBSERVERS,
+)
 
 from homeassistant.const import CONF_ID, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import aiohttp_client
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import aiohttp_client, device_registry as dr
 
+from .const import DOMAIN, MANUFACTURER
 from .coordinator import AirzoneCloudConfigEntry, AirzoneUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -42,9 +51,51 @@ async def async_setup_entry(
 
     entry.runtime_data = coordinator
 
+    _async_register_devices(hass, entry, coordinator)
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
+
+
+@callback
+def _async_register_devices(
+    hass: HomeAssistant,
+    entry: AirzoneCloudConfigEntry,
+    coordinator: AirzoneUpdateCoordinator,
+) -> None:
+    """Register WebServer and System devices referenced as via_device parents.
+
+    Child devices resolve their via_device_id at add time, so the parents must
+    already exist regardless of which platform creates their own entities.
+    """
+    device_registry = dr.async_get(hass)
+
+    for ws_id, ws_data in coordinator.data.get(AZD_WEBSERVERS, {}).items():
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            connections={(dr.CONNECTION_NETWORK_MAC, ws_id)},
+            identifiers={(DOMAIN, ws_id)},
+            manufacturer=MANUFACTURER,
+            model="WebServer",
+            name=ws_data[AZD_NAME],
+            sw_version=ws_data[AZD_FIRMWARE],
+        )
+
+    for system_id, system_data in coordinator.data.get(AZD_SYSTEMS, {}).items():
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, system_id)},
+            manufacturer=MANUFACTURER,
+            model=system_data.get(AZD_MODEL),
+            name=system_data[AZD_NAME],
+            sw_version=system_data.get(AZD_FIRMWARE),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass,
+                (DOMAIN, system_data[AZD_WEBSERVER]),
+                config_entry_id=entry.entry_id,
+            ),
+        )
 
 
 async def async_unload_entry(

--- a/homeassistant/components/airzone_cloud/entity.py
+++ b/homeassistant/components/airzone_cloud/entity.py
@@ -73,7 +73,11 @@ class AirzoneAidooEntity(AirzoneEntity):
             manufacturer=MANUFACTURER,
             model=aidoo_data[AZD_MODEL],
             name=aidoo_data[AZD_NAME],
-            via_device=(DOMAIN, aidoo_data[AZD_WEBSERVER]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, aidoo_data[AZD_WEBSERVER]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
 
     @override
@@ -164,7 +168,11 @@ class AirzoneHotWaterEntity(AirzoneEntity):
             manufacturer=MANUFACTURER,
             model="Hot Water",
             name=dhw_data[AZD_NAME],
-            via_device=(DOMAIN, dhw_data[AZD_WEBSERVER]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, dhw_data[AZD_WEBSERVER]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
 
     @override
@@ -257,7 +265,11 @@ class AirzoneSystemEntity(AirzoneEntity):
             model=system_data.get(AZD_MODEL),
             manufacturer=MANUFACTURER,
             name=system_data[AZD_NAME],
-            via_device=(DOMAIN, system_data[AZD_WEBSERVER]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, system_data[AZD_WEBSERVER]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             sw_version=system_data.get(AZD_FIRMWARE),
         )
 
@@ -322,7 +334,11 @@ class AirzoneZoneEntity(AirzoneEntity):
             model=zone_data.get(AZD_THERMOSTAT_MODEL),
             manufacturer=MANUFACTURER,
             name=zone_data[AZD_NAME],
-            via_device=(DOMAIN, self.system_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, self.system_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             sw_version=zone_data.get(AZD_THERMOSTAT_FW),
         )
 

--- a/tests/components/airzone_cloud/test_init.py
+++ b/tests/components/airzone_cloud/test_init.py
@@ -7,8 +7,9 @@ from aioairzone_cloud.exceptions import AirzoneTimeout
 from homeassistant.components.airzone_cloud.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
-from .util import CONFIG
+from .util import CONFIG, WS_ID, WS_ID_AIDOO, async_init_integration
 
 from tests.common import MockConfigEntry
 
@@ -52,6 +53,39 @@ async def test_unload_entry(hass: HomeAssistant) -> None:
         await hass.config_entries.async_unload(config_entry.entry_id)
         await hass.async_block_till_done()
         assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_device_via_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that child devices are linked to their via_device parents."""
+    await async_init_integration(hass)
+
+    ws_device = device_registry.async_get_device(identifiers={(DOMAIN, WS_ID)})
+    assert ws_device is not None
+    assert ws_device.via_device_id is None
+
+    ws_aidoo_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, WS_ID_AIDOO)}
+    )
+    assert ws_aidoo_device is not None
+
+    system_device = device_registry.async_get_device(identifiers={(DOMAIN, "system1")})
+    assert system_device is not None
+    assert system_device.via_device_id == ws_device.id
+
+    zone_device = device_registry.async_get_device(identifiers={(DOMAIN, "zone1")})
+    assert zone_device is not None
+    assert zone_device.via_device_id == system_device.id
+
+    dhw_device = device_registry.async_get_device(identifiers={(DOMAIN, "dhw1")})
+    assert dhw_device is not None
+    assert dhw_device.via_device_id == ws_device.id
+
+    aidoo_device = device_registry.async_get_device(identifiers={(DOMAIN, "aidoo1")})
+    assert aidoo_device is not None
+    assert aidoo_device.via_device_id == ws_aidoo_device.id
 
 
 async def test_init_api_timeout(hass: HomeAssistant) -> None:

--- a/tests/components/airzone_cloud/test_init.py
+++ b/tests/components/airzone_cloud/test_init.py
@@ -62,28 +62,40 @@ async def test_device_via_device(
     """Test that child devices are linked to their via_device parents."""
     await async_init_integration(hass)
 
-    ws_device = device_registry.async_get_device(identifiers={(DOMAIN, WS_ID)})
+    config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    ws_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, WS_ID), config_entry.entry_id
+    )
     assert ws_device is not None
     assert ws_device.via_device_id is None
 
-    ws_aidoo_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, WS_ID_AIDOO)}
+    ws_aidoo_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, WS_ID_AIDOO), config_entry.entry_id
     )
     assert ws_aidoo_device is not None
 
-    system_device = device_registry.async_get_device(identifiers={(DOMAIN, "system1")})
+    system_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "system1"), config_entry.entry_id
+    )
     assert system_device is not None
     assert system_device.via_device_id == ws_device.id
 
-    zone_device = device_registry.async_get_device(identifiers={(DOMAIN, "zone1")})
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "zone1"), config_entry.entry_id
+    )
     assert zone_device is not None
     assert zone_device.via_device_id == system_device.id
 
-    dhw_device = device_registry.async_get_device(identifiers={(DOMAIN, "dhw1")})
+    dhw_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "dhw1"), config_entry.entry_id
+    )
     assert dhw_device is not None
     assert dhw_device.via_device_id == ws_device.id
 
-    aidoo_device = device_registry.async_get_device(identifiers={(DOMAIN, "aidoo1")})
+    aidoo_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "aidoo1"), config_entry.entry_id
+    )
     assert aidoo_device is not None
     assert aidoo_device.via_device_id == ws_aidoo_device.id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `airzone_cloud`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
