### PR TITLE
Fix via_device race in elkm1

### DIFF
--- a/homeassistant/components/elkm1/__init__.py
+++ b/homeassistant/components/elkm1/__init__.py
@@ -26,7 +26,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.network import is_ip_address
@@ -58,6 +58,7 @@ from .discovery import (
     async_trigger_discovery,
     async_update_entry_from_discovery,
 )
+from .entity import create_elk_system_device_info
 from .models import ELKM1Data
 from .services import async_setup_services
 
@@ -306,6 +307,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ElkM1ConfigEntry) -> boo
         auto_configure=auto_configure,
         config=config,
         keypads={},
+    )
+
+    # Register the ElkM1 system device before forwarding platforms so entities
+    # on any platform can deterministically resolve it as their via_device.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **create_elk_system_device_info(elk, prefix, entry.unique_id),
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/elkm1/entity.py
+++ b/homeassistant/components/elkm1/entity.py
@@ -10,6 +10,7 @@ from elkm1_lib.elk import Elk
 
 from homeassistant.const import ATTR_CONNECTIONS
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -45,6 +46,23 @@ def create_elk_entities(
 
         entities.append(class_(element, elk, elk_data))
     return entities
+
+
+def create_elk_system_device_info(elk: Elk, prefix: str, mac: str | None) -> DeviceInfo:
+    """Return the device info for the ElkM1 system device."""
+    device_name = "ElkM1"
+    if prefix:
+        device_name += f" {prefix}"
+    device_info = DeviceInfo(
+        identifiers={(DOMAIN, f"{prefix}_system")},
+        manufacturer="ELK Products, Inc.",
+        model="M1",
+        name=device_name,
+        sw_version=elk.panel.elkm1_version,
+    )
+    if mac:
+        device_info[ATTR_CONNECTIONS] = {(CONNECTION_NETWORK_MAC, mac)}
+    return device_info
 
 
 def generate_unique_id(prefix: str, element: Element) -> str:
@@ -128,10 +146,16 @@ class ElkEntity(Entity):
     @override
     def device_info(self) -> DeviceInfo:
         """Device info connecting via the ElkM1 system."""
+        config_entry = self.platform.config_entry
+        assert config_entry
         return DeviceInfo(
             name=self._element.name,
             identifiers={(DOMAIN, self._unique_id)},
-            via_device=(DOMAIN, f"{self._prefix}_system"),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, f"{self._prefix}_system"),
+                config_entry_id=config_entry.entry_id,
+            ),
         )
 
 
@@ -142,16 +166,4 @@ class ElkAttachedEntity(ElkEntity):
     @override
     def device_info(self) -> DeviceInfo:
         """Device info for the underlying ElkM1 system."""
-        device_name = "ElkM1"
-        if self._prefix:
-            device_name += f" {self._prefix}"
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{self._prefix}_system")},
-            manufacturer="ELK Products, Inc.",
-            model="M1",
-            name=device_name,
-            sw_version=self._elk.panel.elkm1_version,
-        )
-        if self._mac:
-            device_info[ATTR_CONNECTIONS] = {(CONNECTION_NETWORK_MAC, self._mac)}
-        return device_info
+        return create_elk_system_device_info(self._elk, self._prefix, self._mac)

--- a/tests/components/elkm1/test_init.py
+++ b/tests/components/elkm1/test_init.py
@@ -79,12 +79,14 @@ async def test_light_via_device_links_to_system_device(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    system_device = device_registry.async_get_device(identifiers={(DOMAIN, "_system")})
+    system_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "_system"), config_entry.entry_id
+    )
     assert system_device is not None
     assert system_device.name == "ElkM1"
 
-    light_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "elkm1_test_light")}
+    light_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "elkm1_test_light"), config_entry.entry_id
     )
     assert light_device is not None
     assert light_device.via_device_id == system_device.id

--- a/tests/components/elkm1/test_init.py
+++ b/tests/components/elkm1/test_init.py
@@ -1,0 +1,90 @@
+"""Tests for the Elk-M1 Control init."""
+
+from unittest.mock import MagicMock, patch
+
+from homeassistant.components.elkm1.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PREFIX, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import MOCK_MAC, _patch_discovery, mock_elk
+
+from tests.common import MockConfigEntry
+
+
+def _mocked_elk_with_light() -> MagicMock:
+    """Return a mocked Elk that exposes a single PLC light and nothing else."""
+    light = MagicMock()
+    light.index = 0
+    light.name = "Test Light"
+    light.default_name.return_value = "test_light"
+    light.configured = True
+    light.status = 0
+    light.as_dict.return_value = {}
+
+    elk = mock_elk(sync_complete=True)
+    elk.is_connected.return_value = True
+    for collection in (
+        "areas",
+        "tasks",
+        "counters",
+        "keypads",
+        "zones",
+        "outputs",
+        "settings",
+        "thermostats",
+    ):
+        setattr(elk, collection, [])
+    elk.lights = [light]
+    # The panel sensor is an attached entity; skip it so the only registered
+    # device besides the system device is the light's own (via_device) device.
+    elk.panel.configured = False
+    elk.panel.elkm1_version = "1.0.0"
+    elk.panel.temperature_units = "F"
+    return elk
+
+
+async def test_light_via_device_links_to_system_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """A child (light) device links to the system device registered at setup.
+
+    With auto configure and only a light present, no sibling attached entity
+    creates the system device, so the link resolves only because setup
+    registers the system device before platforms are forwarded.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "elks://1.2.3.4",
+            CONF_USERNAME: "user",
+            CONF_PASSWORD: "pass",
+            CONF_PREFIX: "",
+            "auto_configure": True,
+        },
+        unique_id=MOCK_MAC,
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        _patch_discovery(),
+        patch(
+            "homeassistant.components.elkm1.Elk",
+            return_value=_mocked_elk_with_light(),
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    system_device = device_registry.async_get_device(identifiers={(DOMAIN, "_system")})
+    assert system_device is not None
+    assert system_device.name == "ElkM1"
+
+    light_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "elkm1_test_light")}
+    )
+    assert light_device is not None
+    assert light_device.via_device_id == system_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `elkm1`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
