### PR TITLE
fix enphase envoy diagnostics report error

### DIFF
--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -4,7 +4,7 @@ import copy
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
-from aiohttp import ClientResponse
+from aiohttp import ClientError, ClientResponse
 from pyenphase.envoy import Envoy
 from pyenphase.exceptions import EnvoyError
 
@@ -92,7 +92,8 @@ async def _get_fixture_collection(envoy: Envoy, serial: str) -> dict[str, Any]:
                     "code": response.status,
                 }
             )
-        except EnvoyError as err:
+        except (EnvoyError, ClientError) as err:
+            # except EnvoyError as err:
             fixture_data[f"{end_point}_log"] = {"Error": repr(err)}
     return fixture_data
 

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -94,7 +94,7 @@ async def _get_fixture_collection(envoy: Envoy, serial: str) -> dict[str, Any]:
             )
         except ClientError as err:
             fixture_data[f"{end_point}_log"] = {
-                "Error": f"Aiohttp Client error {'' if not hasattr(err, 'status') else err.status}"
+                "Error": f"Aiohttp Client error {type(err).__name__ if not hasattr(err, 'status') else err.status}"
             }
         except EnvoyError as err:
             fixture_data[f"{end_point}_log"] = {"Error": repr(err)}

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -93,7 +93,6 @@ async def _get_fixture_collection(envoy: Envoy, serial: str) -> dict[str, Any]:
                 }
             )
         except (EnvoyError, ClientError) as err:
-            # except EnvoyError as err:
             fixture_data[f"{end_point}_log"] = {"Error": repr(err)}
     return fixture_data
 

--- a/homeassistant/components/enphase_envoy/diagnostics.py
+++ b/homeassistant/components/enphase_envoy/diagnostics.py
@@ -92,7 +92,11 @@ async def _get_fixture_collection(envoy: Envoy, serial: str) -> dict[str, Any]:
                     "code": response.status,
                 }
             )
-        except (EnvoyError, ClientError) as err:
+        except ClientError as err:
+            fixture_data[f"{end_point}_log"] = {
+                "Error": f"Aiohttp Client error {'' if not hasattr(err, 'status') else err.status}"
+            }
+        except EnvoyError as err:
             fixture_data[f"{end_point}_log"] = {"Error": repr(err)}
     return fixture_data
 

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock
 
-from aiohttp import ClientResponseError
+from aiohttp import ClientConnectionError, ClientResponseError
 from aiohttp.client import RequestInfo
 from freezegun.api import FrozenDateTimeFactory
 from pyenphase.exceptions import EnvoyError
@@ -130,6 +130,14 @@ async def test_entry_diagnostics_with_fixtures_with_clientresponse_error(
         hass, hass_client, config_entry_options
     )
     assert diagnostics["fixtures"]["/info_log"] == {"Error": "EnvoyError('Test')"}
+
+    mock_envoy.request.side_effect = ClientConnectionError
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry_options
+    )
+    assert diagnostics["fixtures"]["/info_log"] == {
+        "Error": "Aiohttp Client error ClientConnectionError"
+    }
 
 
 @pytest.mark.parametrize(

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from unittest.mock import AsyncMock
 
+from aiohttp import ClientError
 from freezegun.api import FrozenDateTimeFactory
 from pyenphase.exceptions import EnvoyError
 from pyenphase.models.meters import CtType
@@ -93,6 +94,22 @@ async def test_entry_diagnostics_with_fixtures_with_error(
     assert await get_diagnostics_for_config_entry(
         hass, hass_client, config_entry_options
     ) == snapshot(exclude=limit_diagnostic_attrs)
+
+
+async def test_entry_diagnostics_with_fixtures_with_clientresponse_error(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    config_entry_options: MockConfigEntry,
+    snapshot: SnapshotAssertion,
+    mock_envoy: AsyncMock,
+) -> None:
+    """Test diagnostics test fixtures with client errors."""
+    await setup_integration(hass, config_entry_options)
+    mock_envoy.request.side_effect = ClientError
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry_options
+    )
+    assert diagnostics["fixtures"]["/info_log"] == {"Error": "ClientError()"}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/enphase_envoy/test_diagnostics.py
+++ b/tests/components/enphase_envoy/test_diagnostics.py
@@ -2,7 +2,8 @@
 
 from unittest.mock import AsyncMock
 
-from aiohttp import ClientError
+from aiohttp import ClientResponseError
+from aiohttp.client import RequestInfo
 from freezegun.api import FrozenDateTimeFactory
 from pyenphase.exceptions import EnvoyError
 from pyenphase.models.meters import CtType
@@ -105,11 +106,30 @@ async def test_entry_diagnostics_with_fixtures_with_clientresponse_error(
 ) -> None:
     """Test diagnostics test fixtures with client errors."""
     await setup_integration(hass, config_entry_options)
-    mock_envoy.request.side_effect = ClientError
+    mock_envoy.request.side_effect = ClientResponseError(
+        RequestInfo(
+            url="http://example.com",
+            method="GET",
+            headers={
+                "Host": "www.example.com",
+                "Connection": "keep-alive",
+                "secret": "very secret secret",
+            },
+            real_url="http://example.com",
+        ),
+        None,
+        status=0,
+    )
     diagnostics = await get_diagnostics_for_config_entry(
         hass, hass_client, config_entry_options
     )
-    assert diagnostics["fixtures"]["/info_log"] == {"Error": "ClientError()"}
+    assert diagnostics["fixtures"]["/info_log"] == {"Error": "Aiohttp Client error 0"}
+
+    mock_envoy.request.side_effect = EnvoyError("Test")
+    diagnostics = await get_diagnostics_for_config_entry(
+        hass, hass_client, config_entry_options
+    )
+    assert diagnostics["fixtures"]["/info_log"] == {"Error": "EnvoyError('Test')"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Can this be included in 2026.8 BETA?

Add exception catching of aiohttp ClientError to the fixture file collection of the enphase envoy diagnostics report. 

A recent released and pushed Enphase IQ Gateway (Envoy) firmware version (8.3.5433) now returns http status 0 for one of the endpoints included in the diagnostics report fixtures section. This breaks the report creation for all other endpoints that still work fine.

This PR now catches the aiohttp ClientError exceptions and reports these in the fixtures section instead of the actual data.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/pyenphase/pyenphase/issues/467#issuecomment-5095923886
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
