### PR TITLE
Fixed device key retrieval issue for Midea

### DIFF
--- a/homeassistant/components/midea/config_flow.py
+++ b/homeassistant/components/midea/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for Midea."""
 
+from functools import partial
 from operator import itemgetter
 from typing import Any, override
 
@@ -46,6 +47,40 @@ def _connect_and_close(dm: MideaDevice) -> bool:
         return dm.connect(check_protocol=True)
     finally:
         dm.close_socket()
+
+
+def _select_and_connect(
+    *,
+    device_id: int,
+    device_type: int,
+    ip_address: str,
+    port: int,
+    token: str,
+    key: str,
+    device_protocol: ProtocolVersion,
+    model: str,
+    subtype: int,
+) -> bool | None:
+    """Select the device implementation and connect to it in a single executor job.
+
+    Returns None if there is no device implementation for device_type.
+    """
+    dm = device_selector(
+        "",
+        device_id,
+        device_type,
+        ip_address,
+        port,
+        token,
+        key,
+        device_protocol,
+        model,
+        subtype,
+        "",
+    )
+    if dm is None:
+        return None
+    return _connect_and_close(dm)
 
 
 class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -370,28 +405,27 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         error = "connect_error"
         # use token/key to connect device and confirm token result
         for k, value in keys.items():
-            dm = await self.hass.async_add_executor_job(
-                device_selector,
-                "",
-                appliance_id,
-                device.get(CONF_TYPE),
-                device.get(CONF_IP_ADDRESS),
-                device.get(CONF_PORT),
-                value["token"],
-                value["key"],
-                ProtocolVersion.V3,
-                device.get(CONF_MODEL),
-                device.get(CONF_SUBTYPE, 0),
-                "",
+            connected = await self.hass.async_add_executor_job(
+                partial(
+                    _select_and_connect,
+                    device_id=appliance_id,
+                    device_type=device.get(CONF_TYPE),
+                    ip_address=device.get(CONF_IP_ADDRESS),
+                    port=device.get(CONF_PORT),
+                    token=value["token"],
+                    key=value["key"],
+                    device_protocol=ProtocolVersion.V3,
+                    model=device.get(CONF_MODEL),
+                    subtype=device.get(CONF_SUBTYPE, 0),
+                ),
             )
-            if dm is None:
+            if connected is None:
                 LOGGER.debug(
                     "No device implementation for device_type %s",
                     device.get(CONF_TYPE),
                 )
                 error = "no_device_implementation"
                 break
-            connected = await self.hass.async_add_executor_job(_connect_and_close, dm)
             if connected:
                 return value
             # return debug log with failed key
@@ -522,23 +556,20 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(str(device_id))
         self._abort_if_unique_id_configured()
 
-        dm = await self.hass.async_add_executor_job(
-            device_selector,
-            "",
-            device_id,
-            user_input[CONF_TYPE],
-            user_input[CONF_IP_ADDRESS],
-            user_input[CONF_PORT],
-            user_input[CONF_TOKEN],
-            user_input[CONF_KEY],
-            user_input[CONF_PROTOCOL],
-            user_input[CONF_MODEL],
-            user_input[CONF_SUBTYPE],
-            "",
+        connected = await self.hass.async_add_executor_job(
+            partial(
+                _select_and_connect,
+                device_id=device_id,
+                device_type=user_input[CONF_TYPE],
+                ip_address=user_input[CONF_IP_ADDRESS],
+                port=user_input[CONF_PORT],
+                token=user_input[CONF_TOKEN],
+                key=user_input[CONF_KEY],
+                device_protocol=user_input[CONF_PROTOCOL],
+                model=user_input[CONF_MODEL],
+                subtype=user_input[CONF_SUBTYPE],
+            ),
         )
-        if dm is None:
-            return self._show_manually_form(user_input, error="device_auth_failed")
-        connected = await self.hass.async_add_executor_job(_connect_and_close, dm)
         if connected:
             device_type = user_input[CONF_TYPE]
             found_name = self.found_device.get(CONF_NAME)

--- a/homeassistant/components/midea/config_flow.py
+++ b/homeassistant/components/midea/config_flow.py
@@ -367,6 +367,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         keys = await self.cloud.get_cloud_keys(appliance_id)
         if default_key:
             keys = {**keys, **(await MideaCloud.get_default_keys())}
+        error = "connect_error"
         # use token/key to connect device and confirm token result
         for k, value in keys.items():
             dm = await self.hass.async_add_executor_job(
@@ -388,6 +389,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     "No device implementation for device_type %s",
                     device.get(CONF_TYPE),
                 )
+                error = "no_device_implementation"
                 break
             connected = await self.hass.async_add_executor_job(_connect_and_close, dm)
             if connected:
@@ -400,7 +402,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         LOGGER.debug(
             "Unable to connect device with all the token/key",
         )
-        return {"error": "connect_error"}
+        return {"error": error}
 
     async def async_step_auto(
         self,

--- a/homeassistant/components/midea/config_flow.py
+++ b/homeassistant/components/midea/config_flow.py
@@ -11,6 +11,7 @@ from midealocal.cloud import (
 )
 from midealocal.const import DeviceType, ProtocolVersion
 from midealocal.device import MideaDevice
+from midealocal.devices import device_selector
 from midealocal.discover import discover
 import voluptuous as vol
 
@@ -368,19 +369,26 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             keys = {**keys, **(await MideaCloud.get_default_keys())}
         # use token/key to connect device and confirm token result
         for k, value in keys.items():
-            dm = MideaDevice(
-                name="",
-                device_id=appliance_id,
-                device_type=device.get(CONF_TYPE),
-                ip_address=device.get(CONF_IP_ADDRESS),
-                port=device.get(CONF_PORT),
-                token=value["token"],
-                key=value["key"],
-                device_protocol=ProtocolVersion.V3,
-                model=device.get(CONF_MODEL),
-                subtype=device.get(CONF_SUBTYPE, 0),
-                attributes={},
+            dm = await self.hass.async_add_executor_job(
+                device_selector,
+                "",
+                appliance_id,
+                device.get(CONF_TYPE),
+                device.get(CONF_IP_ADDRESS),
+                device.get(CONF_PORT),
+                value["token"],
+                value["key"],
+                ProtocolVersion.V3,
+                device.get(CONF_MODEL),
+                device.get(CONF_SUBTYPE, 0),
+                "",
             )
+            if dm is None:
+                LOGGER.debug(
+                    "No device implementation for device_type %s",
+                    device.get(CONF_TYPE),
+                )
+                break
             connected = await self.hass.async_add_executor_job(_connect_and_close, dm)
             if connected:
                 return value
@@ -512,19 +520,22 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         await self.async_set_unique_id(str(device_id))
         self._abort_if_unique_id_configured()
 
-        dm = MideaDevice(
-            name="",
-            device_id=device_id,
-            device_type=user_input[CONF_TYPE],
-            ip_address=user_input[CONF_IP_ADDRESS],
-            port=user_input[CONF_PORT],
-            token=user_input[CONF_TOKEN],
-            key=user_input[CONF_KEY],
-            device_protocol=user_input[CONF_PROTOCOL],
-            model=user_input[CONF_MODEL],
-            subtype=user_input[CONF_SUBTYPE],
-            attributes={},
+        dm = await self.hass.async_add_executor_job(
+            device_selector,
+            "",
+            device_id,
+            user_input[CONF_TYPE],
+            user_input[CONF_IP_ADDRESS],
+            user_input[CONF_PORT],
+            user_input[CONF_TOKEN],
+            user_input[CONF_KEY],
+            user_input[CONF_PROTOCOL],
+            user_input[CONF_MODEL],
+            user_input[CONF_SUBTYPE],
+            "",
         )
+        if dm is None:
+            return self._show_manually_form(user_input, error="device_auth_failed")
         connected = await self.hass.async_add_executor_job(_connect_and_close, dm)
         if connected:
             device_type = user_input[CONF_TYPE]

--- a/tests/components/midea/test_config_flow.py
+++ b/tests/components/midea/test_config_flow.py
@@ -1,16 +1,17 @@
 """Tests for the Midea config flow."""
 
+from functools import partial
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from midealocal.const import DeviceType, ProtocolVersion
 from midealocal.device import MideaDevice
-from midealocal.devices import device_selector
 import pytest
 
 from homeassistant.components.midea.config_flow import (
     DEFAULT_CLOUD,
     LOGIN_MODE_ACCOUNT,
     LOGIN_MODE_PRESET,
+    _select_and_connect,
 )
 from homeassistant.components.midea.const import (
     CONF_ACCOUNT,
@@ -1489,9 +1490,10 @@ async def test_manual_step_v3_missing_token_key_sets_retrieved_values(
     assert result["step_id"] == "manually"
     assert result["errors"] == {"base": "device_auth_failed"}
 
-    # device_selector() is called positionally (name, device_id, device_type,
-    # ip_address, port, token, key, ...) so it can run via
-    # hass.async_add_executor_job without a wrapping partial/lambda.
+    # _select_and_connect() calls device_selector() positionally (name,
+    # device_id, device_type, ip_address, port, token, key, ...); it is itself
+    # submitted to hass.async_add_executor_job via functools.partial so device
+    # selection and the connection attempt share a single executor job.
     assert mock_device_selector.call_args.args[5] == TEST_TOKEN
     assert mock_device_selector.call_args.args[6] == TEST_KEY
 
@@ -1725,7 +1727,9 @@ async def test_manually_flow_runs_device_selector_in_executor(
     Regression test: device_selector() calls importlib.import_module() to
     dynamically load the concrete device subclass. That is a blocking call,
     so it must never run directly on the event loop - Home Assistant's
-    blocking-call detector flags exactly that.
+    blocking-call detector flags exactly that. device_selector() is invoked
+    from within _select_and_connect(), which is what actually gets dispatched
+    to the executor (wrapped in a functools.partial).
     """
     result = await hass.config_entries.flow.async_init(
         DOMAIN,
@@ -1768,7 +1772,10 @@ async def test_manually_flow_runs_device_selector_in_executor(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     dispatched_funcs = [call.args[0] for call in mock_executor_job.call_args_list]
-    assert device_selector in dispatched_funcs
+    assert any(
+        isinstance(func, partial) and func.func is _select_and_connect
+        for func in dispatched_funcs
+    )
 
 
 async def test_login_credentials_step_falls_back_to_default_cloud(

--- a/tests/components/midea/test_config_flow.py
+++ b/tests/components/midea/test_config_flow.py
@@ -1692,11 +1692,10 @@ async def test_manually_flow_builds_concrete_device_subclass(
             "homeassistant.components.midea.config_flow.discover",
             return_value=DISCOVERY_RESULT,
         ),
-        patch(
-            "homeassistant.components.midea.config_flow._connect_and_close",
-        ) as mock_connect_and_close,
+        patch.object(MideaDevice, "connect", autospec=True) as mock_connect,
+        patch.object(MideaDevice, "close_socket", autospec=True),
     ):
-        mock_connect_and_close.return_value = True
+        mock_connect.return_value = True
         result = await hass.config_entries.flow.async_configure(
             flow_id,
             user_input={
@@ -1713,7 +1712,7 @@ async def test_manually_flow_builds_concrete_device_subclass(
         )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
-    dm = mock_connect_and_close.call_args.args[0]
+    dm = mock_connect.call_args.args[0]
     assert type(dm) is not MideaDevice
     assert isinstance(dm.build_query(), list)
 
@@ -1744,10 +1743,8 @@ async def test_manually_flow_runs_device_selector_in_executor(
             "homeassistant.components.midea.config_flow.discover",
             return_value=DISCOVERY_RESULT,
         ),
-        patch(
-            "homeassistant.components.midea.config_flow._connect_and_close",
-            return_value=True,
-        ),
+        patch.object(MideaDevice, "connect", autospec=True, return_value=True),
+        patch.object(MideaDevice, "close_socket", autospec=True),
         patch.object(
             hass,
             "async_add_executor_job",

--- a/tests/components/midea/test_config_flow.py
+++ b/tests/components/midea/test_config_flow.py
@@ -3,6 +3,8 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from midealocal.const import DeviceType, ProtocolVersion
+from midealocal.device import MideaDevice
+from midealocal.devices import device_selector
 import pytest
 
 from homeassistant.components.midea.config_flow import (
@@ -69,12 +71,12 @@ async def test_manual_flow_success(hass: HomeAssistant) -> None:
             return_value=DISCOVERY_RESULT,
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
-        ) as mock_midea_device,
+            "homeassistant.components.midea.config_flow.device_selector",
+        ) as mock_device_selector,
     ):
         mock_device = MagicMock()
         mock_device.connect.return_value = True
-        mock_midea_device.return_value = mock_device
+        mock_device_selector.return_value = mock_device
 
         result = await hass.config_entries.flow.async_configure(
             flow_id,
@@ -128,12 +130,12 @@ async def test_manual_flow_duplicate_unique_id(hass: HomeAssistant) -> None:
             return_value=DISCOVERY_RESULT,
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
-        ) as mock_midea_device,
+            "homeassistant.components.midea.config_flow.device_selector",
+        ) as mock_device_selector,
     ):
         mock_device = MagicMock()
         mock_device.connect.return_value = True
-        mock_midea_device.return_value = mock_device
+        mock_device_selector.return_value = mock_device
 
         await hass.config_entries.flow.async_configure(
             flow_id,
@@ -317,7 +319,7 @@ async def test_manual_step_errors(
             return_value=discover_result,
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
         patch(
@@ -416,7 +418,7 @@ async def test_manual_step_retries_discovery_after_mismatch(
             ],
         ) as mock_discover,
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -532,7 +534,7 @@ async def test_auto_flow_cloud_device_info_overrides_name_and_subtype(
             AsyncMock(return_value={}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -604,7 +606,7 @@ async def test_auto_flow_v3_preset_phase1_cloud_keys_success(
             AsyncMock(return_value={}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -673,7 +675,7 @@ async def test_auto_flow_v3_preset_phase1_default_key_success(
             AsyncMock(return_value={"builtin": {"token": TEST_TOKEN, "key": TEST_KEY}}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -748,7 +750,7 @@ async def test_auto_flow_v3_token_retrieval_exhausted(hass: HomeAssistant) -> No
             AsyncMock(return_value={"builtin": {"token": TEST_TOKEN, "key": TEST_KEY}}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -949,7 +951,7 @@ async def test_auto_flow_v3_phase2_success_after_phase1_failure(
             AsyncMock(return_value={}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -1079,7 +1081,7 @@ async def test_auto_flow_v1_v2_success_when_cloud_down(
             return_value=mock_devices,
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
         patch(
@@ -1307,7 +1309,7 @@ async def test_login_credentials_step_recovers_after_failed_login(
             AsyncMock(return_value={}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):
@@ -1474,10 +1476,10 @@ async def test_manual_step_v3_missing_token_key_sets_retrieved_values(
             AsyncMock(return_value={}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
-        ) as mock_midea_device,
+            "homeassistant.components.midea.config_flow.device_selector",
+        ) as mock_device_selector,
     ):
-        mock_midea_device.return_value = dm
+        mock_device_selector.return_value = dm
         result = await hass.config_entries.flow.async_configure(
             flow_id,
             user_input=user_input,
@@ -1487,8 +1489,87 @@ async def test_manual_step_v3_missing_token_key_sets_retrieved_values(
     assert result["step_id"] == "manually"
     assert result["errors"] == {"base": "device_auth_failed"}
 
-    assert mock_midea_device.call_args.kwargs["token"] == TEST_TOKEN
-    assert mock_midea_device.call_args.kwargs["key"] == TEST_KEY
+    # device_selector() is called positionally (name, device_id, device_type,
+    # ip_address, port, token, key, ...) so it can run via
+    # hass.async_add_executor_job without a wrapping partial/lambda.
+    assert mock_device_selector.call_args.args[5] == TEST_TOKEN
+    assert mock_device_selector.call_args.args[6] == TEST_KEY
+
+
+async def test_manual_step_v3_missing_token_key_unsupported_device_type(
+    hass: HomeAssistant,
+) -> None:
+    """Test cloud key retrieval surfaces token_unavailable when device_selector() finds no module.
+
+    device_selector() returns None when there is no device implementation
+    module for the given device_type. _check_key_from_cloud() must stop
+    trying candidate keys and report no usable token, rather than crashing
+    on a None device.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    assert result["type"] is FlowResultType.MENU
+    flow_id = result["flow_id"]
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "manually"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manually"
+
+    device = {
+        **BASE_DATA,
+        CONF_TYPE: TEST_TYPE,
+        CONF_PROTOCOL: ProtocolVersion.V3,
+        CONF_IP_ADDRESS: TEST_IP_ADDRESS,
+        CONF_SUBTYPE: TEST_SUBTYPE,
+    }
+    user_input: dict[str, object] = {
+        **EXTENDED_DATA,
+        CONF_PROTOCOL: ProtocolVersion.V3,
+        CONF_TOKEN: "",
+        CONF_KEY: "",
+    }
+
+    cloud = MagicMock()
+    cloud.login = AsyncMock(return_value=True)
+    cloud.get_cloud_keys = AsyncMock(
+        return_value={"method": {"token": TEST_TOKEN, "key": TEST_KEY}}
+    )
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.discover",
+            return_value={TEST_DEVICE_ID: device},
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.async_get_clientsession",
+            return_value=object(),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.get_midea_cloud",
+            return_value=cloud,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.MideaCloud.get_default_keys",
+            AsyncMock(return_value={}),
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.device_selector",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input=user_input,
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manually"
+    assert result["errors"] == {"base": "token_unavailable"}
 
 
 async def test_manually_flow_success(hass: HomeAssistant) -> None:
@@ -1514,12 +1595,12 @@ async def test_manually_flow_success(hass: HomeAssistant) -> None:
             return_value=DISCOVERY_RESULT,
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
-        ) as mock_midea_device,
+            "homeassistant.components.midea.config_flow.device_selector",
+        ) as mock_device_selector,
     ):
         mock_device = MagicMock()
         mock_device.connect.return_value = True
-        mock_midea_device.return_value = mock_device
+        mock_device_selector.return_value = mock_device
 
         result = await hass.config_entries.flow.async_configure(
             flow_id,
@@ -1542,6 +1623,155 @@ async def test_manually_flow_success(hass: HomeAssistant) -> None:
     assert result["data"][CONF_IP_ADDRESS] == TEST_IP_ADDRESS
     assert result["data"][CONF_TOKEN] == TEST_TOKEN
     assert result["data"][CONF_KEY] == TEST_KEY
+
+
+async def test_manually_flow_unsupported_device_type(hass: HomeAssistant) -> None:
+    """Test entry creation surfaces device_auth_failed when device_selector() finds no module.
+
+    device_selector() returns None when there is no device implementation
+    module for the given device_type, which must be treated the same as a
+    failed connection rather than crashing on a None device.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    result = await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "manually"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manually"
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.discover",
+            return_value=DISCOVERY_RESULT,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow.device_selector",
+            return_value=None,
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={**EXTENDED_DATA},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "manually"
+    assert result["errors"] == {"base": "device_auth_failed"}
+
+
+async def test_manually_flow_builds_concrete_device_subclass(
+    hass: HomeAssistant,
+) -> None:
+    """Test entry creation builds a concrete device subclass, not the base class.
+
+    Regression test: _async_create_midea_entry previously instantiated the
+    abstract midealocal.device.MideaDevice directly instead of going through
+    device_selector(). Its build_query() unconditionally raises
+    NotImplementedError, so refresh_status() would fail immediately after a
+    successful authentication for every real device.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "manually"},
+    )
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.discover",
+            return_value=DISCOVERY_RESULT,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow._connect_and_close",
+        ) as mock_connect_and_close,
+    ):
+        mock_connect_and_close.return_value = True
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={
+                CONF_DEVICE_ID: TEST_DEVICE_ID,
+                CONF_TYPE: TEST_TYPE,
+                CONF_IP_ADDRESS: TEST_IP_ADDRESS,
+                CONF_PORT: TEST_PORT,
+                CONF_PROTOCOL: TEST_PROTOCOL,
+                CONF_MODEL: TEST_MODEL,
+                CONF_SUBTYPE: TEST_SUBTYPE,
+                CONF_TOKEN: TEST_TOKEN,
+                CONF_KEY: TEST_KEY,
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    dm = mock_connect_and_close.call_args.args[0]
+    assert type(dm) is not MideaDevice
+    assert isinstance(dm.build_query(), list)
+
+
+async def test_manually_flow_runs_device_selector_in_executor(
+    hass: HomeAssistant,
+) -> None:
+    """Test device_selector() is dispatched via the executor, not the event loop.
+
+    Regression test: device_selector() calls importlib.import_module() to
+    dynamically load the concrete device subclass. That is a blocking call,
+    so it must never run directly on the event loop - Home Assistant's
+    blocking-call detector flags exactly that.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+    )
+    flow_id = result["flow_id"]
+
+    await hass.config_entries.flow.async_configure(
+        flow_id,
+        user_input={"next_step_id": "manually"},
+    )
+
+    with (
+        patch(
+            "homeassistant.components.midea.config_flow.discover",
+            return_value=DISCOVERY_RESULT,
+        ),
+        patch(
+            "homeassistant.components.midea.config_flow._connect_and_close",
+            return_value=True,
+        ),
+        patch.object(
+            hass,
+            "async_add_executor_job",
+            wraps=hass.async_add_executor_job,
+        ) as mock_executor_job,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            flow_id,
+            user_input={
+                CONF_DEVICE_ID: TEST_DEVICE_ID,
+                CONF_TYPE: TEST_TYPE,
+                CONF_IP_ADDRESS: TEST_IP_ADDRESS,
+                CONF_PORT: TEST_PORT,
+                CONF_PROTOCOL: TEST_PROTOCOL,
+                CONF_MODEL: TEST_MODEL,
+                CONF_SUBTYPE: TEST_SUBTYPE,
+                CONF_TOKEN: TEST_TOKEN,
+                CONF_KEY: TEST_KEY,
+            },
+        )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    dispatched_funcs = [call.args[0] for call in mock_executor_job.call_args_list]
+    assert device_selector in dispatched_funcs
 
 
 async def test_login_credentials_step_falls_back_to_default_cloud(
@@ -1663,7 +1893,7 @@ async def test_login_credentials_step_success_resumes_auto_flow(
             AsyncMock(return_value={}),
         ),
         patch(
-            "homeassistant.components.midea.config_flow.MideaDevice",
+            "homeassistant.components.midea.config_flow.device_selector",
             return_value=dm,
         ),
     ):


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fixed device key retrieval issue for Midea

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177679
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
