### PR TITLE
Fix via_device race in lookin

### DIFF
--- a/homeassistant/components/lookin/__init__.py
+++ b/homeassistant/components/lookin/__init__.py
@@ -32,6 +32,7 @@ from .const import (
     TYPE_TO_PLATFORM,
 )
 from .coordinator import LookinDataUpdateCoordinator, LookinPushCoordinator
+from .entity import _lookin_device_to_device_info
 from .models import LookinConfigEntry, LookinData
 
 LOGGER = logging.getLogger(__name__)
@@ -180,6 +181,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: LookinConfigEntry) -> bo
         devices=devices,
         lookin_protocol=lookin_protocol,
         device_coordinators=device_coordinators,
+    )
+
+    # Register the lookin device so entities on the controlled devices can link
+    # to it via via_device_id, regardless of which platform is set up first.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **_lookin_device_to_device_info(lookin_device, host),
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/lookin/entity.py
+++ b/homeassistant/components/lookin/entity.py
@@ -14,6 +14,7 @@ from aiolookin import (
 )
 from aiolookin.models import Device, UDPCommandType, UDPEvent
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -37,15 +38,17 @@ def _lookin_device_to_device_info(lookin_device: Device, host: str) -> DeviceInf
 
 
 def _lookin_controlled_device_to_device_info(
-    lookin_device: Device, uuid: str, device: Climate | Remote, host: str
+    uuid: str, device: Climate | Remote, host: str, via_device_id: str | None
 ) -> DeviceInfo:
-    return DeviceInfo(
+    device_info = DeviceInfo(
         identifiers={(DOMAIN, uuid)},
         name=device.name,
         model=device.device_type,
-        via_device=(DOMAIN, lookin_device.id),
         configuration_url=f"http://{host}/data/{uuid}",
     )
+    if via_device_id is not None:
+        device_info["via_device_id"] = via_device_id
+    return device_info
 
 
 class LookinDeviceMixIn:
@@ -113,7 +116,14 @@ class LookinCoordinatorEntity(
         self._set_lookin_device_attrs(lookin_data)
         self._set_lookin_entity_attrs(uuid, device, lookin_data)
         self._attr_device_info = _lookin_controlled_device_to_device_info(
-            self._lookin_device, uuid, device, lookin_data.host
+            uuid,
+            device,
+            lookin_data.host,
+            dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, self._lookin_device.id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
         self._attr_unique_id = uuid
         self._attr_name = device.name

--- a/tests/components/lookin/test_init.py
+++ b/tests/components/lookin/test_init.py
@@ -71,11 +71,13 @@ async def test_controlled_device_links_to_lookin_device(
 
     assert entry.state is ConfigEntryState.LOADED
 
-    lookin_device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    lookin_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), entry.entry_id
+    )
     assert lookin_device is not None
 
-    controlled_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MEDIA_UUID)}
+    controlled_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MEDIA_UUID), entry.entry_id
     )
     assert controlled_device is not None
     assert controlled_device.via_device_id == lookin_device.id

--- a/tests/components/lookin/test_init.py
+++ b/tests/components/lookin/test_init.py
@@ -1,0 +1,81 @@
+"""Tests for the lookin integration setup."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.components.lookin.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from . import DEVICE_ID, DEVICE_NAME, IP_ADDRESS, MODULE
+
+from tests.common import MockConfigEntry
+
+MEDIA_UUID = "9999"
+
+
+def _mocked_device() -> MagicMock:
+    device = MagicMock()
+    device.name = DEVICE_NAME
+    device.id = DEVICE_ID
+    # A model < 2 device has no meteo sensor, so the lookin device is only
+    # registered by async_setup_entry, not by a sibling sensor entity.
+    device.model = 1
+    device.firmware = "1.2.3"
+    return device
+
+
+def _mocked_remote() -> MagicMock:
+    remote = MagicMock()
+    remote.name = "Living Room TV"
+    remote.device_type = "TV"
+    remote.status = "1000"
+    remote.functions = []
+    return remote
+
+
+def _mocked_protocol(device: MagicMock, remote: MagicMock) -> MagicMock:
+    protocol = MagicMock()
+    protocol.get_info = AsyncMock(return_value=device)
+    protocol.get_devices = AsyncMock(return_value=[{"Type": "01", "UUID": MEDIA_UUID}])
+    protocol.get_remote = AsyncMock(return_value=remote)
+    protocol.get_media_sources = AsyncMock(return_value=[])
+    protocol.send_command = AsyncMock()
+    return protocol
+
+
+async def test_controlled_device_links_to_lookin_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test a controlled device links to the lookin device via via_device_id."""
+    device = _mocked_device()
+    remote = _mocked_remote()
+    protocol = _mocked_protocol(device, remote)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN, data={CONF_HOST: IP_ADDRESS}, unique_id=DEVICE_ID
+    )
+    entry.add_to_hass(hass)
+
+    subscriptions = MagicMock()
+    subscriptions.subscribe_event = MagicMock(return_value=MagicMock())
+
+    with (
+        patch(f"{MODULE}.LookInHttpProtocol", return_value=protocol),
+        patch(f"{MODULE}.LookinUDPSubscriptions", return_value=subscriptions),
+        patch(f"{MODULE}.start_lookin_udp", AsyncMock(return_value=MagicMock())),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    lookin_device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert lookin_device is not None
+
+    controlled_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, MEDIA_UUID)}
+    )
+    assert controlled_device is not None
+    assert controlled_device.via_device_id == lookin_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `lookin`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
