### PR TITLE
Fix via_device race in motion_blinds

### DIFF
--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -4,7 +4,7 @@
 import asyncio
 import logging
 
-from motionblinds import DEVICE_TYPES_GATEWAY, AsyncMotionMulticast
+from motionblinds import DEVICE_TYPES_GATEWAY, DEVICE_TYPES_WIFI, AsyncMotionMulticast
 
 from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
@@ -104,8 +104,14 @@ async def async_setup_entry(
     entry.runtime_data = coordinator
 
     # Register the gateway device up front so child blinds can resolve it as their
-    # via_device parent regardless of the order platforms are set up in.
-    if motion_gateway.device_type in DEVICE_TYPES_GATEWAY:
+    # via_device parent regardless of the order platforms are set up in. The any()
+    # is the exact complement of the children's linking condition, so the gateway is
+    # still registered if it self-reports an unexpected device_type while RF (non
+    # Wi-Fi) blinds depend on it.
+    if motion_gateway.device_type in DEVICE_TYPES_GATEWAY or any(
+        blind.device_type not in DEVICE_TYPES_WIFI
+        for blind in motion_gateway.device_list.values()
+    ):
         dr.async_get(hass).async_get_or_create(
             config_entry_id=entry.entry_id,
             **gateway_device_info(motion_gateway),

--- a/homeassistant/components/motion_blinds/__init__.py
+++ b/homeassistant/components/motion_blinds/__init__.py
@@ -4,11 +4,12 @@
 import asyncio
 import logging
 
-from motionblinds import AsyncMotionMulticast
+from motionblinds import DEVICE_TYPES_GATEWAY, AsyncMotionMulticast
 
 from homeassistant.const import CONF_API_KEY, CONF_HOST, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 
 from .const import (
     CONF_BLIND_TYPE_LIST,
@@ -21,6 +22,7 @@ from .const import (
     PLATFORMS,
 )
 from .coordinator import DataUpdateCoordinatorMotionBlinds, MotionBlindsConfigEntry
+from .entity import gateway_device_info
 from .gateway import ConnectMotionGateway
 
 _LOGGER = logging.getLogger(__name__)
@@ -100,6 +102,14 @@ async def async_setup_entry(
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register the gateway device up front so child blinds can resolve it as their
+    # via_device parent regardless of the order platforms are set up in.
+    if motion_gateway.device_type in DEVICE_TYPES_GATEWAY:
+        dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id,
+            **gateway_device_info(motion_gateway),
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/motion_blinds/entity.py
+++ b/homeassistant/components/motion_blinds/entity.py
@@ -24,6 +24,23 @@ from .coordinator import DataUpdateCoordinatorMotionBlinds
 from .gateway import device_name
 
 
+def gateway_device_info(gateway: MotionGateway) -> DeviceInfo:
+    """Return the device info of a Motionblinds gateway."""
+    if gateway.firmware is not None:
+        sw_version = f"{gateway.firmware}, protocol: {gateway.protocol}"
+    else:
+        sw_version = f"Protocol: {gateway.protocol}"
+
+    return DeviceInfo(
+        connections={(dr.CONNECTION_NETWORK_MAC, gateway.mac)},
+        identifiers={(DOMAIN, gateway.mac)},
+        manufacturer=MANUFACTURER,
+        name=DEFAULT_GATEWAY_NAME,
+        model="Wi-Fi bridge",
+        sw_version=sw_version,
+    )
+
+
 class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlinds]):
     """Representation of a Motionblind entity."""
 
@@ -50,42 +67,37 @@ class MotionCoordinatorEntity(CoordinatorEntity[DataUpdateCoordinatorMotionBlind
             self._update_interval_moving = UPDATE_INTERVAL_MOVING
 
         if blind.device_type in DEVICE_TYPES_GATEWAY:
-            gateway = blind
+            self._attr_device_info = gateway_device_info(blind)
         else:
             gateway = blind._gateway  # noqa: SLF001
-        if gateway.firmware is not None:
-            sw_version = f"{gateway.firmware}, protocol: {gateway.protocol}"
-        else:
-            sw_version = f"Protocol: {gateway.protocol}"
+            if gateway.firmware is not None:
+                sw_version = f"{gateway.firmware}, protocol: {gateway.protocol}"
+            else:
+                sw_version = f"Protocol: {gateway.protocol}"
 
-        if blind.device_type in DEVICE_TYPES_GATEWAY:
-            self._attr_device_info = DeviceInfo(
-                connections={(dr.CONNECTION_NETWORK_MAC, blind.mac)},
-                identifiers={(DOMAIN, blind.mac)},
-                manufacturer=MANUFACTURER,
-                name=DEFAULT_GATEWAY_NAME,
-                model="Wi-Fi bridge",
-                sw_version=sw_version,
-            )
-        elif blind.device_type in DEVICE_TYPES_WIFI:
-            self._attr_device_info = DeviceInfo(
-                connections={(dr.CONNECTION_NETWORK_MAC, blind.mac)},
-                identifiers={(DOMAIN, blind.mac)},
-                manufacturer=MANUFACTURER,
-                model=blind.blind_type,
-                name=device_name(blind),
-                sw_version=sw_version,
-                hw_version=blind.wireless_name,
-            )
-        else:
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, blind.mac)},
-                manufacturer=MANUFACTURER,
-                model=blind.blind_type,
-                name=device_name(blind),
-                via_device=(DOMAIN, blind._gateway.mac),  # noqa: SLF001
-                hw_version=blind.wireless_name,
-            )
+            if blind.device_type in DEVICE_TYPES_WIFI:
+                self._attr_device_info = DeviceInfo(
+                    connections={(dr.CONNECTION_NETWORK_MAC, blind.mac)},
+                    identifiers={(DOMAIN, blind.mac)},
+                    manufacturer=MANUFACTURER,
+                    model=blind.blind_type,
+                    name=device_name(blind),
+                    sw_version=sw_version,
+                    hw_version=blind.wireless_name,
+                )
+            else:
+                self._attr_device_info = DeviceInfo(
+                    identifiers={(DOMAIN, blind.mac)},
+                    manufacturer=MANUFACTURER,
+                    model=blind.blind_type,
+                    name=device_name(blind),
+                    via_device_id=dr.async_get_device_id_by_identifier(
+                        coordinator.hass,
+                        (DOMAIN, gateway.mac),
+                        config_entry_id=coordinator.config_entry.entry_id,
+                    ),
+                    hw_version=blind.wireless_name,
+                )
 
     @property
     @override

--- a/tests/components/motion_blinds/test_init.py
+++ b/tests/components/motion_blinds/test_init.py
@@ -81,11 +81,11 @@ async def test_sub_blind_links_to_gateway_device(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    gateway_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_GATEWAY_MAC)}
+    gateway_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_GATEWAY_MAC), entry.entry_id
     )
-    blind_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_BLIND_MAC)}
+    blind_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_BLIND_MAC), entry.entry_id
     )
 
     assert gateway_device is not None

--- a/tests/components/motion_blinds/test_init.py
+++ b/tests/components/motion_blinds/test_init.py
@@ -3,7 +3,7 @@
 from collections.abc import Generator
 from unittest.mock import AsyncMock, Mock, patch
 
-from motionblinds import DEVICE_TYPES_GATEWAY, BlindType
+from motionblinds import DEVICE_TYPES_GATEWAY, DEVICE_TYPES_WIFI, BlindType
 from motionblinds.motion_blinds import DEVICE_TYPE_BLIND
 import pytest
 
@@ -66,11 +66,27 @@ def mock_connect_fixture(mock_gateway: Mock) -> Generator[None]:
         yield
 
 
+@pytest.mark.parametrize(
+    "gateway_device_type",
+    [
+        pytest.param(DEVICE_TYPES_GATEWAY[0], id="reported-gateway-type"),
+        pytest.param(DEVICE_TYPES_WIFI[0], id="unexpected-non-gateway-type"),
+    ],
+)
 async def test_sub_blind_links_to_gateway_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    mock_gateway: Mock,
+    gateway_device_type: str,
 ) -> None:
-    """Test that a sub-blind device links to the gateway device as its parent."""
+    """Test that a sub-blind device links to the gateway device as its parent.
+
+    The gateway device must be registered up front even when the gateway
+    self-reports a device_type outside DEVICE_TYPES_GATEWAY, so RF (non-Wi-Fi)
+    blinds can still resolve it as their via_device parent.
+    """
+    mock_gateway.device_type = gateway_device_type
+
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=TEST_GATEWAY_MAC,

--- a/tests/components/motion_blinds/test_init.py
+++ b/tests/components/motion_blinds/test_init.py
@@ -1,0 +1,93 @@
+"""Test the Motionblinds setup."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, Mock, patch
+
+from motionblinds import DEVICE_TYPES_GATEWAY, BlindType
+from motionblinds.motion_blinds import DEVICE_TYPE_BLIND
+import pytest
+
+from homeassistant.components.motion_blinds.const import DEFAULT_INTERFACE, DOMAIN
+from homeassistant.const import CONF_API_KEY, CONF_HOST
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+TEST_HOST = "1.2.3.4"
+TEST_API_KEY = "12ab345c-d67e-8f"
+TEST_GATEWAY_MAC = "abcdefghijkl"
+TEST_BLIND_MAC = "abcdefghijkl0001"
+
+
+@pytest.fixture(name="mock_gateway")
+def mock_gateway_fixture() -> Mock:
+    """Return a mocked gateway with a single sub-blind."""
+    blind = Mock()
+    blind.mac = TEST_BLIND_MAC
+    blind.device_type = DEVICE_TYPE_BLIND
+    blind.type = BlindType.RollerBlind
+    blind.blind_type = BlindType.RollerBlind.name
+    blind.wireless_name = "RF"
+    blind.battery_voltage = 0
+    blind.limit_status = "Limit2Detected"
+    blind.position = 0
+    blind.angle = 0
+    blind.RSSI = -50
+
+    gateway = Mock()
+    gateway.mac = TEST_GATEWAY_MAC
+    gateway.device_type = DEVICE_TYPES_GATEWAY[0]
+    gateway.firmware = "1.0.0"
+    gateway.protocol = "1.0"
+    gateway.device_list = {TEST_BLIND_MAC: blind}
+    gateway.blind_type_list = {TEST_BLIND_MAC: BlindType.RollerBlind.value}
+
+    blind._gateway = gateway
+    return gateway
+
+
+@pytest.fixture(name="mock_connect", autouse=True)
+def mock_connect_fixture(mock_gateway: Mock) -> Generator[None]:
+    """Mock the connection to the Motion gateway."""
+    with (
+        patch(
+            "homeassistant.components.motion_blinds.AsyncMotionMulticast"
+        ) as multicast_class,
+        patch(
+            "homeassistant.components.motion_blinds.ConnectMotionGateway"
+        ) as connect_class,
+    ):
+        multicast_class.return_value.Start_listen = AsyncMock()
+        connect = connect_class.return_value
+        connect.async_check_interface = AsyncMock(return_value=DEFAULT_INTERFACE)
+        connect.async_connect_gateway = AsyncMock(return_value=True)
+        connect.gateway_device = mock_gateway
+        yield
+
+
+async def test_sub_blind_links_to_gateway_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a sub-blind device links to the gateway device as its parent."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_GATEWAY_MAC,
+        data={CONF_HOST: TEST_HOST, CONF_API_KEY: TEST_API_KEY},
+    )
+    entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    gateway_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, TEST_GATEWAY_MAC)}
+    )
+    blind_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, TEST_BLIND_MAC)}
+    )
+
+    assert gateway_device is not None
+    assert blind_device is not None
+    assert blind_device.via_device_id == gateway_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `motion_blinds`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
