### PR TITLE
Fix via_device race in sense

### DIFF
--- a/homeassistant/components/sense/__init__.py
+++ b/homeassistant/components/sense/__init__.py
@@ -15,10 +15,12 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_TIMEOUT, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import (
     ACTIVE_UPDATE_RATE,
+    DOMAIN,
     SENSE_CONNECT_EXCEPTIONS,
     SENSE_TIMEOUT_EXCEPTIONS,
     SENSE_WEBSOCKET_EXCEPTIONS,
@@ -115,6 +117,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: SenseConfigEntry) -> boo
         data=gateway,
         trends=trends_coordinator,
         rt=realtime_coordinator,
+    )
+
+    # Register the monitor device up front so child devices can reference it via
+    # via_device_id; child entities are added by concurrently-loaded platforms
+    # before any of them registers the monitor device.
+    sense_monitor_id = gateway.sense_monitor_id
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        name=f"Sense {sense_monitor_id}",
+        identifiers={(DOMAIN, sense_monitor_id)},
+        model="Sense",
+        manufacturer="Sense Labs, Inc.",
+        configuration_url="https://home.sense.com",
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/sense/entity.py
+++ b/homeassistant/components/sense/entity.py
@@ -3,6 +3,7 @@
 from sense_energy import ASyncSenseable
 from sense_energy.sense_api import SenseDevice
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -67,5 +68,9 @@ class SenseDeviceEntity(CoordinatorEntity[SenseCoordinator]):
             model="Sense",
             manufacturer="Sense Labs, Inc.",
             configuration_url="https://home.sense.com",
-            via_device=(DOMAIN, sense_monitor_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, sense_monitor_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )

--- a/tests/components/sense/test_init.py
+++ b/tests/components/sense/test_init.py
@@ -22,9 +22,9 @@ from .const import DEVICE_1_ID, MONITOR_ID
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.usefixtures("mock_sense")
 async def test_device_via_device_link(
     hass: HomeAssistant,
-    mock_sense: MagicMock,
     config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
@@ -34,13 +34,13 @@ async def test_device_via_device_link(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    monitor_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MONITOR_ID)}
+    monitor_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MONITOR_ID), config_entry.entry_id
     )
     assert monitor_device is not None
 
-    child_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MONITOR_ID}:{DEVICE_1_ID}")}
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MONITOR_ID}:{DEVICE_1_ID}"), config_entry.entry_id
     )
     assert child_device is not None
     assert child_device.via_device_id == monitor_device.id

--- a/tests/components/sense/test_init.py
+++ b/tests/components/sense/test_init.py
@@ -12,10 +12,38 @@ from sense_energy import (
     SenseWebsocketException,
 )
 
+from homeassistant.components.sense.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .const import DEVICE_1_ID, MONITOR_ID
 
 from tests.common import MockConfigEntry
+
+
+async def test_device_via_device_link(
+    hass: HomeAssistant,
+    mock_sense: MagicMock,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test child devices link to the monitor device via via_device_id."""
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    monitor_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, MONITOR_ID)}
+    )
+    assert monitor_device is not None
+
+    child_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, f"{MONITOR_ID}:{DEVICE_1_ID}")}
+    )
+    assert child_device is not None
+    assert child_device.via_device_id == monitor_device.id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `sense`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
