### PR TITLE
Adapt bosch_shc to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/bosch_shc/binary_sensor.py
+++ b/homeassistant/components/bosch_shc/binary_sensor.py
@@ -37,6 +37,7 @@ async def async_setup_entry(
 
     entities: list[BinarySensorEntity] = [
         ShutterContactSensor(
+            hass=hass,
             device=binary_sensor,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -49,6 +50,7 @@ async def async_setup_entry(
 
     entities.extend(
         BatterySensor(
+            hass=hass,
             device=binary_sensor,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -75,9 +77,11 @@ class ShutterContactSensor(SHCEntity, BinarySensorEntity):
     _attr_name = None
     _device: SHCShutterContact
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, device: SHCDevice, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize an SHC shutter contact sensor."""
-        super().__init__(device, parent_id, entry_id)
+        super().__init__(hass, device, parent_id, entry_id)
         switcher: dict[str | None, BinarySensorDeviceClass] = {
             "ENTRANCE_DOOR": BinarySensorDeviceClass.DOOR,
             "REGULAR_WINDOW": BinarySensorDeviceClass.WINDOW,
@@ -101,9 +105,11 @@ class BatterySensor(SHCEntity, BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.BATTERY
     _device: SHCBatteryDevice
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, device: SHCDevice, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize an SHC battery reporting sensor."""
-        super().__init__(device, parent_id, entry_id)
+        super().__init__(hass, device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_battery"
 
     @property

--- a/homeassistant/components/bosch_shc/cover.py
+++ b/homeassistant/components/bosch_shc/cover.py
@@ -33,6 +33,7 @@ async def async_setup_entry(
 
     async_add_entities(
         ShutterControlCover(
+            hass=hass,
             device=cover,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -2,7 +2,7 @@
 
 from typing import override
 
-from boschshcpy import SHCDevice, SHCIntrusionSystem
+from boschshcpy import SHCDevice
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -30,9 +30,7 @@ class SHCBaseEntity(Entity):
     _attr_should_poll = False
     _attr_has_entity_name = True
 
-    def __init__(
-        self, device: SHCDevice | SHCIntrusionSystem, parent_id: str, entry_id: str
-    ) -> None:
+    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
         """Initialize the generic SHC device."""
         self._device = device
         self._entry_id = entry_id
@@ -111,37 +109,3 @@ class SHCEntity(SHCBaseEntity):
     def available(self) -> bool:
         """Return false if status is unavailable."""
         return self._device.status == "AVAILABLE"
-
-
-class SHCDomainEntity(SHCBaseEntity):
-    """Representation of a SHC domain service entity."""
-
-    _device: SHCIntrusionSystem
-
-    def __init__(
-        self,
-        hass: HomeAssistant,
-        domain: SHCIntrusionSystem,
-        parent_id: str,
-        entry_id: str,
-    ) -> None:
-        """Initialize the generic SHC device."""
-        self._attr_unique_id = domain.id
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, domain.id)},
-            manufacturer=domain.manufacturer,
-            model=domain.device_model,
-            name=domain.name,
-        )
-        if hub := dr.async_get(hass).async_get_device_by_identifier(
-            (DOMAIN, parent_id), entry_id
-        ):
-            device_info["via_device_id"] = hub.id
-        self._attr_device_info = device_info
-        super().__init__(device=domain, parent_id=parent_id, entry_id=entry_id)
-
-    @property
-    @override
-    def available(self) -> bool:
-        """Return false if status is unavailable."""
-        return self._device.system_availability

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -72,15 +72,20 @@ class SHCEntity(SHCBaseEntity):
     ) -> None:
         """Initialize generic SHC device."""
         self._attr_unique_id = device.serial
-        self._attr_device_info = DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, device.id)},
             manufacturer=device.manufacturer,
             model=device.device_model,
             name=device.name,
-            via_device_id=dr.async_get_device_id_by_identifier(
-                hass, (DOMAIN, device.root_device_id), config_entry_id=entry_id
-            ),
         )
+        # boschshcpy may render the hub identifier (shc_info.unique_id) and a
+        # device's root_device_id differently, so the lookup can miss; link only
+        # when it resolves instead of raising out of setup.
+        if hub := dr.async_get(hass).async_get_device_by_identifier(
+            (DOMAIN, device.root_device_id), entry_id
+        ):
+            device_info["via_device_id"] = hub.id
+        self._attr_device_info = device_info
         super().__init__(device=device, parent_id=parent_id, entry_id=entry_id)
 
     @override
@@ -122,15 +127,17 @@ class SHCDomainEntity(SHCBaseEntity):
     ) -> None:
         """Initialize the generic SHC device."""
         self._attr_unique_id = domain.id
-        self._attr_device_info = DeviceInfo(
+        device_info = DeviceInfo(
             identifiers={(DOMAIN, domain.id)},
             manufacturer=domain.manufacturer,
             model=domain.device_model,
             name=domain.name,
-            via_device_id=dr.async_get_device_id_by_identifier(
-                hass, (DOMAIN, parent_id), config_entry_id=entry_id
-            ),
         )
+        if hub := dr.async_get(hass).async_get_device_by_identifier(
+            (DOMAIN, parent_id), entry_id
+        ):
+            device_info["via_device_id"] = hub.id
+        self._attr_device_info = device_info
         super().__init__(device=domain, parent_id=parent_id, entry_id=entry_id)
 
     @property

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -67,7 +67,9 @@ class SHCEntity(SHCBaseEntity):
 
     _device: SHCDevice
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, device: SHCDevice, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize generic SHC device."""
         self._attr_unique_id = device.serial
         self._attr_device_info = DeviceInfo(
@@ -75,7 +77,9 @@ class SHCEntity(SHCBaseEntity):
             manufacturer=device.manufacturer,
             model=device.device_model,
             name=device.name,
-            via_device=(DOMAIN, device.root_device_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass, (DOMAIN, device.root_device_id), config_entry_id=entry_id
+            ),
         )
         super().__init__(device=device, parent_id=parent_id, entry_id=entry_id)
 
@@ -110,7 +114,11 @@ class SHCDomainEntity(SHCBaseEntity):
     _device: SHCIntrusionSystem
 
     def __init__(
-        self, domain: SHCIntrusionSystem, parent_id: str, entry_id: str
+        self,
+        hass: HomeAssistant,
+        domain: SHCIntrusionSystem,
+        parent_id: str,
+        entry_id: str,
     ) -> None:
         """Initialize the generic SHC device."""
         self._attr_unique_id = domain.id
@@ -119,9 +127,8 @@ class SHCDomainEntity(SHCBaseEntity):
             manufacturer=domain.manufacturer,
             model=domain.device_model,
             name=domain.name,
-            via_device=(
-                DOMAIN,
-                parent_id,
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass, (DOMAIN, parent_id), config_entry_id=entry_id
             ),
         )
         super().__init__(device=domain, parent_id=parent_id, entry_id=entry_id)

--- a/homeassistant/components/bosch_shc/sensor.py
+++ b/homeassistant/components/bosch_shc/sensor.py
@@ -212,6 +212,7 @@ async def async_setup_entry(
 
     entities: list[SensorEntity] = [
         SHCSensor(
+            hass,
             device,
             description,
             shc_info.unique_id,
@@ -226,6 +227,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSensor(
+            hass,
             device,
             description,
             shc_info.unique_id,
@@ -240,6 +242,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSensor(
+            hass,
             device,
             description,
             shc_info.unique_id,
@@ -263,6 +266,7 @@ async def async_setup_entry(
     ]
     entities.extend(
         SHCSensor(
+            hass,
             device,
             description,
             shc_info.unique_id,
@@ -274,6 +278,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSensor(
+            hass,
             device,
             description,
             shc_info.unique_id,
@@ -297,13 +302,14 @@ class SHCSensor[_DeviceT: SHCDevice](SHCEntity, SensorEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: _DeviceT,
         entity_description: SHCSensorEntityDescription[_DeviceT],
         parent_id: str,
         entry_id: str,
     ) -> None:
         """Initialize sensor."""
-        super().__init__(device, parent_id, entry_id)
+        super().__init__(hass, device, parent_id, entry_id)
         self._device: _DeviceT = device
         self.entity_description = entity_description
         self._attr_unique_id = f"{device.serial}_{entity_description.key}"

--- a/homeassistant/components/bosch_shc/switch.py
+++ b/homeassistant/components/bosch_shc/switch.py
@@ -89,6 +89,7 @@ async def async_setup_entry(
 
     entities: list[SwitchEntity] = [
         SHCSwitch(
+            hass=hass,
             device=switch,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -99,6 +100,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCRoutingSwitch(
+            hass=hass,
             device=switch,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -108,6 +110,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSwitch(
+            hass=hass,
             device=switch,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -118,6 +121,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSwitch(
+            hass=hass,
             device=switch,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -128,6 +132,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSwitch(
+            hass=hass,
             device=switch,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -138,6 +143,7 @@ async def async_setup_entry(
 
     entities.extend(
         SHCSwitch(
+            hass=hass,
             device=switch,
             parent_id=shc_info.unique_id,
             entry_id=config_entry.entry_id,
@@ -156,13 +162,14 @@ class SHCSwitch(SHCEntity, SwitchEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
         device: SHCDevice,
         parent_id: str,
         entry_id: str,
         description: SHCSwitchEntityDescription,
     ) -> None:
         """Initialize a SHC switch."""
-        super().__init__(device, parent_id, entry_id)
+        super().__init__(hass, device, parent_id, entry_id)
         self.entity_description = description
 
     @property
@@ -202,9 +209,11 @@ class SHCRoutingSwitch(SHCEntity, SwitchEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _device: SHCSmartPlug
 
-    def __init__(self, device: SHCDevice, parent_id: str, entry_id: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, device: SHCDevice, parent_id: str, entry_id: str
+    ) -> None:
         """Initialize an SHC routing switch."""
-        super().__init__(device, parent_id, entry_id)
+        super().__init__(hass, device, parent_id, entry_id)
         self._attr_unique_id = f"{device.serial}_routing"
 
     @property

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -2,10 +2,10 @@
 
 from unittest.mock import MagicMock
 
-from boschshcpy import SHCDevice, SHCIntrusionSystem
+from boschshcpy import SHCDevice
 
 from homeassistant.components.bosch_shc.const import DOMAIN
-from homeassistant.components.bosch_shc.entity import SHCDomainEntity, SHCEntity
+from homeassistant.components.bosch_shc.entity import SHCEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -43,35 +43,6 @@ async def test_shc_entity_via_device_id(
     assert entity.device_info["via_device_id"] == hub_device.id
 
 
-async def test_shc_domain_entity_via_device_id(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
-    """Test SHCDomainEntity links its device to the SHC hub via via_device_id."""
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    hub_device = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, "root-serial")},
-        manufacturer="Bosch",
-        name="Bosch SHC",
-        model="SmartHomeController",
-    )
-
-    domain = MagicMock(spec=SHCIntrusionSystem)
-    domain.id = "intrusion-id"
-    domain.manufacturer = "Bosch"
-    domain.device_model = "ISENS"
-    domain.name = "Intrusion Detection System"
-
-    entity = SHCDomainEntity(
-        hass=hass, domain=domain, parent_id="root-serial", entry_id=entry.entry_id
-    )
-
-    assert entity.device_info is not None
-    assert entity.device_info["via_device_id"] == hub_device.id
-
-
 async def test_shc_entity_via_device_id_mismatch(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
@@ -101,38 +72,6 @@ async def test_shc_entity_via_device_id_mismatch(
 
     entity = SHCEntity(
         hass=hass, device=device, parent_id="hub-serial", entry_id=entry.entry_id
-    )
-
-    assert entity.device_info is not None
-    assert "via_device_id" not in entity.device_info
-
-
-async def test_shc_domain_entity_via_device_id_mismatch(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
-) -> None:
-    """Test SHCDomainEntity sets up without a link when the hub identifier mismatches."""
-    entry = MockConfigEntry(domain=DOMAIN)
-    entry.add_to_hass(hass)
-
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, "hub-serial")},
-        manufacturer="Bosch",
-        name="Bosch SHC",
-        model="SmartHomeController",
-    )
-
-    domain = MagicMock(spec=SHCIntrusionSystem)
-    domain.id = "intrusion-id"
-    domain.manufacturer = "Bosch"
-    domain.device_model = "ISENS"
-    domain.name = "Intrusion Detection System"
-
-    entity = SHCDomainEntity(
-        hass=hass,
-        domain=domain,
-        parent_id="root-serial-mismatch",
-        entry_id=entry.entry_id,
     )
 
     assert entity.device_info is not None

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -70,3 +70,70 @@ async def test_shc_domain_entity_via_device_id(
 
     assert entity.device_info is not None
     assert entity.device_info["via_device_id"] == hub_device.id
+
+
+async def test_shc_entity_via_device_id_mismatch(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test SHCEntity sets up without a link when the hub identifier does not match.
+
+    boschshcpy may render the hub identifier and a device's root_device_id
+    differently, so the lookup can miss; setup must not crash in that case.
+    """
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "hub-serial")},
+        manufacturer="Bosch",
+        name="Bosch SHC",
+        model="SmartHomeController",
+    )
+
+    device = MagicMock(spec=SHCDevice)
+    device.serial = "child-serial"
+    device.manufacturer = "Bosch"
+    device.device_model = "SWD"
+    device.name = "Shutter Contact"
+    device.id = "child-id"
+    device.root_device_id = "root-serial-mismatch"
+
+    entity = SHCEntity(
+        hass=hass, device=device, parent_id="hub-serial", entry_id=entry.entry_id
+    )
+
+    assert entity.device_info is not None
+    assert "via_device_id" not in entity.device_info
+
+
+async def test_shc_domain_entity_via_device_id_mismatch(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test SHCDomainEntity sets up without a link when the hub identifier mismatches."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "hub-serial")},
+        manufacturer="Bosch",
+        name="Bosch SHC",
+        model="SmartHomeController",
+    )
+
+    domain = MagicMock(spec=SHCIntrusionSystem)
+    domain.id = "intrusion-id"
+    domain.manufacturer = "Bosch"
+    domain.device_model = "ISENS"
+    domain.name = "Intrusion Detection System"
+
+    entity = SHCDomainEntity(
+        hass=hass,
+        domain=domain,
+        parent_id="root-serial-mismatch",
+        entry_id=entry.entry_id,
+    )
+
+    assert entity.device_info is not None
+    assert "via_device_id" not in entity.device_info

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -1,0 +1,72 @@
+"""Tests for the Bosch SHC entity base classes."""
+
+from unittest.mock import MagicMock
+
+from boschshcpy import SHCDevice, SHCIntrusionSystem
+
+from homeassistant.components.bosch_shc.const import DOMAIN
+from homeassistant.components.bosch_shc.entity import SHCDomainEntity, SHCEntity
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+async def test_shc_entity_via_device_id(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test SHCEntity links its device to the SHC hub via via_device_id."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    hub_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "root-serial")},
+        manufacturer="Bosch",
+        name="Bosch SHC",
+        model="SmartHomeController",
+    )
+
+    device = MagicMock(spec=SHCDevice)
+    device.serial = "child-serial"
+    device.manufacturer = "Bosch"
+    device.device_model = "SWD"
+    device.name = "Shutter Contact"
+    device.id = "child-id"
+    device.root_device_id = "root-serial"
+
+    entity = SHCEntity(
+        hass=hass, device=device, parent_id="root-serial", entry_id=entry.entry_id
+    )
+
+    assert entity.device_info is not None
+    assert entity.device_info["via_device_id"] == hub_device.id
+
+
+async def test_shc_domain_entity_via_device_id(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test SHCDomainEntity links its device to the SHC hub via via_device_id."""
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+
+    hub_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "root-serial")},
+        manufacturer="Bosch",
+        name="Bosch SHC",
+        model="SmartHomeController",
+    )
+
+    domain = MagicMock(spec=SHCIntrusionSystem)
+    domain.id = "intrusion-id"
+    domain.manufacturer = "Bosch"
+    domain.device_model = "ISENS"
+    domain.name = "Intrusion Detection System"
+
+    entity = SHCDomainEntity(
+        hass=hass, domain=domain, parent_id="root-serial", entry_id=entry.entry_id
+    )
+
+    assert entity.device_info is not None
+    assert entity.device_info["via_device_id"] == hub_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt bosch_shc to set via_device_id in DeviceInfo

As part of this, remove the unused class `SHCDomainEntity` is removed.

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
