### PR TITLE
compit: fix KeyError in test fixture for devices without CURRENT_TEMPERATURE mapping

### DIFF
--- a/tests/components/compit/conftest.py
+++ b/tests/components/compit/conftest.py
@@ -90,11 +90,8 @@ def mock_connector():
         return all_devices.get(device_id)
 
     def get_current_value(device_id: int, parameter_code: CompitParameter):
-        # Mirrors CompitApiConnector._resolve_parameter_code: a device code
-        # missing from PARAMS[parameter_code] falls back to the parameter's
-        # own value instead of raising, since not every device supports
-        # every parameter (e.g. device 224/R 900 has no CURRENT_TEMPERATURE
-        # mapping).
+        # Not every device supports every parameter; fall back instead of
+        # raising when this device has no mapping for it.
         code = PARAMS.get(parameter_code, {}).get(
             all_devices[device_id].definition.code, parameter_code.value
         )

--- a/tests/components/compit/conftest.py
+++ b/tests/components/compit/conftest.py
@@ -90,7 +90,14 @@ def mock_connector():
         return all_devices.get(device_id)
 
     def get_current_value(device_id: int, parameter_code: CompitParameter):
-        code = PARAMS[parameter_code][all_devices[device_id].definition.code]
+        # Mirrors CompitApiConnector._resolve_parameter_code: a device code
+        # missing from PARAMS[parameter_code] falls back to the parameter's
+        # own value instead of raising, since not every device supports
+        # every parameter (e.g. device 224/R 900 has no CURRENT_TEMPERATURE
+        # mapping).
+        code = PARAMS.get(parameter_code, {}).get(
+            all_devices[device_id].definition.code, parameter_code.value
+        )
         param = next(
             (p for p in all_devices[device_id].state.params if p.code == code),
             None,

--- a/tests/components/compit/snapshots/test_binary_sensor.ambr
+++ b/tests/components/compit/snapshots/test_binary_sensor.ambr
@@ -141,8 +141,8 @@
 # name: test_binary_sensor_entities_snapshot[binary_sensor.nano_color_2_ground_heat_exchanger_attached-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
-      'device_class': 'connectivity',
-      'friendly_name': 'Nano Color 2 Ground heat exchanger attached',
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'connectivity',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Nano Color 2 Ground heat exchanger attached',
     }),
     'context': <ANY>,
     'entity_id': 'binary_sensor.nano_color_2_ground_heat_exchanger_attached',


### PR DESCRIPTION
## Proposed change

Fixes `tests/components/compit/test_binary_sensor.py::test_binary_sensor_entities_snapshot`, broken on `dev` since #174239 merged. Two independent issues:

**1. `KeyError` in the test fixture for devices without a parameter mapping.** `conftest.py`'s `mock_connector.get_current_value()` indexed `PARAMS[parameter_code]` directly by the mock device's `definition.code`, which raises `KeyError` whenever a device/parameter combination has no entry in `PARAMS` — not every device supports every parameter (e.g. device code `224` / "R 900" has no `CURRENT_TEMPERATURE` entry). This crashed `climate.py`'s `current_temperature` during entity setup; the exception was swallowed by `entity_platform`'s own error handling (logged, not re-raised) but corrupted entity state as a side effect. The real `CompitApiConnector._resolve_parameter_code` already falls back to the parameter's own value on a missing mapping instead of raising — the fixture now mirrors that with `.get()`.

**2. Stale snapshot serialization from a branch-merge race.** The new `ground_heat_exchanger_attached` state snapshot added in #174239 was recorded before #174633 migrated state attribute dict keys to `EntityStateAttribute` StrEnum members. #174633 re-recorded every *existing* state snapshot with enum-style keys, but #174239's branch predated it — so its new snapshot landed on `dev` with old plain-string keys (`'device_class':`) while its two siblings in the same file (`airing`, `co2_level`) already use enum-style keys (`<EntityStateAttribute.DEVICE_CLASS: ...>`). The PR's own CI was green because it ran against the pre-migration base. Re-recorded that one snapshot.

`tests/components/compit/` fully green locally after both fixes (95 passed).

## Type of change

- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
