### PR TITLE
Fix via_device race in netgear

### DIFF
--- a/homeassistant/components/netgear/__init__.py
+++ b/homeassistant/components/netgear/__init__.py
@@ -74,6 +74,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: NetgearConfigEntry) -> b
         coordinator_link=coordinator_link,
     )
 
+    # Register the router device before platforms so tracked devices can always
+    # resolve it as their via_device parent, regardless of platform setup order.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id, **router.device_info
+    )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/netgear/entity.py
+++ b/homeassistant/components/netgear/entity.py
@@ -3,7 +3,6 @@
 from abc import abstractmethod
 from typing import Any, override
 
-from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
@@ -37,7 +36,11 @@ class NetgearDeviceEntity(CoordinatorEntity[NetgearTrackerCoordinator]):
             connections={(dr.CONNECTION_NETWORK_MAC, self._mac)},
             default_name=self._device_name,
             default_model=device["device_model"],
-            via_device=(DOMAIN, coordinator.router.unique_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.router.unique_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
 
     def get_device_name(self):
@@ -69,22 +72,8 @@ class NetgearRouterEntity(Entity):
     def __init__(self, router: NetgearRouter) -> None:
         """Initialize a Netgear device."""
         self._router = router
-
-        configuration_url = None
-        if host := router.entry.data[CONF_HOST]:
-            configuration_url = f"http://{host}/"
-
         self._attr_unique_id = router.serial_number
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, router.unique_id)},
-            manufacturer="Netgear",
-            name=router.device_name,
-            model=router.model,
-            serial_number=router.serial_number,
-            sw_version=router.firmware_version,
-            hw_version=router.hardware_version,
-            configuration_url=configuration_url,
-        )
+        self._attr_device_info = router.device_info
 
 
 class NetgearRouterCoordinatorEntity[T: NetgearDataCoordinator[Any]](

--- a/homeassistant/components/netgear/router.py
+++ b/homeassistant/components/netgear/router.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -269,6 +270,24 @@ class NetgearRouter:
         """Update the router to the latest firmware."""
         async with self.api_lock:
             await self.hass.async_add_executor_job(self.api.update_new_firmware)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device information for the router."""
+        configuration_url = None
+        if host := self.entry.data[CONF_HOST]:
+            configuration_url = f"http://{host}/"
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.unique_id)},
+            manufacturer="Netgear",
+            name=self.device_name,
+            model=self.model,
+            serial_number=self.serial_number,
+            sw_version=self.firmware_version,
+            hw_version=self.hardware_version,
+            configuration_url=configuration_url,
+        )
 
     @property
     def port(self) -> int:

--- a/tests/components/netgear/test_init.py
+++ b/tests/components/netgear/test_init.py
@@ -77,11 +77,13 @@ async def test_tracked_device_links_to_router(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    router_device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    router_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), entry.entry_id
+    )
     assert router_device is not None
 
-    tracked_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(TRACKED_DEVICE.mac))}
+    tracked_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, dr.format_mac(TRACKED_DEVICE.mac)), entry.entry_id
     )
     assert tracked_device is not None
     assert tracked_device.via_device_id == router_device.id

--- a/tests/components/netgear/test_init.py
+++ b/tests/components/netgear/test_init.py
@@ -1,0 +1,87 @@
+"""Tests for the Netgear integration setup."""
+
+from unittest.mock import Mock, patch
+
+from pynetgear import Device
+
+from homeassistant.components.netgear.const import DOMAIN
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    CONF_SSL,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+SERIAL = "5ER1AL0000001"
+HOST = "10.0.0.1"
+
+ROUTER_INFOS = {
+    "DeviceMode": "0",
+    "ModelName": "RBR20",
+    "SerialNumber": SERIAL,
+    "Firmwareversion": "V2.3.5.26",
+    "Hardwareversion": "N/A",
+    "DeviceName": "Desk",
+}
+
+TRACKED_DEVICE = Device(
+    name="Tracked-Device",
+    ip="10.0.0.10",
+    mac="AA:BB:CC:DD:EE:FF",
+    type="wireless",
+    signal=100,
+    link_rate=800,
+    allow_or_block="Allow",
+    device_type=32,
+    device_model="iPhone",
+    ssid="MyWifi",
+    conn_ap_mac="",
+)
+
+
+async def test_tracked_device_links_to_router(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test a tracked device is linked to the router via its via_device."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: HOST,
+            CONF_PORT: 80,
+            CONF_SSL: False,
+            CONF_USERNAME: "admin",
+            CONF_PASSWORD: "password",
+        },
+        unique_id=SERIAL,
+    )
+    entry.add_to_hass(hass)
+
+    with patch("homeassistant.components.netgear.router.Netgear") as netgear_mock:
+        api = netgear_mock.return_value
+        api.login_try_port = Mock(return_value=True)
+        api.get_info = Mock(return_value=ROUTER_INFOS)
+        api.port = 80
+        api.ssl = False
+        api.get_attached_devices_2 = Mock(return_value=[TRACKED_DEVICE])
+        api.get_traffic_meter = Mock(return_value=None)
+        api.get_new_speed_test_result = Mock(return_value=None)
+        api.check_new_firmware = Mock(return_value=None)
+        api.get_system_info = Mock(return_value=None)
+        api.check_ethernet_link = Mock(return_value=None)
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    router_device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    assert router_device is not None
+
+    tracked_device = device_registry.async_get_device(
+        connections={(dr.CONNECTION_NETWORK_MAC, dr.format_mac(TRACKED_DEVICE.mac))}
+    )
+    assert tracked_device is not None
+    assert tracked_device.via_device_id == router_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `netgear`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
