### PR TITLE
Avoid naive datetime.now() in backblaze_b2 tests

### DIFF
--- a/tests/components/backblaze_b2/test_init.py
+++ b/tests/components/backblaze_b2/test_init.py
@@ -1,6 +1,5 @@
 """Test the Backblaze B2 storage integration."""
 
-from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from b2sdk.v2 import exception
@@ -9,6 +8,7 @@ import pytest
 from homeassistant.components.backblaze_b2.const import CONF_APPLICATION_KEY
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import setup_integration
 
@@ -101,7 +101,7 @@ async def test_periodic_issue_check(
     ):
         await setup_integration(hass, mock_config_entry)
         assert captured_callback is not None
-        await captured_callback(datetime.now())  # pylint: disable=home-assistant-enforce-naive-now
+        await captured_callback(dt_util.utcnow())
 
         assert mock_check.call_count == 2  # setup + callback
         mock_check.assert_called_with(hass, mock_config_entry)


### PR DESCRIPTION
## Proposed change

The backblaze_b2 test suite called a naive `datetime.now()` directly to fabricate a callback timestamp, which required suppressing the `home-assistant-enforce-naive-now` pylint check. `async_track_time_interval` always invokes its callback with a UTC-aware datetime, so the test now passes `dt_util.utcnow()` instead. This removes the need for the `datetime` import and the pylint suppression.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177791
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
