### PR TITLE
Fix via_device race in sensibo

### DIFF
--- a/homeassistant/components/sensibo/__init__.py
+++ b/homeassistant/components/sensibo/__init__.py
@@ -6,12 +6,17 @@ from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_API_KEY
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import config_validation as cv, entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.helpers.typing import ConfigType
 
 from .const import DOMAIN, LOGGER, PLATFORMS
 from .coordinator import SensiboDataUpdateCoordinator
+from .entity import get_device_info
 from .services import async_setup_services
 from .util import NoDevicesError, NoUsernameError, async_validate_api
 
@@ -33,6 +38,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: SensiboConfigEntry) -> b
     coordinator = SensiboDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+
+    device_registry = dr.async_get(hass)
+
+    def _async_register_devices() -> None:
+        """Register parent AC devices so motion sensors can resolve via_device_id.
+
+        Registered before the platforms so it runs first on every coordinator
+        update, ensuring a parent device exists before the (concurrently set up)
+        motion sensors resolve it, including devices added dynamically at runtime.
+        """
+        for device in coordinator.data.parsed.values():
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id, **get_device_info(device)
+            )
+
+    _async_register_devices()
+    entry.async_on_unload(coordinator.async_add_listener(_async_register_devices))
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/sensibo/entity.py
+++ b/homeassistant/components/sensibo/entity.py
@@ -7,11 +7,28 @@ from typing import TYPE_CHECKING, Any, Concatenate, override
 from pysensibo.model import MotionSensor, SensiboDevice
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, LOGGER, SENSIBO_ERRORS, TIMEOUT
 from .coordinator import SensiboDataUpdateCoordinator
+
+
+def get_device_info(device: SensiboDevice) -> DeviceInfo:
+    """Return device info for a Sensibo device."""
+    return DeviceInfo(
+        identifiers={(DOMAIN, device.id)},
+        name=device.name,
+        connections={(CONNECTION_NETWORK_MAC, device.mac)},
+        manufacturer="Sensibo",
+        configuration_url="https://home.sensibo.com/",
+        model=device.model,
+        sw_version=device.fw_ver,
+        hw_version=device.fw_type,
+        suggested_area=device.name,
+        serial_number=device.serial,
+    )
 
 
 def async_handle_api_call[_T: SensiboDeviceBaseEntity, **_P](
@@ -90,18 +107,7 @@ class SensiboDeviceBaseEntity(SensiboBaseEntity):
     ) -> None:
         """Initiate Sensibo Device."""
         super().__init__(coordinator, device_id)
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self.device_data.id)},
-            name=self.device_data.name,
-            connections={(CONNECTION_NETWORK_MAC, self.device_data.mac)},
-            manufacturer="Sensibo",
-            configuration_url="https://home.sensibo.com/",
-            model=self.device_data.model,
-            sw_version=self.device_data.fw_ver,
-            hw_version=self.device_data.fw_type,
-            suggested_area=self.device_data.name,
-            serial_number=self.device_data.serial,
-        )
+        self._attr_device_info = get_device_info(self.device_data)
 
 
 class SensiboMotionBaseEntity(SensiboBaseEntity):
@@ -120,7 +126,11 @@ class SensiboMotionBaseEntity(SensiboBaseEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, sensor_id)},
             name=f"{self.device_data.name} Motion Sensor",
-            via_device=(DOMAIN, device_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, device_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             manufacturer="Sensibo",
             configuration_url="https://home.sensibo.com/",
             model=sensor_data.model,

--- a/tests/components/sensibo/test_entity.py
+++ b/tests/components/sensibo/test_entity.py
@@ -1,7 +1,11 @@
 """The test for the sensibo entity."""
 
+from datetime import timedelta
+from typing import Any
 from unittest.mock import MagicMock
 
+from freezegun.api import FrozenDateTimeFactory
+from pysensibo.model import SensiboData
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -10,12 +14,14 @@ from homeassistant.components.climate import (
     DOMAIN as CLIMATE_DOMAIN,
     SERVICE_SET_FAN_MODE,
 )
-from homeassistant.components.sensibo.const import SENSIBO_ERRORS
+from homeassistant.components.sensibo.const import DOMAIN, SENSIBO_ERRORS
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_ENTITY_ID
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
+
+from tests.common import async_fire_time_changed
 
 
 async def test_device(
@@ -34,6 +40,78 @@ async def test_device(
     )
     device_entries.sort(key=lambda d: d.name)
     assert device_entries == snapshot
+
+
+@pytest.mark.parametrize("load_platforms", [[Platform.BINARY_SENSOR]])
+async def test_motion_sensor_via_device(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    load_int: ConfigEntry,
+) -> None:
+    """Test the motion sensor is linked to its parent device.
+
+    Only the binary sensor platform is loaded so that the parent device is
+    solely registered during setup, guarding against the child resolving its
+    via_device_id before the parent exists.
+    """
+    parent_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "ABC999111")}
+    )
+    assert parent_device
+    motion_device = device_registry.async_get_device(identifiers={(DOMAIN, "AABBCC")})
+    assert motion_device
+    assert motion_device.via_device_id == parent_device.id
+
+
+@pytest.mark.parametrize("load_platforms", [[Platform.BINARY_SENSOR]])
+async def test_motion_sensor_via_device_dynamic_add(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    load_int: ConfigEntry,
+    mock_client: MagicMock,
+    get_data: tuple[SensiboData, dict[str, Any], dict[str, Any]],
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the motion sensor links to its parent when added at runtime.
+
+    Only the binary sensor platform is loaded, so the parent AC device is
+    registered solely by the integration, never by a climate entity. The parent
+    is removed and re-added via a coordinator update to exercise the dynamic-add
+    path, where the motion sensor must still resolve its parent's via_device_id.
+    """
+    new_result = [
+        device for device in get_data[2]["result"] if device["id"] != "ABC999111"
+    ]
+    new_parsed = {k: v for k, v in get_data[0].parsed.items() if k != "ABC999111"}
+    mock_client.async_get_devices.return_value = {
+        "status": "success",
+        "result": new_result,
+    }
+    mock_client.async_get_devices_data.return_value = SensiboData(
+        new_result, new_parsed
+    )
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert not device_registry.async_get_device(identifiers={(DOMAIN, "ABC999111")})
+    assert not device_registry.async_get_device(identifiers={(DOMAIN, "AABBCC")})
+
+    mock_client.async_get_devices.return_value = get_data[2]
+    mock_client.async_get_devices_data.return_value = get_data[0]
+
+    freezer.tick(timedelta(minutes=5))
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    parent_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "ABC999111")}
+    )
+    assert parent_device
+    motion_device = device_registry.async_get_device(identifiers={(DOMAIN, "AABBCC")})
+    assert motion_device
+    assert motion_device.via_device_id == parent_device.id
 
 
 @pytest.mark.parametrize("p_error", SENSIBO_ERRORS)

--- a/tests/components/sensibo/test_entity.py
+++ b/tests/components/sensibo/test_entity.py
@@ -43,8 +43,8 @@ async def test_device(
 
 
 @pytest.mark.parametrize("load_platforms", [[Platform.BINARY_SENSOR]])
+@pytest.mark.usefixtures("hass")
 async def test_motion_sensor_via_device(
-    hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     load_int: ConfigEntry,
 ) -> None:
@@ -54,11 +54,13 @@ async def test_motion_sensor_via_device(
     solely registered during setup, guarding against the child resolving its
     via_device_id before the parent exists.
     """
-    parent_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "ABC999111")}
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ABC999111"), load_int.entry_id
     )
     assert parent_device
-    motion_device = device_registry.async_get_device(identifiers={(DOMAIN, "AABBCC")})
+    motion_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "AABBCC"), load_int.entry_id
+    )
     assert motion_device
     assert motion_device.via_device_id == parent_device.id
 
@@ -95,8 +97,12 @@ async def test_motion_sensor_via_device_dynamic_add(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "ABC999111")})
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "AABBCC")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ABC999111"), load_int.entry_id
+    )
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "AABBCC"), load_int.entry_id
+    )
 
     mock_client.async_get_devices.return_value = get_data[2]
     mock_client.async_get_devices_data.return_value = get_data[0]
@@ -105,11 +111,13 @@ async def test_motion_sensor_via_device_dynamic_add(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    parent_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "ABC999111")}
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ABC999111"), load_int.entry_id
     )
     assert parent_device
-    motion_device = device_registry.async_get_device(identifiers={(DOMAIN, "AABBCC")})
+    motion_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "AABBCC"), load_int.entry_id
+    )
     assert motion_device
     assert motion_device.via_device_id == parent_device.id
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `sensibo`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
