### PR TITLE
Migrate mailgun off hass.data[DOMAIN] to typed HassKey

### DIFF
--- a/homeassistant/components/mailgun/__init__.py
+++ b/homeassistant/components/mailgun/__init__.py
@@ -1,5 +1,4 @@
 """Support for Mailgun."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 import hashlib
 import hmac
@@ -16,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_entry_flow, config_validation as cv
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DOMAIN
+from .const import DATA_CONFIG, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +44,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     if DOMAIN not in config:
         return True
 
-    hass.data[DOMAIN] = config[DOMAIN]
+    hass.data[DATA_CONFIG] = config[DOMAIN]
     return True
 
 
@@ -76,7 +75,7 @@ async def handle_webhook(
 
 async def verify_webhook(hass, token=None, timestamp=None, signature=None):
     """Verify webhook was signed by Mailgun."""
-    if DOMAIN not in hass.data:
+    if DATA_CONFIG not in hass.data:
         _LOGGER.warning("Cannot validate Mailgun webhook, missing API Key")
         return True
 
@@ -84,7 +83,7 @@ async def verify_webhook(hass, token=None, timestamp=None, signature=None):
         return False
 
     hmac_digest = hmac.new(
-        key=bytes(hass.data[DOMAIN][CONF_API_KEY], "utf-8"),
+        key=bytes(hass.data[DATA_CONFIG][CONF_API_KEY], "utf-8"),
         msg=bytes(f"{timestamp}{token}", "utf-8"),
         digestmod=hashlib.sha256,
     ).hexdigest()

--- a/homeassistant/components/mailgun/const.py
+++ b/homeassistant/components/mailgun/const.py
@@ -1,3 +1,11 @@
 """Const for Mailgun."""
 
+from typing import Any
+
+from homeassistant.util.hass_dict import HassKey
+
 DOMAIN = "mailgun"
+
+# YAML component config (api_key / domain / sandbox) used by notify + webhook verify.
+# Domain-level, not per config entry — entries only register webhooks.
+DATA_CONFIG: HassKey[dict[str, Any]] = HassKey(DOMAIN)

--- a/homeassistant/components/mailgun/notify.py
+++ b/homeassistant/components/mailgun/notify.py
@@ -22,7 +22,8 @@ from homeassistant.const import CONF_API_KEY, CONF_DOMAIN, CONF_RECIPIENT, CONF_
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from . import CONF_SANDBOX, DOMAIN
+from . import CONF_SANDBOX
+from .const import DATA_CONFIG
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +43,7 @@ def get_service(
     discovery_info: DiscoveryInfoType | None = None,
 ) -> MailgunNotificationService | None:
     """Get the Mailgun notification service."""
-    # Uses legacy hass.data[DOMAIN] pattern
-    # pylint: disable-next=home-assistant-use-runtime-data
-    data = hass.data[DOMAIN]
+    data = hass.data[DATA_CONFIG]
     mailgun_service = MailgunNotificationService(
         data.get(CONF_DOMAIN),
         data.get(CONF_SANDBOX),


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate `mailgun` off the legacy `hass.data[DOMAIN]` pattern tracked in #168781 (part of home-assistant/epics#43).

Mailgun's `hass.data[DOMAIN]` held **YAML component config** (`api_key` / `domain` / `sandbox`) shared by the notify platform and inbound webhook signature verification. Config entries only register webhooks and do **not** own that config, so there is no per-entry state to put on `entry.runtime_data`. The matching pattern used elsewhere for domain-level YAML data (e.g. yeelight custom effects, geofency mobile beacons, flux_led discovery) is a typed `HassKey`.

Changes:
- Add `DATA_CONFIG: HassKey[dict[str, Any]] = HassKey(DOMAIN)` in `const.py`
- Store/read YAML config via `hass.data[DATA_CONFIG]` in `__init__.py` and `notify.py`
- Remove both `home-assistant-use-runtime-data` pylint suppressions

No user-facing behavior changes. Existing webhook tests exercise the API-key and no-API-key paths and do not assert on `hass.data` keys.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168781
- This PR is related to issue: home-assistant/epics#43
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

### AI/LLM disclosure

- AI coding tools (including Grok agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning (YAML domain config → typed `HassKey`; no per-entry runtime state on mailgun webhook entries), and verified the diff against the yeelight/geofency/flux_led domain-level patterns before submitting.
- This submission is original work of authorship under the project CLA; AI output was not pasted unreviewed.