### PR TITLE
Adapt xiaomi_aqara to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/xiaomi_aqara/entity.py
+++ b/homeassistant/components/xiaomi_aqara/entity.py
@@ -103,6 +103,7 @@ class XiaomiDevice(Entity):
         else:
             if TYPE_CHECKING:
                 assert self._gateway_id is not None
+                assert self.platform.config_entry is not None
             device_info = DeviceInfo(
                 connections={(dr.CONNECTION_ZIGBEE, self._device_id)},
                 identifiers={(DOMAIN, self._device_id)},
@@ -110,7 +111,11 @@ class XiaomiDevice(Entity):
                 model=self._model,
                 name=self._device_name,
                 sw_version=self._protocol,
-                via_device=(DOMAIN, self._gateway_id),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    self.hass,
+                    (DOMAIN, self._gateway_id),
+                    config_entry_id=self.platform.config_entry.entry_id,
+                ),
             )
 
         return device_info

--- a/tests/components/xiaomi_aqara/test_init.py
+++ b/tests/components/xiaomi_aqara/test_init.py
@@ -1,0 +1,84 @@
+"""Test the Xiaomi Aqara setup and device registry linking."""
+
+from collections import defaultdict
+from unittest.mock import AsyncMock, Mock, patch
+
+from homeassistant.components.xiaomi_aqara import const
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_HOST, CONF_MAC, CONF_PORT, CONF_PROTOCOL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+TEST_HOST = "1.2.3.4"
+TEST_PORT = 1234
+TEST_PROTOCOL = "1.1.1"
+TEST_MAC = "ab:cd:ef:00:11:22"
+TEST_MOTION_SID = "158d0001a2b3c4"
+
+
+async def test_child_device_links_to_gateway_via_device_id(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test a Zigbee child device is linked to its gateway via via_device_id."""
+    mock_gateway = Mock()
+    mock_gateway.sid = TEST_MAC.replace(":", "").lower()
+    mock_gateway.callbacks = defaultdict(list)
+    mock_gateway.devices = {
+        "binary_sensor": [
+            {
+                "sid": TEST_MOTION_SID,
+                "model": "motion",
+                "proto": TEST_PROTOCOL,
+                "data": {},
+                "raw_data": {"cmd": "report"},
+            }
+        ],
+        "sensor": [],
+    }
+
+    mock_multicast = Mock()
+    mock_multicast.start_listen = AsyncMock()
+    mock_multicast.stop_listen = Mock()
+
+    entry = MockConfigEntry(
+        domain=const.DOMAIN,
+        unique_id=TEST_MAC,
+        data={
+            CONF_HOST: TEST_HOST,
+            CONF_PORT: TEST_PORT,
+            CONF_MAC: TEST_MAC,
+            const.CONF_INTERFACE: "any",
+            CONF_PROTOCOL: TEST_PROTOCOL,
+            const.CONF_KEY: None,
+            const.CONF_SID: mock_gateway.sid,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(
+            "homeassistant.components.xiaomi_aqara.XiaomiGateway",
+            return_value=mock_gateway,
+        ),
+        patch(
+            "homeassistant.components.xiaomi_aqara.AsyncXiaomiGatewayMulticast",
+            return_value=mock_multicast,
+        ),
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    gateway_device = device_registry.async_get_device_by_identifier(
+        (const.DOMAIN, TEST_MAC), entry.entry_id
+    )
+    child_device = device_registry.async_get_device_by_identifier(
+        (const.DOMAIN, TEST_MOTION_SID), entry.entry_id
+    )
+
+    assert gateway_device is not None
+    assert child_device is not None
+    assert child_device.via_device_id == gateway_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `xiaomi_aqara` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
