### PR TITLE
Fix via_device race in isy994

### DIFF
--- a/homeassistant/components/isy994/__init__.py
+++ b/homeassistant/components/isy994/__init__.py
@@ -138,12 +138,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: IsyConfigEntry) -> bool:
         ) from err
 
     isy_data = entry.runtime_data = IsyData()
-    _categorize_nodes(isy_data, isy.nodes, ignore_identifier, sensor_identifier)
+    isy_data.root = isy
+    _async_get_or_create_isy_device_in_registry(hass, entry, isy)
+    via_device_id = dr.async_get_device_id_by_identifier(
+        hass, (DOMAIN, isy.uuid), config_entry_id=entry.entry_id
+    )
+    _categorize_nodes(
+        isy_data, isy.nodes, ignore_identifier, sensor_identifier, via_device_id
+    )
     _categorize_programs(isy_data, isy.programs)
     # Gather ISY Variables to be added.
     if isy.variables.children:
         isy_data.devices[CONF_VARIABLES] = _create_service_device_info(
-            isy, name=CONF_VARIABLES.title(), unique_id=CONF_VARIABLES
+            isy,
+            name=CONF_VARIABLES.title(),
+            unique_id=CONF_VARIABLES,
+            via_device_id=via_device_id,
         )
         numbers = isy_data.variables[Platform.NUMBER]
         for vtype, _, vid in isy.variables.children:
@@ -152,16 +162,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: IsyConfigEntry) -> bool:
         isy.conf[CONFIG_NETWORKING] or isy.conf.get(CONFIG_PORTAL)
     ) and isy.networking.nobjs:
         isy_data.devices[CONF_NETWORK] = _create_service_device_info(
-            isy, name=CONFIG_NETWORKING, unique_id=CONF_NETWORK
+            isy,
+            name=CONFIG_NETWORKING,
+            unique_id=CONF_NETWORK,
+            via_device_id=via_device_id,
         )
         for resource in isy.networking.nobjs:
             isy_data.net_resources.append(resource)
 
     # Dump ISY Clock Information. Future: Add ISY as sensor to Hass with attrs
     LOGGER.debug(repr(isy.clock))
-
-    isy_data.root = isy
-    _async_get_or_create_isy_device_in_registry(hass, entry, isy)
 
     # Load platforms for the devices in the ISY controller that we support.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
@@ -202,9 +212,11 @@ def _async_get_or_create_isy_device_in_registry(
     )
 
 
-def _create_service_device_info(isy: ISY, name: str, unique_id: str) -> DeviceInfo:
+def _create_service_device_info(
+    isy: ISY, name: str, unique_id: str, via_device_id: str | None
+) -> DeviceInfo:
     """Create device info for ISY service devices."""
-    return DeviceInfo(
+    device_info = DeviceInfo(
         identifiers={
             (
                 DOMAIN,
@@ -216,9 +228,11 @@ def _create_service_device_info(isy: ISY, name: str, unique_id: str) -> DeviceIn
         model=isy.conf[ISY_CONF_MODEL],
         sw_version=isy.conf[ISY_CONF_FIRMWARE],
         configuration_url=isy.conn.url,
-        via_device=(DOMAIN, isy.uuid),
         entry_type=DeviceEntryType.SERVICE,
     )
+    if via_device_id is not None:
+        device_info["via_device_id"] = via_device_id
+    return device_info
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: IsyConfigEntry) -> bool:

--- a/homeassistant/components/isy994/helpers.py
+++ b/homeassistant/components/isy994/helpers.py
@@ -288,17 +288,18 @@ def _add_backlight_if_supported(isy_data: IsyData, node: Node) -> None:
     isy_data.aux_properties[Platform.NUMBER].append((node, CMD_BACKLIGHT))
 
 
-def _generate_device_info(node: Node) -> DeviceInfo:
+def _generate_device_info(node: Node, via_device_id: str | None) -> DeviceInfo:
     """Generate the device info for a root node device."""
     isy = node.isy
     device_info = DeviceInfo(
         identifiers={(DOMAIN, f"{isy.uuid}_{node.address}")},
         manufacturer=node.protocol.title(),
         name=node.name,
-        via_device=(DOMAIN, isy.uuid),
         configuration_url=isy.conn.url,
         suggested_area=node.folder,
     )
+    if via_device_id is not None:
+        device_info["via_device_id"] = via_device_id
 
     # ISYv5 Device Types can provide model and manufacturer
     model: str = str(node.address).rpartition(" ")[0] or node.address
@@ -328,7 +329,11 @@ def _generate_device_info(node: Node) -> DeviceInfo:
 
 
 def _categorize_nodes(
-    isy_data: IsyData, nodes: Nodes, ignore_identifier: str, sensor_identifier: str
+    isy_data: IsyData,
+    nodes: Nodes,
+    ignore_identifier: str,
+    sensor_identifier: str,
+    via_device_id: str | None,
 ) -> None:
     """Sort the nodes to their proper platforms."""
     for path, node in nodes:
@@ -339,7 +344,7 @@ def _categorize_nodes(
 
         if hasattr(node, "parent_node") and node.parent_node is None:
             # This is a physical device / parent node
-            isy_data.devices[node.address] = _generate_device_info(node)
+            isy_data.devices[node.address] = _generate_device_info(node, via_device_id)
             isy_data.root_nodes[Platform.BUTTON].append(node)
             # Any parent node can have communication errors:
             isy_data.aux_properties[Platform.SENSOR].append((node, PROP_COMMS_ERROR))

--- a/tests/components/isy994/test_init.py
+++ b/tests/components/isy994/test_init.py
@@ -1,5 +1,7 @@
 """Test the Universal Devices ISY/IoX integration init."""
 
+from collections.abc import Callable
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +10,7 @@ from homeassistant.components.isy994.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, CONF_VERIFY_SSL
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -71,3 +74,30 @@ async def test_setup_forwards_verify_ssl_to_pyisy(
 
     assert entry.state is ConfigEntryState.LOADED
     assert isy_constructor.call_args.kwargs["verify_ssl"] is verify_ssl
+
+
+async def test_node_device_linked_to_isy_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_isy: MagicMock,
+    mock_node: Callable[..., Any],
+) -> None:
+    """Test a root node's device is linked to the ISY device via via_device_id."""
+    mock_config_entry.add_to_hass(hass)
+
+    node = mock_node(mock_isy, "22 22 22 1", "Test Node", "GenericNode")
+    mock_isy.nodes.__iter__.return_value = [("Test Node", node)]
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    isy_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_isy.uuid), mock_config_entry.entry_id
+    )
+    node_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_isy.uuid}_{node.address}"), mock_config_entry.entry_id
+    )
+    assert isy_device is not None
+    assert node_device is not None
+    assert node_device.via_device_id == isy_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `isy994`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
