### PR TITLE
Fix via_device race in playstation_network

### DIFF
--- a/homeassistant/components/playstation_network/__init__.py
+++ b/homeassistant/components/playstation_network/__init__.py
@@ -1,9 +1,13 @@
 """The PlayStation Network integration."""
 
+from typing import TYPE_CHECKING
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType
 
-from .const import CONF_NPSSO
+from .const import CONF_NPSSO, DOMAIN
 from .coordinator import (
     PlaystationNetworkConfigEntry,
     PlaystationNetworkFriendDataCoordinator,
@@ -52,6 +56,18 @@ async def async_setup_entry(
 
     entry.runtime_data = PlaystationNetworkRuntimeData(
         coordinator, trophy_titles, groups, friends, friends_list
+    )
+
+    # Register the account device up front so entities on concurrently set up
+    # platforms (media players, friends) can resolve it as their via_device.
+    if TYPE_CHECKING:
+        assert entry.unique_id
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.unique_id)},
+        name=coordinator.data.username,
+        entry_type=DeviceEntryType.SERVICE,
+        manufacturer="Sony Interactive Entertainment",
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/playstation_network/entity.py
+++ b/homeassistant/components/playstation_network/entity.py
@@ -3,6 +3,7 @@
 from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigSubentry
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -50,5 +51,11 @@ class PlaystationNetworkServiceEntity(
         )
         if subentry:
             self._attr_device_info.update(
-                DeviceInfo(via_device=(DOMAIN, coordinator.config_entry.unique_id))
+                DeviceInfo(
+                    via_device_id=dr.async_get_device_id_by_identifier(
+                        coordinator.hass,
+                        (DOMAIN, coordinator.config_entry.unique_id),
+                        config_entry_id=coordinator.config_entry.entry_id,
+                    )
+                )
             )

--- a/homeassistant/components/playstation_network/media_player.py
+++ b/homeassistant/components/playstation_network/media_player.py
@@ -109,7 +109,11 @@ class PsnMediaPlayerEntity(
             name=PLATFORM_MAP[platform],
             manufacturer="Sony Interactive Entertainment",
             model=PLATFORM_MAP[platform],
-            via_device=(DOMAIN, coordinator.config_entry.unique_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.unique_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
         self.trophy_titles = trophy_titles
 

--- a/tests/components/playstation_network/test_media_player.py
+++ b/tests/components/playstation_network/test_media_player.py
@@ -7,10 +7,13 @@ from unittest.mock import MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.playstation_network.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+from .conftest import PSN_ID
 
 from tests.common import MockConfigEntry, snapshot_platform
 
@@ -124,6 +127,29 @@ async def test_platform(
     assert config_entry.state is ConfigEntryState.LOADED
 
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_psnawpapi", "mock_token")
+async def test_media_player_via_device(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the media player device is linked to the account device via_device."""
+    config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    account_device = device_registry.async_get_device(identifiers={(DOMAIN, PSN_ID)})
+    assert account_device is not None
+
+    media_player_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{PSN_ID}_PS5")}
+    )
+    assert media_player_device is not None
+    assert media_player_device.via_device_id == account_device.id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/playstation_network/test_media_player.py
+++ b/tests/components/playstation_network/test_media_player.py
@@ -142,11 +142,13 @@ async def test_media_player_via_device(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    account_device = device_registry.async_get_device(identifiers={(DOMAIN, PSN_ID)})
+    account_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, PSN_ID), config_entry.entry_id
+    )
     assert account_device is not None
 
-    media_player_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{PSN_ID}_PS5")}
+    media_player_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{PSN_ID}_PS5"), config_entry.entry_id
     )
     assert media_player_device is not None
     assert media_player_device.via_device_id == account_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `playstation_network`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
