### PR TITLE
Fix via_device race in habitica

### DIFF
--- a/homeassistant/components/habitica/__init__.py
+++ b/homeassistant/components/habitica/__init__.py
@@ -1,8 +1,10 @@
 """The habitica integration."""
 
+from typing import TYPE_CHECKING
 from uuid import UUID
 
 from habiticalib import Habitica
+from yarl import URL
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.const import CONF_API_KEY, CONF_URL, CONF_VERIFY_SSL, Platform
@@ -16,7 +18,7 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
-from .const import CONF_API_USER, DOMAIN, X_CLIENT
+from .const import CONF_API_USER, DOMAIN, MANUFACTURER, NAME, X_CLIENT
 from .coordinator import (
     HabiticaConfigEntry,
     HabiticaDataUpdateCoordinator,
@@ -71,6 +73,23 @@ async def async_setup_entry(
 
     config_entry.runtime_data = coordinator
 
+    if TYPE_CHECKING:
+        assert config_entry.unique_id
+
+    # Register the user device so children (party device) can resolve it
+    # deterministically as their via_device parent before platforms are set up.
+    device_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        entry_type=dr.DeviceEntryType.SERVICE,
+        manufacturer=MANUFACTURER,
+        model=NAME,
+        name=coordinator.data.user.profile.name,
+        configuration_url=(
+            URL(config_entry.data[CONF_URL]) / "profile" / config_entry.unique_id
+        ),
+        identifiers={(DOMAIN, config_entry.unique_id)},
+    )
+
     party = coordinator.data.user.party.id
     hass.data.setdefault(HABITICA_KEY, {})
 
@@ -80,6 +99,23 @@ async def async_setup_entry(
 
         hass.data[HABITICA_KEY][party] = party_coordinator
         party_added_by_this_entry = party
+
+    if party is not None:
+        # Register the party device so party member devices can resolve it
+        # deterministically as their via_device parent.
+        device_reg.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            entry_type=dr.DeviceEntryType.SERVICE,
+            manufacturer=MANUFACTURER,
+            model=NAME,
+            name=hass.data[HABITICA_KEY][party].data.party.summary,
+            identifiers={(DOMAIN, f"{config_entry.unique_id}_{party!s}")},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass,
+                (DOMAIN, config_entry.unique_id),
+                config_entry_id=config_entry.entry_id,
+            ),
+        )
 
     @callback
     def _party_update_listener() -> None:

--- a/homeassistant/components/habitica/entity.py
+++ b/homeassistant/components/habitica/entity.py
@@ -8,6 +8,7 @@ from yarl import URL
 
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_URL
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -57,14 +58,14 @@ class HabiticaBase(CoordinatorEntity[HabiticaDataUpdateCoordinator]):
         )
 
         if subentry:
-            self._attr_device_info.update(
-                DeviceInfo(
-                    via_device=(
-                        (
-                            DOMAIN,
-                            f"{coordinator.config_entry.unique_id}_{self.user.party.id}",
-                        )
-                    )
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (
+                        DOMAIN,
+                        f"{coordinator.config_entry.unique_id}_{self.user.party.id}",
+                    ),
+                    config_entry_id=coordinator.config_entry.entry_id,
                 )
             )
 
@@ -138,6 +139,10 @@ class HabiticaPartyBase(CoordinatorEntity[HabiticaPartyCoordinator]):
             model=NAME,
             name=coordinator.data.party.summary,
             identifiers={(DOMAIN, unique_id)},
-            via_device=(DOMAIN, config_entry.unique_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, config_entry.unique_id),
+                config_entry_id=config_entry.entry_id,
+            ),
         )
         self.content = content

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -193,7 +193,6 @@ async def test_device_via_device_links(
 
     config_entry_with_subentry.add_to_hass(hass)
     await hass.config_entries.async_setup(config_entry_with_subentry.entry_id)
-    await hass.async_block_till_done()
 
     assert config_entry_with_subentry.state is ConfigEntryState.LOADED
 

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -198,17 +198,22 @@ async def test_device_via_device_links(
     assert config_entry_with_subentry.state is ConfigEntryState.LOADED
 
     unique_id = config_entry_with_subentry.unique_id
+    entry_id = config_entry_with_subentry.entry_id
 
-    user_device = device_registry.async_get_device({(DOMAIN, unique_id)})
+    user_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, unique_id), entry_id
+    )
     assert user_device is not None
     assert user_device.via_device_id is None
 
-    party_device = device_registry.async_get_device(
-        {(DOMAIN, f"{unique_id}_{group_id}")}
+    party_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{unique_id}_{group_id}"), entry_id
     )
     assert party_device is not None
     assert party_device.via_device_id == user_device.id
 
-    member_device = device_registry.async_get_device({(DOMAIN, member_id)})
+    member_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, member_id), entry_id
+    )
     assert member_device is not None
     assert member_device.via_device_id == party_device.id

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -179,3 +179,36 @@ async def test_remove_party_and_reload(
         hass.states.get("notify.test_user_private_message_test_partymember_displayname")
         is None
     )
+
+
+@pytest.mark.usefixtures("habitica")
+async def test_device_via_device_links(
+    hass: HomeAssistant,
+    config_entry_with_subentry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the via_device links between user, party and party member devices."""
+    group_id = "1e87097c-4c03-4f8c-a475-67cc7da7f409"
+    member_id = "ffce870c-3ff3-4fa4-bad1-87612e52b8e7"
+
+    config_entry_with_subentry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry_with_subentry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry_with_subentry.state is ConfigEntryState.LOADED
+
+    unique_id = config_entry_with_subentry.unique_id
+
+    user_device = device_registry.async_get_device({(DOMAIN, unique_id)})
+    assert user_device is not None
+    assert user_device.via_device_id is None
+
+    party_device = device_registry.async_get_device(
+        {(DOMAIN, f"{unique_id}_{group_id}")}
+    )
+    assert party_device is not None
+    assert party_device.via_device_id == user_device.id
+
+    member_device = device_registry.async_get_device({(DOMAIN, member_id)})
+    assert member_device is not None
+    assert member_device.via_device_id == party_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `habitica`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
