### PR TITLE
Fix via_device race in synology_dsm

### DIFF
--- a/homeassistant/components/synology_dsm/__init__.py
+++ b/homeassistant/components/synology_dsm/__init__.py
@@ -134,6 +134,39 @@ async def async_setup_entry(hass: HomeAssistant, entry: SynologyDSMConfigEntry) 
         coordinator_cameras=coordinator_cameras,
         coordinator_switches=coordinator_switches,
     )
+
+    # Register parent devices before forwarding platform setups so that child
+    # devices (storage/USB devices, surveillance station, cameras) can resolve
+    # their via_device_id regardless of platform setup order.
+    if TYPE_CHECKING:
+        assert api.information is not None
+        assert api.network is not None
+    central_device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, api.information.serial)},
+        connections={(dr.CONNECTION_NETWORK_MAC, mac) for mac in api.network.macs},
+        name=api.network.hostname,
+        manufacturer="Synology",
+        model=api.information.model,
+        sw_version=api.information.version_string,
+        configuration_url=api.config_url,
+    )
+    if api.surveillance_station is not None:
+        dev_reg.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            identifiers={
+                (
+                    DOMAIN,
+                    f"{api.information.serial}_{SynoSurveillanceStation.INFO_API_KEY}",
+                )
+            },
+            name=f"{api.network.hostname} Surveillance Station",
+            manufacturer="Synology",
+            model=api.information.model,
+            sw_version=coordinator_switches.version if coordinator_switches else None,
+            via_device_id=central_device.id,
+        )
+
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     if entry.options[CONF_BACKUP_SHARE]:

--- a/homeassistant/components/synology_dsm/camera.py
+++ b/homeassistant/components/synology_dsm/camera.py
@@ -16,6 +16,7 @@ from homeassistant.components.camera import (
     CameraEntityFeature,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -100,9 +101,13 @@ class SynoDSMCamera(SynologyDSMBaseEntity[SynologyDSMCameraUpdateCoordinator], C
             identifiers={(DOMAIN, f"{information.serial}_{self.camera_data.id}")},
             name=self.camera_data.name,
             model=self.camera_data.model,
-            via_device=(
-                DOMAIN,
-                f"{information.serial}_{SynoSurveillanceStation.INFO_API_KEY}",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (
+                    DOMAIN,
+                    f"{information.serial}_{SynoSurveillanceStation.INFO_API_KEY}",
+                ),
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 

--- a/homeassistant/components/synology_dsm/entity.py
+++ b/homeassistant/components/synology_dsm/entity.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, override
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -158,6 +159,10 @@ class SynologyDSMDeviceEntity(
             manufacturer=self._device_manufacturer,
             model=self._device_model,
             sw_version=self._device_firmware,
-            via_device=(DOMAIN, information.serial),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, information.serial),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
             configuration_url=self._api.config_url,
         )

--- a/homeassistant/components/synology_dsm/switch.py
+++ b/homeassistant/components/synology_dsm/switch.py
@@ -8,6 +8,7 @@ from synology_dsm.api.surveillance_station import SynoSurveillanceStation
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -128,5 +129,9 @@ class SynoDSMSurveillanceHomeModeToggle(
             manufacturer="Synology",
             model=self._api.information.model,
             sw_version=self._version,
-            via_device=(DOMAIN, self._api.information.serial),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, self._api.information.serial),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
         )

--- a/tests/components/synology_dsm/conftest.py
+++ b/tests/components/synology_dsm/conftest.py
@@ -1,7 +1,7 @@
 """Configure Synology DSM tests."""
 
 from collections.abc import Generator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
 from .common import mock_dsm_hardware, mock_dsm_information
+from .consts import HOST, MACS
 
 
 @pytest.fixture
@@ -34,7 +35,9 @@ def fixture_dsm():
         dsm.update = AsyncMock(return_value=True)
 
         dsm.information = mock_dsm_information()
-        dsm.network.update = AsyncMock(return_value=True)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)

--- a/tests/components/synology_dsm/test_backup.py
+++ b/tests/components/synology_dsm/test_backup.py
@@ -92,7 +92,9 @@ def mock_dsm_with_filestation():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.storage = Mock(
             disks_ids=["sda", "sdb", "sdc"],
@@ -146,7 +148,9 @@ def mock_dsm_without_filestation():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.information = mock_dsm_information()
         dsm.storage = Mock(

--- a/tests/components/synology_dsm/test_config_flow.py
+++ b/tests/components/synology_dsm/test_config_flow.py
@@ -67,7 +67,9 @@ def mock_controller_service():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.storage = Mock(
             disks_ids=["sda", "sdb", "sdc"],
@@ -91,7 +93,9 @@ def mock_controller_service_2sa():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.storage = Mock(
             disks_ids=["sda", "sdb", "sdc"],
@@ -113,7 +117,9 @@ def mock_controller_service_vdsm():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.storage = Mock(
             disks_ids=[],
@@ -135,7 +141,9 @@ def mock_controller_service_with_filestation():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.storage = Mock(
             disks_ids=["sda", "sdb", "sdc"],

--- a/tests/components/synology_dsm/test_media_source.py
+++ b/tests/components/synology_dsm/test_media_source.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 import tempfile
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 from aiohttp import web
 import pytest
@@ -41,7 +41,7 @@ def dsm_with_photos() -> MagicMock:
     dsm.login = AsyncMock(return_value=True)
     dsm.update = AsyncMock(return_value=True)
     dsm.information = mock_dsm_information()
-    dsm.network.update = AsyncMock(return_value=True)
+    dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS, hostname=HOST)
     dsm.hardware = mock_dsm_hardware()
     dsm.surveillance_station.update = AsyncMock(return_value=True)
     dsm.upgrade.update = AsyncMock(return_value=True)

--- a/tests/components/synology_dsm/test_repairs.py
+++ b/tests/components/synology_dsm/test_repairs.py
@@ -41,7 +41,9 @@ def mock_dsm_with_filestation():
         dsm.surveillance_station.update = AsyncMock(return_value=True)
         dsm.upgrade.update = AsyncMock(return_value=True)
         dsm.utilisation = Mock(cpu_user_load=1, update=AsyncMock(return_value=True))
-        dsm.network = Mock(update=AsyncMock(return_value=True), macs=MACS)
+        dsm.network = Mock(
+            update=AsyncMock(return_value=True), macs=MACS, hostname=HOST
+        )
         dsm.hardware = mock_dsm_hardware()
         dsm.storage = Mock(
             disks_ids=["sda", "sdb", "sdc"],

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -414,17 +414,18 @@ async def test_storage_device_via_device(
 ) -> None:
     """Test that storage/USB child devices link to the hub via via_device_id."""
     dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    hub_device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    entry_id = setup_dsm_with_usb.mock_entry.entry_id
+    hub_device = dev_reg.async_get_device_by_identifier((DOMAIN, SERIAL), entry_id)
     assert hub_device is not None
 
-    volume_device = dev_reg.async_get_device(
-        identifiers={(DOMAIN, f"{SERIAL}_volume_1")}
+    volume_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{SERIAL}_volume_1"), entry_id
     )
     assert volume_device is not None
     assert volume_device.via_device_id == hub_device.id
 
-    usb_partition_device = dev_reg.async_get_device(
-        identifiers={(DOMAIN, f"{SERIAL}_USB Disk 1 Partition 1")}
+    usb_partition_device = dev_reg.async_get_device_by_identifier(
+        (DOMAIN, f"{SERIAL}_USB Disk 1 Partition 1"), entry_id
     )
     assert usb_partition_device is not None
     assert usb_partition_device.via_device_id == hub_device.id

--- a/tests/components/synology_dsm/test_sensor.py
+++ b/tests/components/synology_dsm/test_sensor.py
@@ -406,3 +406,25 @@ async def test_hub_device_info_mac_connections(
         ("mac", "00:11:32:xx:xx:59"),
         ("mac", "00:11:32:xx:xx:5a"),
     }
+
+
+async def test_storage_device_via_device(
+    hass: HomeAssistant,
+    setup_dsm_with_usb: MagicMock,
+) -> None:
+    """Test that storage/USB child devices link to the hub via via_device_id."""
+    dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
+    hub_device = dev_reg.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    assert hub_device is not None
+
+    volume_device = dev_reg.async_get_device(
+        identifiers={(DOMAIN, f"{SERIAL}_volume_1")}
+    )
+    assert volume_device is not None
+    assert volume_device.via_device_id == hub_device.id
+
+    usb_partition_device = dev_reg.async_get_device(
+        identifiers={(DOMAIN, f"{SERIAL}_USB Disk 1 Partition 1")}
+    )
+    assert usb_partition_device is not None
+    assert usb_partition_device.via_device_id == hub_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `synology_dsm`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
