### PR TITLE
Fix via_device race in litejet

### DIFF
--- a/homeassistant/components/litejet/__init__.py
+++ b/homeassistant/components/litejet/__init__.py
@@ -8,8 +8,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PORT, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
-from .const import PLATFORMS
+from .const import DOMAIN, PLATFORMS
 
 type LiteJetConfigEntry = ConfigEntry[pylitejet.LiteJet]
 
@@ -41,6 +42,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: LiteJetConfigEntry) -> b
     )
 
     entry.runtime_data = system
+
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{entry.entry_id}_mcp")},
+        name="LiteJet",
+        manufacturer="Centralite",
+        model=system.model_name,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/litejet/light.py
+++ b/homeassistant/components/litejet/light.py
@@ -13,6 +13,7 @@ from homeassistant.components.light import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -34,7 +35,7 @@ async def async_setup_entry(
     entities = []
     for index in system.loads():
         name = await system.get_load_name(index)
-        entities.append(LiteJetLight(config_entry, system, index, name))
+        entities.append(LiteJetLight(hass, config_entry, system, index, name))
 
     async_add_entities(entities, True)
 
@@ -50,7 +51,12 @@ class LiteJetLight(LightEntity):
     _attr_name = None
 
     def __init__(
-        self, config_entry: LiteJetConfigEntry, system: LiteJet, index: int, name: str
+        self,
+        hass: HomeAssistant,
+        config_entry: LiteJetConfigEntry,
+        system: LiteJet,
+        index: int,
+        name: str,
     ) -> None:
         """Initialize a LiteJet light."""
         self._config_entry = config_entry
@@ -63,7 +69,11 @@ class LiteJetLight(LightEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{config_entry.entry_id}_light_{index}")},
             name=name,
-            via_device=(DOMAIN, f"{config_entry.entry_id}_mcp"),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass,
+                (DOMAIN, f"{config_entry.entry_id}_mcp"),
+                config_entry_id=config_entry.entry_id,
+            ),
         )
 
     @override

--- a/homeassistant/components/litejet/switch.py
+++ b/homeassistant/components/litejet/switch.py
@@ -7,6 +7,7 @@ from pylitejet import LiteJet, LiteJetError
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -28,7 +29,7 @@ async def async_setup_entry(
     entities = []
     for i in system.button_switches():
         name = await system.get_switch_name(i)
-        entities.append(LiteJetSwitch(config_entry.entry_id, system, i, name))
+        entities.append(LiteJetSwitch(hass, config_entry.entry_id, system, i, name))
 
     async_add_entities(entities, True)
 
@@ -41,7 +42,9 @@ class LiteJetSwitch(SwitchEntity):
     _attr_entity_registry_enabled_default = False
     _attr_device_class = SwitchDeviceClass.SWITCH
 
-    def __init__(self, entry_id: str, system: LiteJet, i: int, name: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, entry_id: str, system: LiteJet, i: int, name: str
+    ) -> None:
         """Initialize a LiteJet switch."""
         self._lj = system
         self._index = i
@@ -55,7 +58,9 @@ class LiteJetSwitch(SwitchEntity):
             identifiers={(DOMAIN, f"{entry_id}_keypad_{keypad_number}")},
             name=system.get_switch_keypad_name(i),
             manufacturer="Centralite",
-            via_device=(DOMAIN, f"{entry_id}_mcp"),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass, (DOMAIN, f"{entry_id}_mcp"), config_entry_id=entry_id
+            ),
         )
 
     @override

--- a/tests/components/litejet/test_init.py
+++ b/tests/components/litejet/test_init.py
@@ -2,6 +2,7 @@
 
 from homeassistant.components.litejet.const import DOMAIN
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
 
 from . import async_init_integration
@@ -11,6 +12,30 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     """Test that nothing happens."""
     assert await async_setup_component(hass, DOMAIN, {}) is True
     assert DOMAIN not in hass.data
+
+
+async def test_child_devices_link_to_mcp(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mock_litejet
+) -> None:
+    """Test that light and switch devices are linked to the MCP parent device."""
+    entry = await async_init_integration(hass, use_switch=True)
+
+    parent = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{entry.entry_id}_mcp")}
+    )
+    assert parent is not None
+
+    light_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{entry.entry_id}_light_1")}
+    )
+    assert light_device is not None
+    assert light_device.via_device_id == parent.id
+
+    switch_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{entry.entry_id}_keypad_101")}
+    )
+    assert switch_device is not None
+    assert switch_device.via_device_id == parent.id
 
 
 async def test_unload_entry(hass: HomeAssistant, mock_litejet) -> None:

--- a/tests/components/litejet/test_init.py
+++ b/tests/components/litejet/test_init.py
@@ -1,5 +1,7 @@
 """The tests for the litejet component."""
 
+import pytest
+
 from homeassistant.components.litejet.const import DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
@@ -14,25 +16,26 @@ async def test_setup_with_no_config(hass: HomeAssistant) -> None:
     assert DOMAIN not in hass.data
 
 
+@pytest.mark.usefixtures("mock_litejet")
 async def test_child_devices_link_to_mcp(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry, mock_litejet
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
     """Test that light and switch devices are linked to the MCP parent device."""
     entry = await async_init_integration(hass, use_switch=True)
 
-    parent = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry.entry_id}_mcp")}
+    parent = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry.entry_id}_mcp"), entry.entry_id
     )
     assert parent is not None
 
-    light_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry.entry_id}_light_1")}
+    light_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry.entry_id}_light_1"), entry.entry_id
     )
     assert light_device is not None
     assert light_device.via_device_id == parent.id
 
-    switch_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry.entry_id}_keypad_101")}
+    switch_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry.entry_id}_keypad_101"), entry.entry_id
     )
     assert switch_device is not None
     assert switch_device.via_device_id == parent.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `litejet`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
