### PR TITLE
Fix via_device race in ntfy

### DIFF
--- a/homeassistant/components/ntfy/__init__.py
+++ b/homeassistant/components/ntfy/__init__.py
@@ -14,7 +14,7 @@ from aiontfy.update import UpdateChecker
 from homeassistant.const import CONF_TOKEN, CONF_URL, CONF_VERIFY_SSL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import config_validation as cv, device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
@@ -91,6 +91,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: NtfyConfigEntry) -> bool
     await version.async_config_entry_first_refresh()
 
     entry.runtime_data = NtfyRuntimeData(coordinator, version)
+
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id, **coordinator.device_info
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/ntfy/coordinator.py
+++ b/homeassistant/components/ntfy/coordinator.py
@@ -15,10 +15,13 @@ from aiontfy.exceptions import (
     NtfyUnauthorizedAuthenticationError,
 )
 from aiontfy.update import LatestRelease, UpdateChecker, UpdateCheckerError
+from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import DOMAIN
@@ -55,6 +58,17 @@ class BaseDataUpdateCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
         )
 
         self.ntfy = ntfy
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info of the ntfy account service device."""
+        return DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            manufacturer="ntfy LLC",
+            model="ntfy",
+            configuration_url=URL(self.config_entry.data[CONF_URL]) / "app",
+            identifiers={(DOMAIN, self.config_entry.entry_id)},
+        )
 
     @abstractmethod
     async def async_update_data(self) -> _DataT:

--- a/homeassistant/components/ntfy/entity.py
+++ b/homeassistant/components/ntfy/entity.py
@@ -4,6 +4,7 @@ from yarl import URL
 
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.const import CONF_URL
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import Entity, EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -39,7 +40,11 @@ class NtfyBaseEntity(Entity):
             name=subentry.title,
             configuration_url=URL(config_entry.data[CONF_URL]) / self.topic,
             identifiers={(DOMAIN, f"{config_entry.entry_id}_{subentry.subentry_id}")},
-            via_device=(DOMAIN, config_entry.entry_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                config_entry.runtime_data.account.hass,
+                (DOMAIN, config_entry.entry_id),
+                config_entry_id=config_entry.entry_id,
+            ),
         )
         self.ntfy = config_entry.runtime_data.account.ntfy
         self.config_entry = config_entry
@@ -60,10 +65,4 @@ class NtfyCommonBaseEntity(CoordinatorEntity[BaseDataUpdateCoordinator]):
         super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{coordinator.config_entry.entry_id}_{description.key}"
-        self._attr_device_info = DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            manufacturer="ntfy LLC",
-            model="ntfy",
-            configuration_url=URL(coordinator.config_entry.data[CONF_URL]) / "app",
-            identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
-        )
+        self._attr_device_info = coordinator.device_info

--- a/tests/components/ntfy/test_init.py
+++ b/tests/components/ntfy/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the ntfy integration."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aiontfy.exceptions import (
     NtfyConnectionError,
@@ -10,8 +10,11 @@ from aiontfy.exceptions import (
 )
 import pytest
 
+from homeassistant.components.ntfy.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
 
@@ -31,6 +34,40 @@ async def test_entry_setup_unload(
     assert await hass.config_entries.async_unload(config_entry.entry_id)
 
     assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.usefixtures("mock_aiontfy")
+async def test_topic_device_via_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test topic device is linked to the account service device.
+
+    The account service device is registered at setup so the topic device,
+    which is created by the event/notify platforms, is always linked to it
+    even when the sensor platform (which also creates the account device) is
+    not loaded.
+    """
+
+    with patch("homeassistant.components.ntfy.PLATFORMS", [Platform.EVENT]):
+        config_entry.add_to_hass(hass)
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    subentry_id = next(iter(config_entry.subentries))
+    account_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, config_entry.entry_id)}
+    )
+    topic_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{config_entry.entry_id}_{subentry_id}")}
+    )
+
+    assert account_device is not None
+    assert topic_device is not None
+    assert topic_device.via_device_id == account_device.id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/ntfy/test_init.py
+++ b/tests/components/ntfy/test_init.py
@@ -58,11 +58,11 @@ async def test_topic_device_via_device(
     assert config_entry.state is ConfigEntryState.LOADED
 
     subentry_id = next(iter(config_entry.subentries))
-    account_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry.entry_id)}
+    account_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry.entry_id), config_entry.entry_id
     )
-    topic_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{config_entry.entry_id}_{subentry_id}")}
+    topic_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{config_entry.entry_id}_{subentry_id}"), config_entry.entry_id
     )
 
     assert account_device is not None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `ntfy`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
