### PR TITLE
Fix via_device race in solarlog

### DIFF
--- a/homeassistant/components/solarlog/__init__.py
+++ b/homeassistant/components/solarlog/__init__.py
@@ -8,10 +8,10 @@ from solarlog_cli.solarlog_connector import SolarLogConnector
 
 from homeassistant.const import CONF_HOST, CONF_TIMEOUT, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_HAS_PWD, DEFAULT_TIMEOUT
+from .const import CONF_HAS_PWD, DEFAULT_TIMEOUT, DOMAIN
 from .coordinator import (
     SolarLogBasicDataCoordinator,
     SolarlogConfigEntry,
@@ -76,6 +76,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: SolarlogConfigEntry) -> 
         device_coordinator = SolarLogDeviceDataCoordinator(hass, entry, solarlog)
         entry.runtime_data.device_data_coordinator = device_coordinator
         await device_coordinator.async_config_entry_first_refresh()
+
+    # Register the controller device so inverter entities can resolve it as
+    # their via_device parent when they are added.
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        manufacturer="Solar-Log",
+        model="Controller",
+        name="SolarLog",
+        configuration_url=solarlog.host,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/solarlog/entity.py
+++ b/homeassistant/components/solarlog/entity.py
@@ -1,6 +1,7 @@
 """Entities for SolarLog integration."""
 
 from homeassistant.components.sensor import SensorEntityDescription
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import slugify
@@ -57,8 +58,12 @@ class SolarLogInverterEntity(CoordinatorEntity[SolarLogDeviceDataCoordinator]):
             manufacturer="Solar-Log",
             model="Inverter",
             identifiers={(DOMAIN, name)},
-            name=coordinator.solarlog.device_name(device_id),
-            via_device=(DOMAIN, coordinator.config_entry.entry_id),
+            name=device_name,
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.entry_id),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
         self.device_id = device_id
         self.entity_description = description

--- a/tests/components/solarlog/test_sensor.py
+++ b/tests/components/solarlog/test_sensor.py
@@ -12,6 +12,7 @@ from solarlog_cli.solarlog_exceptions import (
 from solarlog_cli.solarlog_models import InverterData
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.solarlog.const import DOMAIN
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceRegistry
@@ -76,6 +77,30 @@ async def test_add_remove_entities(
     assert hass.states.get("sensor.inv_1_consumption_year").state == "354.687"
     assert hass.states.get("sensor.inverter_2_consumption_year") is None
     assert hass.states.get("sensor.inverter_3_consumption_year").state == "0.454"
+
+
+@pytest.mark.usefixtures("mock_solarlog_connector")
+async def test_inverter_via_device_id(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: DeviceRegistry,
+    entity_registry: EntityRegistry,
+) -> None:
+    """Test inverter devices are linked to the controller device via via_device_id."""
+    await setup_platform(hass, mock_config_entry, [Platform.SENSOR])
+
+    controller_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    )
+    assert controller_device is not None
+
+    entity = entity_registry.async_get("sensor.inverter_1_consumption_year")
+    assert entity is not None
+    assert entity.device_id is not None
+    inverter_device = device_registry.async_get(entity.device_id)
+    assert inverter_device is not None
+
+    assert inverter_device.via_device_id == controller_device.id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `solarlog`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
