### PR TITLE
Fix via_device race in eheimdigital

### DIFF
--- a/homeassistant/components/eheimdigital/__init__.py
+++ b/homeassistant/components/eheimdigital/__init__.py
@@ -1,11 +1,17 @@
 """The EHEIM Digital integration."""
 
+from typing import TYPE_CHECKING
+
+from eheimdigital.device import EheimDigitalDevice
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .entity import async_device_info
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -27,6 +33,17 @@ async def async_setup_entry(
     coordinator = EheimDigitalUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+
+    main = coordinator.hub.main
+    if TYPE_CHECKING:
+        # After the first refresh at least one device is found and so there is
+        # always a main device set.
+        assert isinstance(main, EheimDigitalDevice)
+    # Register the main device up front so child devices can resolve their
+    # via_device_id link during concurrent platform setup.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id, **async_device_info(coordinator, main)
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/eheimdigital/entity.py
+++ b/homeassistant/components/eheimdigital/entity.py
@@ -10,11 +10,28 @@ from eheimdigital.types import EheimDigitalClientError
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EheimDigitalUpdateCoordinator
+
+
+def async_device_info(
+    coordinator: EheimDigitalUpdateCoordinator, device: EheimDigitalDevice
+) -> DeviceInfo:
+    """Return the base device info for an EHEIM Digital device."""
+    return DeviceInfo(
+        configuration_url=f"http://{coordinator.config_entry.data[CONF_HOST]}",
+        name=device.name,
+        connections={(CONNECTION_NETWORK_MAC, device.mac_address)},
+        manufacturer="EHEIM",
+        model=device.model_name,
+        identifiers={(DOMAIN, device.mac_address)},
+        suggested_area=device.aquarium_name,
+        sw_version=device.sw_version,
+    )
 
 
 class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
@@ -29,21 +46,22 @@ class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
     ) -> None:
         """Initialize a EHEIM Digital entity."""
         super().__init__(coordinator)
+        main = coordinator.hub.main
         if TYPE_CHECKING:
             # At this point at least one device is found
             # and so there is always a main device set
-            assert isinstance(coordinator.hub.main, EheimDigitalDevice)
-        self._attr_device_info = DeviceInfo(
-            configuration_url=f"http://{coordinator.config_entry.data[CONF_HOST]}",
-            name=device.name,
-            connections={(CONNECTION_NETWORK_MAC, device.mac_address)},
-            manufacturer="EHEIM",
-            model=device.model_name,
-            identifiers={(DOMAIN, device.mac_address)},
-            suggested_area=device.aquarium_name,
-            sw_version=device.sw_version,
-            via_device=(DOMAIN, coordinator.hub.main.mac_address),
-        )
+            assert isinstance(main, EheimDigitalDevice)
+        self._attr_device_info = async_device_info(coordinator, device)
+        if device.mac_address != main.mac_address:
+            # The main device is registered during setup, before the platforms
+            # are forwarded, so this link always resolves deterministically.
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, main.mac_address),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                )
+            )
         self._device = device
         self._device_address = device.mac_address
 

--- a/tests/components/eheimdigital/test_init.py
+++ b/tests/components/eheimdigital/test_init.py
@@ -135,14 +135,14 @@ async def test_child_device_via_device(
         )
     await hass.async_block_till_done()
 
-    main_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:01")}
+    main_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:01"), mock_config_entry.entry_id
     )
     assert main_device is not None
     assert main_device.via_device_id is None
 
-    child_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:02")}
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:02"), mock_config_entry.entry_id
     )
     assert child_device is not None
     assert child_device.via_device_id == main_device.id

--- a/tests/components/eheimdigital/test_init.py
+++ b/tests/components/eheimdigital/test_init.py
@@ -117,3 +117,32 @@ async def test_entry_setup_error(
     eheimdigital_hub_mock.return_value.connect.side_effect = EheimDigitalClientError()
     await init_integration(hass, mock_config_entry)
     assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_child_device_via_device(
+    hass: HomeAssistant,
+    eheimdigital_hub_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that child devices are linked to the main device."""
+    await init_integration(hass, mock_config_entry)
+
+    for device_address in eheimdigital_hub_mock.return_value.devices:
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device_address,
+            eheimdigital_hub_mock.return_value.devices[device_address].device_type,
+        )
+    await hass.async_block_till_done()
+
+    main_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:00:00:00:00:01")}
+    )
+    assert main_device is not None
+    assert main_device.via_device_id is None
+
+    child_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "00:00:00:00:00:02")}
+    )
+    assert child_device is not None
+    assert child_device.via_device_id == main_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `eheimdigital`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
