### PR TITLE
Fix via_device race in tractive

### DIFF
--- a/homeassistant/components/tractive/__init__.py
+++ b/homeassistant/components/tractive/__init__.py
@@ -19,7 +19,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import Event, HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.dispatcher import async_dispatcher_send
 
@@ -119,6 +119,21 @@ async def async_setup_entry(hass: HomeAssistant, entry: TractiveConfigEntry) -> 
     filtered_trackables = [item for item in trackables if item]
 
     entry.runtime_data = TractiveData(tractive, filtered_trackables)
+
+    # Register the tracker devices so entities on the pet devices can resolve
+    # their via_device link at construction time.
+    device_registry = dr.async_get(hass)
+    for item in filtered_trackables:
+        device_registry.async_get_or_create(
+            config_entry_id=entry.entry_id,
+            configuration_url="https://my.tractive.com/",
+            identifiers={(DOMAIN, item.tracker_details["_id"])},
+            translation_key="tracker",
+            translation_placeholders={"id": item.tracker_details["_id"]},
+            manufacturer="Tractive GmbH",
+            sw_version=item.tracker_details["fw_version"],
+            model_id=item.tracker_details["model_number"],
+        )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/tractive/binary_sensor.py
+++ b/homeassistant/components/tractive/binary_sensor.py
@@ -23,12 +23,16 @@ class TractiveBinarySensor(TractiveEntity, BinarySensorEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
+        entry: TractiveConfigEntry,
         client: TractiveClient,
         item: Trackables,
         description: TractiveBinarySensorEntityDescription,
     ) -> None:
         """Initialize sensor entity."""
         super().__init__(
+            hass,
+            entry,
             client,
             item.trackable,
             item.tracker_details,
@@ -80,7 +84,7 @@ async def async_setup_entry(
     trackables = entry.runtime_data.trackables
 
     entities = [
-        TractiveBinarySensor(client, item, description)
+        TractiveBinarySensor(hass, entry, client, item, description)
         for description in SENSOR_TYPES
         for item in trackables
         if description.supported(item.tracker_details)

--- a/homeassistant/components/tractive/device_tracker.py
+++ b/homeassistant/components/tractive/device_tracker.py
@@ -21,7 +21,7 @@ async def async_setup_entry(
     client = entry.runtime_data.client
     trackables = entry.runtime_data.trackables
 
-    entities = [TractiveDeviceTracker(client, item) for item in trackables]
+    entities = [TractiveDeviceTracker(hass, entry, client, item) for item in trackables]
 
     async_add_entities(entities)
 
@@ -32,9 +32,17 @@ class TractiveDeviceTracker(TractiveEntity, TrackerEntity):
     _attr_translation_key = "tracker"
     _attr_name = None
 
-    def __init__(self, client: TractiveClient, item: Trackables) -> None:
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: TractiveConfigEntry,
+        client: TractiveClient,
+        item: Trackables,
+    ) -> None:
         """Initialize tracker entity."""
         super().__init__(
+            hass,
+            entry,
             client,
             item.trackable,
             item.tracker_details,

--- a/homeassistant/components/tractive/entity.py
+++ b/homeassistant/components/tractive/entity.py
@@ -2,12 +2,13 @@
 
 from typing import Any, override
 
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity import Entity
 
-from . import TractiveClient
+from . import TractiveClient, TractiveConfigEntry
 from .const import DOMAIN, SERVER_UNAVAILABLE
 
 
@@ -18,6 +19,8 @@ class TractiveEntity(Entity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
+        entry: TractiveConfigEntry,
         client: TractiveClient,
         trackable: dict[str, Any],
         tracker_details: dict[str, Any],
@@ -39,7 +42,11 @@ class TractiveEntity(Entity):
             self._attr_device_info = DeviceInfo(
                 identifiers={(DOMAIN, trackable["_id"])},
                 name=trackable["details"]["name"],
-                via_device=(DOMAIN, tracker_details["_id"]),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    hass,
+                    (DOMAIN, tracker_details["_id"]),
+                    config_entry_id=entry.entry_id,
+                ),
                 entry_type=DeviceEntryType.SERVICE,
             )
 

--- a/homeassistant/components/tractive/sensor.py
+++ b/homeassistant/components/tractive/sensor.py
@@ -51,6 +51,8 @@ class TractiveSensor(TractiveEntity, SensorEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
+        entry: TractiveConfigEntry,
         client: TractiveClient,
         item: Trackables,
         description: TractiveSensorEntityDescription,
@@ -63,6 +65,8 @@ class TractiveSensor(TractiveEntity, SensorEntity):
         else:
             dispatcher_signal = f"{description.signal_prefix}-{item.trackable['_id']}"
         super().__init__(
+            hass,
+            entry,
             client,
             item.trackable,
             item.tracker_details,
@@ -156,7 +160,7 @@ async def async_setup_entry(
     trackables = entry.runtime_data.trackables
 
     entities = [
-        TractiveSensor(client, item, description)
+        TractiveSensor(hass, entry, client, item, description)
         for description in SENSOR_TYPES
         for item in trackables
     ]

--- a/homeassistant/components/tractive/switch.py
+++ b/homeassistant/components/tractive/switch.py
@@ -65,7 +65,7 @@ async def async_setup_entry(
     trackables = entry.runtime_data.trackables
 
     entities = [
-        TractiveSwitch(client, item, description)
+        TractiveSwitch(hass, entry, client, item, description)
         for description in SWITCH_TYPES
         for item in trackables
     ]
@@ -80,12 +80,16 @@ class TractiveSwitch(TractiveEntity, SwitchEntity):
 
     def __init__(
         self,
+        hass: HomeAssistant,
+        entry: TractiveConfigEntry,
         client: TractiveClient,
         item: Trackables,
         description: TractiveSwitchEntityDescription,
     ) -> None:
         """Initialize switch entity."""
         super().__init__(
+            hass,
+            entry,
             client,
             item.trackable,
             item.tracker_details,

--- a/tests/components/tractive/test_sensor.py
+++ b/tests/components/tractive/test_sensor.py
@@ -49,6 +49,7 @@ async def test_sensor_device_assignment(
 
     pet_device = device_registry.async_get_device(identifiers={(DOMAIN, "pet_id_123")})
     assert pet_device is not None
+    assert pet_device.via_device_id == tracker_device.id
 
     for entity_id in (
         "sensor.tracker_device_id_123_battery",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `tractive`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
