### PR TITLE
Fix via_device race in directv

### DIFF
--- a/homeassistant/components/directv/__init__.py
+++ b/homeassistant/components/directv/__init__.py
@@ -8,7 +8,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .const import DOMAIN
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.REMOTE]
 SCAN_INTERVAL = timedelta(seconds=30)
@@ -27,6 +30,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: DirecTVConfigEntry) -> b
         raise ConfigEntryNotReady from err
 
     entry.runtime_data = dtv
+
+    # Register the receiver device so client entities can link to it via_device_id.
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, dtv.device.info.receiver_id)},
+        manufacturer=dtv.device.info.brand,
+        name=next(
+            (
+                str.title(location.name)
+                for location in dtv.device.locations
+                if not location.client
+            ),
+            None,
+        ),
+        sw_version=dtv.device.info.version,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/directv/entity.py
+++ b/homeassistant/components/directv/entity.py
@@ -2,9 +2,12 @@
 
 from directv import DIRECTV
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
+from . import DirecTVConfigEntry
 from .const import DOMAIN
 
 
@@ -14,16 +17,32 @@ class DIRECTVEntity(Entity):
     _attr_has_entity_name = True
     _attr_name = None
 
-    def __init__(self, *, dtv: DIRECTV, name: str, address: str = "0") -> None:
+    def __init__(
+        self,
+        *,
+        hass: HomeAssistant,
+        dtv: DIRECTV,
+        entry: DirecTVConfigEntry,
+        name: str,
+        address: str = "0",
+    ) -> None:
         """Initialize the DirecTV entity."""
         self._address = address
         self._device_id = address if address != "0" else dtv.device.info.receiver_id
         self._is_client = address != "0"
         self.dtv = dtv
+        via_device_id: str | None = None
+        if self._is_client:
+            via_device_id = dr.async_get_device_id_by_identifier(
+                hass,
+                (DOMAIN, dtv.device.info.receiver_id),
+                config_entry_id=entry.entry_id,
+            )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._device_id)},
-            manufacturer=self.dtv.device.info.brand,
+            manufacturer=dtv.device.info.brand,
             name=name,
-            sw_version=self.dtv.device.info.version,
-            via_device=(DOMAIN, self.dtv.device.info.receiver_id),
+            sw_version=dtv.device.info.version,
         )
+        if via_device_id is not None:
+            self._attr_device_info["via_device_id"] = via_device_id

--- a/homeassistant/components/directv/media_player.py
+++ b/homeassistant/components/directv/media_player.py
@@ -61,7 +61,9 @@ async def async_setup_entry(
     async_add_entities(
         (
             DIRECTVMediaPlayer(
+                hass=hass,
                 dtv=dtv,
+                entry=entry,
                 name=str.title(location.name),
                 address=location.address,
             )
@@ -74,10 +76,20 @@ async def async_setup_entry(
 class DIRECTVMediaPlayer(DIRECTVEntity, MediaPlayerEntity):
     """Representation of a DirecTV receiver on the network."""
 
-    def __init__(self, *, dtv: DIRECTV, name: str, address: str = "0") -> None:
+    def __init__(
+        self,
+        *,
+        hass: HomeAssistant,
+        dtv: DIRECTV,
+        entry: DirecTVConfigEntry,
+        name: str,
+        address: str = "0",
+    ) -> None:
         """Initialize DirecTV media player."""
         super().__init__(
+            hass=hass,
             dtv=dtv,
+            entry=entry,
             name=name,
             address=address,
         )

--- a/homeassistant/components/directv/remote.py
+++ b/homeassistant/components/directv/remote.py
@@ -29,7 +29,9 @@ async def async_setup_entry(
     async_add_entities(
         (
             DIRECTVRemote(
+                hass=hass,
                 dtv=dtv,
+                entry=entry,
                 name=str.title(location.name),
                 address=location.address,
             )
@@ -42,10 +44,20 @@ async def async_setup_entry(
 class DIRECTVRemote(DIRECTVEntity, RemoteEntity):
     """Device that sends commands to a DirecTV receiver."""
 
-    def __init__(self, *, dtv: DIRECTV, name: str, address: str = "0") -> None:
+    def __init__(
+        self,
+        *,
+        hass: HomeAssistant,
+        dtv: DIRECTV,
+        entry: DirecTVConfigEntry,
+        name: str,
+        address: str = "0",
+    ) -> None:
         """Initialize DirecTV remote."""
         super().__init__(
+            hass=hass,
             dtv=dtv,
+            entry=entry,
             name=name,
             address=address,
         )

--- a/tests/components/directv/test_media_player.py
+++ b/tests/components/directv/test_media_player.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.directv.const import DOMAIN
 from homeassistant.components.directv.media_player import (
     ATTR_MEDIA_CURRENTLY_RECORDING,
     ATTR_MEDIA_RATING,
@@ -46,10 +47,10 @@ from homeassistant.const import (
     STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from . import setup_integration
+from . import RECEIVER_ID, setup_integration
 
 from tests.test_util.aiohttp import AiohttpClientMocker
 
@@ -160,6 +161,29 @@ async def test_unique_id(
     unavailable_client = entity_registry.async_get(UNAVAILABLE_ENTITY_ID)
     assert unavailable_client.original_device_class == MediaPlayerDeviceClass.RECEIVER
     assert unavailable_client.unique_id == "9XXXXXXXXXX9"
+
+
+async def test_client_device_via_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test a client's device links to the receiver device via via_device_id."""
+    entry = await setup_integration(hass, aioclient_mock)
+
+    receiver_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, RECEIVER_ID), entry.entry_id
+    )
+    assert receiver_device is not None
+
+    client_entity = entity_registry.async_get(CLIENT_ENTITY_ID)
+    assert client_entity is not None
+    assert client_entity.device_id is not None
+
+    client_device = device_registry.async_get(client_entity.device_id)
+    assert client_device is not None
+    assert client_device.via_device_id == receiver_device.id
 
 
 async def test_supported_features(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `directv`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
