### PR TITLE
Fix via_device race in point

### DIFF
--- a/homeassistant/components/point/coordinator.py
+++ b/homeassistant/components/point/coordinator.py
@@ -9,6 +9,7 @@ from pypoint import PointSession
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util.dt import parse_datetime
 
@@ -50,7 +51,16 @@ class PointDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]
 
         if new_homes := set(self.point.homes) - self._known_homes:
             _LOGGER.debug("Found new homes: %s", new_homes)
+            device_registry = dr.async_get(self.hass)
             for home_id in new_homes:
+                # Register the home before its child devices so they can resolve
+                # it as their via_device parent when their entities are created.
+                device_registry.async_get_or_create(
+                    config_entry_id=self.config_entry.entry_id,
+                    identifiers={(DOMAIN, home_id)},
+                    manufacturer="Minut",
+                    name=self.point.homes[home_id]["name"],
+                )
                 if self.new_home_callback:
                     self.new_home_callback(home_id)
             self._known_homes.update(new_homes)

--- a/homeassistant/components/point/entity.py
+++ b/homeassistant/components/point/entity.py
@@ -33,7 +33,11 @@ class MinutPointEntity(CoordinatorEntity[PointDataUpdateCoordinator]):
             name=device["description"],
             hw_version=device["hardware_version"],
             sw_version=device["firmware"]["installed"],
-            via_device=(DOMAIN, device["home"]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, device["home"]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
         if self.device_class:
             self._attr_name = f"{self._name} {self.device_class.capitalize()}"

--- a/homeassistant/components/point/entity.py
+++ b/homeassistant/components/point/entity.py
@@ -33,12 +33,11 @@ class MinutPointEntity(CoordinatorEntity[PointDataUpdateCoordinator]):
             name=device["description"],
             hw_version=device["hardware_version"],
             sw_version=device["firmware"]["installed"],
-            via_device_id=dr.async_get_device_id_by_identifier(
-                coordinator.hass,
-                (DOMAIN, device["home"]),
-                config_entry_id=coordinator.config_entry.entry_id,
-            ),
         )
+        if parent := dr.async_get(coordinator.hass).async_get_device_by_identifier(
+            (DOMAIN, device["home"]), coordinator.config_entry.entry_id
+        ):
+            self._attr_device_info["via_device_id"] = parent.id
         if self.device_class:
             self._attr_name = f"{self._name} {self.device_class.capitalize()}"
 

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -208,9 +208,13 @@ async def test_device_via_device_link(
 
     assert config_entry.state is ConfigEntryState.LOADED
 
-    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    home_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, HOME_ID), config_entry.entry_id
+    )
     assert home_device is not None
 
-    point_device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    point_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), config_entry.entry_id
+    )
     assert point_device is not None
     assert point_device.via_device_id == home_device.id

--- a/tests/components/point/test_init.py
+++ b/tests/components/point/test_init.py
@@ -1,15 +1,146 @@
 """Tests for the Point component."""
 
-from unittest.mock import patch
+import time
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
+import pytest
+
+from homeassistant.components.application_credentials import (
+    DOMAIN as APPLICATION_CREDENTIALS_DOMAIN,
+    ClientCredential,
+    async_import_client_credential,
+)
 from homeassistant.components.point import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
+from homeassistant.setup import async_setup_component
 
 from tests.common import MockConfigEntry
+
+HOME_ID = "home_1"
+DEVICE_ID = "device_1"
+
+DEVICE_RAW: dict[str, Any] = {
+    "device_id": DEVICE_ID,
+    "device_mac": "00:11:22:33:44:55",
+    "description": "Kitchen",
+    "hardware_version": "1",
+    "firmware": {"installed": "2.0.0"},
+    "home": HOME_ID,
+    "last_heard_from_at": "2023-01-01T00:00:00+00:00",
+    "active": True,
+    "offline": False,
+    "battery": {"percent": 100},
+    "ongoing_events": [],
+}
+
+HOME_RAW: dict[str, Any] = {
+    "home_id": HOME_ID,
+    "name": "My Home",
+    "devices": [DEVICE_ID],
+    "alarm_status": "off",
+}
+
+
+class FakeDevice:
+    """Minimal fake of pypoint.Device."""
+
+    def __init__(self, raw: dict[str, Any]) -> None:
+        """Initialize."""
+        self._raw = raw
+
+    @property
+    def device_id(self) -> str:
+        """Return the device id."""
+        return self._raw["device_id"]
+
+    @property
+    def device(self) -> dict[str, Any]:
+        """Return the raw representation."""
+        return self._raw
+
+    @property
+    def name(self) -> str:
+        """Return the device name."""
+        return self._raw["description"]
+
+    @property
+    def last_update(self) -> str:
+        """Return the last update timestamp."""
+        return self._raw["last_heard_from_at"]
+
+    @property
+    def ongoing_events(self) -> list[str]:
+        """Return ongoing events."""
+        return self._raw["ongoing_events"]
+
+    @property
+    def webhook(self) -> str:
+        """Return the webhook."""
+        return "webhook"
+
+    @property
+    def device_status(self) -> dict[str, Any]:
+        """Return the device status."""
+        return {
+            "active": self._raw["active"],
+            "offline": self._raw["offline"],
+            "last_update": self.last_update,
+            "battery_level": self._raw["battery"]["percent"],
+        }
+
+    async def sensor(self, sensor_type: str) -> float:
+        """Return a sensor value."""
+        return 1.0
+
+
+class FakePointSession:
+    """Minimal fake of pypoint.PointSession."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize."""
+        self._devices = {DEVICE_ID: DEVICE_RAW}
+        self._homes = {HOME_ID: HOME_RAW}
+        self.webhook = "webhook"
+
+    async def update(self) -> bool:
+        """Update the session."""
+        return True
+
+    @property
+    def homes(self) -> dict[str, dict[str, Any]]:
+        """Return known homes."""
+        return self._homes
+
+    @property
+    def device_ids(self) -> Any:
+        """Return known device ids."""
+        return self._devices.keys()
+
+    @property
+    def devices(self) -> Any:
+        """Return device representations."""
+        return (FakeDevice(raw) for raw in self._devices.values())
+
+    def device(self, device_id: str) -> FakeDevice:
+        """Return a single device."""
+        return FakeDevice(self._devices[device_id])
+
+
+@pytest.fixture
+async def setup_credentials(hass: HomeAssistant) -> None:
+    """Fixture to set up application credentials."""
+    assert await async_setup_component(hass, APPLICATION_CREDENTIALS_DOMAIN, {})
+    await async_import_client_credential(
+        hass,
+        DOMAIN,
+        ClientCredential("1234", "5678"),
+    )
 
 
 async def test_oauth_implementation_not_available(
@@ -38,3 +169,48 @@ async def test_oauth_implementation_not_available(
         await hass.async_block_till_done()
 
     assert config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+@pytest.mark.usefixtures("setup_credentials")
+async def test_device_via_device_link(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a Point device is linked to its home via_device."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="abcd",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+                "expires_at": time.time() + 3600,
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.point.PointSession",
+            FakePointSession,
+        ),
+        patch(
+            "homeassistant.components.point.async_setup_webhook",
+            new=AsyncMock(),
+        ),
+    ):
+        await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    home_device = device_registry.async_get_device(identifiers={(DOMAIN, HOME_ID)})
+    assert home_device is not None
+
+    point_device = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert point_device is not None
+    assert point_device.via_device_id == home_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `point`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
