### PR TITLE
Fix via_device race in rainbird

### DIFF
--- a/homeassistant/components/rainbird/__init__.py
+++ b/homeassistant/components/rainbird/__init__.py
@@ -130,6 +130,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: RainbirdConfigEntry) -> 
     await data.coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = data
+
+    # Register the controller device up front so that child zone/switch devices
+    # can resolve their via_device_id link during platform setup, regardless of
+    # which platform loads first.
+    if device_info := data.coordinator.device_info:
+        dr.async_get(hass).async_get_or_create(
+            config_entry_id=entry.entry_id, **device_info
+        )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_update_listener))

--- a/homeassistant/components/rainbird/switch.py
+++ b/homeassistant/components/rainbird/switch.py
@@ -8,6 +8,7 @@ from pyrainbird.exceptions import RainbirdApiException, RainbirdDeviceBusyExcept
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -66,7 +67,11 @@ class RainBirdSwitch(CoordinatorEntity[RainbirdUpdateCoordinator], SwitchEntity)
                 name=device_name,
                 identifiers={(DOMAIN, self._attr_unique_id)},
                 manufacturer=MANUFACTURER,
-                via_device=(DOMAIN, coordinator.unique_id),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, coordinator.unique_id),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                ),
             )
 
     @property

--- a/tests/components/rainbird/test_init.py
+++ b/tests/components/rainbird/test_init.py
@@ -549,9 +549,11 @@ async def test_reload_migration_with_leading_zero_mac(
     assert reloaded_entity_entry is not None
     assert reloaded_entity_entry.unique_id == f"{mac_address_unique_id}-1-zone1"
 
+    # Two devices: the controller (registered at setup) and the migrated zone
+    # device. Neither was duplicated by the reload.
     assert (
         len(dr.async_entries_for_config_entry(device_registry, config_entry.entry_id))
-        == 1
+        == 2
     )
     assert (
         len(er.async_entries_for_config_entry(entity_registry, config_entry.entry_id))

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -114,19 +114,20 @@ async def test_zones(
     assert entity_entry.unique_id == "4c:a1:61:00:11:22-3"
 
 
+@pytest.mark.usefixtures("hass")
 async def test_zone_device_linked_to_controller(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
 ) -> None:
     """Test the zone switch device is linked to the controller device."""
 
-    controller_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
+    controller_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MAC_ADDRESS_UNIQUE_ID), config_entry.entry_id
     )
     assert controller_device is not None
 
-    zone_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MAC_ADDRESS_UNIQUE_ID}-1")}
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MAC_ADDRESS_UNIQUE_ID}-1"), config_entry.entry_id
     )
     assert zone_device is not None
     assert zone_device.via_device_id == controller_device.id

--- a/tests/components/rainbird/test_switch.py
+++ b/tests/components/rainbird/test_switch.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import (
     ACK_ECHO,
@@ -17,6 +17,7 @@ from .conftest import (
     EMPTY_STATIONS_RESPONSE,
     HOST,
     MAC_ADDRESS,
+    MAC_ADDRESS_UNIQUE_ID,
     PASSWORD,
     RAIN_DELAY_OFF,
     RAIN_SENSOR_OFF,
@@ -111,6 +112,24 @@ async def test_zones(
     # Verify unique id for one of the switches
     entity_entry = entity_registry.async_get("switch.rain_bird_sprinkler_3")
     assert entity_entry.unique_id == "4c:a1:61:00:11:22-3"
+
+
+async def test_zone_device_linked_to_controller(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the zone switch device is linked to the controller device."""
+
+    controller_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, MAC_ADDRESS_UNIQUE_ID)}
+    )
+    assert controller_device is not None
+
+    zone_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MAC_ADDRESS_UNIQUE_ID}-1")}
+    )
+    assert zone_device is not None
+    assert zone_device.via_device_id == controller_device.id
 
 
 async def test_switch_on(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `rainbird`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
