### PR TITLE
Add binary_sensor platform to Subaru

### DIFF
--- a/homeassistant/components/subaru/binary_sensor.py
+++ b/homeassistant/components/subaru/binary_sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from functools import partial
 from typing import Any, override
 
 from homeassistant.components.binary_sensor import (
@@ -49,8 +50,8 @@ LOCK_STATUS_KEYS: dict[str, str] = {
     "LOCK_BOOT_STATUS": "lock_status_boot",
 }
 
-# EV_IS_PLUGGED_IN values meaning connected. Other known values (e.g.
-# UNPLUGGED) mean not connected; UNKNOWN/missing short-circuits earlier.
+# EV_IS_PLUGGED_IN values meaning connected; other known values mean not
+# connected.
 EV_PLUGGED_IN_STATES = frozenset({"CHARGING", "LOCKED_CONNECTED", "UNLOCKED_CONNECTED"})
 API_KEY_EV_IS_PLUGGED_IN = "EV_IS_PLUGGED_IN"
 API_KEY_EV_CHARGER_STATE_TYPE = "EV_CHARGER_STATE_TYPE"
@@ -61,10 +62,7 @@ HEALTH_ISTROUBLE = "ISTROUBLE"
 HEALTH_FEATURES = "FEATURES"
 
 # Subaru MIL (Malfunction Indicator Lamp) feature codes -> translation keys.
-# Only codes the vehicle actually reports (via vehicle_features) get
-# entities. ATF_MIL is the one non-obvious mapping: Subaru's API groups it
-# under b2cCode "oilTemp", i.e. it's a transmission *temperature* warning,
-# not a fluid-level one.
+# ATF_MIL is a transmission temperature warning, not fluid level.
 MIL_TRANSLATION_KEYS: dict[str, str] = {
     "SRS_MIL": "mil_srs",
     "AWD_MIL": "mil_awd",
@@ -87,14 +85,9 @@ MIL_TRANSLATION_KEYS: dict[str, str] = {
     "SRH_MIL": "mil_srh",
 }
 
-# Status values that mean a door/window is closed. The API has used both
-# "CLOSED" (doors) and "CLOSE" (windows) historically.
+# "CLOSED" (doors) or "CLOSE" (windows) means closed.
 OPENING_CLOSED_VALUES = frozenset({"CLOSED", "CLOSE"})
-# Per-field sentinels meaning "no data", distinct from the whole-coordinator
-# unavailable state. Compared case-insensitively since the API is inconsistent.
-# NOT_EQUIPPED matters for door fields specifically: unlike windows/locks
-# (omitted entirely when unsupported), subarulink always populates door
-# fields, using NOT_EQUIPPED for trims without a given door's sensor.
+# Sentinel values meaning "no data"; compared case-insensitively.
 UNKNOWN_STATUSES = frozenset({"UNKNOWN", "UNAVAILABLE", "NOT_EQUIPPED"})
 
 
@@ -105,67 +98,34 @@ class SubaruBinarySensorEntityDescription(BinarySensorEntityDescription):
     is_on_fn: Callable[[dict[str, Any]], bool | None]
 
 
-def _vehicle_status_is_on(
-    api_key: str,
-    is_on: Callable[[str], bool],
-) -> Callable[[dict[str, Any]], bool | None]:
-    """Build an is_on getter for a single vehicle_status string field.
-
-    Missing or unknown/unavailable values short-circuit to None so the
-    entity reports as `unknown` rather than a false off/on.
-    """
-
-    def getter(vehicle_data: dict[str, Any]) -> bool | None:
-        status = (vehicle_data.get(VEHICLE_STATUS) or {}).get(api_key)
-        if status is None:
-            return None
-        status = status.upper()
-        if status in UNKNOWN_STATUSES:
-            return None
-        return is_on(status)
-
-    return getter
-
-
-def _mil_is_on(feature: str) -> Callable[[dict[str, Any]], bool | None]:
-    """Per-MIL getter from vehicle_health.FEATURES[<feature>].ISTROUBLE."""
-
-    def getter(vehicle_data: dict[str, Any]) -> bool | None:
-        features = (vehicle_data.get(VEHICLE_HEALTH) or {}).get(HEALTH_FEATURES) or {}
-        feature_health = features.get(feature)
-        if not feature_health or HEALTH_ISTROUBLE not in feature_health:
-            return None
-        return bool(feature_health[HEALTH_ISTROUBLE])
-
-    return getter
-
-
-def _overall_trouble_is_on(vehicle_data: dict[str, Any]) -> bool | None:
-    """Overall vehicle_health.ISTROUBLE rollup."""
-    health = vehicle_data.get(VEHICLE_HEALTH)
-    if not health or HEALTH_ISTROUBLE not in health:
+def _vehicle_status_value(vehicle_data: dict[str, Any], api_key: str) -> str | None:
+    """Return the normalized vehicle_status value for api_key, or None if missing/unknown."""
+    status = (vehicle_data.get(VEHICLE_STATUS) or {}).get(api_key)
+    if status is None:
         return None
-    return bool(health[HEALTH_ISTROUBLE])
+    status = status.upper()
+    return None if status in UNKNOWN_STATUSES else status
 
 
-def _is_open(status: str) -> bool:
-    """Door/window predicate — anything not in the closed set is open."""
-    return status not in OPENING_CLOSED_VALUES
+def _opening_is_on(vehicle_data: dict[str, Any], api_key: str) -> bool | None:
+    """Whether a door/window field is open."""
+    value = _vehicle_status_value(vehicle_data, api_key)
+    return None if value is None else value not in OPENING_CLOSED_VALUES
 
 
-def _is_unlocked(status: str) -> bool:
-    """Per-door lock predicate — anything other than LOCKED is unlocked."""
-    return status != "LOCKED"
+def _lock_is_on(vehicle_data: dict[str, Any], api_key: str) -> bool | None:
+    """Whether a lock field is unlocked."""
+    value = _vehicle_status_value(vehicle_data, api_key)
+    return None if value is None else value != "LOCKED"
 
 
-def _is_plugged_in(status: str) -> bool:
-    """EV plug predicate — any documented connected state counts as plugged in."""
-    return status in EV_PLUGGED_IN_STATES
-
-
-def _is_charging(status: str) -> bool:
-    """EV charging predicate — only CHARGING means actively charging."""
-    return status == EV_CHARGING_STATE
+def _mil_trouble(vehicle_data: dict[str, Any], feature: str) -> bool | None:
+    """Return vehicle_health.FEATURES[feature].ISTROUBLE, or None if not reported."""
+    features = (vehicle_data.get(VEHICLE_HEALTH) or {}).get(HEALTH_FEATURES) or {}
+    feature_health = features.get(feature)
+    if not feature_health or HEALTH_ISTROUBLE not in feature_health:
+        return None
+    return bool(feature_health[HEALTH_ISTROUBLE])
 
 
 # Static descriptions for entities that are created for every Gen2+ vehicle.
@@ -176,7 +136,7 @@ BINARY_SENSORS: tuple[SubaruBinarySensorEntityDescription, ...] = (
             key=api_key,
             translation_key=trans_key,
             device_class=BinarySensorDeviceClass.DOOR,
-            is_on_fn=_vehicle_status_is_on(api_key, _is_open),
+            is_on_fn=partial(_opening_is_on, api_key=api_key),
         )
         for api_key, trans_key in DOOR_POSITION_KEYS.items()
     ),
@@ -185,7 +145,7 @@ BINARY_SENSORS: tuple[SubaruBinarySensorEntityDescription, ...] = (
             key=api_key,
             translation_key=trans_key,
             device_class=BinarySensorDeviceClass.WINDOW,
-            is_on_fn=_vehicle_status_is_on(api_key, _is_open),
+            is_on_fn=partial(_opening_is_on, api_key=api_key),
         )
         for api_key, trans_key in WINDOW_STATUS_KEYS.items()
     ),
@@ -194,7 +154,7 @@ BINARY_SENSORS: tuple[SubaruBinarySensorEntityDescription, ...] = (
             key=api_key,
             translation_key=trans_key,
             device_class=BinarySensorDeviceClass.LOCK,
-            is_on_fn=_vehicle_status_is_on(api_key, _is_unlocked),
+            is_on_fn=partial(_lock_is_on, api_key=api_key),
         )
         for api_key, trans_key in LOCK_STATUS_KEYS.items()
     ),
@@ -205,14 +165,22 @@ OVERALL_HEALTH_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
     translation_key="health_istrouble",
     device_class=BinarySensorDeviceClass.PROBLEM,
     entity_category=EntityCategory.DIAGNOSTIC,
-    is_on_fn=_overall_trouble_is_on,
+    is_on_fn=lambda d: (
+        None
+        if not (health := d.get(VEHICLE_HEALTH)) or HEALTH_ISTROUBLE not in health
+        else bool(health[HEALTH_ISTROUBLE])
+    ),
 )
 
 EV_PLUG_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
     key=API_KEY_EV_IS_PLUGGED_IN,
     translation_key="ev_is_plugged_in",
     device_class=BinarySensorDeviceClass.PLUG,
-    is_on_fn=_vehicle_status_is_on(API_KEY_EV_IS_PLUGGED_IN, _is_plugged_in),
+    is_on_fn=lambda d: (
+        None
+        if (v := _vehicle_status_value(d, API_KEY_EV_IS_PLUGGED_IN)) is None
+        else v in EV_PLUGGED_IN_STATES
+    ),
 )
 
 EV_CHARGING_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
@@ -220,7 +188,11 @@ EV_CHARGING_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
     translation_key="is_charging",
     device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
     entity_registry_enabled_default=False,
-    is_on_fn=_vehicle_status_is_on(API_KEY_EV_CHARGER_STATE_TYPE, _is_charging),
+    is_on_fn=lambda d: (
+        None
+        if (v := _vehicle_status_value(d, API_KEY_EV_CHARGER_STATE_TYPE)) is None
+        else v == EV_CHARGING_STATE
+    ),
 )
 
 
@@ -241,11 +213,25 @@ def _build_mil_descriptions(
             # Disabled by default to avoid ~19 mostly-off entries per
             # vehicle; the overall health rollup stays enabled.
             entity_registry_enabled_default=False,
-            is_on_fn=_mil_is_on(feature),
+            is_on_fn=partial(_mil_trouble, feature=feature),
         )
         for feature in features
         if feature in MIL_TRANSLATION_KEYS
     ]
+
+
+def _has_data(
+    description: SubaruBinarySensorEntityDescription, vehicle_status: dict[str, Any]
+) -> bool:
+    """Whether a door/window/lock description should be created.
+
+    Doors report even on an empty vehicle_status (a failed fetch), so
+    they're excluded only when explicitly NOT_EQUIPPED. Windows/locks/EV
+    fields are omitted entirely when unsupported, so presence decides.
+    """
+    if description.key in DOOR_POSITION_KEYS:
+        return vehicle_status.get(description.key, "").upper() != "NOT_EQUIPPED"
+    return description.key in vehicle_status
 
 
 async def async_setup_entry(
@@ -265,20 +251,17 @@ async def async_setup_entry(
         vehicle_data = (coordinator.data or {}).get(info[VEHICLE_VIN]) or {}
         vehicle_status = vehicle_data.get(VEHICLE_STATUS) or {}
 
-        # Doors always report, even on a failed/empty fetch; windows/locks
-        # are omitted from vehicle_status when unsupported, so gate those.
-        # Built once at setup like MIL below: a vehicle whose first fetch
-        # fails entirely won't get window/lock entities until a reload.
         descriptions: list[SubaruBinarySensorEntityDescription] = [
             description
             for description in BINARY_SENSORS
-            if description.key in DOOR_POSITION_KEYS
-            or description.key in vehicle_status
+            if _has_data(description, vehicle_status)
         ]
         descriptions.append(OVERALL_HEALTH_BINARY_SENSOR)
         if info[VEHICLE_HAS_EV]:
-            descriptions.append(EV_PLUG_BINARY_SENSOR)
-            descriptions.append(EV_CHARGING_BINARY_SENSOR)
+            if EV_PLUG_BINARY_SENSOR.key in vehicle_status:
+                descriptions.append(EV_PLUG_BINARY_SENSOR)
+            if EV_CHARGING_BINARY_SENSOR.key in vehicle_status:
+                descriptions.append(EV_CHARGING_BINARY_SENSOR)
 
         features = vehicle_data.get(VEHICLE_FEATURES) or []
         descriptions.extend(_build_mil_descriptions(features))

--- a/homeassistant/components/subaru/binary_sensor.py
+++ b/homeassistant/components/subaru/binary_sensor.py
@@ -267,6 +267,8 @@ async def async_setup_entry(
 
         # Doors always report, even on a failed/empty fetch; windows/locks
         # are omitted from vehicle_status when unsupported, so gate those.
+        # Built once at setup like MIL below: a vehicle whose first fetch
+        # fails entirely won't get window/lock entities until a reload.
         descriptions: list[SubaruBinarySensorEntityDescription] = [
             description
             for description in BINARY_SENSORS

--- a/homeassistant/components/subaru/binary_sensor.py
+++ b/homeassistant/components/subaru/binary_sensor.py
@@ -265,12 +265,13 @@ async def async_setup_entry(
         vehicle_data = (coordinator.data or {}).get(info[VEHICLE_VIN]) or {}
         vehicle_status = vehicle_data.get(VEHICLE_STATUS) or {}
 
-        # Windows/locks are omitted from vehicle_status when unsupported
-        # (doors always report); only add descriptions with real data.
+        # Doors always report, even on a failed/empty fetch; windows/locks
+        # are omitted from vehicle_status when unsupported, so gate those.
         descriptions: list[SubaruBinarySensorEntityDescription] = [
             description
             for description in BINARY_SENSORS
-            if description.key in vehicle_status
+            if description.key in DOOR_POSITION_KEYS
+            or description.key in vehicle_status
         ]
         descriptions.append(OVERALL_HEALTH_BINARY_SENSOR)
         if info[VEHICLE_HAS_EV]:

--- a/homeassistant/components/subaru/binary_sensor.py
+++ b/homeassistant/components/subaru/binary_sensor.py
@@ -49,8 +49,8 @@ LOCK_STATUS_KEYS: dict[str, str] = {
     "LOCK_BOOT_STATUS": "lock_status_boot",
 }
 
-# EV_IS_PLUGGED_IN values that indicate the plug is connected. Any other
-# value (including UNPLUGGED / UNKNOWN / None) counts as not plugged in.
+# EV_IS_PLUGGED_IN values meaning connected. Other known values (e.g.
+# UNPLUGGED) mean not connected; UNKNOWN/missing short-circuits earlier.
 EV_PLUGGED_IN_STATES = frozenset({"CHARGING", "LOCKED_CONNECTED", "UNLOCKED_CONNECTED"})
 API_KEY_EV_IS_PLUGGED_IN = "EV_IS_PLUGGED_IN"
 API_KEY_EV_CHARGER_STATE_TYPE = "EV_CHARGER_STATE_TYPE"
@@ -262,13 +262,21 @@ async def async_setup_entry(
         # Doors/windows/locks/health are only reported on Gen2+ vehicles.
         if info[VEHICLE_API_GEN] not in GEN_2_AND_NEWER:
             continue
-        descriptions: list[SubaruBinarySensorEntityDescription] = list(BINARY_SENSORS)
+        vehicle_data = (coordinator.data or {}).get(info[VEHICLE_VIN]) or {}
+        vehicle_status = vehicle_data.get(VEHICLE_STATUS) or {}
+
+        # Windows/locks are omitted from vehicle_status when unsupported
+        # (doors always report); only add descriptions with real data.
+        descriptions: list[SubaruBinarySensorEntityDescription] = [
+            description
+            for description in BINARY_SENSORS
+            if description.key in vehicle_status
+        ]
         descriptions.append(OVERALL_HEALTH_BINARY_SENSOR)
         if info[VEHICLE_HAS_EV]:
             descriptions.append(EV_PLUG_BINARY_SENSOR)
             descriptions.append(EV_CHARGING_BINARY_SENSOR)
 
-        vehicle_data = (coordinator.data or {}).get(info[VEHICLE_VIN]) or {}
         features = vehicle_data.get(VEHICLE_FEATURES) or []
         descriptions.extend(_build_mil_descriptions(features))
 

--- a/homeassistant/components/subaru/binary_sensor.py
+++ b/homeassistant/components/subaru/binary_sensor.py
@@ -1,0 +1,301 @@
+"""Support for Subaru binary sensors."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, override
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .const import (
+    GEN_2_AND_NEWER,
+    VEHICLE_API_GEN,
+    VEHICLE_FEATURES,
+    VEHICLE_HAS_EV,
+    VEHICLE_HEALTH,
+    VEHICLE_STATUS,
+    VEHICLE_VIN,
+)
+from .coordinator import SubaruConfigEntry, SubaruDataUpdateCoordinator
+from .entity import SubaruCoordinatorEntity
+
+# Keys returned by subarulink controller.get_data() inside vehicle_status.
+DOOR_POSITION_KEYS: dict[str, str] = {
+    "DOOR_FRONT_LEFT_POSITION": "door_front_left",
+    "DOOR_FRONT_RIGHT_POSITION": "door_front_right",
+    "DOOR_REAR_LEFT_POSITION": "door_rear_left",
+    "DOOR_REAR_RIGHT_POSITION": "door_rear_right",
+    "DOOR_BOOT_POSITION": "door_boot",
+    "DOOR_ENGINE_HOOD_POSITION": "door_engine_hood",
+}
+WINDOW_STATUS_KEYS: dict[str, str] = {
+    "WINDOW_FRONT_LEFT_STATUS": "window_front_left",
+    "WINDOW_FRONT_RIGHT_STATUS": "window_front_right",
+    "WINDOW_REAR_LEFT_STATUS": "window_rear_left",
+    "WINDOW_REAR_RIGHT_STATUS": "window_rear_right",
+    "WINDOW_SUNROOF_STATUS": "window_sunroof",
+}
+LOCK_STATUS_KEYS: dict[str, str] = {
+    "LOCK_FRONT_LEFT_STATUS": "lock_status_front_left",
+    "LOCK_FRONT_RIGHT_STATUS": "lock_status_front_right",
+    "LOCK_REAR_LEFT_STATUS": "lock_status_rear_left",
+    "LOCK_REAR_RIGHT_STATUS": "lock_status_rear_right",
+    "LOCK_BOOT_STATUS": "lock_status_boot",
+}
+
+# EV_IS_PLUGGED_IN values that indicate the plug is connected. Any other
+# value (including UNPLUGGED / UNKNOWN / None) counts as not plugged in.
+EV_PLUGGED_IN_STATES = frozenset({"CHARGING", "LOCKED_CONNECTED", "UNLOCKED_CONNECTED"})
+API_KEY_EV_IS_PLUGGED_IN = "EV_IS_PLUGGED_IN"
+API_KEY_EV_CHARGER_STATE_TYPE = "EV_CHARGER_STATE_TYPE"
+EV_CHARGING_STATE = "CHARGING"
+
+# vehicle_health response shape (see integration debug diagnostics).
+HEALTH_ISTROUBLE = "ISTROUBLE"
+HEALTH_FEATURES = "FEATURES"
+
+# Subaru MIL (Malfunction Indicator Lamp) feature codes -> translation keys.
+# Only codes the vehicle actually reports (via vehicle_features) get
+# entities. ATF_MIL is the one non-obvious mapping: Subaru's API groups it
+# under b2cCode "oilTemp", i.e. it's a transmission *temperature* warning,
+# not a fluid-level one.
+MIL_TRANSLATION_KEYS: dict[str, str] = {
+    "SRS_MIL": "mil_srs",
+    "AWD_MIL": "mil_awd",
+    "ABS_MIL": "mil_abs",
+    "ATF_MIL": "mil_atf",
+    "BSDRCT_MIL": "mil_bsdrct",
+    "CEL_MIL": "mil_cel",
+    "EBD_MIL": "mil_ebd",
+    "EPB_MIL": "mil_epb",
+    "EOL_MIL": "mil_eol",
+    "ESS_MIL": "mil_ess",
+    "ISS_MIL": "mil_iss",
+    "OPL_MIL": "mil_opl",
+    "EPAS_MIL": "mil_epas",
+    "RAB_MIL": "mil_rab",
+    "TEL_MIL": "mil_tel",
+    "TPMS_MIL": "mil_tpms",
+    "VDC_MIL": "mil_vdc",
+    "WASH_MIL": "mil_wash",
+    "SRH_MIL": "mil_srh",
+}
+
+# Status values that mean a door/window is closed. The API has used both
+# "CLOSED" (doors) and "CLOSE" (windows) historically.
+OPENING_CLOSED_VALUES = frozenset({"CLOSED", "CLOSE"})
+# Per-field sentinels meaning "no data", distinct from the whole-coordinator
+# unavailable state. Compared case-insensitively since the API is inconsistent.
+# NOT_EQUIPPED matters for door fields specifically: unlike windows/locks
+# (omitted entirely when unsupported), subarulink always populates door
+# fields, using NOT_EQUIPPED for trims without a given door's sensor.
+UNKNOWN_STATUSES = frozenset({"UNKNOWN", "UNAVAILABLE", "NOT_EQUIPPED"})
+
+
+@dataclass(frozen=True, kw_only=True)
+class SubaruBinarySensorEntityDescription(BinarySensorEntityDescription):
+    """Describes a Subaru binary sensor entity."""
+
+    is_on_fn: Callable[[dict[str, Any]], bool | None]
+
+
+def _vehicle_status_is_on(
+    api_key: str,
+    is_on: Callable[[str], bool],
+) -> Callable[[dict[str, Any]], bool | None]:
+    """Build an is_on getter for a single vehicle_status string field.
+
+    Missing or unknown/unavailable values short-circuit to None so the
+    entity reports as `unknown` rather than a false off/on.
+    """
+
+    def getter(vehicle_data: dict[str, Any]) -> bool | None:
+        status = (vehicle_data.get(VEHICLE_STATUS) or {}).get(api_key)
+        if status is None:
+            return None
+        status = status.upper()
+        if status in UNKNOWN_STATUSES:
+            return None
+        return is_on(status)
+
+    return getter
+
+
+def _mil_is_on(feature: str) -> Callable[[dict[str, Any]], bool | None]:
+    """Per-MIL getter from vehicle_health.FEATURES[<feature>].ISTROUBLE."""
+
+    def getter(vehicle_data: dict[str, Any]) -> bool | None:
+        features = (vehicle_data.get(VEHICLE_HEALTH) or {}).get(HEALTH_FEATURES) or {}
+        feature_health = features.get(feature)
+        if not feature_health or HEALTH_ISTROUBLE not in feature_health:
+            return None
+        return bool(feature_health[HEALTH_ISTROUBLE])
+
+    return getter
+
+
+def _overall_trouble_is_on(vehicle_data: dict[str, Any]) -> bool | None:
+    """Overall vehicle_health.ISTROUBLE rollup."""
+    health = vehicle_data.get(VEHICLE_HEALTH)
+    if not health or HEALTH_ISTROUBLE not in health:
+        return None
+    return bool(health[HEALTH_ISTROUBLE])
+
+
+def _is_open(status: str) -> bool:
+    """Door/window predicate — anything not in the closed set is open."""
+    return status not in OPENING_CLOSED_VALUES
+
+
+def _is_unlocked(status: str) -> bool:
+    """Per-door lock predicate — anything other than LOCKED is unlocked."""
+    return status != "LOCKED"
+
+
+def _is_plugged_in(status: str) -> bool:
+    """EV plug predicate — any documented connected state counts as plugged in."""
+    return status in EV_PLUGGED_IN_STATES
+
+
+def _is_charging(status: str) -> bool:
+    """EV charging predicate — only CHARGING means actively charging."""
+    return status == EV_CHARGING_STATE
+
+
+# Static descriptions for entities that are created for every Gen2+ vehicle.
+# MIL diagnostics are built dynamically below based on vehicle_features.
+BINARY_SENSORS: tuple[SubaruBinarySensorEntityDescription, ...] = (
+    *(
+        SubaruBinarySensorEntityDescription(
+            key=api_key,
+            translation_key=trans_key,
+            device_class=BinarySensorDeviceClass.DOOR,
+            is_on_fn=_vehicle_status_is_on(api_key, _is_open),
+        )
+        for api_key, trans_key in DOOR_POSITION_KEYS.items()
+    ),
+    *(
+        SubaruBinarySensorEntityDescription(
+            key=api_key,
+            translation_key=trans_key,
+            device_class=BinarySensorDeviceClass.WINDOW,
+            is_on_fn=_vehicle_status_is_on(api_key, _is_open),
+        )
+        for api_key, trans_key in WINDOW_STATUS_KEYS.items()
+    ),
+    *(
+        SubaruBinarySensorEntityDescription(
+            key=api_key,
+            translation_key=trans_key,
+            device_class=BinarySensorDeviceClass.LOCK,
+            is_on_fn=_vehicle_status_is_on(api_key, _is_unlocked),
+        )
+        for api_key, trans_key in LOCK_STATUS_KEYS.items()
+    ),
+)
+
+OVERALL_HEALTH_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
+    key="health_istrouble",
+    translation_key="health_istrouble",
+    device_class=BinarySensorDeviceClass.PROBLEM,
+    entity_category=EntityCategory.DIAGNOSTIC,
+    is_on_fn=_overall_trouble_is_on,
+)
+
+EV_PLUG_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
+    key=API_KEY_EV_IS_PLUGGED_IN,
+    translation_key="ev_is_plugged_in",
+    device_class=BinarySensorDeviceClass.PLUG,
+    is_on_fn=_vehicle_status_is_on(API_KEY_EV_IS_PLUGGED_IN, _is_plugged_in),
+)
+
+EV_CHARGING_BINARY_SENSOR = SubaruBinarySensorEntityDescription(
+    key=API_KEY_EV_CHARGER_STATE_TYPE,
+    translation_key="is_charging",
+    device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+    entity_registry_enabled_default=False,
+    is_on_fn=_vehicle_status_is_on(API_KEY_EV_CHARGER_STATE_TYPE, _is_charging),
+)
+
+
+def _build_mil_descriptions(
+    features: list[str],
+) -> list[SubaruBinarySensorEntityDescription]:
+    """Return MIL descriptions for MIL feature codes that the vehicle reports.
+
+    Built once at setup; a MIL code that starts appearing later (partial
+    first poll, or a code only reported once triggered) needs a reload.
+    """
+    return [
+        SubaruBinarySensorEntityDescription(
+            key=feature,
+            translation_key=MIL_TRANSLATION_KEYS[feature],
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            # Disabled by default to avoid ~19 mostly-off entries per
+            # vehicle; the overall health rollup stays enabled.
+            entity_registry_enabled_default=False,
+            is_on_fn=_mil_is_on(feature),
+        )
+        for feature in features
+        if feature in MIL_TRANSLATION_KEYS
+    ]
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: SubaruConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the Subaru binary sensors by config_entry."""
+    coordinator = config_entry.runtime_data.coordinator
+    vehicle_info = config_entry.runtime_data.vehicles
+
+    entities: list[SubaruBinarySensor] = []
+    for info in vehicle_info.values():
+        # Doors/windows/locks/health are only reported on Gen2+ vehicles.
+        if info[VEHICLE_API_GEN] not in GEN_2_AND_NEWER:
+            continue
+        descriptions: list[SubaruBinarySensorEntityDescription] = list(BINARY_SENSORS)
+        descriptions.append(OVERALL_HEALTH_BINARY_SENSOR)
+        if info[VEHICLE_HAS_EV]:
+            descriptions.append(EV_PLUG_BINARY_SENSOR)
+            descriptions.append(EV_CHARGING_BINARY_SENSOR)
+
+        vehicle_data = (coordinator.data or {}).get(info[VEHICLE_VIN]) or {}
+        features = vehicle_data.get(VEHICLE_FEATURES) or []
+        descriptions.extend(_build_mil_descriptions(features))
+
+        entities.extend(
+            SubaruBinarySensor(info, coordinator, description)
+            for description in descriptions
+        )
+    async_add_entities(entities)
+
+
+class SubaruBinarySensor(SubaruCoordinatorEntity, BinarySensorEntity):
+    """Representation of a Subaru binary sensor."""
+
+    entity_description: SubaruBinarySensorEntityDescription
+
+    def __init__(
+        self,
+        vehicle_info: dict[str, Any],
+        coordinator: SubaruDataUpdateCoordinator,
+        description: SubaruBinarySensorEntityDescription,
+    ) -> None:
+        """Initialize the binary sensor."""
+        super().__init__(vehicle_info, coordinator, description.key)
+        self.entity_description = description
+
+    @property
+    @override
+    def is_on(self) -> bool | None:
+        """Return True if the sensor is on (open / unlocked / has trouble)."""
+        return self.entity_description.is_on_fn(self.coordinator.data[self.vin])

--- a/homeassistant/components/subaru/const.py
+++ b/homeassistant/components/subaru/const.py
@@ -25,6 +25,7 @@ VEHICLE_HAS_SAFETY_SERVICE = "has_safety"
 VEHICLE_LAST_UPDATE = "last_update"
 VEHICLE_STATUS = "vehicle_status"
 VEHICLE_HEALTH = "vehicle_health"
+VEHICLE_FEATURES = "vehicle_features"
 
 # Synthetic keys for sensors that don't read a single field directly; used
 # as both unique_id suffix and translation_key, so they must stay stable
@@ -38,9 +39,13 @@ API_GEN_1 = "g1"
 API_GEN_2 = "g2"
 API_GEN_3 = "g3"
 API_GEN_4 = "g4"
+# Generations that report vehicle_status/vehicle_health data, used to gate
+# binary_sensor entity creation.
+GEN_2_AND_NEWER = (API_GEN_2, API_GEN_3, API_GEN_4)
 MANUFACTURER = "Subaru"
 
 PLATFORMS = [
+    Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.DEVICE_TRACKER,
     Platform.LOCK,

--- a/homeassistant/components/subaru/strings.json
+++ b/homeassistant/components/subaru/strings.json
@@ -106,7 +106,7 @@
         "name": "Check engine"
       },
       "mil_ebd": {
-        "name": "Electronic brakeforce distribution warning"
+        "name": "Electronic brake force distribution warning"
       },
       "mil_eol": {
         "name": "Engine oil level warning"

--- a/homeassistant/components/subaru/strings.json
+++ b/homeassistant/components/subaru/strings.json
@@ -47,6 +47,122 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "door_boot": {
+        "name": "Tailgate"
+      },
+      "door_engine_hood": {
+        "name": "Hood"
+      },
+      "door_front_left": {
+        "name": "Door front left"
+      },
+      "door_front_right": {
+        "name": "Door front right"
+      },
+      "door_rear_left": {
+        "name": "Door rear left"
+      },
+      "door_rear_right": {
+        "name": "Door rear right"
+      },
+      "ev_is_plugged_in": {
+        "name": "EV plug"
+      },
+      "health_istrouble": {
+        "name": "Vehicle health"
+      },
+      "is_charging": {
+        "name": "Charging"
+      },
+      "lock_status_boot": {
+        "name": "Lock status tailgate"
+      },
+      "lock_status_front_left": {
+        "name": "Lock status front left"
+      },
+      "lock_status_front_right": {
+        "name": "Lock status front right"
+      },
+      "lock_status_rear_left": {
+        "name": "Lock status rear left"
+      },
+      "lock_status_rear_right": {
+        "name": "Lock status rear right"
+      },
+      "mil_abs": {
+        "name": "ABS warning"
+      },
+      "mil_atf": {
+        "name": "Transmission temperature warning"
+      },
+      "mil_awd": {
+        "name": "AWD warning"
+      },
+      "mil_bsdrct": {
+        "name": "Blind spot and rear cross traffic warning"
+      },
+      "mil_cel": {
+        "name": "Check engine"
+      },
+      "mil_ebd": {
+        "name": "Electronic brakeforce distribution warning"
+      },
+      "mil_eol": {
+        "name": "Engine oil level warning"
+      },
+      "mil_epas": {
+        "name": "Electric power steering warning"
+      },
+      "mil_epb": {
+        "name": "Electric parking brake warning"
+      },
+      "mil_ess": {
+        "name": "EyeSight warning"
+      },
+      "mil_iss": {
+        "name": "Idle stop & start warning"
+      },
+      "mil_opl": {
+        "name": "Oil pressure warning"
+      },
+      "mil_rab": {
+        "name": "Reverse automatic braking warning"
+      },
+      "mil_srh": {
+        "name": "Steering responsive headlights warning"
+      },
+      "mil_srs": {
+        "name": "Airbag warning"
+      },
+      "mil_tel": {
+        "name": "Telematics warning"
+      },
+      "mil_tpms": {
+        "name": "Tire pressure warning"
+      },
+      "mil_vdc": {
+        "name": "Vehicle dynamics control warning"
+      },
+      "mil_wash": {
+        "name": "Washer fluid warning"
+      },
+      "window_front_left": {
+        "name": "Window front left"
+      },
+      "window_front_right": {
+        "name": "Window front right"
+      },
+      "window_rear_left": {
+        "name": "Window rear left"
+      },
+      "window_rear_right": {
+        "name": "Window rear right"
+      },
+      "window_sunroof": {
+        "name": "Sunroof"
+      }
+    },
     "button": {
       "remote_start": {
         "name": "Remote start"

--- a/tests/components/subaru/api_responses.py
+++ b/tests/components/subaru/api_responses.py
@@ -8,6 +8,7 @@ from homeassistant.components.subaru.const import (
     API_GEN_3,
     API_GEN_4,
     VEHICLE_API_GEN,
+    VEHICLE_FEATURES,
     VEHICLE_HAS_EV,
     VEHICLE_HAS_REMOTE_SERVICE,
     VEHICLE_HAS_REMOTE_START,
@@ -92,6 +93,11 @@ VEHICLE_STATUS_EV = {
         "EV_STATE_OF_CHARGE_MODE": "EV_MODE",
         "EV_STATE_OF_CHARGE_PERCENT": 20,
         "EV_TIME_TO_FULLY_CHARGED_UTC": MOCK_DATETIME,
+        "LOCK_BOOT_STATUS": "LOCKED",
+        "LOCK_FRONT_LEFT_STATUS": "LOCKED",
+        "LOCK_FRONT_RIGHT_STATUS": "LOCKED",
+        "LOCK_REAR_LEFT_STATUS": "LOCKED",
+        "LOCK_REAR_RIGHT_STATUS": "LOCKED",
         "ODOMETER": 1234,
         "TIMESTAMP": 1595560000.0,
         "TRANSMISSION_MODE": "UNKNOWN",
@@ -111,7 +117,13 @@ VEHICLE_STATUS_EV = {
     },
     VEHICLE_HEALTH: {
         "RECOMMENDED_TIRE_PRESSURE": {"FRONT_TIRES": 35, "REAR_TIRES": 33},
+        "ISTROUBLE": False,
+        "FEATURES": {
+            "TPMS_MIL": {"ISTROUBLE": False, "ONDATE": None},
+            "CEL_MIL": {"ISTROUBLE": True, "ONDATE": None},
+        },
     },
+    VEHICLE_FEATURES: ["TPMS_MIL", "CEL_MIL"],
 }
 
 

--- a/tests/components/subaru/api_responses.py
+++ b/tests/components/subaru/api_responses.py
@@ -117,7 +117,9 @@ VEHICLE_STATUS_EV = {
     },
     VEHICLE_HEALTH: {
         "RECOMMENDED_TIRE_PRESSURE": {"FRONT_TIRES": 35, "REAR_TIRES": 33},
-        "ISTROUBLE": False,
+        # subarulink ORs MIL ISTROUBLE into the top-level one, so it can't
+        # be False here while a feature below is True.
+        "ISTROUBLE": True,
         "FEATURES": {
             "TPMS_MIL": {"ISTROUBLE": False, "ONDATE": None},
             "CEL_MIL": {"ISTROUBLE": True, "ONDATE": None},

--- a/tests/components/subaru/snapshots/test_binary_sensor.ambr
+++ b/tests/components/subaru/snapshots/test_binary_sensor.ambr
@@ -863,7 +863,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'off',
+    'state': 'on',
   })
 # ---
 # name: test_all_entities[binary_sensor.test_vehicle_2_window_front_left-entry]

--- a/tests/components/subaru/snapshots/test_binary_sensor.ambr
+++ b/tests/components/subaru/snapshots/test_binary_sensor.ambr
@@ -1,0 +1,1072 @@
+# serializer version: 1
+# name: test_all_entities[binary_sensor.test_vehicle_2_charging-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_charging',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Charging',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.BATTERY_CHARGING: 'battery_charging'>,
+    'original_icon': None,
+    'original_name': 'Charging',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'is_charging',
+    'unique_id': 'JF2ABCDE6L0000002_EV_CHARGER_STATE_TYPE',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_charging-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'battery_charging',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Charging',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_charging',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_check_engine-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.test_vehicle_2_check_engine',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Check engine',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Check engine',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mil_cel',
+    'unique_id': 'JF2ABCDE6L0000002_CEL_MIL',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_check_engine-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Check engine',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_check_engine',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_front_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_front_left',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Door front left',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door front left',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_front_left',
+    'unique_id': 'JF2ABCDE6L0000002_DOOR_FRONT_LEFT_POSITION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_front_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Door front left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_front_right-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_front_right',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Door front right',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door front right',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_front_right',
+    'unique_id': 'JF2ABCDE6L0000002_DOOR_FRONT_RIGHT_POSITION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_front_right-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Door front right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_rear_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_rear_left',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Door rear left',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door rear left',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_rear_left',
+    'unique_id': 'JF2ABCDE6L0000002_DOOR_REAR_LEFT_POSITION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_rear_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Door rear left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_rear_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_rear_right-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_rear_right',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Door rear right',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Door rear right',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_rear_right',
+    'unique_id': 'JF2ABCDE6L0000002_DOOR_REAR_RIGHT_POSITION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_door_rear_right-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Door rear right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_door_rear_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_ev_plug-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_ev_plug',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'EV plug',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PLUG: 'plug'>,
+    'original_icon': None,
+    'original_name': 'EV plug',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'ev_is_plugged_in',
+    'unique_id': 'JF2ABCDE6L0000002_EV_IS_PLUGGED_IN',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_ev_plug-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'plug',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 EV plug',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_ev_plug',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_hood-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_hood',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Hood',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Hood',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_engine_hood',
+    'unique_id': 'JF2ABCDE6L0000002_DOOR_ENGINE_HOOD_POSITION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_hood-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Hood',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_hood',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_front_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_front_left',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lock status front left',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+    'original_icon': None,
+    'original_name': 'Lock status front left',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_status_front_left',
+    'unique_id': 'JF2ABCDE6L0000002_LOCK_FRONT_LEFT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_front_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'lock',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Lock status front left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_front_right-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_front_right',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lock status front right',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+    'original_icon': None,
+    'original_name': 'Lock status front right',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_status_front_right',
+    'unique_id': 'JF2ABCDE6L0000002_LOCK_FRONT_RIGHT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_front_right-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'lock',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Lock status front right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_rear_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_rear_left',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lock status rear left',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+    'original_icon': None,
+    'original_name': 'Lock status rear left',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_status_rear_left',
+    'unique_id': 'JF2ABCDE6L0000002_LOCK_REAR_LEFT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_rear_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'lock',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Lock status rear left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_rear_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_rear_right-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_rear_right',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lock status rear right',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+    'original_icon': None,
+    'original_name': 'Lock status rear right',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_status_rear_right',
+    'unique_id': 'JF2ABCDE6L0000002_LOCK_REAR_RIGHT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_rear_right-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'lock',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Lock status rear right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_rear_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_tailgate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_tailgate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Lock status tailgate',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.LOCK: 'lock'>,
+    'original_icon': None,
+    'original_name': 'Lock status tailgate',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'lock_status_boot',
+    'unique_id': 'JF2ABCDE6L0000002_LOCK_BOOT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_lock_status_tailgate-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'lock',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Lock status tailgate',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_lock_status_tailgate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_sunroof-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_sunroof',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Sunroof',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Sunroof',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'window_sunroof',
+    'unique_id': 'JF2ABCDE6L0000002_WINDOW_SUNROOF_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_sunroof-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'window',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Sunroof',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_sunroof',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_tailgate-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_tailgate',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Tailgate',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.DOOR: 'door'>,
+    'original_icon': None,
+    'original_name': 'Tailgate',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_boot',
+    'unique_id': 'JF2ABCDE6L0000002_DOOR_BOOT_POSITION',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_tailgate-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'door',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Tailgate',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_tailgate',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_tire_pressure_warning-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.test_vehicle_2_tire_pressure_warning',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Tire pressure warning',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Tire pressure warning',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'mil_tpms',
+    'unique_id': 'JF2ABCDE6L0000002_TPMS_MIL',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_tire_pressure_warning-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Tire pressure warning',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_tire_pressure_warning',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_vehicle_health-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'binary_sensor.test_vehicle_2_vehicle_health',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Vehicle health',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.PROBLEM: 'problem'>,
+    'original_icon': None,
+    'original_name': 'Vehicle health',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'health_istrouble',
+    'unique_id': 'JF2ABCDE6L0000002_health_istrouble',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_vehicle_health-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'problem',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Vehicle health',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_vehicle_health',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_front_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_front_left',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Window front left',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Window front left',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'window_front_left',
+    'unique_id': 'JF2ABCDE6L0000002_WINDOW_FRONT_LEFT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_front_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'window',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Window front left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_front_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_front_right-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_front_right',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Window front right',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Window front right',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'window_front_right',
+    'unique_id': 'JF2ABCDE6L0000002_WINDOW_FRONT_RIGHT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_front_right-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'window',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Window front right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_front_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_rear_left-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_rear_left',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Window rear left',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Window rear left',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'window_rear_left',
+    'unique_id': 'JF2ABCDE6L0000002_WINDOW_REAR_LEFT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_rear_left-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'window',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Window rear left',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_rear_left',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_rear_right-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'binary_sensor',
+    'entity_category': None,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_rear_right',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Window rear right',
+    'options': dict({
+    }),
+    'original_device_class': <BinarySensorDeviceClass.WINDOW: 'window'>,
+    'original_icon': None,
+    'original_name': 'Window rear right',
+    'platform': 'subaru',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'window_rear_right',
+    'unique_id': 'JF2ABCDE6L0000002_WINDOW_REAR_RIGHT_STATUS',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_all_entities[binary_sensor.test_vehicle_2_window_rear_right-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'window',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'test_vehicle_2 Window rear right',
+    }),
+    'context': <ANY>,
+    'entity_id': 'binary_sensor.test_vehicle_2_window_rear_right',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'unknown',
+  })
+# ---

--- a/tests/components/subaru/snapshots/test_diagnostics.ambr
+++ b/tests/components/subaru/snapshots/test_diagnostics.ambr
@@ -10,7 +10,22 @@
     }),
     'data': list([
       dict({
+        'vehicle_features': list([
+          'TPMS_MIL',
+          'CEL_MIL',
+        ]),
         'vehicle_health': dict({
+          'FEATURES': dict({
+            'CEL_MIL': dict({
+              'ISTROUBLE': True,
+              'ONDATE': None,
+            }),
+            'TPMS_MIL': dict({
+              'ISTROUBLE': False,
+              'ONDATE': None,
+            }),
+          }),
+          'ISTROUBLE': False,
           'RECOMMENDED_TIRE_PRESSURE': dict({
             'FRONT_TIRES': 35,
             'REAR_TIRES': 33,
@@ -34,6 +49,11 @@
           'EV_STATE_OF_CHARGE_PERCENT': 20,
           'EV_TIME_TO_FULLY_CHARGED_UTC': '2020-07-24T03:06:40+00:00',
           'LATITUDE': '**REDACTED**',
+          'LOCK_BOOT_STATUS': 'LOCKED',
+          'LOCK_FRONT_LEFT_STATUS': 'LOCKED',
+          'LOCK_FRONT_RIGHT_STATUS': 'LOCKED',
+          'LOCK_REAR_LEFT_STATUS': 'LOCKED',
+          'LOCK_REAR_RIGHT_STATUS': 'LOCKED',
           'LONGITUDE': '**REDACTED**',
           'ODOMETER': '**REDACTED**',
           'TIMESTAMP': 1595560000.0,
@@ -67,7 +87,22 @@
       'username': '**REDACTED**',
     }),
     'data': dict({
+      'vehicle_features': list([
+        'TPMS_MIL',
+        'CEL_MIL',
+      ]),
       'vehicle_health': dict({
+        'FEATURES': dict({
+          'CEL_MIL': dict({
+            'ISTROUBLE': True,
+            'ONDATE': None,
+          }),
+          'TPMS_MIL': dict({
+            'ISTROUBLE': False,
+            'ONDATE': None,
+          }),
+        }),
+        'ISTROUBLE': False,
         'RECOMMENDED_TIRE_PRESSURE': dict({
           'FRONT_TIRES': 35,
           'REAR_TIRES': 33,
@@ -91,6 +126,11 @@
         'EV_STATE_OF_CHARGE_PERCENT': 20,
         'EV_TIME_TO_FULLY_CHARGED_UTC': '2020-07-24T03:06:40+00:00',
         'LATITUDE': '**REDACTED**',
+        'LOCK_BOOT_STATUS': 'LOCKED',
+        'LOCK_FRONT_LEFT_STATUS': 'LOCKED',
+        'LOCK_FRONT_RIGHT_STATUS': 'LOCKED',
+        'LOCK_REAR_LEFT_STATUS': 'LOCKED',
+        'LOCK_REAR_RIGHT_STATUS': 'LOCKED',
         'LONGITUDE': '**REDACTED**',
         'ODOMETER': '**REDACTED**',
         'TIMESTAMP': 1595560000.0,

--- a/tests/components/subaru/snapshots/test_diagnostics.ambr
+++ b/tests/components/subaru/snapshots/test_diagnostics.ambr
@@ -25,7 +25,7 @@
               'ONDATE': None,
             }),
           }),
-          'ISTROUBLE': False,
+          'ISTROUBLE': True,
           'RECOMMENDED_TIRE_PRESSURE': dict({
             'FRONT_TIRES': 35,
             'REAR_TIRES': 33,
@@ -102,7 +102,7 @@
             'ONDATE': None,
           }),
         }),
-        'ISTROUBLE': False,
+        'ISTROUBLE': True,
         'RECOMMENDED_TIRE_PRESSURE': dict({
           'FRONT_TIRES': 35,
           'REAR_TIRES': 33,

--- a/tests/components/subaru/test_binary_sensor.py
+++ b/tests/components/subaru/test_binary_sensor.py
@@ -1,5 +1,6 @@
 """Test Subaru binary sensors."""
 
+import copy
 from unittest.mock import patch
 
 import pytest
@@ -13,16 +14,16 @@ from homeassistant.components.subaru.binary_sensor import (
     LOCK_STATUS_KEYS,
     MIL_TRANSLATION_KEYS,
     OVERALL_HEALTH_BINARY_SENSOR,
-    _is_charging,
-    _is_open,
-    _is_plugged_in,
-    _is_unlocked,
-    _mil_is_on,
-    _vehicle_status_is_on,
 )
-from homeassistant.components.subaru.const import DOMAIN, VEHICLE_HEALTH, VEHICLE_STATUS
+from homeassistant.components.subaru.const import DOMAIN, VEHICLE_STATUS
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
+from homeassistant.const import (
+    STATE_OFF,
+    STATE_ON,
+    STATE_UNAVAILABLE,
+    STATE_UNKNOWN,
+    Platform,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -32,15 +33,12 @@ from .api_responses import (
     TEST_VIN_3_G3,
     TEST_VIN_4_G4,
     VEHICLE_DATA,
+    VEHICLE_STATUS_EV,
     VEHICLE_STATUS_G3,
 )
 from .conftest import setup_subaru_config_entry
 
 from tests.common import MockConfigEntry, snapshot_platform
-
-
-def _unique_id(vin: str, key: str) -> str:
-    return f"{vin}_{key}"
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -69,7 +67,7 @@ async def test_mil_entities_disabled_by_default(
 ) -> None:
     """MIL entities are created for reported MIL features and disabled by default."""
     entity_id = entity_registry.async_get_entity_id(
-        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_2_EV, feature)
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_{feature}"
     )
     assert entity_id is not None
     entry = entity_registry.async_get(entity_id)
@@ -98,7 +96,7 @@ async def test_no_binary_sensors_for_g1(
     )
     assert (
         entity_registry.async_get_entity_id(
-            BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_1_G1, key)
+            BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_1_G1}_{key}"
         )
         is None
     )
@@ -121,7 +119,7 @@ async def test_no_ev_plug_binary_sensor_for_g3(
         entity_registry.async_get_entity_id(
             BINARY_SENSOR_DOMAIN,
             DOMAIN,
-            _unique_id(TEST_VIN_3_G3, EV_PLUG_BINARY_SENSOR.key),
+            f"{TEST_VIN_3_G3}_{EV_PLUG_BINARY_SENSOR.key}",
         )
         is None
     )
@@ -149,9 +147,74 @@ async def test_no_lock_sensors_when_unsupported(
     )
     assert (
         entity_registry.async_get_entity_id(
-            BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_3_G3, key)
+            BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_3_G3}_{key}"
         )
         is None
+    )
+
+
+@pytest.mark.parametrize("not_equipped", ["NOT_EQUIPPED", "not_equipped"])
+async def test_door_not_equipped_gets_no_entity(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    not_equipped: str,
+) -> None:
+    """A door reported as NOT_EQUIPPED gets no entity, unlike a failed fetch.
+
+    Unlike windows/locks, doors are always present in vehicle_status, so
+    a per-door NOT_EQUIPPED value (not the key's absence) is what signals
+    the trim genuinely lacks that sensor. Checked case-insensitively.
+    """
+    vehicle_status = copy.deepcopy(VEHICLE_STATUS_EV)
+    vehicle_status[VEHICLE_STATUS]["DOOR_ENGINE_HOOD_POSITION"] = not_equipped
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, vehicle_status=vehicle_status
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN,
+            DOMAIN,
+            f"{TEST_VIN_2_EV}_DOOR_ENGINE_HOOD_POSITION",
+        )
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN,
+            DOMAIN,
+            f"{TEST_VIN_2_EV}_DOOR_FRONT_LEFT_POSITION",
+        )
+        is not None
+    )
+
+
+async def test_no_ev_charging_sensor_when_unsupported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """EV charging isn't created for an EV that doesn't report it, unlike EV plug."""
+    vehicle_status = copy.deepcopy(VEHICLE_STATUS_EV)
+    del vehicle_status[VEHICLE_STATUS]["EV_CHARGER_STATE_TYPE"]
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, vehicle_status=vehicle_status
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN,
+            DOMAIN,
+            f"{TEST_VIN_2_EV}_{EV_CHARGING_BINARY_SENSOR.key}",
+        )
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN,
+            DOMAIN,
+            f"{TEST_VIN_2_EV}_{EV_PLUG_BINARY_SENSOR.key}",
+        )
+        is not None
     )
 
 
@@ -169,7 +232,7 @@ async def test_overall_health_unknown_without_vehicle_health(
         vehicle_status=VEHICLE_STATUS_G3,
     )
     overall = entity_registry.async_get_entity_id(
-        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_3_G3, "health_istrouble")
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_3_G3}_health_istrouble"
     )
     assert overall is not None
     state = hass.states.get(overall)
@@ -192,7 +255,7 @@ async def test_binary_sensors_created_for_g4(
     )
     assert (
         entity_registry.async_get_entity_id(
-            BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_4_G4, "health_istrouble")
+            BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_4_G4}_health_istrouble"
         )
         is not None
     )
@@ -206,7 +269,7 @@ async def test_ev_charging_disabled_by_default(
     entity_id = entity_registry.async_get_entity_id(
         BINARY_SENSOR_DOMAIN,
         DOMAIN,
-        _unique_id(TEST_VIN_2_EV, EV_CHARGING_BINARY_SENSOR.key),
+        f"{TEST_VIN_2_EV}_{EV_CHARGING_BINARY_SENSOR.key}",
     )
     assert entity_id is not None
     entry = entity_registry.async_get(entity_id)
@@ -231,7 +294,7 @@ async def test_entities_unavailable_when_vehicle_data_fetch_fails(
     assert subaru_config_entry.state is ConfigEntryState.LOADED
 
     entity_id = entity_registry.async_get_entity_id(
-        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_2_EV, key)
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_{key}"
     )
     assert entity_id is not None
     state = hass.states.get(entity_id)
@@ -239,101 +302,163 @@ async def test_entities_unavailable_when_vehicle_data_fetch_fails(
     assert state.state == STATE_UNAVAILABLE
 
 
-@pytest.mark.parametrize(
-    ("status", "expected"),
-    [
-        ("CLOSED", False),
-        ("CLOSE", False),
-        ("OPEN", True),
-        ("VENTED", True),
-    ],
-)
-def test_is_open(status: str, expected: bool) -> None:
-    """Anything not in the closed set counts as open."""
-    assert _is_open(status) is expected
+async def test_no_window_or_lock_entities_when_vehicle_data_fetch_fails(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """Unlike doors, windows/locks aren't created when the initial fetch fails."""
+    await setup_subaru_config_entry(hass, subaru_config_entry, vehicle_status={})
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_WINDOW_FRONT_LEFT_STATUS"
+        )
+        is None
+    )
 
 
 @pytest.mark.parametrize(
-    ("status", "expected"),
+    ("status", "expected_state"),
     [
-        ("LOCKED", False),
-        ("UNLOCKED", True),
+        ("CLOSED", STATE_OFF),
+        ("CLOSE", STATE_OFF),
+        ("closed", STATE_OFF),
+        ("OPEN", STATE_ON),
+        ("VENTED", STATE_ON),
+        ("UNKNOWN", STATE_UNKNOWN),
+        ("UNAVAILABLE", STATE_UNKNOWN),
     ],
 )
-def test_is_unlocked(status: str, expected: bool) -> None:
-    """Anything other than LOCKED counts as unlocked."""
-    assert _is_unlocked(status) is expected
+async def test_door_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    status: str,
+    expected_state: str,
+) -> None:
+    """Door state reflects the raw status, case-insensitively; sentinels are unknown."""
+    vehicle_status = copy.deepcopy(VEHICLE_STATUS_EV)
+    vehicle_status[VEHICLE_STATUS]["DOOR_FRONT_LEFT_POSITION"] = status
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, vehicle_status=vehicle_status
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_DOOR_FRONT_LEFT_POSITION"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
 @pytest.mark.parametrize(
-    ("status", "expected"),
+    ("status", "expected_state"),
     [
-        ("CHARGING", True),
-        ("LOCKED_CONNECTED", True),
-        ("UNLOCKED_CONNECTED", True),
-        ("UNPLUGGED", False),
+        ("LOCKED", STATE_OFF),
+        ("UNLOCKED", STATE_ON),
     ],
 )
-def test_is_plugged_in(status: str, expected: bool) -> None:
-    """Only documented connected states count as plugged in."""
-    assert _is_plugged_in(status) is expected
+async def test_lock_sensor_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    status: str,
+    expected_state: str,
+) -> None:
+    """Lock-status sensor is on when unlocked."""
+    vehicle_status = copy.deepcopy(VEHICLE_STATUS_EV)
+    vehicle_status[VEHICLE_STATUS]["LOCK_FRONT_LEFT_STATUS"] = status
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, vehicle_status=vehicle_status
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_LOCK_FRONT_LEFT_STATUS"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
 @pytest.mark.parametrize(
-    ("status", "expected"),
+    ("status", "expected_state"),
     [
-        ("CHARGING", True),
-        ("NOT_CHARGING", False),
-        ("UNPLUGGED", False),
+        ("CHARGING", STATE_ON),
+        ("LOCKED_CONNECTED", STATE_ON),
+        ("UNLOCKED_CONNECTED", STATE_ON),
+        ("UNPLUGGED", STATE_OFF),
     ],
 )
-def test_is_charging(status: str, expected: bool) -> None:
-    """Only CHARGING counts as actively charging."""
-    assert _is_charging(status) is expected
+async def test_ev_plug_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    status: str,
+    expected_state: str,
+) -> None:
+    """EV plug sensor is on for any documented connected state."""
+    vehicle_status = copy.deepcopy(VEHICLE_STATUS_EV)
+    vehicle_status[VEHICLE_STATUS]["EV_IS_PLUGGED_IN"] = status
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, vehicle_status=vehicle_status
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_EV_IS_PLUGGED_IN"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
-    ("raw_status", "expected"),
+    ("status", "expected_state"),
     [
-        ("CLOSED", False),
-        ("closed", False),
-        ("OPEN", True),
-        ("UNKNOWN", None),
-        ("UNAVAILABLE", None),
-        ("NOT_EQUIPPED", None),
+        ("CHARGING", STATE_ON),
+        ("NOT_CHARGING", STATE_OFF),
+        ("UNPLUGGED", STATE_OFF),
     ],
 )
-def test_vehicle_status_is_on_getter(raw_status: str, expected: bool | None) -> None:
-    """The getter normalizes case and short-circuits on sentinel values."""
-    getter = _vehicle_status_is_on("DOOR_FRONT_LEFT_POSITION", _is_open)
-    vehicle_data = {VEHICLE_STATUS: {"DOOR_FRONT_LEFT_POSITION": raw_status}}
-    assert getter(vehicle_data) is expected
+async def test_ev_charging_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    status: str,
+    expected_state: str,
+) -> None:
+    """EV charging sensor is on only while actively CHARGING."""
+    vehicle_status = copy.deepcopy(VEHICLE_STATUS_EV)
+    vehicle_status[VEHICLE_STATUS]["EV_CHARGER_STATE_TYPE"] = status
+    await setup_subaru_config_entry(
+        hass, subaru_config_entry, vehicle_status=vehicle_status
+    )
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_EV_CHARGER_STATE_TYPE"
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == expected_state
 
 
-def test_vehicle_status_is_on_getter_missing_key() -> None:
-    """The getter returns None when the field is absent entirely."""
-    getter = _vehicle_status_is_on("DOOR_FRONT_LEFT_POSITION", _is_open)
-    assert getter({VEHICLE_STATUS: {}}) is None
-    assert getter({}) is None
-
-
-@pytest.mark.parametrize(
-    ("feature_health", "expected"),
-    [
-        ({"ISTROUBLE": True, "ONDATE": None}, True),
-        ({"ISTROUBLE": False, "ONDATE": None}, False),
-        ({}, None),
-    ],
-)
-def test_mil_is_on(feature_health: dict, expected: bool | None) -> None:
-    """The MIL getter reads ISTROUBLE for the requested feature only."""
-    getter = _mil_is_on("CEL_MIL")
-    vehicle_data = {VEHICLE_HEALTH: {"FEATURES": {"CEL_MIL": feature_health}}}
-    assert getter(vehicle_data) is expected
-
-
-def test_mil_is_on_missing_feature() -> None:
-    """The MIL getter returns None when the vehicle never reported that MIL."""
-    getter = _mil_is_on("CEL_MIL")
-    assert getter({VEHICLE_HEALTH: {"FEATURES": {}}}) is None
-    assert getter({}) is None
+@pytest.mark.usefixtures("entity_registry_enabled_by_default", "ev_entry")
+async def test_mil_sensor_state(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """MIL sensor reflects the per-feature ISTROUBLE flag."""
+    on_entity = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_CEL_MIL"
+    )
+    off_entity = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, f"{TEST_VIN_2_EV}_TPMS_MIL"
+    )
+    assert on_entity is not None
+    assert off_entity is not None
+    on_state = hass.states.get(on_entity)
+    off_state = hass.states.get(off_entity)
+    assert on_state is not None
+    assert off_state is not None
+    assert on_state.state == STATE_ON
+    assert off_state.state == STATE_OFF

--- a/tests/components/subaru/test_binary_sensor.py
+++ b/tests/components/subaru/test_binary_sensor.py
@@ -214,10 +214,12 @@ async def test_ev_charging_disabled_by_default(
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
+@pytest.mark.parametrize("key", ["health_istrouble", "DOOR_FRONT_LEFT_POSITION"])
 async def test_entities_unavailable_when_vehicle_data_fetch_fails(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
     subaru_config_entry: MockConfigEntry,
+    key: str,
 ) -> None:
     """Setup survives a vehicle whose data fetch fails; its entities go unavailable.
 
@@ -229,7 +231,7 @@ async def test_entities_unavailable_when_vehicle_data_fetch_fails(
     assert subaru_config_entry.state is ConfigEntryState.LOADED
 
     entity_id = entity_registry.async_get_entity_id(
-        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_2_EV, "health_istrouble")
+        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_2_EV, key)
     )
     assert entity_id is not None
     state = hass.states.get(entity_id)

--- a/tests/components/subaru/test_binary_sensor.py
+++ b/tests/components/subaru/test_binary_sensor.py
@@ -10,6 +10,7 @@ from homeassistant.components.subaru.binary_sensor import (
     BINARY_SENSORS,
     EV_CHARGING_BINARY_SENSOR,
     EV_PLUG_BINARY_SENSOR,
+    LOCK_STATUS_KEYS,
     MIL_TRANSLATION_KEYS,
     OVERALL_HEALTH_BINARY_SENSOR,
     _is_charging,
@@ -121,6 +122,34 @@ async def test_no_ev_plug_binary_sensor_for_g3(
             BINARY_SENSOR_DOMAIN,
             DOMAIN,
             _unique_id(TEST_VIN_3_G3, EV_PLUG_BINARY_SENSOR.key),
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("key", list(LOCK_STATUS_KEYS))
+async def test_no_lock_sensors_when_unsupported(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    key: str,
+) -> None:
+    """Lock sensors aren't created for a vehicle whose status omits them.
+
+    VEHICLE_STATUS_G3 has no LOCK_* keys, matching a real vehicle without
+    lock-status support -- subarulink omits these fields entirely rather
+    than reporting them as unknown.
+    """
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_3_G3],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_3_G3],
+        vehicle_status=VEHICLE_STATUS_G3,
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_3_G3, key)
         )
         is None
     )

--- a/tests/components/subaru/test_binary_sensor.py
+++ b/tests/components/subaru/test_binary_sensor.py
@@ -1,0 +1,308 @@
+"""Test Subaru binary sensors."""
+
+from unittest.mock import patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.subaru.binary_sensor import (
+    BINARY_SENSORS,
+    EV_CHARGING_BINARY_SENSOR,
+    EV_PLUG_BINARY_SENSOR,
+    MIL_TRANSLATION_KEYS,
+    OVERALL_HEALTH_BINARY_SENSOR,
+    _is_charging,
+    _is_open,
+    _is_plugged_in,
+    _is_unlocked,
+    _mil_is_on,
+    _vehicle_status_is_on,
+)
+from homeassistant.components.subaru.const import DOMAIN, VEHICLE_HEALTH, VEHICLE_STATUS
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from .api_responses import (
+    TEST_VIN_1_G1,
+    TEST_VIN_2_EV,
+    TEST_VIN_3_G3,
+    TEST_VIN_4_G4,
+    VEHICLE_DATA,
+    VEHICLE_STATUS_G3,
+)
+from .conftest import setup_subaru_config_entry
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+
+def _unique_id(vin: str, key: str) -> str:
+    return f"{vin}_{key}"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_all_entities(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """Snapshot all binary sensors created for an EV vehicle."""
+    with patch(
+        "homeassistant.components.subaru.PLATFORMS",
+        [Platform.BINARY_SENSOR],
+    ):
+        await setup_subaru_config_entry(hass, subaru_config_entry)
+    await snapshot_platform(
+        hass, entity_registry, snapshot, subaru_config_entry.entry_id
+    )
+
+
+@pytest.mark.parametrize("feature", ["TPMS_MIL", "CEL_MIL"])
+@pytest.mark.usefixtures("ev_entry")
+async def test_mil_entities_disabled_by_default(
+    entity_registry: er.EntityRegistry,
+    feature: str,
+) -> None:
+    """MIL entities are created for reported MIL features and disabled by default."""
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_2_EV, feature)
+    )
+    assert entity_id is not None
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+    assert entry.translation_key == MIL_TRANSLATION_KEYS[feature]
+
+
+@pytest.mark.parametrize(
+    "key",
+    [desc.key for desc in BINARY_SENSORS]
+    + [OVERALL_HEALTH_BINARY_SENSOR.key, EV_PLUG_BINARY_SENSOR.key],
+)
+async def test_no_binary_sensors_for_g1(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+    key: str,
+) -> None:
+    """Gen1 vehicles do not get any binary sensors (no door/lock/health data)."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_1_G1],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_1_G1],
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_1_G1, key)
+        )
+        is None
+    )
+
+
+async def test_no_ev_plug_binary_sensor_for_g3(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """Non-EV vehicles do not get the EV plug binary sensor."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_3_G3],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_3_G3],
+        vehicle_status=VEHICLE_STATUS_G3,
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN,
+            DOMAIN,
+            _unique_id(TEST_VIN_3_G3, EV_PLUG_BINARY_SENSOR.key),
+        )
+        is None
+    )
+
+
+async def test_overall_health_unknown_without_vehicle_health(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """Overall vehicle health is `unknown` when the API has not yet returned health data."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_3_G3],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_3_G3],
+        vehicle_status=VEHICLE_STATUS_G3,
+    )
+    overall = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_3_G3, "health_istrouble")
+    )
+    assert overall is not None
+    state = hass.states.get(overall)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN
+
+
+async def test_binary_sensors_created_for_g4(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """Gen4 vehicles get binary sensors, same as Gen2/Gen3."""
+    await setup_subaru_config_entry(
+        hass,
+        subaru_config_entry,
+        vehicle_list=[TEST_VIN_4_G4],
+        vehicle_data=VEHICLE_DATA[TEST_VIN_4_G4],
+        vehicle_status=VEHICLE_STATUS_G3,
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_4_G4, "health_istrouble")
+        )
+        is not None
+    )
+
+
+@pytest.mark.usefixtures("ev_entry")
+async def test_ev_charging_disabled_by_default(
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """The EV charging sensor is disabled by default, unlike the EV plug sensor."""
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN,
+        DOMAIN,
+        _unique_id(TEST_VIN_2_EV, EV_CHARGING_BINARY_SENSOR.key),
+    )
+    assert entity_id is not None
+    entry = entity_registry.async_get(entity_id)
+    assert entry is not None
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+async def test_entities_unavailable_when_vehicle_data_fetch_fails(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    subaru_config_entry: MockConfigEntry,
+) -> None:
+    """Setup survives a vehicle whose data fetch fails; its entities go unavailable.
+
+    _refresh_subaru_data only adds coordinator.data[vin] when the per-vehicle
+    API call succeeds, so a failure must not crash setup for descriptions
+    that are created unconditionally (e.g. the door/health sensors).
+    """
+    await setup_subaru_config_entry(hass, subaru_config_entry, vehicle_status={})
+    assert subaru_config_entry.state is ConfigEntryState.LOADED
+
+    entity_id = entity_registry.async_get_entity_id(
+        BINARY_SENSOR_DOMAIN, DOMAIN, _unique_id(TEST_VIN_2_EV, "health_istrouble")
+    )
+    assert entity_id is not None
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("CLOSED", False),
+        ("CLOSE", False),
+        ("OPEN", True),
+        ("VENTED", True),
+    ],
+)
+def test_is_open(status: str, expected: bool) -> None:
+    """Anything not in the closed set counts as open."""
+    assert _is_open(status) is expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("LOCKED", False),
+        ("UNLOCKED", True),
+    ],
+)
+def test_is_unlocked(status: str, expected: bool) -> None:
+    """Anything other than LOCKED counts as unlocked."""
+    assert _is_unlocked(status) is expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("CHARGING", True),
+        ("LOCKED_CONNECTED", True),
+        ("UNLOCKED_CONNECTED", True),
+        ("UNPLUGGED", False),
+    ],
+)
+def test_is_plugged_in(status: str, expected: bool) -> None:
+    """Only documented connected states count as plugged in."""
+    assert _is_plugged_in(status) is expected
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        ("CHARGING", True),
+        ("NOT_CHARGING", False),
+        ("UNPLUGGED", False),
+    ],
+)
+def test_is_charging(status: str, expected: bool) -> None:
+    """Only CHARGING counts as actively charging."""
+    assert _is_charging(status) is expected
+
+
+@pytest.mark.parametrize(
+    ("raw_status", "expected"),
+    [
+        ("CLOSED", False),
+        ("closed", False),
+        ("OPEN", True),
+        ("UNKNOWN", None),
+        ("UNAVAILABLE", None),
+        ("NOT_EQUIPPED", None),
+    ],
+)
+def test_vehicle_status_is_on_getter(raw_status: str, expected: bool | None) -> None:
+    """The getter normalizes case and short-circuits on sentinel values."""
+    getter = _vehicle_status_is_on("DOOR_FRONT_LEFT_POSITION", _is_open)
+    vehicle_data = {VEHICLE_STATUS: {"DOOR_FRONT_LEFT_POSITION": raw_status}}
+    assert getter(vehicle_data) is expected
+
+
+def test_vehicle_status_is_on_getter_missing_key() -> None:
+    """The getter returns None when the field is absent entirely."""
+    getter = _vehicle_status_is_on("DOOR_FRONT_LEFT_POSITION", _is_open)
+    assert getter({VEHICLE_STATUS: {}}) is None
+    assert getter({}) is None
+
+
+@pytest.mark.parametrize(
+    ("feature_health", "expected"),
+    [
+        ({"ISTROUBLE": True, "ONDATE": None}, True),
+        ({"ISTROUBLE": False, "ONDATE": None}, False),
+        ({}, None),
+    ],
+)
+def test_mil_is_on(feature_health: dict, expected: bool | None) -> None:
+    """The MIL getter reads ISTROUBLE for the requested feature only."""
+    getter = _mil_is_on("CEL_MIL")
+    vehicle_data = {VEHICLE_HEALTH: {"FEATURES": {"CEL_MIL": feature_health}}}
+    assert getter(vehicle_data) is expected
+
+
+def test_mil_is_on_missing_feature() -> None:
+    """The MIL getter returns None when the vehicle never reported that MIL."""
+    getter = _mil_is_on("CEL_MIL")
+    assert getter({VEHICLE_HEALTH: {"FEATURES": {}}}) is None
+    assert getter({}) is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `binary_sensor` platform to the Subaru integration: door, window, and per-door lock sensors, EV plug/charging state, an overall vehicle-health rollup, and per-MIL (malfunction indicator lamp) diagnostic sensors, for Gen2+ vehicles. Per-MIL and EV-charging sensors are disabled by default to avoid creating ~19 mostly-off entities per vehicle.

Built on `SubaruCoordinatorEntity` from #176246 (merged). Third and last of the split requested by @zweckj on #176164 (base entity / quality scale / binary sensor, each its own PR); #176164 and its docs PR were closed in favor of this split.

Known limitation, same as most static-description-list platforms: MIL entities are built once from setup-time `vehicle_features` data, so a MIL code that only starts being reported after setup won't get an entity until the integration reloads.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #176164
- Link to documentation pull request: home-assistant/home-assistant.io#47187
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

