### PR TITLE
Fix via_device race in ouman_eh_800

### DIFF
--- a/homeassistant/components/ouman_eh_800/__init__.py
+++ b/homeassistant/components/ouman_eh_800/__init__.py
@@ -2,7 +2,9 @@
 
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
+from .const import OumanDevice
 from .coordinator import OumanEh800ConfigEntry, OumanEh800Coordinator
 
 _PLATFORMS: list[Platform] = [
@@ -22,6 +24,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: OumanEh800ConfigEntry) -
     coordinator.sync_circuit_device_names()
 
     entry.runtime_data = coordinator
+
+    # Register the main device up front so the L1/L2 sub-devices can
+    # deterministically resolve their via_device_id, regardless of which
+    # platform's entities are added first.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **coordinator.device_info(OumanDevice.MAIN),
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 

--- a/homeassistant/components/ouman_eh_800/coordinator.py
+++ b/homeassistant/components/ouman_eh_800/coordinator.py
@@ -24,6 +24,7 @@ from homeassistant.exceptions import (
     ConfigEntryNotReady,
     HomeAssistantError,
 )
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
@@ -63,10 +64,10 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
         )
 
         entry_id = config_entry.entry_id
-        main_device_identifier = (DOMAIN, entry_id)
-        self.device_info: dict[OumanDevice, DeviceInfo] = {
+        self._main_device_identifier = (DOMAIN, entry_id)
+        self._device_info: dict[OumanDevice, DeviceInfo] = {
             OumanDevice.MAIN: DeviceInfo(
-                identifiers={main_device_identifier},
+                identifiers={self._main_device_identifier},
                 manufacturer="Ouman",
                 model="EH-800",
                 configuration_url=config_entry.data[CONF_URL],
@@ -75,15 +76,24 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
                 identifiers={(DOMAIN, f"{entry_id}_{OumanDevice.L1}")},
                 translation_key="heating_circuit",
                 translation_placeholders={"circuit_number": "1"},
-                via_device=main_device_identifier,
             ),
             OumanDevice.L2: DeviceInfo(
                 identifiers={(DOMAIN, f"{entry_id}_{OumanDevice.L2}")},
                 translation_key="heating_circuit",
                 translation_placeholders={"circuit_number": "2"},
-                via_device=main_device_identifier,
             ),
         }
+
+    def device_info(self, device: OumanDevice) -> DeviceInfo:
+        """Return the device info for a logical device."""
+        device_info = self._device_info[device]
+        if device is not OumanDevice.MAIN and "via_device_id" not in device_info:
+            device_info["via_device_id"] = dr.async_get_device_id_by_identifier(
+                self.hass,
+                self._main_device_identifier,
+                config_entry_id=self.config_entry.entry_id,
+            )
+        return device_info
 
     @override
     async def _async_setup(self) -> None:
@@ -132,7 +142,7 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
         ):
             if circuit_name := self.data.get(endpoint):
                 assert isinstance(circuit_name, str)
-                device_info = self.device_info[device]
+                device_info = self._device_info[device]
                 device_info["translation_key"] = "heating_circuit_with_name"
                 device_info["translation_placeholders"] = {
                     "circuit_number": circuit_number,

--- a/homeassistant/components/ouman_eh_800/entity.py
+++ b/homeassistant/components/ouman_eh_800/entity.py
@@ -1,9 +1,11 @@
 """Base entity for Ouman EH-800."""
 
 from dataclasses import dataclass
+from typing import override
 
 from ouman_eh_800_api import OumanEndpoint
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -39,4 +41,9 @@ class OumanEh800Entity(CoordinatorEntity[OumanEh800Coordinator]):
             f"{coordinator.config_entry.entry_id}"
             f"_{description.device}_{description.key}"
         )
-        self._attr_device_info = coordinator.device_info[description.device]
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return the device info."""
+        return self.coordinator.device_info(self.entity_description.device)

--- a/tests/components/ouman_eh_800/test_init.py
+++ b/tests/components/ouman_eh_800/test_init.py
@@ -26,7 +26,6 @@ async def test_sub_devices_link_to_main_device(
     mock_config_entry.add_to_hass(hass)
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()
 
     entry_id = mock_config_entry.entry_id
     main_device = device_registry.async_get_device(identifiers={(DOMAIN, entry_id)})

--- a/tests/components/ouman_eh_800/test_init.py
+++ b/tests/components/ouman_eh_800/test_init.py
@@ -8,10 +8,36 @@ from ouman_eh_800_api import (
 )
 import pytest
 
+from homeassistant.components.ouman_eh_800.const import DOMAIN, OumanDevice
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
+
+
+@pytest.mark.usefixtures("mock_ouman_client")
+async def test_sub_devices_link_to_main_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that the L1/L2 sub-devices link to the main device via via_device_id."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entry_id = mock_config_entry.entry_id
+    main_device = device_registry.async_get_device(identifiers={(DOMAIN, entry_id)})
+    assert main_device is not None
+
+    for sub_device in (OumanDevice.L1, OumanDevice.L2):
+        device = device_registry.async_get_device(
+            identifiers={(DOMAIN, f"{entry_id}_{sub_device}")}
+        )
+        assert device is not None
+        assert device.via_device_id == main_device.id
 
 
 @pytest.mark.usefixtures("mock_ouman_client")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `ouman_eh_800`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
