### PR TITLE
Fix via_device race in guardian

### DIFF
--- a/homeassistant/components/guardian/__init__.py
+++ b/homeassistant/components/guardian/__init__.py
@@ -115,6 +115,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: GuardianConfigEntry) -> 
         paired_sensor_manager=paired_sensor_manager,
     )
 
+    # Register the valve controller device up front so paired sensors can resolve
+    # it as their via device when they are added:
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.data[CONF_UID])},
+        manufacturer="Elexa",
+        name=f"Guardian valve controller {entry.data[CONF_UID]}",
+        sw_version=valve_controller_coordinators[API_SYSTEM_DIAGNOSTICS].data[
+            "firmware"
+        ],
+    )
+
     # Set up all of the Guardian entity platforms:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/guardian/entity.py
+++ b/homeassistant/components/guardian/entity.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -43,7 +44,11 @@ class PairedSensorEntity(GuardianEntity):
             manufacturer="Elexa",
             model=coordinator.data["codename"],
             name=f"Guardian paired sensor {paired_sensor_uid}",
-            via_device=(DOMAIN, entry.data[CONF_UID]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, entry.data[CONF_UID]),
+                config_entry_id=entry.entry_id,
+            ),
         )
         self._attr_unique_id = f"{paired_sensor_uid}_{description.key}"
 

--- a/tests/components/guardian/conftest.py
+++ b/tests/components/guardian/conftest.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from homeassistant.components.guardian import CONF_UID, DOMAIN
-from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
+from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 from homeassistant.util.json import JsonObjectType
@@ -97,10 +97,17 @@ def data_wifi_status_fixture() -> JsonObjectType:
     return load_json_object_fixture("wifi_status_data.json", "guardian")
 
 
+@pytest.fixture(name="platforms")
+def platforms_fixture() -> list[Platform]:
+    """Define a platforms fixture."""
+    return []
+
+
 @pytest.fixture(name="setup_guardian")
 async def setup_guardian_fixture(
     hass: HomeAssistant,
     config: dict[str, Any],
+    platforms: list[Platform],
     data_sensor_pair_dump: JsonObjectType,
     data_sensor_pair_sensor: JsonObjectType,
     data_sensor_paired_sensor_status: JsonObjectType,
@@ -150,7 +157,7 @@ async def setup_guardian_fixture(
         ),
         patch(
             "homeassistant.components.guardian.PLATFORMS",
-            [],
+            platforms,
         ),
     ):
         assert await async_setup_component(hass, DOMAIN, config)

--- a/tests/components/guardian/test_init.py
+++ b/tests/components/guardian/test_init.py
@@ -1,13 +1,16 @@
 """Test the Elexa Guardian init module."""
 
+from datetime import timedelta
+
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.guardian import CONF_UID, DOMAIN, GuardianData
+from homeassistant.components.guardian import CONF_UID, DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture(name="platforms")
@@ -18,14 +21,16 @@ def platforms_fixture() -> list[Platform]:
 
 async def test_paired_sensor_via_device_id(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
     device_registry: dr.DeviceRegistry,
     config_entry: MockConfigEntry,
     setup_guardian: None,  # relies on config_entry fixture
 ) -> None:
     """Test that a paired sensor is linked to the valve controller via via_device_id."""
-    data: GuardianData = config_entry.runtime_data
-
-    await data.paired_sensor_manager.async_pair_sensor("AABBCCDDEEFF")
+    # Advance time so the sensor pair dump coordinator refreshes and discovers the
+    # paired sensor from the fixture data:
+    freezer.tick(timedelta(seconds=30))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
     valve_controller_device = device_registry.async_get_device_by_identifier(

--- a/tests/components/guardian/test_init.py
+++ b/tests/components/guardian/test_init.py
@@ -1,0 +1,40 @@
+"""Test the Elexa Guardian init module."""
+
+import pytest
+
+from homeassistant.components.guardian import CONF_UID, DOMAIN, GuardianData
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+
+@pytest.fixture(name="platforms")
+def platforms_fixture() -> list[Platform]:
+    """Override to exercise the paired sensor entity setup."""
+    return [Platform.SENSOR]
+
+
+async def test_paired_sensor_via_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    setup_guardian: None,  # relies on config_entry fixture
+) -> None:
+    """Test that a paired sensor is linked to the valve controller via via_device_id."""
+    data: GuardianData = config_entry.runtime_data
+
+    await data.paired_sensor_manager.async_pair_sensor("AABBCCDDEEFF")
+    await hass.async_block_till_done()
+
+    valve_controller_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry.data[CONF_UID]), config_entry.entry_id
+    )
+    paired_sensor_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "AABBCCDDEEFF"), config_entry.entry_id
+    )
+
+    assert valve_controller_device is not None
+    assert paired_sensor_device is not None
+    assert paired_sensor_device.via_device_id == valve_controller_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `guardian`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
