### PR TITLE
Fix via_device race in yale_smart_alarm

### DIFF
--- a/homeassistant/components/yale_smart_alarm/__init__.py
+++ b/homeassistant/components/yale_smart_alarm/__init__.py
@@ -4,7 +4,7 @@ from homeassistant.components.lock import CONF_DEFAULT_CODE, DOMAIN as LOCK_DOMA
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_CODE, CONF_NAME
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .const import LOGGER, PLATFORMS
 from .coordinator import YaleDataUpdateCoordinator
@@ -18,6 +18,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: YaleConfigEntry) -> bool
     coordinator = YaleDataUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+
+    # Register the alarm panel device so child devices can link to it via
+    # via_device_id, since the panel is otherwise only registered by a sibling
+    # entity on a concurrently loaded platform.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **coordinator.device_info,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/yale_smart_alarm/coordinator.py
+++ b/homeassistant/components/yale_smart_alarm/coordinator.py
@@ -10,12 +10,20 @@ from yalesmartalarmclient.exceptions import AuthenticationError
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 if TYPE_CHECKING:
     from . import YaleConfigEntry
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LOGGER, YALE_BASE_ERRORS
+from .const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+    MANUFACTURER,
+    MODEL,
+    YALE_BASE_ERRORS,
+)
 
 
 class YaleDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -35,6 +43,19 @@ class YaleDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             always_update=False,
         )
         self.locks: list[YaleLock] = []
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info for the alarm panel."""
+        panel_info = self.data["panel_info"]
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.config_entry.data[CONF_USERNAME])},
+            connections={(CONNECTION_NETWORK_MAC, panel_info["mac"])},
+            manufacturer=MANUFACTURER,
+            model=MODEL,
+            name=self.config_entry.title,
+            sw_version=panel_info["version"],
+        )
 
     def _yale_setup(self) -> tuple[YaleSmartAlarmClient, list[YaleLock]]:
         """Set up connection to Yale."""

--- a/homeassistant/components/yale_smart_alarm/entity.py
+++ b/homeassistant/components/yale_smart_alarm/entity.py
@@ -3,7 +3,8 @@
 from yalesmartalarmclient import YaleLock
 
 from homeassistant.const import CONF_USERNAME
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -25,7 +26,11 @@ class YaleEntity(CoordinatorEntity[YaleDataUpdateCoordinator]):
             manufacturer=MANUFACTURER,
             model=MODEL,
             identifiers={(DOMAIN, data["address"])},
-            via_device=(DOMAIN, coordinator.config_entry.data[CONF_USERNAME]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_USERNAME]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
 
 
@@ -43,7 +48,11 @@ class YaleLockEntity(CoordinatorEntity[YaleDataUpdateCoordinator]):
             manufacturer=MANUFACTURER,
             model=MODEL,
             identifiers={(DOMAIN, lock.sid())},
-            via_device=(DOMAIN, coordinator.config_entry.data[CONF_USERNAME]),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.config_entry.data[CONF_USERNAME]),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )
         self.lock_data = lock
 
@@ -56,12 +65,4 @@ class YaleAlarmEntity(CoordinatorEntity[YaleDataUpdateCoordinator], Entity):
     def __init__(self, coordinator: YaleDataUpdateCoordinator) -> None:
         """Initialize an Yale device."""
         super().__init__(coordinator)
-        panel_info = coordinator.data["panel_info"]
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, coordinator.config_entry.data[CONF_USERNAME])},
-            manufacturer=MANUFACTURER,
-            model=MODEL,
-            name=coordinator.config_entry.title,
-            connections={(CONNECTION_NETWORK_MAC, panel_info["mac"])},
-            sw_version=panel_info["version"],
-        )
+        self._attr_device_info = coordinator.device_info

--- a/tests/components/yale_smart_alarm/test_init.py
+++ b/tests/components/yale_smart_alarm/test_init.py
@@ -47,26 +47,37 @@ async def test_setup_entry(
     assert entry.state is ConfigEntryState.NOT_LOADED
 
 
-@pytest.mark.parametrize("load_platforms", [[Platform.LOCK]])
+@pytest.mark.parametrize(
+    ("load_platforms", "child_identifier"),
+    [
+        pytest.param([Platform.LOCK], "1111", id="lock"),
+        pytest.param([Platform.BINARY_SENSOR], "RF4", id="binary_sensor"),
+    ],
+)
 async def test_child_devices_linked_to_panel(
     hass: HomeAssistant,
     load_config_entry: tuple[MockConfigEntry, Mock],
     device_registry: dr.DeviceRegistry,
+    child_identifier: str,
 ) -> None:
     """Test child devices link to the alarm panel through via_device_id.
 
-    Only the lock platform is loaded, whose entities never create the panel
-    device themselves, so the link is established solely by the panel being
-    registered at setup.
+    Only a single platform is loaded per case, whose entities never create the
+    panel device themselves, so the link is established solely by the panel
+    being registered at setup. Covers both YaleEntity and YaleLockEntity.
     """
-    panel_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, ENTRY_CONFIG["username"])}
+    config_entry, _ = load_config_entry
+
+    panel_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, ENTRY_CONFIG["username"]), config_entry.entry_id
     )
     assert panel_device is not None
 
-    lock_device = device_registry.async_get_device(identifiers={(DOMAIN, "1111")})
-    assert lock_device is not None
-    assert lock_device.via_device_id == panel_device.id
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, child_identifier), config_entry.entry_id
+    )
+    assert child_device is not None
+    assert child_device.via_device_id == panel_device.id
 
 
 async def test_migrate_entry(

--- a/tests/components/yale_smart_alarm/test_init.py
+++ b/tests/components/yale_smart_alarm/test_init.py
@@ -2,11 +2,14 @@
 
 from unittest.mock import Mock, patch
 
+import pytest
+
 from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
 from homeassistant.components.yale_smart_alarm.const import DOMAIN
 from homeassistant.config_entries import SOURCE_USER, ConfigEntryState
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 from .conftest import ENTRY_CONFIG, OPTIONS_CONFIG
 
@@ -42,6 +45,28 @@ async def test_setup_entry(
 
     await hass.config_entries.async_unload(entry.entry_id)
     assert entry.state is ConfigEntryState.NOT_LOADED
+
+
+@pytest.mark.parametrize("load_platforms", [[Platform.LOCK]])
+async def test_child_devices_linked_to_panel(
+    hass: HomeAssistant,
+    load_config_entry: tuple[MockConfigEntry, Mock],
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test child devices link to the alarm panel through via_device_id.
+
+    Only the lock platform is loaded, whose entities never create the panel
+    device themselves, so the link is established solely by the panel being
+    registered at setup.
+    """
+    panel_device = device_registry.async_get_device(
+        identifiers={(DOMAIN, ENTRY_CONFIG["username"])}
+    )
+    assert panel_device is not None
+
+    lock_device = device_registry.async_get_device(identifiers={(DOMAIN, "1111")})
+    assert lock_device is not None
+    assert lock_device.via_device_id == panel_device.id
 
 
 async def test_migrate_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `yale_smart_alarm`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
