### PR TITLE
HomeKit Bridge area filtering

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -67,17 +67,16 @@ from homeassistant.helpers import (
     instance_id,
 )
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entityfilter import (
-    BASE_FILTER_SCHEMA,
-    FILTER_SCHEMA,
-    EntityFilter,
-)
 from homeassistant.helpers.reload import async_integration_yaml_config
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.target import (
+    TARGET_FILTER_CONFIG_SCHEMA,
+    TARGET_FILTER_SCHEMA,
+    TargetFilter,
     TargetSelection,
     async_extract_referenced_entity_ids,
+    async_track_target_filter_changes,
 )
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.loader import IntegrationNotFound, async_get_integration
@@ -164,6 +163,7 @@ STATUS_STOPPED = 2
 STATUS_WAIT = 3
 
 PORT_CLEANUP_CHECK_INTERVAL_SECS = 1
+TARGET_CHANGE_RELOAD_COOLDOWN = 3
 
 _HOMEKIT_CONFIG_UPDATE_TIME = (
     10  # number of seconds to wait for homekit to see the c# change
@@ -210,7 +210,7 @@ BRIDGE_SCHEMA = vol.All(
             vol.Optional(CONF_ADVERTISE_IP): vol.All(
                 cv.ensure_list, [ipaddress.ip_address], [cv.string]
             ),
-            vol.Optional(CONF_FILTER, default={}): BASE_FILTER_SCHEMA,
+            vol.Optional(CONF_FILTER, default={}): TARGET_FILTER_CONFIG_SCHEMA,
             vol.Optional(CONF_ENTITY_CONFIG, default={}): validate_entity_config,
             vol.Optional(CONF_DEVICES): cv.ensure_list,
         },
@@ -368,7 +368,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeKitConfigEntry) -> b
     )
     homekit_mode: str = options.get(CONF_HOMEKIT_MODE, DEFAULT_HOMEKIT_MODE)
     entity_config: dict[str, Any] = options.get(CONF_ENTITY_CONFIG, {}).copy()
-    entity_filter: EntityFilter = FILTER_SCHEMA(options.get(CONF_FILTER, {}))
+    target_filter: TargetFilter = TARGET_FILTER_SCHEMA(options.get(CONF_FILTER, {}))
     devices: list[str] = options.get(CONF_DEVICES, [])
 
     homekit = HomeKit(
@@ -376,7 +376,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeKitConfigEntry) -> b
         name,
         port,
         ip_address,
-        entity_filter,
+        target_filter,
         exclude_accessory_mode,
         entity_config,
         homekit_mode,
@@ -389,6 +389,20 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeKitConfigEntry) -> b
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
     entry.async_on_unload(
         hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, homekit.async_stop)
+    )
+
+    @callback
+    def _async_schedule_reload() -> None:
+        """Schedule a reload when the filter's expanded targets change."""
+        hass.config_entries.async_schedule_reload(entry.entry_id)
+
+    entry.async_on_unload(
+        async_track_target_filter_changes(
+            hass,
+            target_filter,
+            _async_schedule_reload,
+            debounce_cooldown=TARGET_CHANGE_RELOAD_COOLDOWN,
+        )
     )
 
     entry_data = HomeKitEntryData(
@@ -548,7 +562,7 @@ class HomeKit:
         name: str,
         port: int,
         ip_address: list[str] | str | None,
-        entity_filter: EntityFilter,
+        target_filter: TargetFilter,
         exclude_accessory_mode: bool,
         entity_config: dict[str, Any],
         homekit_mode: str,
@@ -562,7 +576,7 @@ class HomeKit:
         self._name = name
         self._port = port
         self._ip_address = ip_address
-        self._filter = entity_filter
+        self._filter = target_filter
         self._config: defaultdict[str, dict[str, Any]] = defaultdict(
             dict, entity_config
         )
@@ -854,7 +868,7 @@ class HomeKit:
         ent_reg = er.async_get(self.hass)
         device_lookup: dict[str, dict[tuple[str, str | None], str]] = {}
         entity_states: list[State] = []
-        entity_filter = self._filter.get_filter()
+        entity_filter = self._filter.async_get_filter(self.hass)
         entries = ent_reg.entities
         for state in self.hass.states.async_all():
             entity_id = state.entity_id

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -195,7 +195,7 @@ async def _async_domain_names(hass: HomeAssistant, domains: list[str]) -> str:
 
 
 @callback
-def _async_build_entities_filter(
+def _async_build_include_filter(
     domains: list[str],
     entities: list[str],
     areas: list[str] | None = None,
@@ -649,7 +649,7 @@ class OptionsFlowHandler(OptionsFlow):
 
         if user_input is not None:
             entities = cv.ensure_list(user_input[CONF_ENTITIES])
-            entity_filter = _async_build_entities_filter(domains, entities)
+            entity_filter = _async_build_include_filter(domains, entities)
             self.included_cameras = _async_entities_in_domain(entities, CAMERA_DOMAIN)
             self.included_climates = _async_entities_in_domain(entities, CLIMATE_DOMAIN)
             hk_options[CONF_FILTER] = entity_filter
@@ -694,7 +694,7 @@ class OptionsFlowHandler(OptionsFlow):
         if user_input is not None:
             entities = cv.ensure_list(user_input[CONF_ENTITIES])
             include_areas = cv.ensure_list(user_input.get(CONF_INCLUDE_AREAS, []))
-            entity_filter = _async_build_entities_filter(
+            entity_filter = _async_build_include_filter(
                 domains, entities, include_areas
             )
             filtered = _async_domain_filtered_entities(

--- a/homeassistant/components/homekit/config_flow.py
+++ b/homeassistant/components/homekit/config_flow.py
@@ -25,6 +25,7 @@ from homeassistant.config_entries import (
     OptionsFlow,
 )
 from homeassistant.const import (
+    ATTR_AREA_ID,
     ATTR_FRIENDLY_NAME,
     CONF_DEVICES,
     CONF_DOMAINS,
@@ -40,6 +41,12 @@ from homeassistant.helpers import (
     device_registry as dr,
     entity_registry as er,
     selector,
+)
+from homeassistant.helpers.target import (
+    CONF_EXCLUDE_TARGETS,
+    CONF_INCLUDE_TARGETS,
+    TARGET_FILTER_CONFIG_SCHEMA,
+    TargetFilter,
 )
 from homeassistant.loader import async_get_integrations
 
@@ -140,8 +147,10 @@ DEFAULT_DOMAINS = [
 
 CONF_INCLUDE_DOMAINS: Final = "include_domains"
 CONF_INCLUDE_ENTITIES: Final = "include_entities"
+CONF_INCLUDE_AREAS: Final = "include_areas"
 CONF_EXCLUDE_DOMAINS: Final = "exclude_domains"
 CONF_EXCLUDE_ENTITIES: Final = "exclude_entities"
+CONF_EXCLUDE_AREAS: Final = "exclude_areas"
 
 
 class EntityFilterDict(TypedDict, total=False):
@@ -149,23 +158,32 @@ class EntityFilterDict(TypedDict, total=False):
 
     include_domains: list[str]
     include_entities: list[str]
+    include_targets: dict[str, list[str]]
     exclude_domains: list[str]
     exclude_entities: list[str]
+    exclude_targets: dict[str, list[str]]
 
 
 def _make_entity_filter(
     include_domains: list[str] | None = None,
     include_entities: list[str] | None = None,
+    include_areas: list[str] | None = None,
     exclude_domains: list[str] | None = None,
     exclude_entities: list[str] | None = None,
+    exclude_areas: list[str] | None = None,
 ) -> EntityFilterDict:
     """Create a filter dict."""
-    return EntityFilterDict(
+    entity_filter = EntityFilterDict(
         include_domains=include_domains or [],
         include_entities=include_entities or [],
         exclude_domains=exclude_domains or [],
         exclude_entities=exclude_entities or [],
     )
+    if include_areas:
+        entity_filter[CONF_INCLUDE_TARGETS] = {ATTR_AREA_ID: include_areas}
+    if exclude_areas:
+        entity_filter[CONF_EXCLUDE_TARGETS] = {ATTR_AREA_ID: exclude_areas}
+    return entity_filter
 
 
 async def _async_domain_names(hass: HomeAssistant, domains: list[str]) -> str:
@@ -178,9 +196,11 @@ async def _async_domain_names(hass: HomeAssistant, domains: list[str]) -> str:
 
 @callback
 def _async_build_entities_filter(
-    domains: list[str], entities: list[str]
+    domains: list[str],
+    entities: list[str],
+    areas: list[str] | None = None,
 ) -> EntityFilterDict:
-    """Build an entities filter from domains and entities."""
+    """Build an entities filter from domains, entities, and areas."""
     # Include all of the domain if there are no entities
     # explicitly included as the user selected the domain
     return _make_entity_filter(
@@ -188,6 +208,7 @@ def _async_build_entities_filter(
             set(domains).difference(_domains_set_from_entities(entities))
         ),
         include_entities=entities,
+        include_areas=areas,
     )
 
 
@@ -198,20 +219,36 @@ def _async_entities_in_domain(entities: list[str], domain: str) -> list[str]:
 
 
 @callback
-def _async_included_domain_entities(
+def _async_domain_filtered_entities(
     hass: HomeAssistant,
     entity_filter: EntityFilterDict,
-    entities: list[str],
-    domain: str,
-) -> list[str]:
-    """Return a domain's included entities, expanding a whole domain include.
+    domains: list[str],
+) -> dict[str, list[str]]:
+    """Return, per domain, the entities the resolved filter would bridge.
 
-    The whole domain is included when none of its entities are selected
-    explicitly.
+    Mirrors the runtime selection in ``HomeKit.async_configure_accessories``:
+    the visible entities the filter keeps, plus explicitly included entities,
+    which are exposed even when hidden or categorized.
     """
-    if domain in entity_filter[CONF_INCLUDE_DOMAINS]:
-        return _async_get_matching_entities(hass, [domain])
-    return _async_entities_in_domain(entities, domain)
+    is_included = TargetFilter(
+        TARGET_FILTER_CONFIG_SCHEMA(entity_filter)
+    ).async_get_filter(hass)
+    include_entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
+    result: dict[str, list[str]] = {}
+    for domain in domains:
+        included = [
+            entity_id
+            for entity_id in _async_get_matching_entities(hass, [domain])
+            if is_included(entity_id)
+        ]
+        seen = set(included)
+        included.extend(
+            entity_id
+            for entity_id in _async_entities_in_domain(include_entities, domain)
+            if entity_id not in seen
+        )
+        result[domain] = included
+    return result
 
 
 async def _async_name_to_type_map(hass: HomeAssistant) -> dict[str, str]:
@@ -656,18 +693,23 @@ class OptionsFlowHandler(OptionsFlow):
         domains = hk_options[CONF_DOMAINS]
         if user_input is not None:
             entities = cv.ensure_list(user_input[CONF_ENTITIES])
-            entity_filter = _async_build_entities_filter(domains, entities)
-            self.included_cameras = _async_included_domain_entities(
-                self.hass, entity_filter, entities, CAMERA_DOMAIN
+            include_areas = cv.ensure_list(user_input.get(CONF_INCLUDE_AREAS, []))
+            entity_filter = _async_build_entities_filter(
+                domains, entities, include_areas
             )
-            self.included_climates = _async_included_domain_entities(
-                self.hass, entity_filter, entities, CLIMATE_DOMAIN
+            filtered = _async_domain_filtered_entities(
+                self.hass, entity_filter, [CAMERA_DOMAIN, CLIMATE_DOMAIN]
             )
+            self.included_cameras = filtered[CAMERA_DOMAIN]
+            self.included_climates = filtered[CLIMATE_DOMAIN]
             hk_options[CONF_FILTER] = entity_filter
             return await self.async_step_cameras()
 
         entity_filter = hk_options.get(CONF_FILTER, {})
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
+        current_include_areas = entity_filter.get(CONF_INCLUDE_TARGETS, {}).get(
+            ATTR_AREA_ID, []
+        )
         all_supported_entities = _async_get_matching_entities(
             self.hass, domains, include_entity_category=True, include_hidden=True
         )
@@ -691,6 +733,11 @@ class OptionsFlowHandler(OptionsFlow):
                             include_entities=all_supported_entities,
                         )
                     ),
+                    vol.Optional(
+                        CONF_INCLUDE_AREAS, default=current_include_areas
+                    ): selector.AreaSelector(
+                        selector.AreaSelectorConfig(multiple=True)
+                    ),
                 }
             ),
         )
@@ -704,25 +751,25 @@ class OptionsFlowHandler(OptionsFlow):
 
         if user_input is not None:
             entities = cv.ensure_list(user_input[CONF_ENTITIES])
-
-            def _remaining_in_domain(domain: str) -> list[str]:
-                if domain not in domains:
-                    return []
-                return [
-                    entity_id
-                    for entity_id in _async_get_matching_entities(self.hass, [domain])
-                    if entity_id not in entities
-                ]
-
-            self.included_cameras = _remaining_in_domain(CAMERA_DOMAIN)
-            self.included_climates = _remaining_in_domain(CLIMATE_DOMAIN)
-            hk_options[CONF_FILTER] = _make_entity_filter(
-                include_domains=domains, exclude_entities=entities
+            exclude_areas = cv.ensure_list(user_input.get(CONF_EXCLUDE_AREAS, []))
+            entity_filter = _make_entity_filter(
+                include_domains=domains,
+                exclude_entities=entities,
+                exclude_areas=exclude_areas,
             )
+            filtered = _async_domain_filtered_entities(
+                self.hass, entity_filter, [CAMERA_DOMAIN, CLIMATE_DOMAIN]
+            )
+            self.included_cameras = filtered[CAMERA_DOMAIN]
+            self.included_climates = filtered[CLIMATE_DOMAIN]
+            hk_options[CONF_FILTER] = entity_filter
             return await self.async_step_cameras()
 
         entity_filter = self.hk_options.get(CONF_FILTER, {})
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
+        current_exclude_areas = entity_filter.get(CONF_EXCLUDE_TARGETS, {}).get(
+            ATTR_AREA_ID, []
+        )
 
         all_supported_entities = _async_get_matching_entities(self.hass, domains)
         if not entities:
@@ -748,6 +795,11 @@ class OptionsFlowHandler(OptionsFlow):
                             include_entities=all_supported_entities,
                         )
                     ),
+                    vol.Optional(
+                        CONF_EXCLUDE_AREAS, default=current_exclude_areas
+                    ): selector.AreaSelector(
+                        selector.AreaSelectorConfig(multiple=True)
+                    ),
                 }
             ),
         )
@@ -772,8 +824,13 @@ class OptionsFlowHandler(OptionsFlow):
         entity_filter: EntityFilterDict = self.hk_options.get(CONF_FILTER, {})
         include_exclude_mode = MODE_INCLUDE
         entities = entity_filter.get(CONF_INCLUDE_ENTITIES, [])
+        include_areas = entity_filter.get(CONF_INCLUDE_TARGETS, {}).get(
+            ATTR_AREA_ID, []
+        )
         if homekit_mode != HOMEKIT_MODE_ACCESSORY:
-            include_exclude_mode = MODE_INCLUDE if entities else MODE_EXCLUDE
+            include_exclude_mode = (
+                MODE_INCLUDE if entities or include_areas else MODE_EXCLUDE
+            )
         domains = entity_filter.get(CONF_INCLUDE_DOMAINS, [])
         if include_entities := entity_filter.get(CONF_INCLUDE_ENTITIES):
             domains.extend(_domains_set_from_entities(include_entities))

--- a/homeassistant/components/homekit/strings.json
+++ b/homeassistant/components/homekit/strings.json
@@ -46,16 +46,18 @@
       },
       "exclude": {
         "data": {
-          "entities": "[%key:component::homekit::options::step::include::data::entities%]"
+          "entities": "[%key:component::homekit::options::step::include::data::entities%]",
+          "exclude_areas": "Excluded areas"
         },
-        "description": "All “{domains}” entities will be included except for the excluded entities and categorized entities.",
+        "description": "All “{domains}” entities will be included except for excluded entities, categorized entities, and entities in an excluded area.",
         "title": "Select the entities to be excluded"
       },
       "include": {
         "data": {
-          "entities": "Entities"
+          "entities": "Entities",
+          "include_areas": "Included areas"
         },
-        "description": "Select entities from each domain in “{domains}”. The include will cover the entire domain if you do not select any entities for a given domain.",
+        "description": "Select entities from each domain in “{domains}”. Selecting one or more areas limits the included entities to those areas. Entities you select are always included, and a domain with no selected entities or areas is included in full.",
         "title": "Select the entities to be included"
       },
       "init": {

--- a/homeassistant/helpers/entityfilter.py
+++ b/homeassistant/helpers/entityfilter.py
@@ -51,6 +51,26 @@ class EntityFilter:
             self._exclude_eg,
         )
 
+    @property
+    def include_domains(self) -> frozenset[str]:
+        """Return the explicitly included domains."""
+        return frozenset(self._include_d)
+
+    @property
+    def include_entities(self) -> frozenset[str]:
+        """Return the explicitly included entity ids."""
+        return frozenset(self._include_e)
+
+    @property
+    def exclude_domains(self) -> frozenset[str]:
+        """Return the explicitly excluded domains."""
+        return frozenset(self._exclude_d)
+
+    @property
+    def exclude_entities(self) -> frozenset[str]:
+        """Return the explicitly excluded entity ids."""
+        return frozenset(self._exclude_e)
+
     def explicitly_included(self, entity_id: str) -> bool:
         """Check if an entity is explicitly included."""
         return entity_id in self._include_e or (

--- a/homeassistant/helpers/target.py
+++ b/homeassistant/helpers/target.py
@@ -392,10 +392,6 @@ class TargetFilter:
         self.base_filter = EntityFilter({key: config[key] for key in _BASE_FILTER_KEYS})
         self.include_targets = TargetSelection(config[CONF_INCLUDE_TARGETS])
         self.exclude_targets = TargetSelection(config[CONF_EXCLUDE_TARGETS])
-        self._include_entities = set(config[CONF_INCLUDE_ENTITIES])
-        self._exclude_entities = set(config[CONF_EXCLUDE_ENTITIES])
-        self._include_domains = set(config[CONF_INCLUDE_DOMAINS])
-        self._exclude_domains = set(config[CONF_EXCLUDE_DOMAINS])
 
     @property
     def has_targets(self) -> bool:
@@ -430,10 +426,10 @@ class TargetFilter:
         included, excluded = self.async_expand_targets(hass)
         base = self.base_filter
         has_include_targets = self.include_targets.has_any_target
-        include_entities = self._include_entities
-        exclude_entities = self._exclude_entities
-        include_domains = self._include_domains
-        exclude_domains = self._exclude_domains
+        include_domains = base.include_domains
+        include_entities = base.include_entities
+        exclude_domains = base.exclude_domains
+        exclude_entities = base.exclude_entities
 
         @callback
         def target_filter(entity_id: str) -> bool:

--- a/homeassistant/helpers/target.py
+++ b/homeassistant/helpers/target.py
@@ -6,7 +6,9 @@ from collections.abc import Callable, Coroutine, Mapping
 import dataclasses
 import logging
 from logging import Logger
-from typing import Any, TypeGuard, override
+from typing import Any, Final, TypeGuard, override
+
+import voluptuous as vol
 
 from homeassistant.const import (
     ATTR_AREA_ID,
@@ -23,6 +25,7 @@ from homeassistant.core import (
     HomeAssistant,
     State,
     callback,
+    split_entity_id,
 )
 from homeassistant.exceptions import HomeAssistantError
 
@@ -35,7 +38,18 @@ from . import (
     group,
     label_registry as lr,
 )
+from .debounce import Debouncer
 from .deprecation import deprecated_class
+from .entityfilter import (
+    BASE_FILTER_SCHEMA,
+    CONF_EXCLUDE_DOMAINS,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_EXCLUDE_ENTITY_GLOBS,
+    CONF_INCLUDE_DOMAINS,
+    CONF_INCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITY_GLOBS,
+    EntityFilter,
+)
 from .event import async_track_state_change_event
 from .typing import ConfigType
 
@@ -292,6 +306,259 @@ def async_extract_referenced_entity_ids(
     )
 
     return selected
+
+
+CONF_INCLUDE_TARGETS: Final = "include_targets"
+CONF_EXCLUDE_TARGETS: Final = "exclude_targets"
+
+_BASE_FILTER_KEYS = (
+    CONF_INCLUDE_DOMAINS,
+    CONF_INCLUDE_ENTITIES,
+    CONF_INCLUDE_ENTITY_GLOBS,
+    CONF_EXCLUDE_DOMAINS,
+    CONF_EXCLUDE_ENTITIES,
+    CONF_EXCLUDE_ENTITY_GLOBS,
+)
+
+TARGET_FIELDS_SCHEMA = vol.Schema(
+    {
+        vol.Optional(ATTR_DEVICE_ID, default=list): vol.All(
+            cv.ensure_list, [cv.string]
+        ),
+        vol.Optional(ATTR_AREA_ID, default=list): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_FLOOR_ID, default=list): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(ATTR_LABEL_ID, default=list): vol.All(cv.ensure_list, [cv.string]),
+    }
+)
+
+TARGET_FILTER_CONFIG_SCHEMA = vol.Schema(
+    {
+        **BASE_FILTER_SCHEMA.schema,
+        vol.Optional(CONF_INCLUDE_TARGETS, default=dict): TARGET_FIELDS_SCHEMA,
+        vol.Optional(CONF_EXCLUDE_TARGETS, default=dict): TARGET_FIELDS_SCHEMA,
+    }
+)
+
+
+@callback
+def _async_expand_target_selection(
+    hass: HomeAssistant, selection: TargetSelection
+) -> frozenset[str]:
+    """Expand a target selection to the entity ids a filter may expose.
+
+    Disabled entities, hidden entities and entities with an entity category
+    are excluded from the expansion, so target selections only ever match
+    entities a consumer may expose; such entities can still be selected
+    through explicit entity inclusion in the base filter.
+    """
+    if not selection.has_any_target:
+        return frozenset()
+    selected = async_extract_referenced_entity_ids(hass, selection, expand_group=False)
+    entities = er.async_get(hass).entities
+    return frozenset(
+        entity_id
+        for entity_id in selected.referenced | selected.indirectly_referenced
+        if (entry := entities.get(entity_id)) is None
+        or (
+            entry.disabled_by is None
+            and entry.hidden_by is None
+            and entry.entity_category is None
+        )
+    )
+
+
+class TargetFilter:
+    """An entity filter extended with registry target selections.
+
+    Filter precedence for an entity id, matching the base entity filter's
+    precedence for configurations without target selections:
+    1. In the base filter's included entity ids: included.
+    2. In the base filter's excluded entity ids: excluded.
+    3. Matching an included entity glob: included.
+    4. Matching an excluded entity glob: excluded.
+    5. Matched by an exclude target selection: excluded.
+    6. When include targets are configured they narrow the include: the
+       entity must be matched by an include target selection, and when the
+       base filter also includes domains its domain must be one of them.
+       Entities in the base filter's excluded domains stay excluded. Include
+       domains and include targets thus combine as an intersection, while the
+       explicit entity and glob includes above remain absolute.
+    7. Otherwise (no include targets configured) the base filter decides.
+    """
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        """Init the filter from a TARGET_FILTER_CONFIG_SCHEMA validated config."""
+        self.config = config
+        self.base_filter = EntityFilter({key: config[key] for key in _BASE_FILTER_KEYS})
+        self.include_targets = TargetSelection(config[CONF_INCLUDE_TARGETS])
+        self.exclude_targets = TargetSelection(config[CONF_EXCLUDE_TARGETS])
+        self._include_entities = set(config[CONF_INCLUDE_ENTITIES])
+        self._exclude_entities = set(config[CONF_EXCLUDE_ENTITIES])
+        self._include_domains = set(config[CONF_INCLUDE_DOMAINS])
+        self._exclude_domains = set(config[CONF_EXCLUDE_DOMAINS])
+
+    @property
+    def has_targets(self) -> bool:
+        """Return whether any target selection is configured."""
+        return (
+            self.include_targets.has_any_target or self.exclude_targets.has_any_target
+        )
+
+    @callback
+    def explicitly_included(self, entity_id: str) -> bool:
+        """Check if an entity is explicitly included in the base filter."""
+        return self.base_filter.explicitly_included(entity_id)
+
+    @callback
+    def explicitly_excluded(self, entity_id: str) -> bool:
+        """Check if an entity is explicitly excluded in the base filter."""
+        return self.base_filter.explicitly_excluded(entity_id)
+
+    @callback
+    def async_expand_targets(
+        self, hass: HomeAssistant
+    ) -> tuple[frozenset[str], frozenset[str]]:
+        """Expand the include and exclude target selections to entity ids."""
+        return (
+            _async_expand_target_selection(hass, self.include_targets),
+            _async_expand_target_selection(hass, self.exclude_targets),
+        )
+
+    @callback
+    def async_get_filter(self, hass: HomeAssistant) -> Callable[[str], bool]:
+        """Return a filter function baked from the current target expansion."""
+        included, excluded = self.async_expand_targets(hass)
+        base = self.base_filter
+        has_include_targets = self.include_targets.has_any_target
+        include_entities = self._include_entities
+        exclude_entities = self._exclude_entities
+        include_domains = self._include_domains
+        exclude_domains = self._exclude_domains
+
+        @callback
+        def target_filter(entity_id: str) -> bool:
+            if entity_id in include_entities:
+                return True
+            if entity_id in exclude_entities:
+                return False
+            # Entity ids are handled above, so the explicit checks
+            # can only match on the glob patterns here.
+            if base.explicitly_included(entity_id):
+                return True
+            if base.explicitly_excluded(entity_id):
+                return False
+            if entity_id in excluded:
+                return False
+            if has_include_targets:
+                # Include targets narrow the include: the entity must match a
+                # target and, when domains are configured, fall in one of them.
+                domain = split_entity_id(entity_id)[0]
+                if domain in exclude_domains or entity_id not in included:
+                    return False
+                return not include_domains or domain in include_domains
+            return base(entity_id)
+
+        return target_filter
+
+
+def convert_target_filter(config: dict[str, Any]) -> TargetFilter:
+    """Convert the target filter schema into a target filter."""
+    return TargetFilter(config)
+
+
+TARGET_FILTER_SCHEMA = vol.All(TARGET_FILTER_CONFIG_SCHEMA, convert_target_filter)
+
+_TRACKED_ENTITY_CHANGES = frozenset(
+    {"area_id", "device_id", "disabled_by", "entity_category", "hidden_by", "labels"}
+)
+_TRACKED_DEVICE_CHANGES = frozenset({"area_id", "labels"})
+
+
+@callback
+def _async_entity_registry_filter(
+    event_data: er.EventEntityRegistryUpdatedData,
+) -> bool:
+    """Check if an entity registry event can affect expanded targets."""
+    if event_data["action"] != "update":
+        return True
+    return "old_entity_id" in event_data or bool(
+        _TRACKED_ENTITY_CHANGES & event_data["changes"].keys()
+    )
+
+
+@callback
+def _async_device_registry_filter(
+    event_data: dr.EventDeviceRegistryUpdatedData,
+) -> bool:
+    """Check if a device registry event can affect expanded targets."""
+    if event_data["action"] != "update":
+        return True
+    return bool(_TRACKED_DEVICE_CHANGES & event_data["changes"].keys())
+
+
+@callback
+def async_track_target_filter_changes(
+    hass: HomeAssistant,
+    target_filter: TargetFilter,
+    action: Callable[[], None],
+    *,
+    debounce_cooldown: float,
+) -> CALLBACK_TYPE:
+    """Run action when a registry change alters the filter's expanded targets.
+
+    Registry events are debounced; after the cooldown the target selections
+    are expanded once and action is only called if the expansion differs
+    from the last observed one. Tracking is a no-op for a filter without
+    target selections. Returns a callback to stop tracking.
+    """
+    if not target_filter.has_targets:
+        return lambda: None
+
+    snapshot = target_filter.async_expand_targets(hass)
+
+    @callback
+    def _async_check_targets() -> None:
+        nonlocal snapshot
+        new_snapshot = target_filter.async_expand_targets(hass)
+        if new_snapshot == snapshot:
+            return
+        snapshot = new_snapshot
+        action()
+
+    debouncer: Debouncer[None] = Debouncer(
+        hass,
+        _LOGGER,
+        cooldown=debounce_cooldown,
+        immediate=False,
+        function=_async_check_targets,
+    )
+
+    @callback
+    def _async_registry_updated(event: Event[Any]) -> None:
+        debouncer.async_schedule_call()
+
+    unsubs = [
+        hass.bus.async_listen(
+            er.EVENT_ENTITY_REGISTRY_UPDATED,
+            _async_registry_updated,
+            event_filter=_async_entity_registry_filter,
+        ),
+        hass.bus.async_listen(
+            dr.EVENT_DEVICE_REGISTRY_UPDATED,
+            _async_registry_updated,
+            event_filter=_async_device_registry_filter,
+        ),
+        # Area registry update events do not include changed fields.
+        hass.bus.async_listen(ar.EVENT_AREA_REGISTRY_UPDATED, _async_registry_updated),
+    ]
+
+    @callback
+    def _async_unsubscribe() -> None:
+        debouncer.async_shutdown()
+        for unsub in unsubs:
+            unsub()
+
+    return _async_unsubscribe
 
 
 class TargetEntityChangeTracker(abc.ABC):

--- a/tests/components/homekit/test_accessory_type.py
+++ b/tests/components/homekit/test_accessory_type.py
@@ -33,7 +33,11 @@ from homeassistant.helpers.entityfilter import (
     CONF_INCLUDE_DOMAINS,
     CONF_INCLUDE_ENTITIES,
     CONF_INCLUDE_ENTITY_GLOBS,
-    convert_filter,
+)
+from homeassistant.helpers.target import (
+    CONF_EXCLUDE_TARGETS,
+    CONF_INCLUDE_TARGETS,
+    convert_target_filter,
 )
 
 from .util import PATH_HOMEKIT
@@ -86,14 +90,16 @@ async def _async_start_bridge(
 ) -> HomeKit:
     """Start a HomeKit instance exposing the demo climate entity."""
     hass.data.setdefault(PERSIST_LOCK_DATA, asyncio.Lock())
-    entity_filter = convert_filter(
+    target_filter = convert_target_filter(
         {
             CONF_INCLUDE_DOMAINS: [],
             CONF_INCLUDE_ENTITIES: [ENTITY_ID],
+            CONF_INCLUDE_ENTITY_GLOBS: [],
+            CONF_INCLUDE_TARGETS: {},
             CONF_EXCLUDE_DOMAINS: [],
             CONF_EXCLUDE_ENTITIES: [],
-            CONF_INCLUDE_ENTITY_GLOBS: [],
             CONF_EXCLUDE_ENTITY_GLOBS: [],
+            CONF_EXCLUDE_TARGETS: {},
         }
     )
     homekit = HomeKit(
@@ -101,7 +107,7 @@ async def _async_start_bridge(
         name="mock_name",
         port=DEFAULT_PORT,
         ip_address=None,
-        entity_filter=entity_filter,
+        target_filter=target_filter,
         exclude_accessory_mode=False,
         entity_config=entity_config or {},
         homekit_mode=homekit_mode,

--- a/tests/components/homekit/test_config_flow.py
+++ b/tests/components/homekit/test_config_flow.py
@@ -17,7 +17,7 @@ from homeassistant.config_entries import SOURCE_IGNORE, SOURCE_IMPORT
 from homeassistant.const import CONF_NAME, CONF_PORT, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import area_registry as ar, entity_registry as er
 from homeassistant.helpers.entityfilter import CONF_INCLUDE_DOMAINS
 from homeassistant.setup import async_setup_component
 
@@ -691,6 +691,216 @@ async def test_options_flow_include_mode_basic(hass: HomeAssistant) -> None:
     await hass.config_entries.async_unload(config_entry.entry_id)
 
 
+async def test_options_flow_include_mode_with_areas(hass: HomeAssistant) -> None:
+    """Test config flow options in include mode with areas."""
+    config_entry = _mock_config_entry_with_options_populated()
+    config_entry.add_to_hass(hass)
+
+    hass.states.async_set("climate.old", "off")
+    hass.states.async_set("climate.new", "off")
+
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "domains": ["fan", "vacuum", "climate"],
+            "include_exclude_mode": "include",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "include"
+    assert _get_schema_default(result["data_schema"].schema, "include_areas") == []
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "entities": ["climate.new"],
+            "include_areas": ["living_room"],
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "climate"
+    result2 = await hass.config_entries.options.async_configure(
+        result2["flow_id"],
+        user_input={},
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "bridged_device_triggers"
+
+    result3 = await hass.config_entries.options.async_configure(
+        result2["flow_id"],
+        user_input={},
+    )
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {
+        "devices": [],
+        "mode": "bridge",
+        "filter": {
+            "include_domains": ["fan", "vacuum"],
+            "include_entities": ["climate.new"],
+            "include_targets": {"area_id": ["living_room"]},
+            "exclude_domains": [],
+            "exclude_entities": [],
+        },
+    }
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_options_flow_include_mode_areas_only_detected(
+    hass: HomeAssistant,
+) -> None:
+    """Test include mode is detected when only areas are included."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "mock_name", CONF_PORT: 12345},
+        options={
+            "mode": "bridge",
+            "filter": {
+                "include_domains": ["fan", "vacuum"],
+                "include_entities": [],
+                "include_targets": {"area_id": ["living_room"]},
+                "exclude_domains": [],
+                "exclude_entities": [],
+            },
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+    assert (
+        _get_schema_default(result["data_schema"].schema, "include_exclude_mode")
+        == "include"
+    )
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "domains": ["fan", "vacuum"],
+            "include_exclude_mode": "include",
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "include"
+    assert _get_schema_default(result2["data_schema"].schema, "include_areas") == [
+        "living_room"
+    ]
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    "domains",
+    [
+        pytest.param(["climate"], id="domain_and_area"),
+        pytest.param([], id="area_only"),
+    ],
+)
+async def test_options_flow_include_area_narrows_climate_step(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+    domains: list[str],
+) -> None:
+    """Test an included area narrows the climate step to the area's entities."""
+    mancave = area_registry.async_create("Mancave")
+    kitchen = area_registry.async_create("Kitchen")
+
+    climate_mancave = entity_registry.async_get_or_create(
+        "climate", "test", "mancave", suggested_object_id="mancave"
+    )
+    entity_registry.async_update_entity(climate_mancave.entity_id, area_id=mancave.id)
+    climate_kitchen = entity_registry.async_get_or_create(
+        "climate", "test", "kitchen", suggested_object_id="kitchen"
+    )
+    entity_registry.async_update_entity(climate_kitchen.entity_id, area_id=kitchen.id)
+    hass.states.async_set(climate_mancave.entity_id, "off")
+    hass.states.async_set(climate_kitchen.entity_id, "off")
+    await hass.async_block_till_done()
+
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: "mock_name", CONF_PORT: 12345},
+        options={"mode": "bridge", "filter": {"include_domains": []}},
+    )
+    config_entry.add_to_hass(hass)
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"domains": domains, "include_exclude_mode": "include"},
+    )
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"entities": [], "include_areas": [mancave.id]},
+    )
+    # Only the climate entity in the included area is offered for accessory
+    # configuration, not every climate entity in the house.
+    assert result2["step_id"] == "climate"
+    labels = [str(key) for key in result2["data_schema"].schema]
+    assert len(labels) == 1
+    assert climate_mancave.entity_id in labels[0]
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
+async def test_options_flow_exclude_mode_with_areas(hass: HomeAssistant) -> None:
+    """Test config flow options in exclude mode with areas."""
+    config_entry = _mock_config_entry_with_options_populated()
+    config_entry.add_to_hass(hass)
+
+    hass.states.async_set("climate.old", "off")
+    hass.states.async_set("climate.new", "off")
+
+    await hass.async_block_till_done()
+
+    result = await hass.config_entries.options.async_init(config_entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "domains": ["fan", "vacuum", "climate"],
+            "include_exclude_mode": "exclude",
+        },
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "exclude"
+    assert _get_schema_default(result["data_schema"].schema, "exclude_areas") == []
+
+    result2 = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={
+            "entities": ["climate.old", "climate.new"],
+            "exclude_areas": ["garage"],
+        },
+    )
+    assert result2["type"] is FlowResultType.FORM
+    assert result2["step_id"] == "bridged_device_triggers"
+
+    result3 = await hass.config_entries.options.async_configure(
+        result2["flow_id"],
+        user_input={},
+    )
+    assert result3["type"] is FlowResultType.CREATE_ENTRY
+    assert config_entry.options == {
+        "devices": [],
+        "mode": "bridge",
+        "filter": {
+            "include_domains": ["fan", "vacuum", "climate"],
+            "include_entities": [],
+            "exclude_domains": [],
+            "exclude_entities": ["climate.old", "climate.new"],
+            "exclude_targets": {"area_id": ["garage"]},
+        },
+    }
+    await hass.config_entries.async_unload(config_entry.entry_id)
+
+
 async def test_options_flow_exclude_mode_with_cameras(hass: HomeAssistant) -> None:
     """Test config flow options in exclude mode with cameras."""
 
@@ -909,6 +1119,7 @@ async def test_options_flow_include_mode_with_cameras(hass: HomeAssistant) -> No
     assert result["step_id"] == "exclude"
     assert result["data_schema"]({}) == {
         "entities": ["camera.native_h264", "camera.transcode_h264"],
+        "exclude_areas": [],
     }
     schema = result["data_schema"].schema
     assert _get_schema_default(schema, "entities") == [
@@ -1060,6 +1271,7 @@ async def test_options_flow_with_camera_audio(hass: HomeAssistant) -> None:
     assert result["step_id"] == "exclude"
     assert result["data_schema"]({}) == {
         "entities": ["camera.audio", "camera.no_audio"],
+        "exclude_areas": [],
     }
     schema = result["data_schema"].schema
     assert _get_schema_default(schema, "entities") == [

--- a/tests/components/homekit/test_homekit.py
+++ b/tests/components/homekit/test_homekit.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, Mock, patch
 from uuid import uuid1
 
+from freezegun.api import FrozenDateTimeFactory
 from pyhap.accessory import Accessory
 from pyhap.const import CATEGORY_CAMERA, CATEGORY_TELEVISION
 import pytest
@@ -19,6 +20,7 @@ from homeassistant.components.homekit import (
     STATUS_RUNNING,
     STATUS_STOPPED,
     STATUS_WAIT,
+    TARGET_CHANGE_RELOAD_COOLDOWN,
     TYPE_AIR_PURIFIER,
     HomeKit,
 )
@@ -46,6 +48,7 @@ from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.components.switch import SwitchDeviceClass
 from homeassistant.config_entries import SOURCE_IMPORT, SOURCE_ZEROCONF
 from homeassistant.const import (
+    ATTR_AREA_ID,
     ATTR_DEVICE_CLASS,
     ATTR_DEVICE_ID,
     ATTR_ENTITY_ID,
@@ -63,6 +66,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import (
+    area_registry as ar,
     device_registry as dr,
     entity_registry as er,
     instance_id,
@@ -74,14 +78,18 @@ from homeassistant.helpers.entityfilter import (
     CONF_INCLUDE_DOMAINS,
     CONF_INCLUDE_ENTITIES,
     CONF_INCLUDE_ENTITY_GLOBS,
-    EntityFilter,
-    convert_filter,
+)
+from homeassistant.helpers.target import (
+    CONF_EXCLUDE_TARGETS,
+    CONF_INCLUDE_TARGETS,
+    TargetFilter,
+    convert_target_filter,
 )
 from homeassistant.setup import async_setup_component
 
 from .util import PATH_HOMEKIT, async_init_entry, async_init_integration
 
-from tests.common import MockConfigEntry, get_fixture_path
+from tests.common import MockConfigEntry, async_fire_time_changed, get_fixture_path
 
 IP_ADDRESS = "127.0.0.1"
 
@@ -95,16 +103,20 @@ def generate_filter(
     exclude_entites,
     include_globs=None,
     exclude_globs=None,
+    include_targets=None,
+    exclude_targets=None,
 ):
-    """Generate an entity filter using the standard method."""
-    return convert_filter(
+    """Generate a target filter using the standard method."""
+    return convert_target_filter(
         {
             CONF_INCLUDE_DOMAINS: include_domains,
             CONF_INCLUDE_ENTITIES: include_entities,
+            CONF_INCLUDE_ENTITY_GLOBS: include_globs or [],
+            CONF_INCLUDE_TARGETS: include_targets or {},
             CONF_EXCLUDE_DOMAINS: exclude_domains,
             CONF_EXCLUDE_ENTITIES: exclude_entites,
-            CONF_INCLUDE_ENTITY_GLOBS: include_globs or [],
             CONF_EXCLUDE_ENTITY_GLOBS: exclude_globs or [],
+            CONF_EXCLUDE_TARGETS: exclude_targets or {},
         }
     )
 
@@ -125,7 +137,7 @@ def _mock_homekit(
     hass: HomeAssistant,
     entry: MockConfigEntry,
     homekit_mode: str,
-    entity_filter: EntityFilter | None = None,
+    entity_filter: TargetFilter | None = None,
     devices: list[str] | None = None,
 ) -> HomeKit:
     return HomeKit(
@@ -133,7 +145,7 @@ def _mock_homekit(
         name=BRIDGE_NAME,
         port=DEFAULT_PORT,
         ip_address=None,
-        entity_filter=entity_filter or generate_filter([], [], [], []),
+        target_filter=entity_filter or generate_filter([], [], [], []),
         exclude_accessory_mode=False,
         entity_config={},
         homekit_mode=homekit_mode,
@@ -578,6 +590,174 @@ async def test_homekit_entity_filter(hass: HomeAssistant) -> None:
     assert hass.states.get("cover.test") in filtered_states
     assert hass.states.get("demo.test") in filtered_states
     assert hass.states.get("light.demo") not in filtered_states
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_area_filter(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the area target filter."""
+    entry = await async_init_integration(hass)
+    include_area = area_registry.async_create("Included Area")
+    exclude_area = area_registry.async_create("Private Area")
+
+    included = entity_registry.async_get_or_create(
+        "light", "demo", "included_by_area", suggested_object_id="included_by_area"
+    )
+    entity_registry.async_update_entity(included.entity_id, area_id=include_area.id)
+    hass.states.async_set("light.included_by_area", "on")
+
+    device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={("test", "device")},
+    )
+    device_registry.async_update_device(device.id, area_id=include_area.id)
+    entity_registry.async_get_or_create(
+        "light",
+        "demo",
+        "included_by_device_area",
+        suggested_object_id="included_by_device_area",
+        device_id=device.id,
+    )
+    hass.states.async_set("light.included_by_device_area", "on")
+
+    config_entity = entity_registry.async_get_or_create(
+        "switch",
+        "demo",
+        "config_entity",
+        suggested_object_id="config_entity",
+        entity_category=EntityCategory.CONFIG,
+    )
+    entity_registry.async_update_entity(
+        config_entity.entity_id, area_id=include_area.id
+    )
+    hass.states.async_set(config_entity.entity_id, "on")
+
+    excluded_by_domain = entity_registry.async_get_or_create(
+        "cover",
+        "demo",
+        "excluded_by_domain",
+        suggested_object_id="excluded_by_domain",
+    )
+    entity_registry.async_update_entity(
+        excluded_by_domain.entity_id, area_id=include_area.id
+    )
+    hass.states.async_set("cover.excluded_by_domain", "open")
+
+    excluded_by_id = entity_registry.async_get_or_create(
+        "light", "demo", "excluded_by_id", suggested_object_id="excluded_by_id"
+    )
+    entity_registry.async_update_entity(
+        excluded_by_id.entity_id, area_id=include_area.id
+    )
+    hass.states.async_set("light.excluded_by_id", "on")
+
+    excluded_by_glob = entity_registry.async_get_or_create(
+        "light", "demo", "excluded_by_glob", suggested_object_id="excluded_by_glob"
+    )
+    entity_registry.async_update_entity(
+        excluded_by_glob.entity_id, area_id=include_area.id
+    )
+    hass.states.async_set("light.excluded_by_glob", "on")
+
+    switch_in_area = entity_registry.async_get_or_create(
+        "switch", "demo", "in_included_area", suggested_object_id="in_included_area"
+    )
+    entity_registry.async_update_entity(
+        switch_in_area.entity_id, area_id=include_area.id
+    )
+    hass.states.async_set("switch.in_included_area", "on")
+
+    excluded_by_area = entity_registry.async_get_or_create(
+        "switch", "demo", "excluded_by_area", suggested_object_id="excluded_by_area"
+    )
+    entity_registry.async_update_entity(
+        excluded_by_area.entity_id, area_id=exclude_area.id
+    )
+    hass.states.async_set("switch.excluded_by_area", "on")
+
+    included_by_id = entity_registry.async_get_or_create(
+        "light", "demo", "included_by_id", suggested_object_id="included_by_id"
+    )
+    entity_registry.async_update_entity(
+        included_by_id.entity_id, area_id=exclude_area.id
+    )
+    hass.states.async_set("light.included_by_id", "on")
+    hass.states.async_set("light.unrelated", "on")
+
+    entity_filter = generate_filter(
+        ["light"],
+        ["light.included_by_id"],
+        ["cover"],
+        ["light.excluded_by_id"],
+        exclude_globs=["light.excluded_by_glob"],
+        include_targets={ATTR_AREA_ID: [include_area.id]},
+        exclude_targets={ATTR_AREA_ID: [exclude_area.id]},
+    )
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE, entity_filter)
+
+    homekit.bridge = Mock()
+    homekit.bridge.accessories = {}
+
+    filtered_states = await homekit.async_configure_accessories()
+    # Matches an include domain and the include area.
+    assert hass.states.get("light.included_by_area") in filtered_states
+    assert hass.states.get("light.included_by_device_area") in filtered_states
+    # An explicit entity include is absolute, even inside an excluded area.
+    assert hass.states.get("light.included_by_id") in filtered_states
+    # Include targets narrow the include domains: an include-domain entity
+    # outside the include area is not bridged.
+    assert hass.states.get("light.unrelated") not in filtered_states
+    # An entity inside the include area whose domain is not an include domain
+    # is not bridged either.
+    assert hass.states.get("switch.in_included_area") not in filtered_states
+    assert hass.states.get(config_entity.entity_id) not in filtered_states
+    assert hass.states.get("cover.excluded_by_domain") not in filtered_states
+    assert hass.states.get("light.excluded_by_id") not in filtered_states
+    assert hass.states.get("light.excluded_by_glob") not in filtered_states
+    assert hass.states.get("switch.excluded_by_area") not in filtered_states
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_homekit_area_filter_areas_only(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test area targets act as the include list without base filter domains."""
+    entry = await async_init_integration(hass)
+    include_area = area_registry.async_create("Included Area")
+
+    in_area = entity_registry.async_get_or_create(
+        "light", "demo", "in_area", suggested_object_id="in_area"
+    )
+    entity_registry.async_update_entity(in_area.entity_id, area_id=include_area.id)
+    hass.states.async_set("light.in_area", "on")
+    hass.states.async_set("light.glob_included", "on")
+    hass.states.async_set("light.unrelated", "on")
+    hass.states.async_set("switch.unrelated", "on")
+
+    entity_filter = generate_filter(
+        [],
+        [],
+        [],
+        [],
+        include_globs=["light.glob_*"],
+        include_targets={ATTR_AREA_ID: [include_area.id]},
+    )
+    homekit = _mock_homekit(hass, entry, HOMEKIT_MODE_BRIDGE, entity_filter)
+
+    homekit.bridge = Mock()
+    homekit.bridge.accessories = {}
+
+    filtered_states = await homekit.async_configure_accessories()
+    assert hass.states.get("light.in_area") in filtered_states
+    assert hass.states.get("light.glob_included") in filtered_states
+    assert hass.states.get("light.unrelated") not in filtered_states
+    assert hass.states.get("switch.unrelated") not in filtered_states
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")
@@ -1746,6 +1926,141 @@ async def test_yaml_updates_update_config_entry_for_name(hass: HomeAssistant) ->
     await hass.async_block_till_done()
 
     mock_homekit().async_start.assert_called()
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_yaml_config_with_area_targets(hass: HomeAssistant) -> None:
+    """Test async_setup with area targets in imported config."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        source=SOURCE_IMPORT,
+        data={CONF_NAME: BRIDGE_NAME, CONF_PORT: DEFAULT_PORT},
+        options={},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit,
+        patch(
+            "homeassistant.components.network.async_get_source_ip",
+            return_value="1.2.3.4",
+        ),
+    ):
+        mock_homekit.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
+        assert await async_setup_component(
+            hass,
+            DOMAIN,
+            {
+                "homekit": {
+                    CONF_NAME: BRIDGE_NAME,
+                    CONF_PORT: 12345,
+                    "filter": {
+                        CONF_INCLUDE_TARGETS: {ATTR_AREA_ID: ["living_room"]},
+                        CONF_EXCLUDE_TARGETS: {ATTR_AREA_ID: ["garage"]},
+                    },
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+    target_filter = mock_homekit.call_args[0][4]
+    assert target_filter.include_targets.area_ids == {"living_room"}
+    assert target_filter.exclude_targets.area_ids == {"garage"}
+
+
+async def _async_setup_area_reload_test(
+    hass: HomeAssistant, area_id: str
+) -> MockConfigEntry:
+    """Set up HomeKit with an area target filter and return its config entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_NAME: BRIDGE_NAME, CONF_PORT: DEFAULT_PORT},
+        options={"filter": {CONF_INCLUDE_TARGETS: {ATTR_AREA_ID: [area_id]}}},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(f"{PATH_HOMEKIT}.HomeKit") as mock_homekit,
+        patch(
+            "homeassistant.components.network.async_get_source_ip",
+            return_value="1.2.3.4",
+        ),
+    ):
+        mock_homekit.return_value = homekit = Mock()
+        type(homekit).async_start = AsyncMock()
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    return entry
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+async def test_area_target_changes_reload_homekit(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test configured area target changes schedule one debounced reload."""
+    target_area = area_registry.async_create("Target Area")
+    other_area = area_registry.async_create("Other Area")
+    registry_entry = entity_registry.async_get_or_create(
+        "light", "demo", "area_reload", suggested_object_id="area_reload"
+    )
+    other_entry = entity_registry.async_get_or_create(
+        "light", "demo", "area_reload_2", suggested_object_id="area_reload_2"
+    )
+    entry = await _async_setup_area_reload_test(hass, target_area.id)
+
+    with patch.object(hass.config_entries, "async_schedule_reload") as mock_reload:
+        entity_registry.async_update_entity(
+            registry_entry.entity_id, area_id=other_area.id
+        )
+        await hass.async_block_till_done()
+        mock_reload.assert_not_called()
+
+        entity_registry.async_update_entity(
+            registry_entry.entity_id, area_id=target_area.id
+        )
+        entity_registry.async_update_entity(
+            other_entry.entity_id, area_id=target_area.id
+        )
+        await hass.async_block_till_done()
+        mock_reload.assert_not_called()
+
+        freezer.tick(TARGET_CHANGE_RELOAD_COOLDOWN)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        mock_reload.assert_called_once_with(entry.entry_id)
+
+
+@pytest.mark.usefixtures("mock_async_zeroconf")
+@patch(f"{PATH_HOMEKIT}.async_port_is_available", return_value=True)
+async def test_area_target_reload_tracking_stops_on_unload(
+    mock_port_available: MagicMock,
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test area target tracking stops when the entry is unloaded."""
+    target_area = area_registry.async_create("Target Area")
+    registry_entry = entity_registry.async_get_or_create(
+        "light", "demo", "area_reload", suggested_object_id="area_reload"
+    )
+    entry = await _async_setup_area_reload_test(hass, target_area.id)
+    await hass.config_entries.async_unload(entry.entry_id)
+
+    with patch.object(hass.config_entries, "async_schedule_reload") as mock_reload:
+        entity_registry.async_update_entity(
+            registry_entry.entity_id, area_id=target_area.id
+        )
+        await hass.async_block_till_done()
+        freezer.tick(TARGET_CHANGE_RELOAD_COOLDOWN)
+        async_fire_time_changed(hass)
+        await hass.async_block_till_done()
+        mock_reload.assert_not_called()
 
 
 @pytest.mark.usefixtures("mock_async_zeroconf")

--- a/tests/helpers/test_entityfilter.py
+++ b/tests/helpers/test_entityfilter.py
@@ -479,3 +479,22 @@ def test_complex_include_exclude_filter() -> None:
     }
     filt: EntityFilter = INCLUDE_EXCLUDE_FILTER_SCHEMA(conf)
     assert filt("switch.espresso_keuken") is True
+
+
+def test_entity_filter_exposes_parsed_sets() -> None:
+    """The parsed include/exclude sets are exposed as read-only properties."""
+    entity_filter = EntityFilter(
+        {
+            "include_domains": ["light"],
+            "include_entities": ["sensor.included"],
+            "include_entity_globs": [],
+            "exclude_domains": ["switch"],
+            "exclude_entities": ["sensor.excluded"],
+            "exclude_entity_globs": [],
+        }
+    )
+
+    assert entity_filter.include_domains == frozenset({"light"})
+    assert entity_filter.include_entities == frozenset({"sensor.included"})
+    assert entity_filter.exclude_domains == frozenset({"switch"})
+    assert entity_filter.exclude_entities == frozenset({"sensor.excluded"})

--- a/tests/helpers/test_target.py
+++ b/tests/helpers/test_target.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Mapping
 from typing import Any
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.group import Group
@@ -34,10 +35,13 @@ from homeassistant.setup import async_setup_component
 from tests.common import (
     MockConfigEntry,
     RegistryEntryWithDefaults,
+    async_fire_time_changed,
     mock_area_registry,
     mock_device_registry,
     mock_registry,
 )
+
+TARGET_FILTER_DEBOUNCE_COOLDOWN = 3
 
 
 async def set_states_and_check_target_events(
@@ -1097,3 +1101,382 @@ async def test_target_trickle_down_to_splits(
     assert selected.referenced_devices == splits
     assert COMPOSITE_ID not in selected.referenced_devices
     assert selected.indirectly_referenced == {"sensor.a", "sensor.b"}
+
+
+@pytest.fixture
+async def target_filter_registries(
+    hass: HomeAssistant,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Create labeled entities, devices, and areas for target filter tests."""
+    include_label = label_registry.async_create("incl")
+    exclude_label = label_registry.async_create("excl")
+
+    labeled: dict[tuple[str, str], set[str]] = {
+        ("light", "labeled_in"): {include_label.label_id},
+        ("cover", "labeled_in"): {include_label.label_id},
+        ("light", "labeled_out"): {exclude_label.label_id},
+        ("light", "explicit_in"): {exclude_label.label_id},
+        ("light", "explicit_out"): {include_label.label_id},
+        ("light", "globx_bad"): {include_label.label_id},
+        ("light", "glob_match"): set(),
+        ("switch", "base"): set(),
+        ("light", "unrelated"): set(),
+    }
+    for (domain, object_id), labels in labeled.items():
+        entry = entity_registry.async_get_or_create(
+            domain, "test", object_id, suggested_object_id=object_id
+        )
+        entity_registry.async_update_entity(entry.entity_id, labels=labels)
+
+    hidden = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "hidden_labeled",
+        suggested_object_id="hidden_labeled",
+        hidden_by=er.RegistryEntryHider.USER,
+    )
+    entity_registry.async_update_entity(
+        hidden.entity_id, labels={include_label.label_id}
+    )
+    config = entity_registry.async_get_or_create(
+        "sensor",
+        "test",
+        "config_labeled",
+        suggested_object_id="config_labeled",
+        entity_category=EntityCategory.CONFIG,
+    )
+    entity_registry.async_update_entity(
+        config.entity_id, labels={include_label.label_id}
+    )
+    disabled = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "disabled_labeled",
+        suggested_object_id="disabled_labeled",
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+    entity_registry.async_update_entity(
+        disabled.entity_id, labels={include_label.label_id}
+    )
+
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+    labeled_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "labeled_device")},
+    )
+    device_registry.async_update_device(
+        labeled_device.id, labels={include_label.label_id}
+    )
+    entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "on_labeled_device",
+        suggested_object_id="on_labeled_device",
+        device_id=labeled_device.id,
+    )
+
+    labeled_area = area_registry.async_create("Labeled area")
+    area_registry.async_update(labeled_area.id, labels={include_label.label_id})
+    in_area = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "in_labeled_area",
+        suggested_object_id="in_labeled_area",
+    )
+    entity_registry.async_update_entity(in_area.entity_id, area_id=labeled_area.id)
+
+
+_TARGET_FILTER_CANDIDATES = [
+    "light.labeled_in",
+    "cover.labeled_in",
+    "light.labeled_out",
+    "light.explicit_in",
+    "light.explicit_out",
+    "light.globx_bad",
+    "light.glob_match",
+    "switch.base",
+    "light.unrelated",
+    "light.hidden_labeled",
+    "sensor.config_labeled",
+    "light.disabled_labeled",
+    "light.on_labeled_device",
+    "light.in_labeled_area",
+]
+
+
+@pytest.mark.parametrize(
+    ("filter_config", "expected_included"),
+    [
+        pytest.param(
+            {
+                "include_domains": ["switch"],
+                "include_entities": ["light.explicit_in"],
+                "include_entity_globs": ["light.glob_*"],
+                "include_targets": {ATTR_LABEL_ID: ["incl"]},
+                "exclude_domains": ["cover"],
+                "exclude_entities": ["light.explicit_out"],
+                "exclude_entity_globs": ["light.globx_*"],
+                "exclude_targets": {ATTR_LABEL_ID: ["excl"]},
+            },
+            # Include domains (switch) intersect the include targets (incl
+            # labels, all on lights), so no target match survives; only the
+            # absolute explicit-entity and glob includes remain.
+            {
+                "light.explicit_in",
+                "light.glob_match",
+            },
+            id="full_precedence",
+        ),
+        pytest.param(
+            {
+                "include_domains": ["light"],
+                "include_targets": {ATTR_LABEL_ID: ["incl"]},
+            },
+            # Include domains narrow the include targets to matching domains:
+            # cover.labeled_in drops out because cover is not an include domain.
+            {
+                "light.labeled_in",
+                "light.explicit_out",
+                "light.globx_bad",
+                "light.on_labeled_device",
+                "light.in_labeled_area",
+            },
+            id="include_domains_intersect_targets",
+        ),
+        pytest.param(
+            {
+                "include_domains": ["light"],
+                "include_targets": {ATTR_AREA_ID: ["labeled_area"]},
+            },
+            # Lights not in the area drop out; the area narrows the domain.
+            {"light.in_labeled_area"},
+            id="include_domain_narrowed_by_area",
+        ),
+        pytest.param(
+            {"include_targets": {ATTR_LABEL_ID: ["incl"]}},
+            {
+                "light.labeled_in",
+                "cover.labeled_in",
+                "light.explicit_out",
+                "light.globx_bad",
+                "light.on_labeled_device",
+                "light.in_labeled_area",
+            },
+            id="targets_only_include",
+        ),
+        pytest.param(
+            {
+                "include_entity_globs": ["light.glob_*"],
+                "include_targets": {ATTR_LABEL_ID: ["incl"]},
+            },
+            {
+                "light.labeled_in",
+                "cover.labeled_in",
+                "light.explicit_out",
+                "light.globx_bad",
+                "light.glob_match",
+                "light.on_labeled_device",
+                "light.in_labeled_area",
+            },
+            id="targets_with_include_globs",
+        ),
+        pytest.param(
+            {"include_targets": {ATTR_AREA_ID: ["labeled_area"]}},
+            {"light.in_labeled_area"},
+            id="area_targets_include",
+        ),
+        pytest.param(
+            {
+                "include_entity_globs": ["light.glob_*"],
+                "include_targets": {ATTR_LABEL_ID: ["incl"]},
+                "exclude_entities": ["light.glob_match"],
+            },
+            {
+                "light.labeled_in",
+                "cover.labeled_in",
+                "light.explicit_out",
+                "light.globx_bad",
+                "light.on_labeled_device",
+                "light.in_labeled_area",
+            },
+            id="excluded_entity_id_beats_include_glob",
+        ),
+        pytest.param(
+            {
+                "include_domains": ["light"],
+                "exclude_targets": {ATTR_LABEL_ID: ["excl"]},
+            },
+            {
+                "light.labeled_in",
+                "light.explicit_out",
+                "light.globx_bad",
+                "light.glob_match",
+                "light.unrelated",
+                "light.hidden_labeled",
+                "light.disabled_labeled",
+                "light.on_labeled_device",
+                "light.in_labeled_area",
+            },
+            id="exclude_targets_with_base_filter",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("target_filter_registries")
+async def test_target_filter(
+    hass: HomeAssistant,
+    filter_config: dict[str, Any],
+    expected_included: set[str],
+) -> None:
+    """Test target filter precedence and expansion policy."""
+    target_filter = target.TARGET_FILTER_SCHEMA(filter_config)
+    entity_filter = target_filter.async_get_filter(hass)
+    assert {
+        entity_id for entity_id in _TARGET_FILTER_CANDIDATES if entity_filter(entity_id)
+    } == expected_included
+
+
+async def _async_debounce_pass(
+    hass: HomeAssistant, freezer: FrozenDateTimeFactory
+) -> None:
+    """Let the target filter debounce cooldown elapse."""
+    await hass.async_block_till_done()
+    freezer.tick(TARGET_FILTER_DEBOUNCE_COOLDOWN)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+
+async def test_track_target_filter_changes(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test tracking calls the action only when expanded targets change."""
+    label = label_registry.async_create("tracked")
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "a", suggested_object_id="a"
+    )
+    other = entity_registry.async_get_or_create(
+        "light", "test", "b", suggested_object_id="b"
+    )
+    target_filter = target.TARGET_FILTER_SCHEMA(
+        {"include_targets": {ATTR_LABEL_ID: [label.label_id]}}
+    )
+    calls: list[None] = []
+    unsub = target.async_track_target_filter_changes(
+        hass,
+        target_filter,
+        lambda: calls.append(None),
+        debounce_cooldown=TARGET_FILTER_DEBOUNCE_COOLDOWN,
+    )
+
+    entity_registry.async_update_entity(entry.entity_id, name="renamed")
+    await _async_debounce_pass(hass, freezer)
+    assert not calls
+
+    entity_registry.async_update_entity(entry.entity_id, labels={label.label_id})
+    await hass.async_block_till_done()
+    assert not calls
+
+    entity_registry.async_update_entity(other.entity_id, labels={label.label_id})
+    await _async_debounce_pass(hass, freezer)
+    assert len(calls) == 1
+
+    disabled = entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "d",
+        suggested_object_id="d",
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+    entity_registry.async_update_entity(disabled.entity_id, labels={label.label_id})
+    await _async_debounce_pass(hass, freezer)
+    assert len(calls) == 1
+
+    entity_registry.async_update_entity(disabled.entity_id, disabled_by=None)
+    await _async_debounce_pass(hass, freezer)
+    assert len(calls) == 2
+
+    unsub()
+    entity_registry.async_update_entity(entry.entity_id, labels=set())
+    await _async_debounce_pass(hass, freezer)
+    assert len(calls) == 2
+
+
+async def test_track_target_filter_changes_indirect(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test tracking reacts to indirect device and area membership changes."""
+    label = label_registry.async_create("tracked")
+    area = area_registry.async_create("Labeled area")
+    area_registry.async_update(area.id, labels={label.label_id})
+    config_entry = MockConfigEntry(domain="test")
+    config_entry.add_to_hass(hass)
+    device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("test", "device")},
+    )
+    entity_registry.async_get_or_create(
+        "light",
+        "test",
+        "on_device",
+        suggested_object_id="on_device",
+        device_id=device.id,
+    )
+    target_filter = target.TARGET_FILTER_SCHEMA(
+        {"include_targets": {ATTR_LABEL_ID: [label.label_id]}}
+    )
+    calls: list[None] = []
+    unsub = target.async_track_target_filter_changes(
+        hass,
+        target_filter,
+        lambda: calls.append(None),
+        debounce_cooldown=TARGET_FILTER_DEBOUNCE_COOLDOWN,
+    )
+
+    device_registry.async_update_device(device.id, area_id=area.id)
+    await _async_debounce_pass(hass, freezer)
+    assert len(calls) == 1
+
+    area_registry.async_update(area.id, name="Renamed area")
+    await _async_debounce_pass(hass, freezer)
+    assert len(calls) == 1
+
+    unsub()
+
+
+async def test_track_target_filter_changes_without_targets(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    entity_registry: er.EntityRegistry,
+    label_registry: lr.LabelRegistry,
+) -> None:
+    """Test tracking is a no-op for a filter without target selections."""
+    label = label_registry.async_create("tracked")
+    entry = entity_registry.async_get_or_create(
+        "light", "test", "a", suggested_object_id="a"
+    )
+    target_filter = target.TARGET_FILTER_SCHEMA({"include_domains": ["light"]})
+    calls: list[None] = []
+    unsub = target.async_track_target_filter_changes(
+        hass,
+        target_filter,
+        lambda: calls.append(None),
+        debounce_cooldown=TARGET_FILTER_DEBOUNCE_COOLDOWN,
+    )
+
+    entity_registry.async_update_entity(entry.entity_id, labels={label.label_id})
+    await _async_debounce_pass(hass, freezer)
+    assert not calls
+
+    unsub()


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Today the HomeKit Bridge filter can only select entities by domain and entity id. This PR adds a general, registry-aware entity filter and makes the HomeKit Bridge its first consumer, so entities can be included/excluded by area (and, through the shared target expansion, by device, floor, and label) rather than special-casing one registry at a time (https://github.com/home-assistant/core/pull/171134/#issuecomment-4929846038).


**Commit 1 — Add area-based target filtering to HomeKit Bridge**

- Adds a shared `TargetFilter` helper in `homeassistant/helpers/target.py`. It   extends the existing `EntityFilter` (by composition) with include/exclude *target selections* — areas, floors, labels, and devices — resolving them through the common target expansion (`async_extract_referenced_entity_ids`), with filter precedence defined in one place. It also adds `async_track_target_filter_changes`, which runs a **debounced** action when registry changes alter a filter's expanded target set.
- Wires the HomeKit Bridge to it: `CONF_FILTER` is now validated by `TARGET_FILTER_CONFIG_SCHEMA` (a superset of the old base filter), so it is configurable from YAML and the options flow. The include/exclude steps gain an area picker, and a debounced reload is scheduled when registry changes affect which entities the filter would expose.

Semantics: include targets **narrow** the include — a selected area intersects with the selected domains, while explicit entity/glob includes stay absolute, and a purely target-based include (no domains) acts as the include list. Existing configurations that use no targets are unaffected: the base entity filter still decides. The climate/camera option sub-pages are computed from the resolved filter so they list exactly the entities that will be bridged.

Scope note: the shared helper (and YAML) supports every target type; the options-flow UI in this PR surfaces **areas** only. Labels/floors/devices can be added as follow-up UI on the same helper.

**Commit 2 — Reuse EntityFilter parsed sets in TargetFilter** (optional)

Exposes `EntityFilter`'s parsed include/exclude domain and entity sets as read-only properties and reads them from `TargetFilter` instead of re-deriving the same sets from config, giving the two a single source of truth. It is isolated on purpose and can be dropped without affecting the feature if you'd rather not grow `EntityFilter`'s public API.

**Commit 3 — Rename the HomeKit include-mode filter builder for clarity** (optional)

Renames the private `_async_build_entities_filter` to `_async_build_include_filter`, since it only ever builds the include side of the filter and the old name read as include/exclude agnostic. Pure rename, no behavior change; also isolated and droppable.

Relation to #171134: the maintainer asked there for the label expansion, registry listeners, snapshot diff, and debounced reload to move into a helper that works for all registry types rather than special-casing each registry in HomeKit. This PR provides exactly that shared helper, with the debounced reload requested in that review.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/core/pull/171134/
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47184
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
