### PR TITLE
Refresh add-on update entities on Supervisor store_reloaded event

### DIFF
--- a/homeassistant/components/hassio/const.py
+++ b/homeassistant/components/hassio/const.py
@@ -90,6 +90,7 @@ EVENT_SUPPORTED_CHANGED = "supported_changed"
 EVENT_ISSUE_CHANGED = "issue_changed"
 EVENT_ISSUE_REMOVED = "issue_removed"
 EVENT_JOB = "job"
+EVENT_STORE_RELOADED = "store_reloaded"
 
 UPDATE_KEY_SUPERVISOR = "supervisor"
 STARTUP_COMPLETE = "complete"

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -1292,10 +1292,16 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
     @callback
     def _supervisor_event(self, event: dict[str, Any]) -> None:
         """Refresh add-on data when Supervisor reloads the store."""
-        if event.get(ATTR_WS_EVENT) == EVENT_STORE_RELOADED:
-            self.config_entry.async_create_task(
-                self.hass, self.async_refresh_after_store_reload()
-            )
+        if event.get(ATTR_WS_EVENT) != EVENT_STORE_RELOADED:
+            return
+        # Without listeners there are no add-on entities to keep in sync.
+        # Scheduled polling is paused in that case as well, so don't let
+        # store reload events trigger refreshes either.
+        if not self._listeners:
+            return
+        self.config_entry.async_create_task(
+            self.hass, self.async_refresh_after_store_reload()
+        )
 
     @override
     async def _async_update_data(self) -> HassioAddonData:

--- a/homeassistant/components/hassio/coordinator.py
+++ b/homeassistant/components/hassio/coordinator.py
@@ -83,6 +83,7 @@ from .const import (
     EVENT_ISSUE_CHANGED,
     EVENT_ISSUE_REMOVED,
     EVENT_JOB,
+    EVENT_STORE_RELOADED,
     EVENT_SUPERVISOR_EVENT,
     EVENT_SUPERVISOR_UPDATE,
     EVENT_SUPPORTED_CHANGED,
@@ -1284,6 +1285,17 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
         self.dev_reg = dev_reg
         self._addon_info_subscriptions: defaultdict[str, set[str]] = defaultdict(set)
         self.supervisor_client = get_supervisor_client(hass)
+        self._dispatcher_disconnect = async_dispatcher_connect(
+            hass, EVENT_SUPERVISOR_EVENT, self._supervisor_event
+        )
+
+    @callback
+    def _supervisor_event(self, event: dict[str, Any]) -> None:
+        """Refresh add-on data when Supervisor reloads the store."""
+        if event.get(ATTR_WS_EVENT) == EVENT_STORE_RELOADED:
+            self.config_entry.async_create_task(
+                self.hass, self.async_refresh_after_store_reload()
+            )
 
     @override
     async def _async_update_data(self) -> HassioAddonData:
@@ -1451,6 +1463,12 @@ class HassioAddOnDataUpdateCoordinator(DataUpdateCoordinator[HassioAddonData]):
             # Update addon info cache in hass.data
             addon_info_cache = self.hass.data.setdefault(DATA_ADDONS_INFO, {})
             addon_info_cache[slug] = info
+
+    @override
+    async def async_shutdown(self) -> None:
+        """Shut down and clean up when config entry unloaded."""
+        await super().async_shutdown()
+        self._dispatcher_disconnect()
 
 
 class HassioMainDataUpdateCoordinator(DataUpdateCoordinator[HassioMainData]):

--- a/homeassistant/components/hassio/websocket_api.py
+++ b/homeassistant/components/hassio/websocket_api.py
@@ -20,7 +20,6 @@ from homeassistant.helpers.dispatcher import (
 
 from .config_entry import async_get_hassio_entry, async_get_update_options
 from .const import (
-    ADDONS_COORDINATOR,
     ATTR_DATA,
     ATTR_ENDPOINT,
     ATTR_METHOD,
@@ -58,10 +57,6 @@ WS_NO_ADMIN_ENDPOINTS = re.compile(
     f"|{RE_ADDONS_INFO_ENDPOINT}"
     r")$"
 )
-
-# Endpoint that reloads the add-on store. Afterwards the add-on update
-# entities must be refreshed so they don't report stale update information.
-STORE_RELOAD_ENDPOINT = "/store/reload"
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -163,15 +158,6 @@ async def websocket_supervisor_api(
         # sensitive information and the frontend does not require it for ingress.
         if not connection.user.is_admin and WS_ADDONS_INFO_ENDPOINT.match(command):
             data.pop("options", None)
-        # Await so the frontend only sees the reload finish once the add-on
-        # update entities reflect the reloaded store.
-        if (
-            command == STORE_RELOAD_ENDPOINT
-            and msg[ATTR_METHOD] == "post"
-            and (coordinator := hass.data.get(ADDONS_COORDINATOR))
-        ):
-            await coordinator.async_refresh_after_store_reload()
-
         connection.send_result(msg[WS_ID], data)
 
 

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -417,6 +417,32 @@ async def test_store_reloaded_event_refreshes_update_entities(
     supervisor_client.store.reload.assert_not_called()
 
 
+async def test_store_reloaded_event_ignored_without_listeners(
+    hass: HomeAssistant,
+    addons_list: AsyncMock,
+) -> None:
+    """Test a store_reloaded event does not refresh without add-on entities."""
+    addons_list.return_value = []
+    config_entry = MockConfigEntry(domain=DOMAIN, data={}, unique_id=DOMAIN)
+    config_entry.add_to_hass(hass)
+
+    with patch.dict(os.environ, MOCK_ENVIRON):
+        assert await async_setup_component(hass, DOMAIN, {"hassio": {}})
+    await hass.async_block_till_done()
+
+    # Without add-on entities the coordinator has no listeners,
+    # so the event must not trigger an add-on data fetch.
+    addons_list.reset_mock()
+    async_dispatcher_send(
+        hass,
+        EVENT_SUPERVISOR_EVENT,
+        {"event": "store_reloaded", "data": {"repositories": ["core"]}},
+    )
+    await hass.async_block_till_done()
+
+    addons_list.assert_not_called()
+
+
 async def test_update_addon(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,

--- a/tests/components/hassio/test_websocket_api.py
+++ b/tests/components/hassio/test_websocket_api.py
@@ -375,14 +375,12 @@ async def test_websocket_non_admin_user(
     assert msg["error"]["message"] == "Unauthorized"
 
 
-async def test_websocket_store_reload_refreshes_update_entities(
+async def test_store_reloaded_event_refreshes_update_entities(
     hass: HomeAssistant,
-    hass_ws_client: WebSocketGenerator,
-    aioclient_mock: AiohttpClientMocker,
     supervisor_client: AsyncMock,
     addons_list: AsyncMock,
 ) -> None:
-    """Test add-on update entities refresh after a store reload via the API proxy."""
+    """Test add-on update entities refresh on a Supervisor store_reloaded event."""
     addons_list.return_value = [
         replace(
             addons_list.return_value[0],
@@ -406,22 +404,16 @@ async def test_websocket_store_reload_refreshes_update_entities(
             version_latest="2.0.1",
         )
     ]
-    aioclient_mock.post(
-        "http://127.0.0.1/store/reload", json={"result": "ok", "data": {}}
-    )
 
-    websocket_client = await hass_ws_client(hass)
-    await websocket_client.send_json_auto_id(
-        {
-            WS_TYPE: WS_TYPE_API,
-            ATTR_ENDPOINT: "/store/reload",
-            ATTR_METHOD: "post",
-        }
+    async_dispatcher_send(
+        hass,
+        EVENT_SUPERVISOR_EVENT,
+        {"event": "store_reloaded", "data": {"repositories": ["core"]}},
     )
-    msg = await websocket_client.receive_json()
-    assert msg["success"]
+    await hass.async_block_till_done()
 
     assert hass.states.get("update.test_update").state == "on"
+    # Supervisor already reloaded the store, so we must not reload it again.
     supervisor_client.store.reload.assert_not_called()
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

#176648 made the add-on `update` entities refresh after a store reload by inspecting `/store/reload` traffic passing through the generic `supervisor/api` websocket proxy. Matching a specific endpoint string inside a generic passthrough is fragile and surprising: it couples the proxy handler to endpoint semantics, only covers frontend-triggered reloads, and breaks silently if the endpoint is ever renamed.

Supervisor now emits a `store_reloaded` event whenever a store reload actually updates a repository (home-assistant/supervisor#7057, shipped with Supervisor 2026.7.5 on stable channel). This switches Core to subscribe to that event directly, the same event-driven mechanism the coordinators already use for `supervisor_update`, `job`, `issue_changed`, etc.

- `HassioAddOnDataUpdateCoordinator` now subscribes to `EVENT_SUPERVISOR_EVENT` and, on `store_reloaded`, refreshes its add-on data through `async_refresh_after_store_reload()` (which skips its own `store.reload()` since Supervisor already reloaded).
- The `/store/reload` endpoint match is removed from the `supervisor/api` proxy handler.

Besides removing the sniffing, this also covers Supervisor's periodic store reloads, not just frontend-triggered ones, so entities stay in sync even without a user clicking "Check for updates". Version skew is harmless: against an older Supervisor the event simply never arrives and the coordinator keeps polling as before.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/core#176584, home-assistant/supervisor#7057
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
