### PR TITLE
Honor override_connection_host on UniFi Protect public-API stream URLs

### DIFF
--- a/homeassistant/components/unifiprotect/camera.py
+++ b/homeassistant/components/unifiprotect/camera.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable
 import logging
 from typing import cast, override
+from urllib.parse import urlsplit, urlunsplit
 
 from uiprotect.data import (
     Camera as UFPCamera,
@@ -51,6 +52,21 @@ _MAIN_QUALITIES = (
     ChannelQuality.MEDIUM,
     ChannelQuality.LOW,
 )
+
+
+def _async_override_stream_host(url: str, host: str) -> str:
+    """Replace the host of a public-API stream URL, keeping port/path/query.
+
+    The public API returns the console's self-advertised host (``nvr.hosts``),
+    which is unreachable when it differs from the address the config entry
+    was set up with (stacked NVRs, NAT, multi-homed consoles). This mirrors
+    the "Override connection host" behaviour that already applies to the
+    private bootstrap connection.
+    """
+    parts = urlsplit(url)
+    netloc_host = f"[{host}]" if ":" in host else host
+    netloc = netloc_host if parts.port is None else f"{netloc_host}:{parts.port}"
+    return urlunsplit(parts._replace(netloc=netloc))
 
 
 @callback
@@ -300,6 +316,8 @@ class ProtectCamera(ProtectDeviceEntity, Camera):
                 )
         else:
             source = streams.get_stream_url(quality, srtp=False)
+            if source and self.data.override_connection_host:
+                source = _async_override_stream_host(source, self.data.connection_host)
         self._attr_supported_features = _ENABLE_FEATURE if source else _DISABLE_FEATURE
         self._stream_source = source
 

--- a/homeassistant/components/unifiprotect/data.py
+++ b/homeassistant/components/unifiprotect/data.py
@@ -29,6 +29,7 @@ from uiprotect.utils import log_event
 from uiprotect.websocket import WebsocketState
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import (
@@ -41,6 +42,7 @@ from .const import (
     AUTH_RETRIES,
     CONF_DISABLE_RTSP,
     CONF_MAX_MEDIA,
+    CONF_OVERRIDE_CHOST,
     DEFAULT_MAX_MEDIA,
     DEVICES_THAT_ADOPT,
     DISPATCH_ADD,
@@ -115,6 +117,16 @@ class ProtectData:
     def max_events(self) -> int:
         """Max number of events to load at once."""
         return self._entry.options.get(CONF_MAX_MEDIA, DEFAULT_MAX_MEDIA)  # type: ignore[no-any-return]
+
+    @property
+    def override_connection_host(self) -> bool:
+        """Check if the connection host should be overridden on stream URLs."""
+        return self._entry.options.get(CONF_OVERRIDE_CHOST, False)  # type: ignore[no-any-return]
+
+    @property
+    def connection_host(self) -> str:
+        """The configured connection host for this config entry."""
+        return self._entry.data[CONF_HOST]  # type: ignore[no-any-return]
 
     def get_rtsps_streams(self, camera_id: str) -> RTSPSStreams | None:
         """Return the library-owned public-API RTSPS streams for a camera.

--- a/tests/components/unifiprotect/test_camera.py
+++ b/tests/components/unifiprotect/test_camera.py
@@ -23,7 +23,11 @@ from homeassistant.components.camera import (
     async_get_image,
     async_get_stream_source,
 )
-from homeassistant.components.unifiprotect.const import CONF_DISABLE_RTSP, DOMAIN
+from homeassistant.components.unifiprotect.const import (
+    CONF_DISABLE_RTSP,
+    CONF_OVERRIDE_CHOST,
+    DOMAIN,
+)
 from homeassistant.components.unifiprotect.utils import get_camera_base_name
 from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
 from homeassistant.const import ATTR_ENTITY_ID, STATE_UNAVAILABLE, Platform
@@ -36,6 +40,7 @@ from homeassistant.helpers import (
 )
 
 from . import patch_ufp_method
+from .conftest import DEFAULT_HOST
 from .utils import (
     MockUFPFixture,
     adopt_devices,
@@ -206,6 +211,41 @@ async def test_disable_rtsp(
 
     high_id = _assert_entity(hass, camera_all, 0, enabled=True)
     assert await async_get_stream_source(hass, high_id) is None
+
+
+async def test_override_connection_host_default_off(
+    hass: HomeAssistant, ufp: MockUFPFixture, camera_all: ProtectCamera
+) -> None:
+    """Without the override, the public API's own host is used verbatim."""
+    await init_entry(hass, ufp, [camera_all])
+
+    high_id = _assert_entity(hass, camera_all, 0, enabled=True)
+    source = await async_get_stream_source(hass, high_id)
+    assert source == camera_all.channels[0].rtsps_no_srtp_url
+    assert DEFAULT_HOST not in source
+
+
+@pytest.mark.parametrize("ufp_options", [{CONF_OVERRIDE_CHOST: True}], indirect=True)
+async def test_override_connection_host(
+    hass: HomeAssistant, ufp: MockUFPFixture, camera_all: ProtectCamera
+) -> None:
+    """Enabling the override rewrites the public-API stream URL's host.
+
+    The public API returns the console's self-advertised host (here mocked as
+    127.0.0.1, distinct from the configured entry host), which can be
+    unreachable (stacked NVRs, NAT, multi-homed consoles). With the override
+    enabled the entry's configured host must be used instead, with port/path
+    preserved.
+    """
+    await init_entry(hass, ufp, [camera_all])
+
+    high_id = _assert_entity(hass, camera_all, 0, enabled=True)
+    source = await async_get_stream_source(hass, high_id)
+    original = camera_all.channels[0].rtsps_no_srtp_url
+
+    assert source is not None
+    assert source != original
+    assert source == original.replace("127.0.0.1", DEFAULT_HOST)
 
 
 async def test_camera_image(


### PR DESCRIPTION
## Proposed change

Since camera streams moved to the Protect public API, `camera.py`'s `_async_set_stream_source` takes the stream URL from `RTSPSStreams.get_stream_url()` verbatim. That URL's host is whatever the console self-advertises (`nvr.hosts`), and the `override_connection_host` option never touched it — the option is only wired into `ProtectApiClient`, which patches the legacy private-bootstrap connection host, not the public-API stream source.

When the console's self-advertised host is unreachable (stacked NVRs, NAT, multi-homed consoles, or a DHCP-fallback address left on an interface), enabling "Override connection host" silently does nothing: camera live views fail while snapshots (which go over the correctly configured host) keep working.

This adds `ProtectData.override_connection_host` / `.connection_host`, and rewrites the public-API stream URL's host (keeping port/path/query intact) when the option is enabled — matching the behavior the UI already documents for it.

Fixes #176487

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

- This change involves the following integrations: `unifiprotect`
- This PR is related to issue: #176487

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/

## Test plan

- Added `test_override_connection_host` and `test_override_connection_host_default_off` to `tests/components/unifiprotect/test_camera.py`, covering: the option off (public-API host used verbatim, current behavior unchanged) and on (URL rewritten to the entry's configured host, port/path/query preserved).
- Verified `ruff check` and `ruff format --check` pass on the changed files.
- Not run against the full test/lint suite in CI locally (this environment's Python is 3.12; core requires 3.14+) — relying on CI to confirm.