### PR TITLE
Fix via_device race in portainer

### DIFF
--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -98,9 +98,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PortainerConfigEntry) ->
         coordinator.data,
         set(coordinator.data),
         {
-            (endpoint_id, stack_name)
+            (endpoint_id, stack_name, stack_data.stack.id)
             for endpoint_id, endpoint_data in coordinator.data.items()
-            for stack_name in endpoint_data.stacks
+            for stack_name, stack_data in endpoint_data.stacks.items()
         },
     )
 

--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 from pyportainer import Portainer, PortainerImageWatcher
 from pyportainer.exceptions import PortainerError
-from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -22,12 +21,12 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
-from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryType
+from homeassistant.helpers.device_registry import DeviceEntry
 import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 
-from .const import API_MAX_RETRIES, DEFAULT_NAME, DOMAIN
+from .const import API_MAX_RETRIES, DOMAIN
 from .coordinator import PortainerCoordinator, PortainerDockerDiskSpaceCoordinator
 from .services import async_setup_services
 
@@ -95,34 +94,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: PortainerConfigEntry) ->
     # Register the endpoint and stack devices up front so that container, stack and
     # volume entities can deterministically resolve them as their via device when
     # their platforms are set up below, regardless of platform/entity add order.
-    device_registry = dr.async_get(hass)
-    base_url = entry.data[CONF_URL]
-    for endpoint_data in coordinator.data.values():
-        endpoint_id = endpoint_data.endpoint.id
-        endpoint_device = device_registry.async_get_or_create(
-            config_entry_id=entry.entry_id,
-            identifiers={(DOMAIN, f"{entry.entry_id}_{endpoint_id}")},
-            configuration_url=URL(f"{base_url}#!/{endpoint_id}/docker/dashboard"),
-            manufacturer=DEFAULT_NAME,
-            model="Endpoint",
-            name=endpoint_data.endpoint.name,
-            entry_type=DeviceEntryType.SERVICE,
-        )
-        for stack_data in endpoint_data.stacks.values():
-            stack = stack_data.stack
-            device_registry.async_get_or_create(
-                config_entry_id=entry.entry_id,
-                identifiers={
-                    (DOMAIN, f"{entry.entry_id}_{endpoint_id}_stack_{stack.id}")
-                },
-                configuration_url=URL(
-                    f"{base_url}#!/{endpoint_id}/docker/stacks/{stack.name}"
-                ),
-                manufacturer=DEFAULT_NAME,
-                model="Stack",
-                name=stack.name,
-                via_device_id=endpoint_device.id,
-            )
+    coordinator.async_register_endpoint_and_stack_devices(
+        coordinator.data,
+        set(coordinator.data),
+        {
+            (endpoint_id, stack_name)
+            for endpoint_id, endpoint_data in coordinator.data.items()
+            for stack_name in endpoint_data.stacks
+        },
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 

--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from pyportainer import Portainer, PortainerImageWatcher
 from pyportainer.exceptions import PortainerError
+from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -21,12 +22,12 @@ from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
 import homeassistant.helpers.device_registry as dr
-from homeassistant.helpers.device_registry import DeviceEntry
+from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryType
 import homeassistant.helpers.entity_registry as er
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType
 
-from .const import API_MAX_RETRIES, DOMAIN
+from .const import API_MAX_RETRIES, DEFAULT_NAME, DOMAIN
 from .coordinator import PortainerCoordinator, PortainerDockerDiskSpaceCoordinator
 from .services import async_setup_services
 
@@ -90,6 +91,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: PortainerConfigEntry) ->
     entry.async_on_unload(async_at_started(hass, _defer_docker_disk_space_refresh))
 
     entry.runtime_data = coordinator
+
+    # Register the endpoint and stack devices up front so that container, stack and
+    # volume entities can deterministically resolve them as their via device when
+    # their platforms are set up below, regardless of platform/entity add order.
+    device_registry = dr.async_get(hass)
+    base_url = entry.data[CONF_URL]
+    for endpoint_data in coordinator.data.values():
+        endpoint_id = endpoint_data.endpoint.id
+        endpoint_device = device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={(DOMAIN, f"{entry.entry_id}_{endpoint_id}")},
+            configuration_url=URL(f"{base_url}#!/{endpoint_id}/docker/dashboard"),
+            manufacturer=DEFAULT_NAME,
+            model="Endpoint",
+            name=endpoint_data.endpoint.name,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+        for stack_data in endpoint_data.stacks.values():
+            stack = stack_data.stack
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                identifiers={
+                    (DOMAIN, f"{entry.entry_id}_{endpoint_id}_stack_{stack.id}")
+                },
+                configuration_url=URL(
+                    f"{base_url}#!/{endpoint_id}/docker/stacks/{stack.name}"
+                ),
+                manufacturer=DEFAULT_NAME,
+                model="Stack",
+                name=stack.name,
+                via_device_id=endpoint_device.id,
+            )
+
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
 
     @callback

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -117,7 +117,7 @@ class PortainerBaseCoordinator[_DataT](DataUpdateCoordinator[_DataT]):
 
         self.known_endpoints: set[int] = set()
         self.known_containers: set[tuple[int, str]] = set()
-        self.known_stacks: set[tuple[int, str]] = set()
+        self.known_stacks: set[tuple[int, str, int]] = set()
         self.known_volumes: set[tuple[int, str]] = set()
 
         self.new_endpoints_callbacks: list[
@@ -418,7 +418,7 @@ class PortainerCoordinator(
         self,
         mapped_endpoints: dict[int, PortainerCoordinatorData],
         endpoint_ids: set[int],
-        stack_keys: set[tuple[int, str]],
+        stack_keys: set[tuple[int, str, int]],
     ) -> None:
         """Register endpoint and stack devices.
 
@@ -442,7 +442,7 @@ class PortainerCoordinator(
                 entry_type=DeviceEntryType.SERVICE,
             )
 
-        for endpoint_id, stack_name in stack_keys:
+        for endpoint_id, stack_name, _stack_id in stack_keys:
             stack = mapped_endpoints[endpoint_id].stacks[stack_name].stack
             device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
@@ -473,10 +473,13 @@ class PortainerCoordinator(
         self.known_endpoints &= current_endpoints
         new_endpoints = current_endpoints - self.known_endpoints
 
+        # The stack ID is part of the key because it is part of the stack device
+        # identifier; a stack recreated with the same name but a new ID must be
+        # detected as new so its device is (re)registered before entities resolve it.
         current_stacks = {
-            (endpoint.id, stack_name)
+            (endpoint.id, stack_name, stack_data.stack.id)
             for endpoint in mapped_endpoints.values()
-            for stack_name in endpoint.stacks
+            for stack_name, stack_data in endpoint.stacks.items()
         }
         self.known_stacks &= current_stacks
         new_stacks = current_stacks - self.known_stacks
@@ -551,7 +554,7 @@ class PortainerCoordinator(
                     mapped_endpoints[endpoint_id],
                     mapped_endpoints[endpoint_id].stacks[name],
                 )
-                for endpoint_id, name in new_stacks
+                for endpoint_id, name, _stack_id in new_stacks
             ]
             for stack_callback in self.new_stacks_callbacks:
                 stack_callback(new_stack_data)

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -433,7 +433,9 @@ class PortainerCoordinator(
             device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
                 identifiers={(DOMAIN, f"{self.config_entry.entry_id}_{endpoint_id}")},
-                configuration_url=URL(f"{self.config_entry.data[CONF_URL]}#!/{endpoint_id}/docker/dashboard"),
+                configuration_url=URL(
+                    f"{self.config_entry.data[CONF_URL]}#!/{endpoint_id}/docker/dashboard"
+                ),
                 manufacturer=DEFAULT_NAME,
                 model="Endpoint",
                 name=endpoint.name,
@@ -444,7 +446,12 @@ class PortainerCoordinator(
             stack = mapped_endpoints[endpoint_id].stacks[stack_name].stack
             device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
-                identifiers={(DOMAIN, f"{self.config_entry.entry_id}_{endpoint_id}_stack_{stack.id}")},
+                identifiers={
+                    (
+                        DOMAIN,
+                        f"{self.config_entry.entry_id}_{endpoint_id}_stack_{stack.id}",
+                    )
+                },
                 configuration_url=URL(
                     f"{self.config_entry.data[CONF_URL]}#!/{endpoint_id}/docker/stacks/{stack.name}"
                 ),

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -427,15 +427,13 @@ class PortainerCoordinator(
         when a later refresh discovers new endpoints or stacks.
         """
         device_registry = dr.async_get(self.hass)
-        base_url = self.config_entry.data[CONF_URL]
-        entry_id = self.config_entry.entry_id
 
         for endpoint_id in endpoint_ids:
             endpoint = mapped_endpoints[endpoint_id].endpoint
             device_registry.async_get_or_create(
-                config_entry_id=entry_id,
-                identifiers={(DOMAIN, f"{entry_id}_{endpoint_id}")},
-                configuration_url=URL(f"{base_url}#!/{endpoint_id}/docker/dashboard"),
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={(DOMAIN, f"{self.config_entry.entry_id}_{endpoint_id}")},
+                configuration_url=URL(f"{self.config_entry.data[CONF_URL]}#!/{endpoint_id}/docker/dashboard"),
                 manufacturer=DEFAULT_NAME,
                 model="Endpoint",
                 name=endpoint.name,
@@ -445,18 +443,18 @@ class PortainerCoordinator(
         for endpoint_id, stack_name in stack_keys:
             stack = mapped_endpoints[endpoint_id].stacks[stack_name].stack
             device_registry.async_get_or_create(
-                config_entry_id=entry_id,
-                identifiers={(DOMAIN, f"{entry_id}_{endpoint_id}_stack_{stack.id}")},
+                config_entry_id=self.config_entry.entry_id,
+                identifiers={(DOMAIN, f"{self.config_entry.entry_id}_{endpoint_id}_stack_{stack.id}")},
                 configuration_url=URL(
-                    f"{base_url}#!/{endpoint_id}/docker/stacks/{stack.name}"
+                    f"{self.config_entry.data[CONF_URL]}#!/{endpoint_id}/docker/stacks/{stack.name}"
                 ),
                 manufacturer=DEFAULT_NAME,
                 model="Stack",
                 name=stack.name,
                 via_device_id=dr.async_get_device_id_by_identifier(
                     self.hass,
-                    (DOMAIN, f"{entry_id}_{endpoint_id}"),
-                    config_entry_id=entry_id,
+                    (DOMAIN, f"{self.config_entry.entry_id}_{endpoint_id}"),
+                    config_entry_id=self.config_entry.entry_id,
                 ),
             )
 

--- a/homeassistant/components/portainer/coordinator.py
+++ b/homeassistant/components/portainer/coordinator.py
@@ -30,14 +30,17 @@ from pyportainer.models.docker_inspect import DockerInfo, DockerInspect, DockerV
 from pyportainer.models.portainer import Endpoint
 from pyportainer.models.stacks import Stack
 from pyportainer.watcher import PortainerImageWatcher
+from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_URL
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+import homeassistant.helpers.device_registry as dr
+from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DOMAIN
+from .const import DEFAULT_NAME, DOMAIN
 from .util import sanitize_container_name
 
 type PortainerConfigEntry = ConfigEntry[PortainerCoordinator]
@@ -411,6 +414,52 @@ class PortainerCoordinator(
 
         return mapped_endpoints
 
+    def async_register_endpoint_and_stack_devices(
+        self,
+        mapped_endpoints: dict[int, PortainerCoordinatorData],
+        endpoint_ids: set[int],
+        stack_keys: set[tuple[int, str]],
+    ) -> None:
+        """Register endpoint and stack devices.
+
+        Must run for an endpoint/stack before any entity that resolves it
+        as its via device is constructed, both during initial setup and
+        when a later refresh discovers new endpoints or stacks.
+        """
+        device_registry = dr.async_get(self.hass)
+        base_url = self.config_entry.data[CONF_URL]
+        entry_id = self.config_entry.entry_id
+
+        for endpoint_id in endpoint_ids:
+            endpoint = mapped_endpoints[endpoint_id].endpoint
+            device_registry.async_get_or_create(
+                config_entry_id=entry_id,
+                identifiers={(DOMAIN, f"{entry_id}_{endpoint_id}")},
+                configuration_url=URL(f"{base_url}#!/{endpoint_id}/docker/dashboard"),
+                manufacturer=DEFAULT_NAME,
+                model="Endpoint",
+                name=endpoint.name,
+                entry_type=DeviceEntryType.SERVICE,
+            )
+
+        for endpoint_id, stack_name in stack_keys:
+            stack = mapped_endpoints[endpoint_id].stacks[stack_name].stack
+            device_registry.async_get_or_create(
+                config_entry_id=entry_id,
+                identifiers={(DOMAIN, f"{entry_id}_{endpoint_id}_stack_{stack.id}")},
+                configuration_url=URL(
+                    f"{base_url}#!/{endpoint_id}/docker/stacks/{stack.name}"
+                ),
+                manufacturer=DEFAULT_NAME,
+                model="Stack",
+                name=stack.name,
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    self.hass,
+                    (DOMAIN, f"{entry_id}_{endpoint_id}"),
+                    config_entry_id=entry_id,
+                ),
+            )
+
     def _async_add_remove_endpoints(
         self, mapped_endpoints: dict[int, PortainerCoordinatorData]
     ) -> None:
@@ -418,6 +467,22 @@ class PortainerCoordinator(
         current_endpoints = {endpoint.id for endpoint in mapped_endpoints.values()}
         self.known_endpoints &= current_endpoints
         new_endpoints = current_endpoints - self.known_endpoints
+
+        current_stacks = {
+            (endpoint.id, stack_name)
+            for endpoint in mapped_endpoints.values()
+            for stack_name in endpoint.stacks
+        }
+        self.known_stacks &= current_stacks
+        new_stacks = current_stacks - self.known_stacks
+
+        if new_endpoints or new_stacks:
+            # Register devices before any callback below constructs an
+            # entity that resolves one of them as its via device.
+            self.async_register_endpoint_and_stack_devices(
+                mapped_endpoints, new_endpoints, new_stacks
+            )
+
         if new_endpoints:
             _LOGGER.debug("New endpoints found: %s", new_endpoints)
             self.known_endpoints.update(new_endpoints)
@@ -473,14 +538,6 @@ class PortainerCoordinator(
                 volume_callback(new_volume_data)
 
         # Stack management
-        current_stacks = {
-            (endpoint.id, stack_name)
-            for endpoint in mapped_endpoints.values()
-            for stack_name in endpoint.stacks
-        }
-
-        self.known_stacks &= current_stacks
-        new_stacks = current_stacks - self.known_stacks
         if new_stacks:
             _LOGGER.debug("New stacks found: %s", new_stacks)
             self.known_stacks.update(new_stacks)

--- a/homeassistant/components/portainer/entity.py
+++ b/homeassistant/components/portainer/entity.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, override
 from yarl import URL
 
 from homeassistant.const import CONF_URL
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -114,11 +115,15 @@ class PortainerContainerEntity(PortainerCoordinatorEntity):
             name=self.device_name,
             # If the container belongs to a stack, nest it under the stack
             # else it's the endpoint
-            via_device=(
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_{self.endpoint_id}_stack_{device_info.stack.id}"
-                if device_info.stack
-                else f"{coordinator.config_entry.entry_id}_{self.endpoint_id}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (
+                    DOMAIN,
+                    f"{coordinator.config_entry.entry_id}_{self.endpoint_id}_stack_{device_info.stack.id}"
+                    if device_info.stack
+                    else f"{coordinator.config_entry.entry_id}_{self.endpoint_id}",
+                ),
+                config_entry_id=coordinator.config_entry.entry_id,
             ),
             translation_key=None if self.device_name else "unknown_container",
             entry_type=DeviceEntryType.SERVICE,
@@ -176,9 +181,10 @@ class PortainerStackEntity(PortainerCoordinatorEntity):
             ),
             model="Stack",
             name=self.device_name,
-            via_device=(
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_{self.endpoint_id}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, f"{coordinator.config_entry.entry_id}_{self.endpoint_id}"),
+                config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
         self._attr_unique_id = (
@@ -280,9 +286,10 @@ class PortainerVolumeEntity(PortainerCoordinatorEntity):
             ),
             model="Volume",
             name=self.volume_name,
-            via_device=(
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_{self.endpoint_id}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, f"{coordinator.config_entry.entry_id}_{self.endpoint_id}"),
+                config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
         self._attr_unique_id = (

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -483,3 +483,77 @@ async def test_new_stack_callback(
     assert len(
         er.async_entries_for_config_entry(entity_registry, mock_config_entry.entry_id)
     ) > len(entities)
+
+
+async def test_stack_recreated_with_new_id(
+    hass: HomeAssistant,
+    mock_portainer_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a stack recreated with the same name but a new ID re-registers its device.
+
+    The stack device identifier and a container's via device are keyed by the stack
+    ID, so a stack recreated with a new ID must be detected as new and its device
+    registered before a container in it resolves the stack as its via device. Tracking
+    only the name would skip registration and the via device lookup would then raise,
+    aborting the refresh.
+    """
+    await setup_integration(hass, mock_config_entry)
+
+    endpoint_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1"), mock_config_entry.entry_id
+    )
+    assert endpoint_device is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{mock_config_entry.entry_id}_1_stack_1"),
+            mock_config_entry.entry_id,
+        )
+        is not None
+    )
+
+    stacks = cast(
+        list[dict[str, Any]],
+        await async_load_json_array_fixture(hass, "stacks.json", DOMAIN),
+    )
+    for stack in stacks:
+        if stack["Name"] == "webstack":
+            stack["Id"] = 99
+    mock_portainer_client.get_stacks.return_value = [
+        Stack.from_dict(stack) for stack in stacks
+    ]
+
+    containers = cast(
+        list[dict[str, Any]],
+        await async_load_json_array_fixture(hass, "containers.json", DOMAIN),
+    )
+    new_container = {
+        **next(c for c in containers if c["Names"] == ["/serene_banach"]),
+        "Names": ["/brave_newton"],
+        "Id": "cc97facfb3b3ed4cd362c1e88fc89a53908ad05fb3a4103bca3f9b28292d14bf",
+    }
+    mock_portainer_client.get_containers.return_value = [
+        DockerContainer.from_dict(container)
+        for container in (*containers, new_container)
+    ]
+
+    coordinator = mock_config_entry.runtime_data
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert coordinator.last_update_success
+
+    new_stack_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_stack_99"),
+        mock_config_entry.entry_id,
+    )
+    assert new_stack_device is not None
+    assert new_stack_device.via_device_id == endpoint_device.id
+
+    new_container_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_brave_newton"),
+        mock_config_entry.entry_id,
+    )
+    assert new_container_device is not None
+    assert new_container_device.via_device_id == new_stack_device.id

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -364,6 +364,7 @@ async def test_new_endpoint_callback(
     mock_portainer_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test new endpoint creates entities after refresh."""
     mock_portainer_client.get_endpoints.return_value = []
@@ -390,6 +391,21 @@ async def test_new_endpoint_callback(
         entity_registry, mock_config_entry.entry_id
     )
     assert len(entities) > 0
+
+    # The endpoint and its stacks are discovered together on this refresh, so
+    # the stack device must resolve the freshly-created endpoint device as its
+    # via device instead of racing its creation.
+    endpoint_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1"), mock_config_entry.entry_id
+    )
+    assert endpoint_device is not None
+
+    stack_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{mock_config_entry.entry_id}_1_stack_2"),
+        mock_config_entry.entry_id,
+    )
+    assert stack_device is not None
+    assert stack_device.via_device_id == endpoint_device.id
 
 
 async def test_new_container_callback(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `portainer`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
