### PR TITLE
Fix via_device race in verisure

### DIFF
--- a/homeassistant/components/verisure/__init__.py
+++ b/homeassistant/components/verisure/__init__.py
@@ -9,10 +9,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_EMAIL, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.storage import STORAGE_DIR
 
-from .const import CONF_LOCK_DEFAULT_CODE, LOGGER
+from .const import CONF_GIID, CONF_LOCK_DEFAULT_CODE, DOMAIN, LOGGER
 from .coordinator import VerisureConfigEntry, VerisureDataUpdateCoordinator
 
 PLATFORMS = [
@@ -38,7 +38,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: VerisureConfigEntry) -> 
 
     entry.runtime_data = coordinator
 
-    # Migrate lock default code from config entry to lock entity
+    # Register the alarm (VBox) device so children can link to it via via_device_id
+    # regardless of platform setup order.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.data[CONF_GIID])},
+        manufacturer="Verisure",
+        model="VBox",
+        name="Verisure Alarm",
+        configuration_url="https://mypages.verisure.com",
+    )
 
     # Set up all platforms for this device/entry.
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)

--- a/homeassistant/components/verisure/binary_sensor.py
+++ b/homeassistant/components/verisure/binary_sensor.py
@@ -8,6 +8,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.const import ATTR_LAST_TRIP_TIME, EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -51,18 +52,17 @@ class VerisureDoorWindowSensor(
         super().__init__(coordinator)
         self._attr_unique_id = f"{serial_number}_door_window"
         self.serial_number = serial_number
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        area = self.coordinator.data["door_window"][self.serial_number]["area"]
-        return DeviceInfo(
+        area = coordinator.data["door_window"][serial_number]["area"]
+        self._attr_device_info = DeviceInfo(
             name=area,
             manufacturer="Verisure",
             model="Shock Sensor Detector",
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.config_entry.data[CONF_GIID]),
+            identifiers={(DOMAIN, serial_number)},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_GIID]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             configuration_url="https://mypages.verisure.com",
         )
 

--- a/homeassistant/components/verisure/camera.py
+++ b/homeassistant/components/verisure/camera.py
@@ -9,6 +9,7 @@ from verisure import Error as VerisureError
 from homeassistant.components.camera import Camera
 from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
@@ -63,18 +64,17 @@ class VerisureSmartcam(CoordinatorEntity[VerisureDataUpdateCoordinator], Camera)
         self._directory_path = directory_path
         self._image: str | None = None
         self._image_id: str | None = None
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        area = self.coordinator.data["cameras"][self.serial_number]["device"]["area"]
-        return DeviceInfo(
+        area = coordinator.data["cameras"][serial_number]["device"]["area"]
+        self._attr_device_info = DeviceInfo(
             name=area,
             manufacturer="Verisure",
             model="SmartCam",
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.config_entry.data[CONF_GIID]),
+            identifiers={(DOMAIN, serial_number)},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_GIID]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             configuration_url="https://mypages.verisure.com",
         )
 

--- a/homeassistant/components/verisure/lock.py
+++ b/homeassistant/components/verisure/lock.py
@@ -8,6 +8,7 @@ from verisure import Error as VerisureError
 from homeassistant.components.lock import LockEntity, LockState
 from homeassistant.const import ATTR_CODE
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
@@ -70,18 +71,17 @@ class VerisureDoorlock(CoordinatorEntity[VerisureDataUpdateCoordinator], LockEnt
         self._attr_is_locked = None
         self._attr_changed_by = None
         self._changed_method: str | None = None
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        area = self.coordinator.data["locks"][self.serial_number]["device"]["area"]
-        return DeviceInfo(
+        area = coordinator.data["locks"][serial_number]["device"]["area"]
+        self._attr_device_info = DeviceInfo(
             name=area,
             manufacturer="Verisure",
             model="Lockguard Smartlock",
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.config_entry.data[CONF_GIID]),
+            identifiers={(DOMAIN, serial_number)},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_GIID]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             configuration_url="https://mypages.verisure.com",
         )
 

--- a/homeassistant/components/verisure/sensor.py
+++ b/homeassistant/components/verisure/sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
@@ -58,21 +59,18 @@ class VerisureThermometer(
         super().__init__(coordinator)
         self._attr_unique_id = f"{serial_number}_temperature"
         self.serial_number = serial_number
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        device_type = self.coordinator.data["climate"][self.serial_number]["device"][
-            "gui"
-        ]["label"]
-        area = self.coordinator.data["climate"][self.serial_number]["device"]["area"]
-        return DeviceInfo(
-            name=area,
+        device = coordinator.data["climate"][serial_number]["device"]
+        device_type = device["gui"]["label"]
+        self._attr_device_info = DeviceInfo(
+            name=device["area"],
             manufacturer="Verisure",
             model=DEVICE_TYPE_NAME.get(device_type, device_type),
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.config_entry.data[CONF_GIID]),
+            identifiers={(DOMAIN, serial_number)},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_GIID]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             configuration_url="https://mypages.verisure.com",
         )
 
@@ -111,21 +109,18 @@ class VerisureHygrometer(
         super().__init__(coordinator)
         self._attr_unique_id = f"{serial_number}_humidity"
         self.serial_number = serial_number
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        device_type = self.coordinator.data["climate"][self.serial_number]["device"][
-            "gui"
-        ]["label"]
-        area = self.coordinator.data["climate"][self.serial_number]["device"]["area"]
-        return DeviceInfo(
-            name=area,
+        device = coordinator.data["climate"][serial_number]["device"]
+        device_type = device["gui"]["label"]
+        self._attr_device_info = DeviceInfo(
+            name=device["area"],
             manufacturer="Verisure",
             model=DEVICE_TYPE_NAME.get(device_type, device_type),
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.config_entry.data[CONF_GIID]),
+            identifiers={(DOMAIN, serial_number)},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_GIID]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             configuration_url="https://mypages.verisure.com",
         )
 

--- a/homeassistant/components/verisure/switch.py
+++ b/homeassistant/components/verisure/switch.py
@@ -5,6 +5,7 @@ from typing import Any, override
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -42,20 +43,17 @@ class VerisureSmartplug(CoordinatorEntity[VerisureDataUpdateCoordinator], Switch
         self.serial_number = serial_number
         self._change_timestamp: float = 0
         self._state = False
-
-    @property
-    @override
-    def device_info(self) -> DeviceInfo:
-        """Return device information about this entity."""
-        area = self.coordinator.data["smart_plugs"][self.serial_number]["device"][
-            "area"
-        ]
-        return DeviceInfo(
+        area = coordinator.data["smart_plugs"][serial_number]["device"]["area"]
+        self._attr_device_info = DeviceInfo(
             name=area,
             manufacturer="Verisure",
             model="SmartPlug",
-            identifiers={(DOMAIN, self.serial_number)},
-            via_device=(DOMAIN, self.coordinator.config_entry.data[CONF_GIID]),
+            identifiers={(DOMAIN, serial_number)},
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_GIID]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
             configuration_url="https://mypages.verisure.com",
         )
 

--- a/tests/components/verisure/conftest.py
+++ b/tests/components/verisure/conftest.py
@@ -28,7 +28,12 @@ OVERVIEW = [
                 "smartLocks": [
                     {"device": {"deviceLabel": "lock-1"}, "status": "LOCKED"}
                 ],
-                "smartplugs": [{"device": {"deviceLabel": "plug-1"}, "status": "on"}],
+                "smartplugs": [
+                    {
+                        "device": {"deviceLabel": "plug-1", "area": "Living room"},
+                        "currentState": "ON",
+                    }
+                ],
             }
         }
     }

--- a/tests/components/verisure/test_init.py
+++ b/tests/components/verisure/test_init.py
@@ -16,6 +16,7 @@ from verisure import (
 )
 
 from homeassistant.components.verisure.const import (
+    CONF_GIID,
     COOKIE_REFRESH_INTERVAL,
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
@@ -24,7 +25,7 @@ from homeassistant.components.verisure.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import update_coordinator
+from homeassistant.helpers import device_registry as dr, update_coordinator
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -67,6 +68,26 @@ async def test_setup_success(
     mock_verisure.login_cookie.assert_called_once()
     mock_verisure.set_giid.assert_called_once()
     assert hass.states.get(ALARM_ENTITY_ID).state == "disarmed"
+
+
+async def test_child_device_links_to_alarm_via_device(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_verisure: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Child devices link to the alarm (VBox) device via via_device_id."""
+    mock_config_entry.add_to_hass(hass)
+    with patch("homeassistant.components.verisure.PLATFORMS", [Platform.SWITCH]):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    giid = mock_config_entry.data[CONF_GIID]
+    alarm_device = device_registry.async_get_device(identifiers={(DOMAIN, giid)})
+    plug_device = device_registry.async_get_device(identifiers={(DOMAIN, "plug-1")})
+    assert alarm_device is not None
+    assert plug_device is not None
+    assert plug_device.via_device_id == alarm_device.id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/verisure/test_init.py
+++ b/tests/components/verisure/test_init.py
@@ -70,10 +70,10 @@ async def test_setup_success(
     assert hass.states.get(ALARM_ENTITY_ID).state == "disarmed"
 
 
+@pytest.mark.usefixtures("mock_verisure")
 async def test_child_device_links_to_alarm_via_device(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
-    mock_verisure: MagicMock,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Child devices link to the alarm (VBox) device via via_device_id."""
@@ -83,8 +83,12 @@ async def test_child_device_links_to_alarm_via_device(
     await hass.async_block_till_done()
 
     giid = mock_config_entry.data[CONF_GIID]
-    alarm_device = device_registry.async_get_device(identifiers={(DOMAIN, giid)})
-    plug_device = device_registry.async_get_device(identifiers={(DOMAIN, "plug-1")})
+    alarm_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, giid), mock_config_entry.entry_id
+    )
+    plug_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "plug-1"), mock_config_entry.entry_id
+    )
     assert alarm_device is not None
     assert plug_device is not None
     assert plug_device.via_device_id == alarm_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `verisure`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
