### PR TITLE
Fix via_device race in reolink

### DIFF
--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -236,17 +236,18 @@ async def async_setup_entry(
     )
 
     if host.api.is_nvr and host.api.model in DUAL_LENS_DUAL_MOTION_MODELS:
-        # ensure the camera device is setup before
+        # ensure the camera devices are setup before
         # the lens sub-devices that use via_device
-        if host.api.supported(0, "UID"):
-            camera_dev_id = f"{host.unique_id}_{host.api.camera_uid(0)}"
-        else:
-            camera_dev_id = f"{host.unique_id}_ch0"
-        device_registry.async_get_or_create(
-            config_entry_id=config_entry.entry_id,
-            identifiers={(DOMAIN, camera_dev_id)},
-            via_device_id=host_device.id,
-        )
+        for channel in host.api.stream_channels:
+            if host.api.supported(channel, "UID"):
+                camera_dev_id = f"{host.unique_id}_{host.api.camera_uid(channel)}"
+            else:
+                camera_dev_id = f"{host.unique_id}_ch{channel}"
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry.entry_id,
+                identifiers={(DOMAIN, camera_dev_id)},
+                via_device_id=host_device.id,
+            )
 
     # ensure the camera devices that chimes connect through are setup
     # before the chime sub-devices that use via_device

--- a/homeassistant/components/reolink/__init__.py
+++ b/homeassistant/components/reolink/__init__.py
@@ -229,7 +229,7 @@ async def async_setup_entry(
 
     # ensure host device is setup before connected camera devices that use via_device
     device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
+    host_device = device_registry.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, host.unique_id)},
         connections={(dr.CONNECTION_NETWORK_MAC, host.api.mac_address)},
@@ -245,7 +245,22 @@ async def async_setup_entry(
         device_registry.async_get_or_create(
             config_entry_id=config_entry.entry_id,
             identifiers={(DOMAIN, camera_dev_id)},
-            via_device=(DOMAIN, host.unique_id),
+            via_device_id=host_device.id,
+        )
+
+    # ensure the camera devices that chimes connect through are setup
+    # before the chime sub-devices that use via_device
+    for chime in host.api.chime_list:
+        if chime.channel is None or not host.api.is_nvr:
+            continue  # chime connected directly to the host device
+        if host.api.supported(chime.channel, "UID"):
+            camera_dev_id = f"{host.unique_id}_{host.api.camera_uid(chime.channel)}"
+        else:
+            camera_dev_id = f"{host.unique_id}_ch{chime.channel}"
+        device_registry.async_get_or_create(
+            config_entry_id=config_entry.entry_id,
+            identifiers={(DOMAIN, camera_dev_id)},
+            via_device_id=host_device.id,
         )
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)

--- a/homeassistant/components/reolink/entity.py
+++ b/homeassistant/components/reolink/entity.py
@@ -7,6 +7,7 @@ from typing import override
 from reolink_aio.api import DUAL_LENS_DUAL_MOTION_MODELS, Chime, Host
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -210,7 +211,11 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._dev_id)},
                 connections=connections,
-                via_device=(DOMAIN, self._host.unique_id),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, self._host.unique_id),
+                    config_entry_id=self.coordinator.config_entry.entry_id,
+                ),
                 name=self._host.api.camera_name(channel),
                 model=self._host.api.camera_model(channel),
                 model_id=self._host.api.item_number(channel),
@@ -231,7 +236,11 @@ class ReolinkChannelCoordinatorEntity(ReolinkHostCoordinatorEntity):
             self._dev_id = f"{self._host.unique_id}_lens{channel}"
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, self._dev_id)},
-                via_device=(DOMAIN, parent_dev_id),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, parent_dev_id),
+                    config_entry_id=self.coordinator.config_entry.entry_id,
+                ),
                 name=f"{self._host.api.camera_name(0)} lens {channel}",
                 model=self._host.api.camera_model(0),
                 manufacturer=self._host.api.manufacturer,
@@ -298,7 +307,11 @@ class ReolinkHostChimeCoordinatorEntity(ReolinkHostCoordinatorEntity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._dev_id)},
-            via_device=(DOMAIN, via_dev_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, via_dev_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             name=chime.name,
             model="Reolink Chime",
             manufacturer=self._host.api.manufacturer,
@@ -336,7 +349,11 @@ class ReolinkChimeCoordinatorEntity(ReolinkChannelCoordinatorEntity):
 
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._dev_id)},
-            via_device=(DOMAIN, via_dev_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, via_dev_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             name=chime.name,
             model="Reolink Chime",
             manufacturer=self._host.api.manufacturer,

--- a/tests/components/reolink/test_binary_sensor.py
+++ b/tests/components/reolink/test_binary_sensor.py
@@ -196,6 +196,36 @@ async def test_dual_lens_sub_devices_nvr(
     assert lens_device.via_device_id == parent_device.id
 
 
+async def test_dual_lens_sub_devices_nvr_multi_channel(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_host: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a lens sub-device on channel >= 1 links to its camera device on a NVR host."""
+    reolink_host.model = TEST_DUO_MODEL
+    reolink_host.channels = [0, 1]
+    reolink_host.stream_channels = [0, 1]
+    # channel 1 camera device uses the "_ch{channel}" id (no UID support)
+    reolink_host.supported.side_effect = lambda ch, cap: (
+        not (cap == "UID" and ch is not None)
+    )
+
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.BINARY_SENSOR]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_UID}_ch1"), config_entry.entry_id
+    )
+    assert parent_device is not None
+    lens_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_UID}_lens1"), config_entry.entry_id
+    )
+    assert lens_device is not None
+    assert lens_device.via_device_id == parent_device.id
+
+
 async def test_smart_ai_sensor(
     hass: HomeAssistant,
     freezer: FrozenDateTimeFactory,

--- a/tests/components/reolink/test_init.py
+++ b/tests/components/reolink/test_init.py
@@ -339,6 +339,36 @@ async def test_removing_chime(
     assert sorted(device_models) == sorted(expected_models)
 
 
+async def test_via_device_id_chain(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    reolink_chime: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the host -> camera -> chime devices are linked via via_device_id."""
+    with patch("homeassistant.components.reolink.PLATFORMS", [Platform.SWITCH]):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    host_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_UID), config_entry.entry_id
+    )
+    assert host_device is not None
+
+    camera_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_UID}_{TEST_UID_CAM}"), config_entry.entry_id
+    )
+    assert camera_device is not None
+    assert camera_device.via_device_id == host_device.id
+
+    chime_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_UID}_chime{reolink_chime.dev_id}"), config_entry.entry_id
+    )
+    assert chime_device is not None
+    assert chime_device.via_device_id == camera_device.id
+
+
 @pytest.mark.parametrize(
     (
         "original_id",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `reolink`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
