### PR TITLE
Fix via_device race in powerwall

### DIFF
--- a/homeassistant/components/powerwall/__init__.py
+++ b/homeassistant/components/powerwall/__init__.py
@@ -28,6 +28,8 @@ from .const import (
     AUTH_COOKIE_KEY,
     CONFIG_ENTRY_COOKIE,
     DOMAIN,
+    MANUFACTURER,
+    MODEL,
     POWERWALL_API_CHANGED,
     POWERWALL_COORDINATOR,
 )
@@ -237,6 +239,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: PowerwallConfigEntry) ->
     entry.runtime_data = runtime_data
 
     await async_migrate_entity_unique_ids(hass, entry, base_info)
+
+    # Register the gateway device so battery devices can link to it via
+    # via_device_id, which must resolve to an already-registered device.
+    model = (
+        f"{MODEL} ({base_info.device_type.name})"
+        if base_info.device_type is not None
+        else MODEL
+    )
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, gateway_din)},
+        manufacturer=MANUFACTURER,
+        model=model,
+        name=base_info.site_name,
+        sw_version=base_info.status.version if base_info.status else None,
+        configuration_url=base_info.url,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/powerwall/entity.py
+++ b/homeassistant/components/powerwall/entity.py
@@ -2,6 +2,7 @@
 
 from tesla_powerwall import BatteryResponse
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -65,7 +66,6 @@ class BatteryEntity(CoordinatorEntity[PowerwallUpdateCoordinator]):
         self.serial_number = battery.serial_number
         self.power_wall = powerwall_data[POWERWALL_API]
         self.base_unique_id = f"{base_info.gateway_din}_{battery.serial_number}"
-
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.base_unique_id)},
             manufacturer=MANUFACTURER,
@@ -73,7 +73,11 @@ class BatteryEntity(CoordinatorEntity[PowerwallUpdateCoordinator]):
             name=f"{base_info.site_name} {battery.serial_number}",
             sw_version=base_info.status.version if base_info.status else None,
             configuration_url=base_info.url,
-            via_device=(DOMAIN, base_info.gateway_din),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, base_info.gateway_din),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
         )
 
     @property

--- a/tests/components/powerwall/test_sensor.py
+++ b/tests/components/powerwall/test_sensor.py
@@ -59,6 +59,12 @@ async def test_sensors(hass: HomeAssistant, device_registry: dr.DeviceRegistry) 
     assert reg_device.manufacturer == "Tesla"
     assert reg_device.name == "MySite"
 
+    battery_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_GATEWAY_DIN}_TG0123456789AB"), config_entry.entry_id
+    )
+    assert battery_device is not None
+    assert battery_device.via_device_id == reg_device.id
+
     state = hass.states.get("sensor.mysite_load_power")
     assert state.state == "1.971"
     attributes = state.attributes


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `powerwall`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
