### PR TITLE
Fix via_device race in bluesound

### DIFF
--- a/homeassistant/components/bluesound/button.py
+++ b/homeassistant/components/bluesound/button.py
@@ -9,6 +9,7 @@ from pyblu import Player
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import CONF_PORT
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     DeviceInfo,
@@ -118,8 +119,13 @@ class BluesoundButton(CoordinatorEntity[BluesoundCoordinator], ButtonEntity):
                 manufacturer=sync_status.brand,
                 model=sync_status.model_name,
                 model_id=sync_status.model,
-                via_device=(DOMAIN, format_mac(sync_status.mac)),
             )
+            # The leader (default-port) device is a separate config entry that may
+            # not be loaded yet; link to it only if it already exists.
+            if leader_devices := dr.async_get(coordinator.hass).async_get_devices(
+                identifiers={(DOMAIN, format_mac(sync_status.mac))}
+            ):
+                self._attr_device_info["via_device_id"] = leader_devices[0].id
 
     @override
     async def async_press(self) -> None:

--- a/homeassistant/components/bluesound/media_player.py
+++ b/homeassistant/components/bluesound/media_player.py
@@ -19,7 +19,11 @@ from homeassistant.components.media_player import (
 from homeassistant.const import CONF_HOST, CONF_PORT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ServiceValidationError
-from homeassistant.helpers import entity_registry as er, issue_registry as ir
+from homeassistant.helpers import (
+    device_registry as dr,
+    entity_registry as er,
+    issue_registry as ir,
+)
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     DeviceInfo,
@@ -131,8 +135,13 @@ class BluesoundPlayer(CoordinatorEntity[BluesoundCoordinator], MediaPlayerEntity
                 manufacturer=sync_status.brand,
                 model=sync_status.model_name,
                 model_id=sync_status.model,
-                via_device=(DOMAIN, format_mac(sync_status.mac)),
             )
+            # The leader (default-port) device is a separate config entry that may
+            # not be loaded yet; link to it only if it already exists.
+            if leader_devices := dr.async_get(coordinator.hass).async_get_devices(
+                identifiers={(DOMAIN, format_mac(sync_status.mac))}
+            ):
+                self._attr_device_info["via_device_id"] = leader_devices[0].id
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/tests/components/bluesound/conftest.py
+++ b/tests/components/bluesound/conftest.py
@@ -160,6 +160,23 @@ def config_entry_secondary() -> MockConfigEntry:
 
 
 @pytest.fixture
+def config_entry_non_default_port() -> MockConfigEntry:
+    """Return a mocked config entry for a non-default-port player.
+
+    Shares its mac (via player_mocks) with the leader `config_entry` at the
+    default port.
+    """
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "1.1.1.2",
+            CONF_PORT: 11001,
+        },
+        unique_id="ff:ff:01:01:01:01-11001",
+    )
+
+
+@pytest.fixture
 async def setup_config_entry(
     hass: HomeAssistant, config_entry: MockConfigEntry, player_mocks: PlayerMocks
 ) -> None:

--- a/tests/components/bluesound/test_init.py
+++ b/tests/components/bluesound/test_init.py
@@ -2,8 +2,10 @@
 
 from pyblu.errors import PlayerUnreachableError
 
+from homeassistant.components.bluesound import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 
 from .conftest import PlayerMocks
 
@@ -45,3 +47,50 @@ async def test_unload_entry_while_player_is_offline(
 
     assert hass.states.get("media_player.player_name1111").state == "unavailable"
     assert config_entry.state is ConfigEntryState.NOT_LOADED
+
+
+async def test_non_default_port_links_to_leader_via_device_id(
+    hass: HomeAssistant,
+    setup_config_entry: None,
+    config_entry_non_default_port: MockConfigEntry,
+    player_mocks: PlayerMocks,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a non-default-port player links to the already-registered leader device."""
+    config_entry_non_default_port.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry_non_default_port.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry_non_default_port.state is ConfigEntryState.LOADED
+
+    leader_devices = device_registry.async_get_devices(
+        identifiers={(DOMAIN, "ff:ff:01:01:01:01")}
+    )
+    assert leader_devices
+    leader_device = leader_devices[0]
+
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ff:ff:01:01:01:01-11001"), config_entry_non_default_port.entry_id
+    )
+    assert child_device is not None
+    assert child_device.via_device_id == leader_device.id
+
+
+async def test_non_default_port_without_leader_has_no_via_device_id(
+    hass: HomeAssistant,
+    config_entry_non_default_port: MockConfigEntry,
+    player_mocks: PlayerMocks,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a non-default-port player sets up fine when the leader device is absent."""
+    config_entry_non_default_port.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(config_entry_non_default_port.entry_id)
+    await hass.async_block_till_done()
+
+    assert config_entry_non_default_port.state is ConfigEntryState.LOADED
+
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ff:ff:01:01:01:01-11001"), config_entry_non_default_port.entry_id
+    )
+    assert child_device is not None
+    assert child_device.via_device_id is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `bluesound`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
