### PR TITLE
Fix via_device race in lupusec

### DIFF
--- a/homeassistant/components/lupusec/__init__.py
+++ b/homeassistant/components/lupusec/__init__.py
@@ -9,6 +9,9 @@ from lupupy.exceptions import LupusecException
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -44,6 +47,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: LupusecConfigEntry) -> b
         return False
 
     entry.runtime_data = lupusec_system
+
+    alarm = await hass.async_add_executor_job(lupusec_system.get_alarm)
+
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        name=alarm.name,
+        manufacturer="Lupus Electronics",
+        model=f"Lupusec-XT{lupusec_system.model}",
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/lupusec/binary_sensor.py
+++ b/homeassistant/components/lupusec/binary_sensor.py
@@ -37,7 +37,7 @@ async def async_setup_entry(
     devices = await hass.async_add_executor_job(partial_func)
 
     async_add_entities(
-        LupusecBinarySensor(device, config_entry.entry_id) for device in devices
+        LupusecBinarySensor(hass, device, config_entry.entry_id) for device in devices
     )
 
 

--- a/homeassistant/components/lupusec/entity.py
+++ b/homeassistant/components/lupusec/entity.py
@@ -2,6 +2,8 @@
 
 import lupupy
 
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -26,17 +28,20 @@ class LupusecDevice(Entity):
 class LupusecBaseSensor(LupusecDevice):
     """Lupusec Sensor base entity."""
 
-    def __init__(self, device: lupupy.devices.LupusecDevice, entry_id: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, device: lupupy.devices.LupusecDevice, entry_id: str
+    ) -> None:
         """Initialize the LupusecBaseSensor."""
         super().__init__(device)
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, device.device_id)},
             name=device.name,
             manufacturer="Lupus Electronics",
             serial_number=device.device_id,
             model=TYPE_TRANSLATION.get(device.type, device.type),
-            via_device=(DOMAIN, entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                hass, (DOMAIN, entry_id), config_entry_id=entry_id
+            ),
         )
 
     def get_type_name(self) -> str:

--- a/homeassistant/components/lupusec/switch.py
+++ b/homeassistant/components/lupusec/switch.py
@@ -31,7 +31,7 @@ async def async_setup_entry(
     devices = await hass.async_add_executor_job(partial_func)
 
     async_add_entities(
-        LupusecSwitch(device, config_entry.entry_id) for device in devices
+        LupusecSwitch(hass, device, config_entry.entry_id) for device in devices
     )
 
 

--- a/tests/components/lupusec/test_init.py
+++ b/tests/components/lupusec/test_init.py
@@ -71,11 +71,15 @@ async def test_child_device_links_to_parent(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    parent = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    parent = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
     assert parent is not None
     assert parent.name == "Alarm Panel"
     assert parent.model == "Lupusec-XT2"
 
-    child = device_registry.async_get_device(identifiers={(DOMAIN, "sensor_1")})
+    child = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "sensor_1"), entry.entry_id
+    )
     assert child is not None
     assert child.via_device_id == parent.id

--- a/tests/components/lupusec/test_init.py
+++ b/tests/components/lupusec/test_init.py
@@ -1,0 +1,81 @@
+"""Tests for the Lupusec integration setup."""
+
+from unittest.mock import MagicMock, patch
+
+import lupupy.constants as CONST
+
+from homeassistant.components.lupusec.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+MOCK_DATA = {
+    CONF_HOST: "test-host.lan",
+    CONF_USERNAME: "test-username",
+    CONF_PASSWORD: "test-password",
+}
+
+
+def _mock_lupusec_system() -> MagicMock:
+    """Return a mocked Lupusec system with an alarm and one binary sensor."""
+    system = MagicMock()
+    system.model = 2
+
+    alarm = MagicMock()
+    alarm.name = "Alarm Panel"
+    alarm.device_id = "0"
+    alarm.is_standby = True
+    alarm.is_away = False
+    alarm.is_home = False
+    alarm.is_alarm_triggered = False
+    system.get_alarm.return_value = alarm
+
+    sensor = MagicMock()
+    sensor.device_id = "sensor_1"
+    sensor.name = "Front Door"
+    sensor.type = "Türkontakt"
+    sensor.generic_type = "door"
+    sensor.is_on = False
+
+    system.get_devices.side_effect = lambda generic_type: (
+        [] if generic_type == CONST.TYPE_SWITCH else [sensor]
+    )
+    return system
+
+
+async def test_child_device_links_to_parent(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test the child device is linked to the alarm panel via via_device_id.
+
+    Only the binary_sensor platform is forwarded, so the alarm panel (parent)
+    device is not created by the sibling alarm_control_panel platform. The child
+    can therefore only resolve its via_device_id if the parent was registered at
+    setup, before the platforms were forwarded.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, title=MOCK_DATA[CONF_HOST], data=MOCK_DATA)
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.lupusec.lupupy.Lupusec",
+            return_value=_mock_lupusec_system(),
+        ),
+        patch(
+            "homeassistant.components.lupusec.PLATFORMS",
+            [Platform.BINARY_SENSOR],
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    parent = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    assert parent is not None
+    assert parent.name == "Alarm Panel"
+    assert parent.model == "Lupusec-XT2"
+
+    child = device_registry.async_get_device(identifiers={(DOMAIN, "sensor_1")})
+    assert child is not None
+    assert child.via_device_id == parent.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `lupusec`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
