### PR TITLE
Replace datetime.now() with time.time() in Watts integration

### DIFF
--- a/homeassistant/components/watts/const.py
+++ b/homeassistant/components/watts/const.py
@@ -23,7 +23,7 @@ OAUTH2_SCOPES = [
 # Update intervals
 UPDATE_INTERVAL_SECONDS = 30
 FAST_POLLING_INTERVAL_SECONDS = 5
-DISCOVERY_INTERVAL_MINUTES = 15
+DISCOVERY_INTERVAL_SECONDS = 15 * 60
 
 # Mapping from Watts Vision+ modes to Home Assistant HVAC modes
 THERMOSTAT_MODE_TO_HVAC: dict[ThermostatMode, HVACMode] = {

--- a/homeassistant/components/watts/coordinator.py
+++ b/homeassistant/components/watts/coordinator.py
@@ -244,10 +244,12 @@ class WattsVisionDeviceCoordinator(DataUpdateCoordinator[WattsVisionDeviceData])
         _LOGGER.debug("Refreshed device %s", self.device_id)
         return WattsVisionDeviceData(device=device)
 
-    def trigger_fast_polling(self, duration: int = 60) -> None:
+    def trigger_fast_polling(self, duration_seconds: int = 60) -> None:
         """Activate fast polling for a specified duration after a command."""
-        self.fast_polling_until = time.time() + duration
+        self.fast_polling_until = time.time() + duration_seconds
         self.update_interval = timedelta(seconds=FAST_POLLING_INTERVAL_SECONDS)
         _LOGGER.debug(
-            "Device %s: Activated fast polling for %d seconds", self.device_id, duration
+            "Device %s: Activated fast polling for %d seconds",
+            self.device_id,
+            duration_seconds,
         )

--- a/homeassistant/components/watts/coordinator.py
+++ b/homeassistant/components/watts/coordinator.py
@@ -1,8 +1,9 @@
 """Data coordinator for Watts Vision integration."""
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
+import time
 from typing import TYPE_CHECKING, override
 
 from visionpluspython.client import WattsVisionClient
@@ -22,7 +23,7 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
 from .const import (
-    DISCOVERY_INTERVAL_MINUTES,
+    DISCOVERY_INTERVAL_SECONDS,
     DOMAIN,
     FAST_POLLING_INTERVAL_SECONDS,
     UPDATE_INTERVAL_SECONDS,
@@ -61,18 +62,17 @@ class WattsVisionHubCoordinator(DataUpdateCoordinator[dict[str, Device]]):
             config_entry=config_entry,
         )
         self.client = client
-        self.last_discovery: datetime | None = None
+        self.last_discovery: float | None = None
         self.previous_devices: set[str] = set()
 
     @override
     async def _async_update_data(self) -> dict[str, Device]:
         """Fetch data and periodic device discovery."""
-        now = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+        now = time.time()
         is_first_refresh = self.last_discovery is None
         discovery_interval_elapsed = (
             self.last_discovery is not None
-            and now - self.last_discovery
-            >= timedelta(minutes=DISCOVERY_INTERVAL_MINUTES)
+            and now - self.last_discovery >= DISCOVERY_INTERVAL_SECONDS
         )
 
         if is_first_refresh or discovery_interval_elapsed:
@@ -185,7 +185,7 @@ class WattsVisionDeviceCoordinator(DataUpdateCoordinator[WattsVisionDeviceData])
         self.client = client
         self.device_id = device_id
         self.hub_coordinator = hub_coordinator
-        self.fast_polling_until: datetime | None = None
+        self.fast_polling_until: float | None = None
 
         # Listen to hub coordinator updates
         self.unsubscribe_hub_listener = hub_coordinator.async_add_listener(
@@ -208,7 +208,7 @@ class WattsVisionDeviceCoordinator(DataUpdateCoordinator[WattsVisionDeviceData])
     @override
     async def _async_update_data(self) -> WattsVisionDeviceData:
         """Refresh specific device."""
-        if self.fast_polling_until and datetime.now() > self.fast_polling_until:  # pylint: disable=home-assistant-enforce-naive-now
+        if self.fast_polling_until and time.time() > self.fast_polling_until:
             self.fast_polling_until = None
             self.update_interval = None
             _LOGGER.debug(
@@ -246,7 +246,7 @@ class WattsVisionDeviceCoordinator(DataUpdateCoordinator[WattsVisionDeviceData])
 
     def trigger_fast_polling(self, duration: int = 60) -> None:
         """Activate fast polling for a specified duration after a command."""
-        self.fast_polling_until = datetime.now() + timedelta(seconds=duration)  # pylint: disable=home-assistant-enforce-naive-now
+        self.fast_polling_until = time.time() + duration
         self.update_interval = timedelta(seconds=FAST_POLLING_INTERVAL_SECONDS)
         _LOGGER.debug(
             "Device %s: Activated fast polling for %d seconds", self.device_id, duration

--- a/homeassistant/components/watts/diagnostics.py
+++ b/homeassistant/components/watts/diagnostics.py
@@ -1,12 +1,13 @@
 """Diagnostics support for Watts Vision +."""
 
 import dataclasses
-from datetime import datetime
+import time
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 from . import WattsVisionConfigEntry
 
@@ -21,7 +22,7 @@ async def async_get_config_entry_diagnostics(
     runtime_data = entry.runtime_data
     hub_coordinator = runtime_data.hub_coordinator
     device_coordinators = runtime_data.device_coordinators
-    now = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+    now = time.time()
 
     return async_redact_data(
         {
@@ -34,7 +35,9 @@ async def async_get_config_entry_diagnostics(
                     else None
                 ),
                 "last_discovery": (
-                    hub_coordinator.last_discovery.isoformat()
+                    dt_util.utc_from_timestamp(
+                        hub_coordinator.last_discovery
+                    ).isoformat()
                     if hub_coordinator.last_discovery
                     else None
                 ),
@@ -54,7 +57,9 @@ async def async_get_config_entry_diagnostics(
                         and coordinator.fast_polling_until > now
                     ),
                     "fast_polling_until": (
-                        coordinator.fast_polling_until.isoformat()
+                        dt_util.utc_from_timestamp(
+                            coordinator.fast_polling_until
+                        ).isoformat()
                         if coordinator.fast_polling_until is not None
                         and coordinator.fast_polling_until > now
                         else None

--- a/tests/components/watts/snapshots/test_diagnostics.ambr
+++ b/tests/components/watts/snapshots/test_diagnostics.ambr
@@ -102,7 +102,7 @@
       'version': 1,
     }),
     'hub_coordinator': dict({
-      'last_discovery': '2026-01-01T12:00:00',
+      'last_discovery': '2026-01-01T12:00:00+00:00',
       'last_exception': None,
       'last_update_success': True,
       'supported_devices': 3,

--- a/tests/components/watts/test_init.py
+++ b/tests/components/watts/test_init.py
@@ -21,7 +21,7 @@ from homeassistant.components.climate import (
     SERVICE_SET_TEMPERATURE,
 )
 from homeassistant.components.watts.const import (
-    DISCOVERY_INTERVAL_MINUTES,
+    DISCOVERY_INTERVAL_SECONDS,
     DOMAIN,
     FAST_POLLING_INTERVAL_SECONDS,
     OAUTH2_TOKEN,
@@ -230,7 +230,7 @@ async def test_dynamic_device_creation(
     current_devices = list(mock_watts_client.discover_devices.return_value)
     mock_watts_client.discover_devices.return_value = [*current_devices, new_device]
 
-    freezer.tick(timedelta(minutes=DISCOVERY_INTERVAL_MINUTES))
+    freezer.tick(timedelta(seconds=DISCOVERY_INTERVAL_SECONDS))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
@@ -270,7 +270,7 @@ async def test_stale_device_removal(
         d for d in current_devices if d.device_id != "thermostat_456"
     ]
 
-    freezer.tick(timedelta(minutes=DISCOVERY_INTERVAL_MINUTES))
+    freezer.tick(timedelta(seconds=DISCOVERY_INTERVAL_SECONDS))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The four naive `datetime.now()` calls in `watts` only measure elapsed time, so they now use
`time.time()` and the pylint suppressions are gone. `DISCOVERY_INTERVAL_MINUTES` is now
`DISCOVERY_INTERVAL_SECONDS`, and the diagnostics timestamps are now in UTC. Nothing changes
for users.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177842
- This PR is related to issue: home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

No new tests: the behaviour does not change and the existing tests already cover both values.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
