### PR TITLE
Fix via_device race in melnor

### DIFF
--- a/homeassistant/components/melnor/__init__.py
+++ b/homeassistant/components/melnor/__init__.py
@@ -7,7 +7,10 @@ from homeassistant.components.bluetooth.match import BluetoothCallbackMatcher
 from homeassistant.const import CONF_ADDRESS, Platform
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 
+from .const import DOMAIN
 from .coordinator import MelnorConfigEntry, MelnorDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
@@ -54,6 +57,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: MelnorConfigEntry) -> bo
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register the parent device up front so zone entities can deterministically
+    # resolve its via_device_id, regardless of platform setup order.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, device.mac)},
+        connections={(CONNECTION_BLUETOOTH, device.mac)},
+        manufacturer="Melnor",
+        model=device.model,
+        name=device.name,
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/melnor/entity.py
+++ b/homeassistant/components/melnor/entity.py
@@ -74,7 +74,7 @@ class MelnorZoneEntity(MelnorBluetoothEntity):
         self._valve = valve
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{self._device.mac}-zone{valve.id}")},
+            identifiers={(DOMAIN, f"{self._device.mac}-zone{self._valve.id}")},
             manufacturer="Melnor",
             name=f"Zone {valve.id + 1}",
             via_device_id=dr.async_get_device_id_by_identifier(

--- a/homeassistant/components/melnor/entity.py
+++ b/homeassistant/components/melnor/entity.py
@@ -7,6 +7,7 @@ from melnor_bluetooth.device import Device, Valve
 
 from homeassistant.components.number import EntityDescription
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -73,10 +74,14 @@ class MelnorZoneEntity(MelnorBluetoothEntity):
         self._valve = valve
 
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{self._device.mac}-zone{self._valve.id}")},
+            identifiers={(DOMAIN, f"{self._device.mac}-zone{valve.id}")},
             manufacturer="Melnor",
             name=f"Zone {valve.id + 1}",
-            via_device=(DOMAIN, self._device.mac),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, self._device.mac),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
 
 

--- a/tests/components/melnor/test_init.py
+++ b/tests/components/melnor/test_init.py
@@ -50,7 +50,6 @@ async def test_zone_device_via_device(
         patch_async_register_callback(),
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
 
     parent_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, FAKE_ADDRESS_1), entry.entry_id

--- a/tests/components/melnor/test_init.py
+++ b/tests/components/melnor/test_init.py
@@ -35,3 +35,30 @@ async def test_device_registry(
         identifiers={(DOMAIN, FAKE_ADDRESS_1)}
     )
     assert device_entry == snapshot
+
+
+async def test_zone_device_via_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that zone devices link to the parent device via via_device_id."""
+    entry = mock_config_entry(hass)
+
+    with (
+        patch_async_ble_device_from_address(),
+        patch_melnor_device(),
+        patch_async_register_callback(),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    parent_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, FAKE_ADDRESS_1)}
+    )
+    zone_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{FAKE_ADDRESS_1}-zone0")}
+    )
+
+    assert parent_device is not None
+    assert zone_device is not None
+    assert zone_device.via_device_id == parent_device.id

--- a/tests/components/melnor/test_init.py
+++ b/tests/components/melnor/test_init.py
@@ -52,11 +52,11 @@ async def test_zone_device_via_device(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    parent_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, FAKE_ADDRESS_1)}
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, FAKE_ADDRESS_1), entry.entry_id
     )
-    zone_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{FAKE_ADDRESS_1}-zone0")}
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{FAKE_ADDRESS_1}-zone0"), entry.entry_id
     )
 
     assert parent_device is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `melnor`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
