### PR TITLE
Fix via_device race in homematicip_cloud

### DIFF
--- a/homeassistant/components/homematicip_cloud/__init__.py
+++ b/homeassistant/components/homematicip_cloud/__init__.py
@@ -7,11 +7,7 @@ import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.const import CONF_NAME, EVENT_HOMEASSISTANT_STOP
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import (
-    config_validation as cv,
-    device_registry as dr,
-    entity_registry as er,
-)
+from homeassistant.helpers import config_validation as cv, entity_registry as er
 from homeassistant.helpers.typing import ConfigType
 
 from .const import (
@@ -95,19 +91,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomematicIPConfigEntry) 
         EVENT_HOMEASSISTANT_STOP, hap.shutdown
     )
 
-    # Register hap as device in registry.
-    device_registry = dr.async_get(hass)
-
-    home = hap.home
-    hapname = home.label if home.label != entry.unique_id else f"Home-{home.label}"
-
-    device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, home.id)},
-        manufacturer="eQ-3",
-        # Add the name from config entry.
-        name=hapname,
-    )
     return True
 
 

--- a/homeassistant/components/homematicip_cloud/alarm_control_panel.py
+++ b/homeassistant/components/homematicip_cloud/alarm_control_panel.py
@@ -1,7 +1,7 @@
 """Support for HomematicIP Cloud alarm control panel."""
 
 import logging
-from typing import override
+from typing import TYPE_CHECKING, override
 
 from homematicip.functionalHomes import SecurityAndAlarmHome
 
@@ -11,6 +11,7 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -51,12 +52,18 @@ class HomematicipAlarmControlPanelEntity(AlarmControlPanelEntity):
     @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
+        if TYPE_CHECKING:
+            assert self.platform.config_entry is not None
         return DeviceInfo(
             identifiers={(DOMAIN, f"ACP {self._home.id}")},
             manufacturer="eQ-3",
             model=CONST_ALARM_CONTROL_PANEL_NAME,
             name=self.name,
-            via_device=(DOMAIN, self._home.id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, self._home.id),
+                config_entry_id=self.platform.config_entry.entry_id,
+            ),
         )
 
     @property

--- a/homeassistant/components/homematicip_cloud/climate.py
+++ b/homeassistant/components/homematicip_cloud/climate.py
@@ -1,6 +1,6 @@
 """Support for HomematicIP Cloud climate devices."""
 
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from homematicip.base.enums import AbsenceType
 from homematicip.device import (
@@ -24,6 +24,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -104,12 +105,18 @@ class HomematicipHeatingGroup(HomematicipGenericEntity, ClimateEntity):
     @override
     def device_info(self) -> DeviceInfo:
         """Return device specific attributes."""
+        if TYPE_CHECKING:
+            assert self.platform.config_entry is not None
         return DeviceInfo(
             identifiers={(DOMAIN, self._device.id)},
             manufacturer="eQ-3",
             model=self._device.modelType,
             name=self._device.label,
-            via_device=(DOMAIN, self._device.homeId),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, self._device.homeId),
+                config_entry_id=self.platform.config_entry.entry_id,
+            ),
         )
 
     @property

--- a/homeassistant/components/homematicip_cloud/entity.py
+++ b/homeassistant/components/homematicip_cloud/entity.py
@@ -2,7 +2,7 @@
 
 import contextlib
 import logging
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from homematicip.base.functionalChannels import FunctionalChannel
 from homematicip.device import Device
@@ -145,6 +145,8 @@ class HomematicipGenericEntity(Entity):
             if device_name and home_name:
                 device_name = f"{home_name} {device_name}"
 
+            if TYPE_CHECKING:
+                assert self.platform.config_entry is not None
             return DeviceInfo(
                 identifiers={
                     # Serial numbers of Homematic IP device
@@ -155,7 +157,11 @@ class HomematicipGenericEntity(Entity):
                 name=device_name,
                 sw_version=self._device.firmwareVersion,
                 # Link to the homematic ip access point.
-                via_device=(DOMAIN, home_id),
+                via_device_id=dr.async_get_device_id_by_identifier(
+                    self.hass,
+                    (DOMAIN, home_id),
+                    config_entry_id=self.platform.config_entry.entry_id,
+                ),
             )
         return None
 

--- a/homeassistant/components/homematicip_cloud/hap.py
+++ b/homeassistant/components/homematicip_cloud/hap.py
@@ -19,9 +19,17 @@ import homeassistant
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.httpx_client import get_async_client
 
-from .const import HMIPC_AUTHTOKEN, HMIPC_HAPID, HMIPC_NAME, HMIPC_PIN, PLATFORMS
+from .const import (
+    DOMAIN,
+    HMIPC_AUTHTOKEN,
+    HMIPC_HAPID,
+    HMIPC_NAME,
+    HMIPC_PIN,
+    PLATFORMS,
+)
 from .errors import HmipcConnectionError
 
 _LOGGER = logging.getLogger(__name__)
@@ -138,11 +146,31 @@ class HomematicipHAP:
             "Connected to HomematicIP with HAP %s", self.config_entry.unique_id
         )
 
+        # Register the access point as a device before forwarding platforms so
+        # child devices can resolve it as their via_device.
+        self._async_register_access_point()
+
         await self.hass.config_entries.async_forward_entry_setups(
             self.config_entry, PLATFORMS
         )
 
         return True
+
+    @callback
+    def _async_register_access_point(self) -> None:
+        """Register the access point as a device in the device registry."""
+        home = self.home
+        hapname = (
+            home.label
+            if home.label != self.config_entry.unique_id
+            else f"Home-{home.label}"
+        )
+        dr.async_get(self.hass).async_get_or_create(
+            config_entry_id=self.config_entry.entry_id,
+            identifiers={(DOMAIN, home.id)},
+            manufacturer="eQ-3",
+            name=hapname,
+        )
 
     @callback
     def async_update(self, *args, **kwargs) -> None:

--- a/tests/components/homematicip_cloud/test_device.py
+++ b/tests/components/homematicip_cloud/test_device.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 from homematicip.base.enums import EventType
 
+from homeassistant.components.homematicip_cloud import DOMAIN
 from homeassistant.components.homematicip_cloud.hap import HomematicipHAP
 from homeassistant.const import STATE_ON, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
@@ -296,3 +297,36 @@ async def test_hmip_multi_area_device(
     # get the hap
     hap_device = device_registry.async_get(device.via_device_id)
     assert hap_device.name == "Home"
+
+
+async def test_hmip_child_device_links_to_access_point(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    device_registry: dr.DeviceRegistry,
+    default_mock_hap_factory: HomeFactory,
+) -> None:
+    """Test a child device links back to the access point via via_device_id."""
+    entity_id = "light.treppe_ch"
+    entity_name = "Treppe CH"
+    device_model = "HmIP-BSL"
+    mock_hap = await default_mock_hap_factory.async_get_mock_hap(
+        test_devices=["Treppe"]
+    )
+
+    ha_state, _hmip_device = get_and_check_entity_basics(
+        hass, mock_hap, entity_id, entity_name, device_model
+    )
+    assert ha_state
+
+    entity = entity_registry.async_get(entity_id)
+    assert entity is not None
+
+    child_device = device_registry.async_get(entity.device_id)
+    assert child_device is not None
+
+    access_point_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_hap.home.id), mock_hap.config_entry.entry_id
+    )
+    assert access_point_device is not None
+
+    assert child_device.via_device_id == access_point_device.id

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -91,9 +91,13 @@ async def test_hap_setup_works(hass: HomeAssistant) -> None:
         domain=DOMAIN,
         data={HMIPC_HAPID: "ABC123", HMIPC_AUTHTOKEN: "123", HMIPC_NAME: "hmip"},
     )
-    home = Mock()
+    entry.add_to_hass(hass)
+    home = Mock(id="ABC123", label="Home")
     hap = HomematicipHAP(hass, entry)
-    with patch.object(hap, "get_hap", return_value=home):
+    with (
+        patch.object(hap, "get_hap", return_value=home),
+        patch.object(hass.config_entries, "async_forward_entry_setups"),
+    ):
         async with entry.setup_lock:
             assert await hap.async_setup()
 
@@ -138,6 +142,7 @@ async def test_hap_create(
 ) -> None:
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(DOMAIN)
+    hmip_config_entry.add_to_hass(hass)
     hap = HomematicipHAP(hass, hmip_config_entry)
     assert hap
     with (
@@ -146,6 +151,7 @@ async def test_hap_create(
             return_value=ConnectionContext(),
         ),
         patch.object(hap, "async_connect"),
+        patch.object(hass.config_entries, "async_forward_entry_setups"),
     ):
         async with hmip_config_entry.setup_lock:
             assert await hap.async_setup()

--- a/tests/components/homematicip_cloud/test_hap.py
+++ b/tests/components/homematicip_cloud/test_hap.py
@@ -137,8 +137,9 @@ async def test_hap_reset_unloads_entry_if_setup(
     assert config_entries[0].state is ConfigEntryState.NOT_LOADED
 
 
+@pytest.mark.usefixtures("simple_mock_home")
 async def test_hap_create(
-    hass: HomeAssistant, hmip_config_entry: MockConfigEntry, simple_mock_home
+    hass: HomeAssistant, hmip_config_entry: MockConfigEntry
 ) -> None:
     """Mock AsyncHome to execute get_hap."""
     hass.config.components.add(DOMAIN)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `homematicip_cloud`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
