### PR TITLE
Fix via_device race in toon

### DIFF
--- a/homeassistant/components/toon/__init__.py
+++ b/homeassistant/components/toon/__init__.py
@@ -113,20 +113,47 @@ async def async_setup_entry(hass: HomeAssistant, entry: ToonConfigEntry) -> bool
 
     entry.runtime_data = coordinator
 
-    # Register device for the Meter Adapter, since it will have no entities.
+    agreement = coordinator.data.agreement
+    agreement_id = agreement.agreement_id
+
+    # Register the parent devices before forwarding the platforms, so that the
+    # child devices created by the entities can deterministically resolve their
+    # via_device_id.
     device_registry = dr.async_get(hass)
-    device_registry.async_get_or_create(
+    display_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, agreement_id)},
+        manufacturer="Eneco",
+        model=agreement.display_hardware_version.rpartition("/")[0],
+        name="Toon Display",
+        sw_version=agreement.display_software_version.rpartition("/")[-1],
+    )
+    # The Meter Adapter has no entities of its own.
+    meter_adapter_device = device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         identifiers={
-            (
-                DOMAIN,
-                coordinator.data.agreement.agreement_id,
-                "meter_adapter",
-            )  # type: ignore[arg-type]
+            (DOMAIN, agreement_id, "meter_adapter"),  # type: ignore[arg-type]
         },
         manufacturer="Eneco",
         name="Meter Adapter",
-        via_device=(DOMAIN, coordinator.data.agreement.agreement_id),
+        via_device_id=display_device.id,
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={
+            (DOMAIN, agreement_id, "electricity"),  # type: ignore[arg-type]
+        },
+        name="Electricity Meter",
+        via_device_id=meter_adapter_device.id,
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={
+            (DOMAIN, agreement_id, "boiler_module"),  # type: ignore[arg-type]
+        },
+        manufacturer="Eneco",
+        name="Boiler Module",
+        via_device_id=display_device.id,
     )
 
     # Spin up the platforms

--- a/homeassistant/components/toon/entity.py
+++ b/homeassistant/components/toon/entity.py
@@ -3,6 +3,7 @@
 from dataclasses import dataclass
 from typing import override
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -44,10 +45,10 @@ class ToonElectricityMeterDeviceEntity(ToonEntity):
             identifiers={
                 (DOMAIN, agreement_id, "electricity"),  # type: ignore[arg-type]
             },
-            via_device=(
-                DOMAIN,
-                agreement_id,  # type: ignore[typeddict-item]
-                "meter_adapter",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, agreement_id, "meter_adapter"),  # type: ignore[arg-type]
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 
@@ -65,10 +66,10 @@ class ToonGasMeterDeviceEntity(ToonEntity):
             identifiers={
                 (DOMAIN, agreement_id, "gas"),  # type: ignore[arg-type]
             },
-            via_device=(
-                DOMAIN,
-                agreement_id,  # type: ignore[typeddict-item]
-                "electricity",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, agreement_id, "electricity"),  # type: ignore[arg-type]
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 
@@ -86,10 +87,10 @@ class ToonWaterMeterDeviceEntity(ToonEntity):
             identifiers={
                 (DOMAIN, agreement_id, "water"),  # type: ignore[arg-type]
             },
-            via_device=(
-                DOMAIN,
-                agreement_id,  # type: ignore[typeddict-item]
-                "electricity",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, agreement_id, "electricity"),  # type: ignore[arg-type]
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 
@@ -107,10 +108,10 @@ class ToonSolarDeviceEntity(ToonEntity):
             identifiers={
                 (DOMAIN, agreement_id, "solar"),  # type: ignore[arg-type]
             },
-            via_device=(
-                DOMAIN,
-                agreement_id,  # type: ignore[typeddict-item]
-                "meter_adapter",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, agreement_id, "meter_adapter"),  # type: ignore[arg-type]
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 
@@ -133,7 +134,11 @@ class ToonBoilerModuleDeviceEntity(ToonEntity):
                     "boiler_module",
                 )
             },
-            via_device=(DOMAIN, agreement_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, agreement_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
         )
 
 
@@ -150,10 +155,10 @@ class ToonBoilerDeviceEntity(ToonEntity):
             identifiers={
                 (DOMAIN, agreement_id, "boiler"),  # type: ignore[arg-type]
             },
-            via_device=(
-                DOMAIN,
-                agreement_id,  # type: ignore[typeddict-item]
-                "boiler_module",
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, agreement_id, "boiler_module"),  # type: ignore[arg-type]
+                config_entry_id=self.coordinator.config_entry.entry_id,
             ),
         )
 

--- a/tests/components/toon/test_init.py
+++ b/tests/components/toon/test_init.py
@@ -135,7 +135,10 @@ async def test_device_registry_via_devices(
     assert config_entry.state is ConfigEntryState.LOADED
 
     def get_device(*identifier: str) -> dr.DeviceEntry:
-        device = device_registry.async_get_device(identifiers={(DOMAIN, *identifier)})
+        device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, *identifier),  # type: ignore[arg-type]
+            config_entry.entry_id,
+        )
         assert device is not None
         return device
 

--- a/tests/components/toon/test_init.py
+++ b/tests/components/toon/test_init.py
@@ -1,10 +1,15 @@
 """Tests for the Toon component."""
 
+import time
 from unittest.mock import patch
+
+from toonapi import Agreement, Status
+from toonapi.models import ThermostatInfo
 
 from homeassistant.components.toon import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import config_entry_oauth2_flow, device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
 )
@@ -66,3 +71,87 @@ async def test_migrate_entry_minor_version_2_2(hass: HomeAssistant) -> None:
         assert entry.version == 2
         assert entry.minor_version == 2
         assert entry.unique_id == "123"
+
+
+async def test_device_registry_via_devices(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that child devices are linked to their parent via via_device_id."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        version=2,
+        minor_version=2,
+        unique_id="test-agreement-id",
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "refresh_token": "mock-refresh-token",
+                "access_token": "mock-access-token",
+                "type": "Bearer",
+                "expires_in": 60,
+                "expires_at": time.time() + 3600,
+            },
+            "agreement_id": "test-agreement-id",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    config_entry_oauth2_flow.async_register_implementation(
+        hass,
+        DOMAIN,
+        config_entry_oauth2_flow.LocalOAuth2Implementation(
+            hass,
+            DOMAIN,
+            "client-id",
+            "client-secret",
+            "https://api.toon.eu/authorize",
+            "https://api.toon.eu/token",
+        ),
+    )
+
+    agreement = Agreement(
+        agreement_id="test-agreement-id",
+        display_common_name="display-common-name",
+        display_hardware_version="qb2/ICY/v0.8",
+        display_software_version="qb2/v1.2",
+        heating_type="gas",
+        is_toon_solar=True,
+    )
+    status = Status(agreement=agreement)
+    status.thermostat = ThermostatInfo(have_opentherm_boiler=True)
+
+    with (
+        patch("toonapi.Toon.activate_agreement"),
+        patch("toonapi.Toon.update", return_value=status),
+        patch(
+            "homeassistant.components.toon.coordinator."
+            "ToonDataUpdateCoordinator.register_webhook"
+        ),
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    def get_device(*identifier: str) -> dr.DeviceEntry:
+        device = device_registry.async_get_device(identifiers={(DOMAIN, *identifier)})
+        assert device is not None
+        return device
+
+    display = get_device("test-agreement-id")
+    assert display.via_device_id is None
+
+    meter_adapter = get_device("test-agreement-id", "meter_adapter")
+    assert meter_adapter.via_device_id == display.id
+
+    electricity = get_device("test-agreement-id", "electricity")
+    assert electricity.via_device_id == meter_adapter.id
+
+    boiler_module = get_device("test-agreement-id", "boiler_module")
+    assert boiler_module.via_device_id == display.id
+
+    assert get_device("test-agreement-id", "gas").via_device_id == electricity.id
+    assert get_device("test-agreement-id", "water").via_device_id == electricity.id
+    assert get_device("test-agreement-id", "solar").via_device_id == meter_adapter.id
+    assert get_device("test-agreement-id", "boiler").via_device_id == boiler_module.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `toon`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
