### PR TITLE
Fix via_device race in proxmoxve

### DIFF
--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -4,7 +4,7 @@ import logging
 
 from homeassistant.const import CONF_TOKEN, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import (
     AUTH_OTHER,
@@ -15,6 +15,7 @@ from .const import (
     DEFAULT_REALM,
 )
 from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
+from .entity import node_device_info
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -32,6 +33,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ProxmoxConfigEntry) -> b
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register node devices before forwarding platforms so that child devices
+    # (VMs, containers, storages) can deterministically resolve their via_device.
+    device_registry = dr.async_get(hass)
+    for node_data in coordinator.data.values():
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            **node_device_info(coordinator, node_data),
+        )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/homeassistant/components/proxmoxve/__init__.py
+++ b/homeassistant/components/proxmoxve/__init__.py
@@ -14,8 +14,7 @@ from .const import (
     CONF_REALM,
     DEFAULT_REALM,
 )
-from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator
-from .entity import node_device_info
+from .coordinator import ProxmoxConfigEntry, ProxmoxCoordinator, node_device_info
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,

--- a/homeassistant/components/proxmoxve/coordinator.py
+++ b/homeassistant/components/proxmoxve/coordinator.py
@@ -10,6 +10,7 @@ from proxmoxer import AuthenticationError, ProxmoxAPI
 from proxmoxer.core import ResourceException
 import requests
 from requests.exceptions import ConnectTimeout, SSLError
+from yarl import URL
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -62,6 +63,32 @@ class ProxmoxNodeData:
     containers: dict[int, dict[str, Any]] = field(default_factory=dict)
     storages: dict[str, dict[str, Any]] = field(default_factory=dict)
     backups: list[dict[str, Any]] = field(default_factory=list)
+
+
+def proxmox_base_url(coordinator: ProxmoxCoordinator) -> URL:
+    """Return the base URL for the Proxmox VE."""
+    data = coordinator.config_entry.data
+    return URL.build(
+        scheme="https",
+        host=data[CONF_HOST],
+        port=data[CONF_PORT],
+    )
+
+
+def node_device_info(
+    coordinator: ProxmoxCoordinator, node_data: ProxmoxNodeData
+) -> dr.DeviceInfo:
+    """Return the device info for a Proxmox VE node device."""
+    return dr.DeviceInfo(
+        identifiers={
+            (DOMAIN, f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}")
+        },
+        name=node_data.node.get("node", str(node_data.node["id"])),
+        model="Node",
+        configuration_url=proxmox_base_url(coordinator).with_fragment(
+            f"v1:0:=node/{node_data.node['node']}"
+        ),
+    )
 
 
 class ProxmoxCoordinator(DataUpdateCoordinator[dict[str, ProxmoxNodeData]]):
@@ -268,6 +295,12 @@ class ProxmoxCoordinator(DataUpdateCoordinator[dict[str, ProxmoxNodeData]]):
             _LOGGER.debug("New nodes found: %s", new_nodes)
             self.known_nodes.update(new_nodes)
             new_node_data = [data[node_name] for node_name in new_nodes]
+            device_registry = dr.async_get(self.hass)
+            for node_data in new_node_data:
+                device_registry.async_get_or_create(
+                    config_entry_id=self.config_entry.entry_id,
+                    **node_device_info(self, node_data),
+                )
             for nodes_callback in self.new_nodes_callbacks:
                 nodes_callback(new_node_data)
 

--- a/homeassistant/components/proxmoxve/entity.py
+++ b/homeassistant/components/proxmoxve/entity.py
@@ -2,41 +2,18 @@
 
 from typing import Any, override
 
-from yarl import URL
-
-from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import ProxmoxCoordinator, ProxmoxNodeData
-
-
-def _proxmox_base_url(coordinator: ProxmoxCoordinator) -> URL:
-    """Return the base URL for the Proxmox VE."""
-    data = coordinator.config_entry.data
-    return URL.build(
-        scheme="https",
-        host=data[CONF_HOST],
-        port=data[CONF_PORT],
-    )
-
-
-def node_device_info(
-    coordinator: ProxmoxCoordinator, node_data: ProxmoxNodeData
-) -> DeviceInfo:
-    """Return the device info for a Proxmox VE node device."""
-    device_id = node_data.node["id"]
-    return DeviceInfo(
-        identifiers={(DOMAIN, f"{coordinator.config_entry.entry_id}_node_{device_id}")},
-        name=node_data.node.get("node", str(device_id)),
-        model="Node",
-        configuration_url=_proxmox_base_url(coordinator).with_fragment(
-            f"v1:0:=node/{node_data.node['node']}"
-        ),
-    )
+from .coordinator import (
+    ProxmoxCoordinator,
+    ProxmoxNodeData,
+    node_device_info,
+    proxmox_base_url,
+)
 
 
 class ProxmoxCoordinatorEntity(CoordinatorEntity[ProxmoxCoordinator]):
@@ -102,7 +79,7 @@ class ProxmoxStorageEntity(ProxmoxCoordinatorEntity):
             },
             name=f"Storage ({self.device_name})",
             model="Storage",
-            configuration_url=_proxmox_base_url(coordinator).with_fragment(
+            configuration_url=proxmox_base_url(coordinator).with_fragment(
                 f"v1:0:=storage/{self._node_name}/{storage_data['storage']}"
             ),
             via_device_id=dr.async_get_device_id_by_identifier(
@@ -161,7 +138,7 @@ class ProxmoxVMEntity(ProxmoxCoordinatorEntity):
             },
             name=self.device_name,
             model="VM",
-            configuration_url=_proxmox_base_url(coordinator).with_fragment(
+            configuration_url=proxmox_base_url(coordinator).with_fragment(
                 f"v1:0:=qemu/{vm_data['vmid']}"
             ),
             via_device_id=dr.async_get_device_id_by_identifier(
@@ -222,7 +199,7 @@ class ProxmoxContainerEntity(ProxmoxCoordinatorEntity):
             },
             name=self.device_name,
             model="Container",
-            configuration_url=_proxmox_base_url(coordinator).with_fragment(
+            configuration_url=proxmox_base_url(coordinator).with_fragment(
                 f"v1:0:=lxc/{container_data['vmid']}"
             ),
             via_device_id=dr.async_get_device_id_by_identifier(

--- a/homeassistant/components/proxmoxve/entity.py
+++ b/homeassistant/components/proxmoxve/entity.py
@@ -5,6 +5,7 @@ from typing import Any, override
 from yarl import URL
 
 from homeassistant.const import CONF_HOST, CONF_PORT
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -20,6 +21,21 @@ def _proxmox_base_url(coordinator: ProxmoxCoordinator) -> URL:
         scheme="https",
         host=data[CONF_HOST],
         port=data[CONF_PORT],
+    )
+
+
+def node_device_info(
+    coordinator: ProxmoxCoordinator, node_data: ProxmoxNodeData
+) -> DeviceInfo:
+    """Return the device info for a Proxmox VE node device."""
+    device_id = node_data.node["id"]
+    return DeviceInfo(
+        identifiers={(DOMAIN, f"{coordinator.config_entry.entry_id}_node_{device_id}")},
+        name=node_data.node.get("node", str(device_id)),
+        model="Node",
+        configuration_url=_proxmox_base_url(coordinator).with_fragment(
+            f"v1:0:=node/{node_data.node['node']}"
+        ),
     )
 
 
@@ -44,16 +60,7 @@ class ProxmoxNodeEntity(ProxmoxCoordinatorEntity):
         self.device_id = node_data.node["id"]
         self.device_name = node_data.node["node"]
         self.entity_description = entity_description
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, f"{coordinator.config_entry.entry_id}_node_{self.device_id}")
-            },
-            name=node_data.node.get("node", str(self.device_id)),
-            model="Node",
-            configuration_url=_proxmox_base_url(coordinator).with_fragment(
-                f"v1:0:=node/{node_data.node['node']}"
-            ),
-        )
+        self._attr_device_info = node_device_info(coordinator, node_data)
 
         self._attr_unique_id = (
             f"{coordinator.config_entry.entry_id}"
@@ -98,9 +105,13 @@ class ProxmoxStorageEntity(ProxmoxCoordinatorEntity):
             configuration_url=_proxmox_base_url(coordinator).with_fragment(
                 f"v1:0:=storage/{self._node_name}/{storage_data['storage']}"
             ),
-            via_device=(
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (
+                    DOMAIN,
+                    f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}",
+                ),
+                config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
 
@@ -153,9 +164,13 @@ class ProxmoxVMEntity(ProxmoxCoordinatorEntity):
             configuration_url=_proxmox_base_url(coordinator).with_fragment(
                 f"v1:0:=qemu/{vm_data['vmid']}"
             ),
-            via_device=(
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (
+                    DOMAIN,
+                    f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}",
+                ),
+                config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
 
@@ -210,9 +225,13 @@ class ProxmoxContainerEntity(ProxmoxCoordinatorEntity):
             configuration_url=_proxmox_base_url(coordinator).with_fragment(
                 f"v1:0:=lxc/{container_data['vmid']}"
             ),
-            via_device=(
-                DOMAIN,
-                f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (
+                    DOMAIN,
+                    f"{coordinator.config_entry.entry_id}_node_{node_data.node['id']}",
+                ),
+                config_entry_id=coordinator.config_entry.entry_id,
             ),
         )
 

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -1,8 +1,8 @@
 """Tests for the Proxmox VE integration initialization."""
 
-from typing import Any
 from unittest.mock import MagicMock
 
+from freezegun.api import FrozenDateTimeFactory
 from proxmoxer import AuthenticationError
 from proxmoxer.core import ResourceException
 import pytest
@@ -17,8 +17,7 @@ from homeassistant.components.proxmoxve.const import (
     DOMAIN,
 )
 from homeassistant.components.proxmoxve.coordinator import (
-    ProxmoxCoordinator,
-    ProxmoxNodeData,
+    DEFAULT_UPDATE_INTERVAL,
     ProxmoxNodesNotFoundError,
     ProxmoxPermissionsError,
 )
@@ -37,7 +36,11 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from . import setup_integration
 
-from tests.common import MockConfigEntry, async_load_json_array_fixture
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    async_load_json_array_fixture,
+)
 
 
 @pytest.mark.parametrize(
@@ -431,51 +434,75 @@ async def test_child_devices_link_to_node(
     assert child_device.via_device_id == node_device.id
 
 
-async def test_new_node_device_registered_before_resource_callbacks(
+async def test_new_node_registers_device_before_children(
     hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test a newly discovered node's device exists before new VM/container/storage callbacks run.
+    """Test a node discovered after setup registers its device before its children.
 
     Regression test for a race where a newly discovered node's VM/container/
-    storage entities could be built before the node's own device was
-    registered, causing via_device_id resolution to raise ValueError.
+    storage entities were built before the node's own device was registered,
+    causing via_device_id resolution to raise ValueError.
+
+    Without audit permissions the node surfaces no entities of its own, so the
+    node device is only registered by the coordinator: without that explicit
+    registration its child (the configured VM, whose entities are always
+    created) cannot resolve its via_device_id.
     """
-    mock_config_entry.add_to_hass(hass)
-    coordinator = ProxmoxCoordinator(hass, mock_config_entry)
+    mock_proxmox_client.access.permissions.get.return_value = {}
+
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # setup_integration enables disabled-by-default entities, which schedules a
+    # debounced config entry reload; let it settle so it doesn't coincide with
+    # (and mask, via a fresh setup) the refresh that discovers the new node.
+    freezer.tick(DEFAULT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    # A second node, bringing its own VM, appears on the next refresh.
+    pve2_vm = {
+        **(await async_load_json_array_fixture(hass, "nodes/qemu.json", DOMAIN))[0],
+        "vmid": 300,
+        "name": "vm-pve2",
+    }
+    pve2_node_mock = MagicMock()
+    pve2_node_mock.qemu.get.return_value = [pve2_vm]
+    pve2_node_mock.lxc.get.return_value = []
+    pve2_node_mock.storage.get.return_value = []
+    pve2_node_mock.tasks.get.return_value = []
+
+    default_node_mock = mock_proxmox_client._node_mock
+    mock_proxmox_client._nodes_mock.side_effect = lambda node: (
+        pve2_node_mock if node == "pve2" else default_node_mock
+    )
+    mock_proxmox_client.nodes.get.return_value = [
+        node
+        for node in mock_proxmox_client._all_nodes
+        if node["node"] in ("pve1", "pve2")
+    ]
+
+    freezer.tick(DEFAULT_UPDATE_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.runtime_data.last_update_success
 
     entry_id = mock_config_entry.entry_id
-    resolved_via_device_ids: list[str] = []
-
-    def _resolve_via_device_on_new_vms(
-        vms: list[tuple[ProxmoxNodeData, dict[str, Any]]],
-    ) -> None:
-        """Mimic what ProxmoxVMEntity.__init__ does when a VM is discovered."""
-        for node_data, _vm in vms:
-            resolved_via_device_ids.append(
-                dr.async_get_device_id_by_identifier(
-                    hass,
-                    (DOMAIN, f"{entry_id}_node_{node_data.node['id']}"),
-                    config_entry_id=entry_id,
-                )
-            )
-
-    coordinator.new_vms_callbacks.append(_resolve_via_device_on_new_vms)
-
-    node_data = ProxmoxNodeData(
-        node={"id": "node/pve2", "node": "pve2"},
-        vms={300: {"vmid": 300, "name": "vm-pve2"}},
-    )
-    coordinator._async_add_remove_nodes({"pve2": node_data})
-
-    assert resolved_via_device_ids
-
     node_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, f"{entry_id}_node_node/pve2"), entry_id
     )
     assert node_device is not None
-    assert resolved_via_device_ids == [node_device.id]
+
+    vm_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_vm_300"), entry_id
+    )
+    assert vm_device is not None
+    assert vm_device.via_device_id == node_device.id
 
 
 async def test_stale_devices_removed(

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -490,8 +490,6 @@ async def test_new_node_registers_device_before_children(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert mock_config_entry.runtime_data.last_update_success
-
     entry_id = mock_config_entry.entry_id
     node_device = device_registry.async_get_device_by_identifier(
         (DOMAIN, f"{entry_id}_node_node/pve2"), entry_id
@@ -503,6 +501,11 @@ async def test_new_node_registers_device_before_children(
     )
     assert vm_device is not None
     assert vm_device.via_device_id == node_device.id
+
+    # The new node's VM entity was built and populated from the refresh.
+    state = hass.states.get("binary_sensor.vm_pve2_status")
+    assert state is not None
+    assert state.state == STATE_ON
 
 
 async def test_stale_devices_removed(

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Proxmox VE integration initialization."""
 
+from typing import Any
 from unittest.mock import MagicMock
 
 from proxmoxer import AuthenticationError
@@ -16,6 +17,8 @@ from homeassistant.components.proxmoxve.const import (
     DOMAIN,
 )
 from homeassistant.components.proxmoxve.coordinator import (
+    ProxmoxCoordinator,
+    ProxmoxNodeData,
     ProxmoxNodesNotFoundError,
     ProxmoxPermissionsError,
 )
@@ -404,9 +407,9 @@ async def test_new_container_creates_entity(
     "child_identifier",
     ["vm_100", "vm_101", "container_200", "container_201", "storage_local"],
 )
+@pytest.mark.usefixtures("mock_proxmox_client")
 async def test_child_devices_link_to_node(
     hass: HomeAssistant,
-    mock_proxmox_client: MagicMock,
     mock_config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     child_identifier: str,
@@ -416,16 +419,63 @@ async def test_child_devices_link_to_node(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     entry_id = mock_config_entry.entry_id
-    node_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry_id}_node_node/pve1")}
+    node_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_node_node/pve1"), entry_id
     )
     assert node_device is not None
 
-    child_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{entry_id}_{child_identifier}")}
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_{child_identifier}"), entry_id
     )
     assert child_device is not None
     assert child_device.via_device_id == node_device.id
+
+
+async def test_new_node_device_registered_before_resource_callbacks(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a newly discovered node's device exists before new VM/container/storage callbacks run.
+
+    Regression test for a race where a newly discovered node's VM/container/
+    storage entities could be built before the node's own device was
+    registered, causing via_device_id resolution to raise ValueError.
+    """
+    mock_config_entry.add_to_hass(hass)
+    coordinator = ProxmoxCoordinator(hass, mock_config_entry)
+
+    entry_id = mock_config_entry.entry_id
+    resolved_via_device_ids: list[str] = []
+
+    def _resolve_via_device_on_new_vms(
+        vms: list[tuple[ProxmoxNodeData, dict[str, Any]]],
+    ) -> None:
+        """Mimic what ProxmoxVMEntity.__init__ does when a VM is discovered."""
+        for node_data, _vm in vms:
+            resolved_via_device_ids.append(
+                dr.async_get_device_id_by_identifier(
+                    hass,
+                    (DOMAIN, f"{entry_id}_node_{node_data.node['id']}"),
+                    config_entry_id=entry_id,
+                )
+            )
+
+    coordinator.new_vms_callbacks.append(_resolve_via_device_on_new_vms)
+
+    node_data = ProxmoxNodeData(
+        node={"id": "node/pve2", "node": "pve2"},
+        vms={300: {"vmid": 300, "name": "vm-pve2"}},
+    )
+    coordinator._async_add_remove_nodes({"pve2": node_data})
+
+    assert resolved_via_device_ids
+
+    node_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{entry_id}_node_node/pve2"), entry_id
+    )
+    assert node_device is not None
+    assert resolved_via_device_ids == [node_device.id]
 
 
 async def test_stale_devices_removed(

--- a/tests/components/proxmoxve/test_init.py
+++ b/tests/components/proxmoxve/test_init.py
@@ -400,6 +400,34 @@ async def test_new_container_creates_entity(
     )
 
 
+@pytest.mark.parametrize(
+    "child_identifier",
+    ["vm_100", "vm_101", "container_200", "container_201", "storage_local"],
+)
+async def test_child_devices_link_to_node(
+    hass: HomeAssistant,
+    mock_proxmox_client: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    child_identifier: str,
+) -> None:
+    """Test that VM/container/storage devices link to their node via via_device_id."""
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    entry_id = mock_config_entry.entry_id
+    node_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{entry_id}_node_node/pve1")}
+    )
+    assert node_device is not None
+
+    child_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{entry_id}_{child_identifier}")}
+    )
+    assert child_device is not None
+    assert child_device.via_device_id == node_device.id
+
+
 async def test_stale_devices_removed(
     hass: HomeAssistant,
     mock_proxmox_client: MagicMock,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `proxmoxve`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
