### PR TITLE
Migrate growatt_server off hass.data[DOMAIN]

### DIFF
--- a/homeassistant/components/growatt_server/__init__.py
+++ b/homeassistant/components/growatt_server/__init__.py
@@ -23,7 +23,6 @@ Error handling pattern for reauth:
   → raise ConfigEntryAuthFailed
 - All other errors → ConfigEntryError (setup) or UpdateFailed (coordinator)
 """
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from collections.abc import Mapping
 import datetime
@@ -49,7 +48,6 @@ from homeassistant.helpers.typing import ConfigType
 from .const import (
     AUTH_API_TOKEN,
     AUTH_PASSWORD,
-    CACHED_API_KEY,
     CONF_AUTH_TYPE,
     CONF_PLANT_ID,
     DEFAULT_PLANT_ID,
@@ -69,6 +67,11 @@ from .services import async_setup_services
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+# Temporary handoff of authenticated Classic API sessions from async_migrate_entry
+# to async_setup_entry. Avoids a second login() during the same startup, which
+# would hit Growatt's 5-minute per-endpoint rate limit. Popped after first use.
+_CACHED_APIS: dict[str, growattServer.GrowattApi] = {}
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
@@ -196,8 +199,7 @@ async def async_migrate_entry(
                 )
 
                 # Cache the logged-in API instance for reuse in async_setup_entry()
-                hass.data.setdefault(DOMAIN, {})
-                hass.data[DOMAIN][f"{CACHED_API_KEY}{config_entry.entry_id}"] = api
+                _CACHED_APIS[config_entry.entry_id] = api
 
                 _LOGGER.info(
                     "Migrated config entry to use specific plant_id '%s'",
@@ -347,9 +349,7 @@ async def async_setup_entry(
         # Check if migration cached an authenticated API instance for us to reuse.
         # This avoids calling login() twice (once in migration, once here) which
         # would trigger rate limiting.
-        cached_api = hass.data.get(DOMAIN, {}).pop(
-            f"{CACHED_API_KEY}{config_entry.entry_id}", None
-        )
+        cached_api = _CACHED_APIS.pop(config_entry.entry_id, None)
 
         if cached_api:
             # Reuse the logged-in API instance from migration (rate limit optimization)

--- a/homeassistant/components/growatt_server/const.py
+++ b/homeassistant/components/growatt_server/const.py
@@ -55,11 +55,6 @@ BATT_MODE_LOAD_FIRST = 0
 BATT_MODE_BATTERY_FIRST = 1
 BATT_MODE_GRID_FIRST = 2
 
-# Internal key prefix for caching authenticated API instance
-# Used to pass logged-in session from async_migrate_entry to async_setup_entry
-# to avoid double login() calls that trigger API rate limiting
-CACHED_API_KEY = "_cached_api_"
-
 # Supported device types for coordinator creation
 SUPPORTED_DEVICE_TYPES = ["inverter", "tlx", "storage", "mix", "min", "sph"]
 

--- a/tests/components/growatt_server/test_init.py
+++ b/tests/components/growatt_server/test_init.py
@@ -10,10 +10,10 @@ import pytest
 import requests
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.growatt_server import _CACHED_APIS
 from homeassistant.components.growatt_server.const import (
     AUTH_API_TOKEN,
     AUTH_PASSWORD,
-    CACHED_API_KEY,
     CONF_AUTH_TYPE,
     CONF_PLANT_ID,
     DEFAULT_PLANT_ID,
@@ -733,10 +733,8 @@ async def test_setup_reuses_cached_api_from_migration(
     # This confirms setup did NOT resolve plant_id again (optimization working)
     mock_growatt_classic_api.plant_list.assert_called_once_with(123456)
 
-    # Verify the cached API was removed after use (should not be in hass.data anymore)
-    assert f"{CACHED_API_KEY}{mock_config_entry.entry_id}" not in hass.data.get(
-        DOMAIN, {}
-    )
+    # Verify the cached API was removed after use (one-time handoff)
+    assert mock_config_entry.entry_id not in _CACHED_APIS
 
 
 async def test_migrate_failure_returns_false(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Finish the `growatt_server` `entry.runtime_data` migration tracked in #176086 (part of home-assistant/epics#43).

Coordinators were already stored on `entry.runtime_data` via `GrowattRuntimeData` / `GrowattConfigEntry`. The only remaining `hass.data[DOMAIN]` use was a temporary handoff of a logged-in Classic API session from `async_migrate_entry` to `async_setup_entry` (avoids a second `login()` and Growatt's 5-minute per-endpoint rate limit).

That handoff now uses a module-level one-shot `_CACHED_APIS` dict keyed by entry id, so:

- `hass.data[DOMAIN]` is no longer used
- the module-level `home-assistant-use-runtime-data` pylint disable is removed
- `CACHED_API_KEY` is removed from `const.py`
- the migration cache test asserts the module cache is cleared after setup

No functional change to setup, platforms, or services. `quality_scale.yaml` already marked `runtime-data: done`.

**AI assistance disclosure:** An AI coding assistant was used to draft this change. The diff was reviewed for correctness against the epic migration recipe and existing growatt_server behavior (runtime_data coordinators unchanged; only the migrate→setup API cache path moved).

**CLA:** If the CLA bot requests a signature for this contribution, I will complete the Home Assistant CLA.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #176086
- This PR is related to issue: home-assistant/epics#43
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr