### PR TITLE
Fix via_device race in overkiz

### DIFF
--- a/homeassistant/components/overkiz/__init__.py
+++ b/homeassistant/components/overkiz/__init__.py
@@ -193,6 +193,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: OverkizDataConfigEntry) 
 
     device_registry = dr.async_get(hass)
 
+    registered_gateway_ids = {gateway.id for gateway in setup.gateways}
+
     for gateway in setup.gateways:
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
@@ -205,6 +207,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: OverkizDataConfigEntry) 
             hw_version=f"{gateway.type}:{gateway.sub_type}"
             if gateway.type and gateway.sub_type
             else None,
+            configuration_url=client.server_config.configuration_url,
+        )
+
+    # Some devices reference a gateway that is not part of setup.gateways
+    # (e.g. a secondary box hosting a device). Register a device for each such
+    # gateway so the via_device link of its child devices resolves.
+    for gateway_id in {
+        device.identifier.gateway_id for device in coordinator.data.values()
+    } - registered_gateway_ids:
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, gateway_id)},
+            manufacturer=client.server_config.manufacturer,
+            name=gateway_id,
             configuration_url=client.server_config.configuration_url,
         )
 

--- a/homeassistant/components/overkiz/entity.py
+++ b/homeassistant/components/overkiz/entity.py
@@ -5,6 +5,7 @@ from typing import cast, override
 from pyoverkiz.enums import APIType, OverkizAttribute, OverkizCommandParam, OverkizState
 from pyoverkiz.models import Device
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -111,7 +112,11 @@ class OverkizEntity(CoordinatorEntity[OverkizDataUpdateCoordinator]):
             model_id=self.device.widget,
             hw_version=self.device.controllable_name,
             suggested_area=suggested_area,
-            via_device=(DOMAIN, self.device.identifier.gateway_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, self.device.identifier.gateway_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             configuration_url=self.coordinator.client.server_config.configuration_url,
         )
 

--- a/tests/components/overkiz/helpers.py
+++ b/tests/components/overkiz/helpers.py
@@ -7,6 +7,7 @@ from freezegun.api import FrozenDateTimeFactory
 from pyoverkiz.enums import DataType, EventName, ExecutionState
 from pyoverkiz.models import (
     DeviceAvailableEvent,
+    DeviceCreatedEvent,
     DeviceRemovedEvent,
     DeviceStateChangedEvent,
     DeviceUnavailableEvent,
@@ -95,6 +96,11 @@ def device_unavailable_event(device_url: str) -> DeviceUnavailableEvent:
 def device_removed_event(device_url: str) -> DeviceRemovedEvent:
     """Build a DEVICE_REMOVED event for the given device."""
     return DeviceRemovedEvent(name=EventName.DEVICE_REMOVED, device_url=device_url)
+
+
+def device_created_event(device_url: str) -> DeviceCreatedEvent:
+    """Build a DEVICE_CREATED event for the given device."""
+    return DeviceCreatedEvent(name=EventName.DEVICE_CREATED, device_url=device_url)
 
 
 def execution_state_changed_event(

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -1,6 +1,6 @@
 """Tests for the Overkiz data update coordinator."""
 
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from aiohttp import ClientConnectorError
 from freezegun.api import FrozenDateTimeFactory
@@ -13,13 +13,14 @@ from pyoverkiz.exceptions import (
 )
 import pytest
 
-from homeassistant.components.overkiz.const import UPDATE_INTERVAL
+from homeassistant.components.overkiz.const import DOMAIN, UPDATE_INTERVAL
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import FixtureDevice, MockOverkizClient, SetupOverkizIntegration
-from .helpers import async_deliver_events, device_removed_event
+from .helpers import async_deliver_events, device_created_event, device_removed_event
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -28,6 +29,14 @@ TEMPERATURE_SENSOR = FixtureDevice(
     "io://1234-5678-1698/15702199#2",
     "sensor.maple_residence_garden_radiator_bathroom_temperature_sensor_temperature",
 )
+
+# A TaHoma v2 setup whose gateways list only holds the main box, while a
+# swinging gate device is hosted by a secondary box absent from setup.gateways.
+TAHOMA_V2_FIXTURE = "setup/cloud_somfy_tahoma_v2_europe.json"
+MAIN_GATEWAY_ID = "1234-1234-6233"
+SECONDARY_GATEWAY_ID = "1234-1234-8983"
+MAIN_GATEWAY_CHILD_URL = "io://1234-1234-6233/12184029"
+SECONDARY_GATEWAY_CHILD_URL = "io://1234-1234-8983/1959462"
 
 
 @pytest.mark.parametrize(
@@ -134,3 +143,61 @@ async def test_device_removed_keeps_device_owned_by_other_entry(
     device = device_registry.async_get(device_id)
     assert device is not None
     assert device.config_entry_id == other_entry.entry_id
+
+
+async def test_child_devices_link_to_their_gateway(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MockOverkizClient,
+    freezer: FrozenDateTimeFactory,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Every child device links to its gateway, even one absent from setup.gateways.
+
+    The secondary box that hosts the swinging gate is not returned in
+    setup.gateways, but the via_device link of its child must still resolve.
+    A DEVICE_CREATED event reloads the entry, which must keep the link intact.
+    """
+    mock_config_entry.add_to_hass(hass)
+    mock_client.set_setup_fixture(TAHOMA_V2_FIXTURE)
+
+    with patch(
+        "homeassistant.components.overkiz.create_cloud_client",
+        return_value=mock_client,
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+        main_gateway = device_registry.async_get_device({(DOMAIN, MAIN_GATEWAY_ID)})
+        secondary_gateway = device_registry.async_get_device(
+            {(DOMAIN, SECONDARY_GATEWAY_ID)}
+        )
+        assert main_gateway is not None
+        assert secondary_gateway is not None
+
+        main_child = device_registry.async_get_device(
+            {(DOMAIN, MAIN_GATEWAY_CHILD_URL)}
+        )
+        secondary_child = device_registry.async_get_device(
+            {(DOMAIN, SECONDARY_GATEWAY_CHILD_URL)}
+        )
+        assert main_child.via_device_id == main_gateway.id
+        assert secondary_child.via_device_id == secondary_gateway.id
+
+        # A DEVICE_CREATED event reloads the entry; the links must survive.
+        await async_deliver_events(
+            hass,
+            freezer,
+            mock_client,
+            [device_created_event(SECONDARY_GATEWAY_CHILD_URL)],
+        )
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    secondary_gateway = device_registry.async_get_device(
+        {(DOMAIN, SECONDARY_GATEWAY_ID)}
+    )
+    secondary_child = device_registry.async_get_device(
+        {(DOMAIN, SECONDARY_GATEWAY_CHILD_URL)}
+    )
+    assert secondary_child.via_device_id == secondary_gateway.id

--- a/tests/components/overkiz/test_coordinator.py
+++ b/tests/components/overkiz/test_coordinator.py
@@ -168,19 +168,23 @@ async def test_child_devices_link_to_their_gateway(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-        main_gateway = device_registry.async_get_device({(DOMAIN, MAIN_GATEWAY_ID)})
-        secondary_gateway = device_registry.async_get_device(
-            {(DOMAIN, SECONDARY_GATEWAY_ID)}
+        main_gateway = device_registry.async_get_device_by_identifier(
+            (DOMAIN, MAIN_GATEWAY_ID), mock_config_entry.entry_id
+        )
+        secondary_gateway = device_registry.async_get_device_by_identifier(
+            (DOMAIN, SECONDARY_GATEWAY_ID), mock_config_entry.entry_id
         )
         assert main_gateway is not None
         assert secondary_gateway is not None
 
-        main_child = device_registry.async_get_device(
-            {(DOMAIN, MAIN_GATEWAY_CHILD_URL)}
+        main_child = device_registry.async_get_device_by_identifier(
+            (DOMAIN, MAIN_GATEWAY_CHILD_URL), mock_config_entry.entry_id
         )
-        secondary_child = device_registry.async_get_device(
-            {(DOMAIN, SECONDARY_GATEWAY_CHILD_URL)}
+        secondary_child = device_registry.async_get_device_by_identifier(
+            (DOMAIN, SECONDARY_GATEWAY_CHILD_URL), mock_config_entry.entry_id
         )
+        assert main_child is not None
+        assert secondary_child is not None
         assert main_child.via_device_id == main_gateway.id
         assert secondary_child.via_device_id == secondary_gateway.id
 
@@ -194,10 +198,12 @@ async def test_child_devices_link_to_their_gateway(
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
-    secondary_gateway = device_registry.async_get_device(
-        {(DOMAIN, SECONDARY_GATEWAY_ID)}
+    secondary_gateway = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SECONDARY_GATEWAY_ID), mock_config_entry.entry_id
     )
-    secondary_child = device_registry.async_get_device(
-        {(DOMAIN, SECONDARY_GATEWAY_CHILD_URL)}
+    secondary_child = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SECONDARY_GATEWAY_CHILD_URL), mock_config_entry.entry_id
     )
+    assert secondary_gateway is not None
+    assert secondary_child is not None
     assert secondary_child.via_device_id == secondary_gateway.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `overkiz`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
