### PR TITLE
Adapt nobo_hub to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/nobo_hub/climate.py
+++ b/homeassistant/components/nobo_hub/climate.py
@@ -29,7 +29,6 @@ from homeassistant.util import dt as dt_util
 
 from . import NoboHubConfigEntry
 from .const import (
-    ATTR_SERIAL,
     ATTR_TEMP_COMFORT_C,
     ATTR_TEMP_ECO_C,
     CONF_OVERRIDE_TYPE,
@@ -78,7 +77,8 @@ async def async_setup_entry(
         new_zones = [zone_id for zone_id in hub.zones if zone_id not in known_zones]
         known_zones.update(new_zones)
         async_add_entities(
-            NoboZone(zone_id, hub, override_type) for zone_id in new_zones
+            NoboZone(hass, zone_id, hub, override_type, config_entry.entry_id)
+            for zone_id in new_zones
         )
 
     _add_zones(hub)
@@ -106,17 +106,25 @@ class NoboZone(NoboBaseEntity, ClimateEntity):
     # Need to poll to get preset change when in HVACMode.AUTO
     _attr_should_poll = True
 
-    def __init__(self, zone_id: str, hub: nobo, override_type: str) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        zone_id: str,
+        hub: nobo,
+        override_type: str,
+        entry_id: str,
+    ) -> None:
         """Initialize the climate device."""
-        super().__init__(hub)
+        super().__init__(hass, hub, entry_id)
         self._id = zone_id
         self._attr_unique_id = f"{hub.hub_serial}:{zone_id}"
         self._override_type = override_type
+        zone_name = hub.zones[zone_id][ATTR_NAME]
         self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, f"{hub.hub_serial}:{zone_id}")},
-            name=hub.zones[zone_id][ATTR_NAME],
-            via_device=(DOMAIN, hub.hub_info[ATTR_SERIAL]),
-            suggested_area=hub.zones[zone_id][ATTR_NAME],
+            identifiers={(DOMAIN, self._attr_unique_id)},
+            name=zone_name,
+            via_device_id=self._hub_device_id,
+            suggested_area=zone_name,
         )
         self._read_state()
 

--- a/homeassistant/components/nobo_hub/entity.py
+++ b/homeassistant/components/nobo_hub/entity.py
@@ -4,8 +4,11 @@ from typing import override
 
 from pynobo import nobo
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import Entity
+
+from .const import ATTR_SERIAL, DOMAIN
 
 
 class NoboBaseEntity(Entity):
@@ -14,10 +17,13 @@ class NoboBaseEntity(Entity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(self, hub: nobo) -> None:
+    def __init__(self, hass: HomeAssistant, hub: nobo, entry_id: str) -> None:
         """Initialize the entity."""
         self._nobo = hub
         self._attr_available = hub.connected
+        self._hub_device_id = dr.async_get_device_id_by_identifier(
+            hass, (DOMAIN, hub.hub_info[ATTR_SERIAL]), config_entry_id=entry_id
+        )
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/nobo_hub/select.py
+++ b/homeassistant/components/nobo_hub/select.py
@@ -14,7 +14,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from . import NoboHubConfigEntry
 from .const import (
     ATTR_HARDWARE_VERSION,
-    ATTR_SERIAL,
     ATTR_SOFTWARE_VERSION,
     CONF_OVERRIDE_TYPE,
     DOMAIN,
@@ -40,7 +39,9 @@ async def async_setup_entry(
         else nobo.API.OVERRIDE_TYPE_CONSTANT
     )
 
-    async_add_entities([NoboGlobalSelector(hub, override_type)], True)
+    async_add_entities(
+        [NoboGlobalSelector(hass, hub, override_type, config_entry.entry_id)], True
+    )
 
     known_zones: set[str] = set()
 
@@ -56,7 +57,11 @@ async def async_setup_entry(
         new_zones = [zone_id for zone_id in hub.zones if zone_id not in known_zones]
         known_zones.update(new_zones)
         async_add_entities(
-            (NoboProfileSelector(zone_id, hub) for zone_id in new_zones), True
+            (
+                NoboProfileSelector(hass, zone_id, hub, config_entry.entry_id)
+                for zone_id in new_zones
+            ),
+            True,
         )
 
     _add_profiles(hub)
@@ -77,9 +82,11 @@ class NoboGlobalSelector(NoboBaseEntity, SelectEntity):
     _attr_options = list(_modes.values())
     _attr_current_option: str | None = None
 
-    def __init__(self, hub: nobo, override_type: str) -> None:
+    def __init__(
+        self, hass: HomeAssistant, hub: nobo, override_type: str, entry_id: str
+    ) -> None:
         """Initialize the global override selector."""
-        super().__init__(hub)
+        super().__init__(hass, hub, entry_id)
         self._attr_unique_id = hub.hub_serial
         self._override_type = override_type
         self._attr_device_info = DeviceInfo(
@@ -126,18 +133,21 @@ class NoboProfileSelector(NoboBaseEntity, SelectEntity):
     _attr_translation_key = "week_profile"
     _attr_current_option: str | None = None
 
-    def __init__(self, zone_id: str, hub: nobo) -> None:
+    def __init__(
+        self, hass: HomeAssistant, zone_id: str, hub: nobo, entry_id: str
+    ) -> None:
         """Initialize the week profile selector."""
-        super().__init__(hub)
+        super().__init__(hass, hub, entry_id)
         self._id = zone_id
         self._profiles: dict[str, str] = {}
         self._attr_options: list[str] = []
         self._attr_unique_id = f"{hub.hub_serial}:{zone_id}:profile"
+        zone_name = hub.zones[zone_id][ATTR_NAME]
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, f"{hub.hub_serial}:{zone_id}")},
-            name=hub.zones[zone_id][ATTR_NAME],
-            via_device=(DOMAIN, hub.hub_info[ATTR_SERIAL]),
-            suggested_area=hub.zones[zone_id][ATTR_NAME],
+            name=zone_name,
+            via_device_id=self._hub_device_id,
+            suggested_area=zone_name,
         )
 
     @override

--- a/homeassistant/components/nobo_hub/sensor.py
+++ b/homeassistant/components/nobo_hub/sensor.py
@@ -48,7 +48,8 @@ async def async_setup_entry(
         ]
         known_components.update(new_components)
         async_add_entities(
-            NoboTemperatureSensor(serial, hub) for serial in new_components
+            NoboTemperatureSensor(hass, serial, hub, config_entry.entry_id)
+            for serial in new_components
         )
 
     _add_sensors(hub)
@@ -64,9 +65,11 @@ class NoboTemperatureSensor(NoboBaseEntity, SensorEntity):
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 1
 
-    def __init__(self, serial: str, hub: nobo) -> None:
+    def __init__(
+        self, hass: HomeAssistant, serial: str, hub: nobo, entry_id: str
+    ) -> None:
         """Initialize the temperature sensor."""
-        super().__init__(hub)
+        super().__init__(hass, hub, entry_id)
         self._temperature: StateType = None
         self._id = serial
         component = hub.components[self._id]
@@ -81,7 +84,7 @@ class NoboTemperatureSensor(NoboBaseEntity, SensorEntity):
             name=component[ATTR_NAME],
             manufacturer=NOBO_MANUFACTURER,
             model=component[ATTR_MODEL].name,
-            via_device=(DOMAIN, hub.hub_info[ATTR_SERIAL]),
+            via_device_id=self._hub_device_id,
             suggested_area=suggested_area,
         )
         self._read_state()

--- a/tests/components/nobo_hub/test_init.py
+++ b/tests/components/nobo_hub/test_init.py
@@ -262,6 +262,34 @@ async def test_setup_registers_hub_device_with_mac(
     }
 
 
+@pytest.mark.parametrize(
+    "platforms", [[Platform.CLIMATE, Platform.SENSOR]], indirect=True
+)
+@pytest.mark.usefixtures("init_integration")
+async def test_zone_and_component_devices_link_to_hub(
+    device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Zone and component devices reference the hub device via via_device_id."""
+    entry_id = mock_config_entry.entry_id
+    hub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), entry_id
+    )
+    assert hub_device is not None
+
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{SERIAL}:1"), entry_id
+    )
+    assert zone_device is not None
+    assert zone_device.via_device_id == hub_device.id
+
+    component_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "200000059091"), entry_id
+    )
+    assert component_device is not None
+    assert component_device.via_device_id == hub_device.id
+
+
 @pytest.mark.usefixtures("init_integration")
 async def test_entity_available_when_hub_connected(hass: HomeAssistant) -> None:
     """Entities are available when the hub reports connected."""


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `nobo_hub` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
