### PR TITLE
Fix via_device race in yardian

### DIFF
--- a/homeassistant/components/yardian/__init__.py
+++ b/homeassistant/components/yardian/__init__.py
@@ -4,6 +4,7 @@ from pyyardian import AsyncYardianClient
 
 from homeassistant.const import CONF_ACCESS_TOKEN, CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .coordinator import YardianConfigEntry, YardianUpdateCoordinator
@@ -32,6 +33,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: YardianConfigEntry) -> b
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Register the main device so zone child devices can resolve it as their
+    # via_device regardless of platform setup order.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        **coordinator.device_info,
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/yardian/entity.py
+++ b/homeassistant/components/yardian/entity.py
@@ -1,5 +1,6 @@
 """Base entities for Yardian integration."""
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -31,5 +32,9 @@ class YardianZoneEntity(CoordinatorEntity[YardianUpdateCoordinator]):
             identifiers={(DOMAIN, f"{coordinator.yid}_{zone_id}")},
             name=coordinator.data.zones[zone_id].name,
             manufacturer=MANUFACTURER,
-            via_device=(DOMAIN, coordinator.yid),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, coordinator.yid),
+                config_entry_id=coordinator.config_entry.entry_id,
+            ),
         )

--- a/tests/components/yardian/conftest.py
+++ b/tests/components/yardian/conftest.py
@@ -81,6 +81,13 @@ def sensor_platform_only() -> Generator[None]:
         yield
 
 
+@pytest.fixture
+def switch_platform_only() -> Generator[None]:
+    """Limit the integration setup to the switch (child-only) platform."""
+    with patch("homeassistant.components.yardian.PLATFORMS", [Platform.SWITCH]):
+        yield
+
+
 @pytest.fixture(autouse=True)
 def mock_ui_refresh_delay() -> Generator[None]:
     """Patch the Switch refresh delay to 0 seconds to speed up tests."""

--- a/tests/components/yardian/test_init.py
+++ b/tests/components/yardian/test_init.py
@@ -39,17 +39,21 @@ async def test_setup_unauthorized(
     assert mock_config_entry.state is entry_state
 
 
+@pytest.mark.usefixtures("mock_yardian_client", "switch_platform_only")
 async def test_zone_device_via_device(
     hass: HomeAssistant,
-    mock_yardian_client: AsyncMock,
     mock_config_entry: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test that zone child devices link to the main device via via_device_id."""
     await setup_integration(hass, mock_config_entry)
 
-    main_device = device_registry.async_get_device(identifiers={(DOMAIN, "yid123")})
-    zone_device = device_registry.async_get_device(identifiers={(DOMAIN, "yid123_0")})
+    main_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "yid123"), mock_config_entry.entry_id
+    )
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "yid123_0"), mock_config_entry.entry_id
+    )
 
     assert main_device is not None
     assert zone_device is not None

--- a/tests/components/yardian/test_init.py
+++ b/tests/components/yardian/test_init.py
@@ -5,8 +5,10 @@ from unittest.mock import AsyncMock
 import pytest
 from pyyardian import NetworkException, NotAuthorizedException
 
+from homeassistant.components.yardian.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from . import setup_integration
 
@@ -35,3 +37,20 @@ async def test_setup_unauthorized(
     await setup_integration(hass, mock_config_entry)
 
     assert mock_config_entry.state is entry_state
+
+
+async def test_zone_device_via_device(
+    hass: HomeAssistant,
+    mock_yardian_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that zone child devices link to the main device via via_device_id."""
+    await setup_integration(hass, mock_config_entry)
+
+    main_device = device_registry.async_get_device(identifiers={(DOMAIN, "yid123")})
+    zone_device = device_registry.async_get_device(identifiers={(DOMAIN, "yid123_0")})
+
+    assert main_device is not None
+    assert zone_device is not None
+    assert zone_device.via_device_id == main_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `yardian`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
