### PR TITLE
Add websocket command to list LLM APIs

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -354,6 +354,7 @@ homeassistant.components.litejet.*
 homeassistant.components.litellm.*
 homeassistant.components.litterrobot.*
 homeassistant.components.llama_cpp.*
+homeassistant.components.llm.*
 homeassistant.components.local_ip.*
 homeassistant.components.local_todo.*
 homeassistant.components.lock.*

--- a/homeassistant/components/llm/__init__.py
+++ b/homeassistant/components/llm/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
 from .const import DOMAIN
+from .websocket_api import async_setup as async_setup_ws_api
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
         hass, DOMAIN, _process_llm_tools_platform
     )
     async_register_api(hass, AssistAPI(hass))
+    async_setup_ws_api(hass)
     return True
 
 

--- a/homeassistant/components/llm/websocket_api.py
+++ b/homeassistant/components/llm/websocket_api.py
@@ -1,0 +1,34 @@
+"""Websocket API for the LLM integration."""
+
+from typing import Any
+
+import voluptuous as vol
+
+from homeassistant.components import websocket_api
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.llm import async_get_apis
+
+
+@callback
+def async_setup(hass: HomeAssistant) -> None:
+    """Set up the LLM websocket API."""
+    websocket_api.async_register_command(hass, websocket_list_apis)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command({vol.Required("type"): "llm/api/list"})
+@callback
+def websocket_list_apis(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """List the registered LLM APIs.
+
+    Each API is described by the ID used to select it and the name shown to
+    the user. APIs are listed in registration order.
+    """
+    connection.send_result(
+        msg["id"],
+        {"apis": [{"id": api.id, "name": api.name} for api in async_get_apis(hass)]},
+    )

--- a/mypy.ini
+++ b/mypy.ini
@@ -3297,6 +3297,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.llm.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.local_ip.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/tests/components/llm/test_websocket_api.py
+++ b/tests/components/llm/test_websocket_api.py
@@ -1,0 +1,74 @@
+"""Tests for the LLM integration websocket API."""
+
+import pytest
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import llm
+from homeassistant.setup import async_setup_component
+
+from tests.typing import WebSocketGenerator
+
+
+class _StubAPI(llm.API):
+    """Minimal LLM API used to populate the registry."""
+
+    async def async_get_api_instance(
+        self, llm_context: llm.LLMContext
+    ) -> llm.APIInstance:
+        """Return the instance of the API."""
+        return llm.APIInstance(
+            api=self, api_prompt="", llm_context=llm_context, tools=[]
+        )
+
+
+@pytest.fixture(autouse=True)
+async def setup_llm(hass: HomeAssistant) -> None:
+    """Set up the LLM integration."""
+    assert await async_setup_component(hass, "llm", {})
+
+
+@pytest.mark.parametrize(
+    ("registered_apis", "expected_apis"),
+    [
+        pytest.param([], [{"id": "assist", "name": "Assist"}], id="assist_only"),
+        pytest.param(
+            [("test-api", "Test API")],
+            [
+                {"id": "assist", "name": "Assist"},
+                {"id": "test-api", "name": "Test API"},
+            ],
+            id="registered_api",
+        ),
+    ],
+)
+async def test_list_apis(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    registered_apis: list[tuple[str, str]],
+    expected_apis: list[dict[str, str]],
+) -> None:
+    """Test listing the registered LLM APIs."""
+    for api_id, name in registered_apis:
+        llm.async_register_api(hass, _StubAPI(hass=hass, id=api_id, name=name))
+    client = await hass_ws_client(hass)
+
+    await client.send_json_auto_id({"type": "llm/api/list"})
+    response = await client.receive_json()
+
+    assert response["success"]
+    assert response["result"] == {"apis": expected_apis}
+
+
+async def test_list_apis_requires_admin(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    hass_read_only_access_token: str,
+) -> None:
+    """Test listing the LLM APIs is only allowed for admins."""
+    client = await hass_ws_client(hass, hass_read_only_access_token)
+
+    await client.send_json_auto_id({"type": "llm/api/list"})
+    response = await client.receive_json()
+
+    assert not response["success"]
+    assert response["error"]["code"] == "unauthorized"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `llm/api/list` websocket command to the `llm` integration, returning the registered LLM APIs:

```json
{"apis": [{"id": "assist", "name": "Assist"}]}
```

Background: since the MCP Server integration began serving a specific LLM API at `/api/mcp/<API ID>`, clients
have to address an API by its ID, but there is no way to find out which IDs exist. `llm.async_get_apis()` is
only reachable from inside Core (config flows and `mcp_server/http.py`), and there is no REST or websocket
exposure. A client that guesses wrong gets `404 Unknown LLM API '<id>'` with nothing to go on, so it can only
ask the user to look the ID up in the UI rather than offer a picker. My own use case is an add-on that bridges
an MCP client to `/api/mcp/<API ID>` and currently cannot validate or suggest an ID.

The handler is a sync `@callback`, since `async_get_apis()` is itself a `@callback` returning `list[API]`, and
APIs are returned in registration order, which is what every existing caller already sees.

Two choices I would particularly like your opinion on:

I gated the command with `require_admin`, matching the `mcp_server` per-API endpoints, which require admin for
every ID except `assist`. The argument against is real: a non-admin can already reach `/api/mcp/assist`, so
this makes discovery unavailable to exactly the callers still permitted to use that endpoint; the sibling
`conversation/agent/list` is not gated; and the only non-static values returned are API names, which for
`mcp`-registered APIs are config entry titles that non-admins can already read via `config_entries/get`. I
defaulted to requiring admin only because relaxing it later is not a breaking change while tightening it would
be. I am happy to drop it if you would rather this were open.

I also left `manifest.json` unchanged, since `websocket_api` is in hassfest's `ALLOWED_USED_COMPONENTS` and the
closest precedents (`labs` and `assist_pipeline`, both `system`/`internal` with their own `websocket_api.py`,
and `conversation`, the only integration depending on `llm`) all omit it. Declaring it would make `llm` setup
hard-fail if `http`/`websocket_api` fail and pull `http` into a bare `llm:` configuration, with no functional
gain, as `async_register_command` only writes into `hass.data` and works regardless of setup order. Happy to
add it if you prefer the explicit declaration.

The second commit adds `homeassistant.components.llm.*` to `.strict-typing`, as the development checklist asks
for when the new source is fully type hinted. The whole integration already passes with the strict flags
enabled, so the only changes are the one line in `.strict-typing` and the section `script.hassfest` generates
in `mypy.ini`. I kept it as a separate commit and am glad to split it into its own PR if you would rather this
one stayed to a single subject.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: home-assistant/developers.home-assistant#3284
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
