### PR TITLE
Fix via_device race in freebox

### DIFF
--- a/homeassistant/components/freebox/__init__.py
+++ b/homeassistant/components/freebox/__init__.py
@@ -8,7 +8,7 @@ from freebox_api.exceptions import HttpRequestError
 from homeassistant.const import CONF_HOST, CONF_PORT, EVENT_HOMEASSISTANT_STOP, Platform
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.event import async_track_time_interval
 
 from .const import DOMAIN, PLATFORMS
@@ -95,6 +95,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: FreeboxConfigEntry) -> b
     )
 
     entry.runtime_data = router
+
+    # Register the router device up front so child devices (home devices, disks)
+    # can deterministically resolve it as their via_device on any platform.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id, **router.device_info
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/freebox/entity.py
+++ b/homeassistant/components/freebox/entity.py
@@ -54,7 +54,11 @@ class FreeboxHomeEntity(Entity):
             model=self._model,
             name=node["label"].strip(),
             sw_version=self._firmware,
-            via_device=(DOMAIN, router.mac),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                router.hass,
+                (DOMAIN, router.mac),
+                config_entry_id=router.config_entry.entry_id,
+            ),
         )
 
     async def async_update_signal(self) -> None:

--- a/homeassistant/components/freebox/router.py
+++ b/homeassistant/components/freebox/router.py
@@ -108,6 +108,7 @@ class FreeboxRouter:
     ) -> None:
         """Initialize a Freebox router."""
         self.hass = hass
+        self.config_entry = entry
         self._host = entry.data[CONF_HOST]
         self._port = entry.data[CONF_PORT]
 

--- a/homeassistant/components/freebox/sensor.py
+++ b/homeassistant/components/freebox/sensor.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -246,9 +247,10 @@ class FreeboxDiskSensor(FreeboxSensor):
             model=disk["model"],
             name=f"Disk {disk['id']}",
             sw_version=disk["firmware"],
-            via_device=(
-                DOMAIN,
-                router.mac,
+            via_device_id=dr.async_get_device_id_by_identifier(
+                router.hass,
+                (DOMAIN, router.mac),
+                config_entry_id=router.config_entry.entry_id,
             ),
         )
 

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -169,6 +169,23 @@ async def test_unique_id_migration(
     )
 
 
+async def test_home_device_via_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    router: Mock,
+) -> None:
+    """Test home devices are linked to the router device via via_device_id."""
+    await setup_platform(hass, BINARY_SENSOR_DOMAIN)
+
+    router_device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_MAC)})
+    assert router_device is not None
+
+    pir_node_id = 26  # Détecteur from fixture
+    pir_device = device_registry.async_get_device(identifiers={(DOMAIN, pir_node_id)})
+    assert pir_device is not None
+    assert pir_device.via_device_id == router_device.id
+
+
 async def test_home_device_label_sync(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -169,19 +169,23 @@ async def test_unique_id_migration(
     )
 
 
+@pytest.mark.usefixtures("router")
 async def test_home_device_via_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    router: Mock,
 ) -> None:
     """Test home devices are linked to the router device via via_device_id."""
-    await setup_platform(hass, BINARY_SENSOR_DOMAIN)
+    entry = await setup_platform(hass, BINARY_SENSOR_DOMAIN)
 
-    router_device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_MAC)})
+    router_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_MAC), entry.entry_id
+    )
     assert router_device is not None
 
     pir_node_id = 26  # Détecteur from fixture
-    pir_device = device_registry.async_get_device(identifiers={(DOMAIN, pir_node_id)})
+    pir_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, pir_node_id), entry.entry_id
+    )
     assert pir_device is not None
     assert pir_device.via_device_id == router_device.id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `freebox`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
