### PR TITLE
Fix via_device race in google_health

### DIFF
--- a/homeassistant/components/google_health/__init__.py
+++ b/homeassistant/components/google_health/__init__.py
@@ -11,7 +11,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import aiohttp_client
+from homeassistant.helpers import aiohttp_client, device_registry as dr
 from homeassistant.helpers.config_entry_oauth2_flow import (
     ImplementationUnavailableError,
     OAuth2Session,
@@ -113,6 +113,16 @@ async def async_setup_entry(
         device_coordinator=device_coordinator,
         nutrition_coordinator=nutrition_coordinator,
         sleep_coordinator=sleep_coordinator,
+    )
+
+    # Register the account device up front so the per-device sensors can resolve
+    # it as their via_device parent even when only the device scope is granted
+    # (the account-level sensors that would otherwise create it are gated on
+    # different scopes).
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, entry.entry_id)},
+        manufacturer="Google",
     )
 
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)

--- a/homeassistant/components/google_health/sensor.py
+++ b/homeassistant/components/google_health/sensor.py
@@ -23,7 +23,11 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
+from homeassistant.helpers.device_registry import (
+    CONNECTION_NETWORK_MAC,
+    DeviceInfo,
+    async_get_device_id_by_identifier,
+)
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -401,7 +405,11 @@ class GoogleHealthDeviceSensor(
             or (device.device_type.title() if device.device_type else "Device"),
             model=device.device_type.title() if device.device_type else None,
             sw_version=device.device_version,
-            via_device=(DOMAIN, entry_id),
+            via_device_id=async_get_device_id_by_identifier(
+                coordinator.hass,
+                (DOMAIN, entry_id),
+                config_entry_id=entry_id,
+            ),
         )
 
         if device.mac_address:

--- a/tests/components/google_health/conftest.py
+++ b/tests/components/google_health/conftest.py
@@ -78,9 +78,9 @@ def mock_expires_at() -> int:
 
 
 @pytest.fixture
-def scopes() -> list[str]:
+def scopes(request: pytest.FixtureRequest) -> list[str]:
     """Fixture with scopes to set up."""
-    return OAUTH_SCOPES
+    return getattr(request, "param", OAUTH_SCOPES)
 
 
 @pytest.fixture(name="token_entry")

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from google_health_api.const import HealthApiScope
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -143,6 +144,11 @@ async def test_sensor_unit_conversions(
         assert state.attributes.get("unit_of_measurement") == expected_unit
 
 
+@pytest.mark.parametrize(
+    "scopes",
+    [[HealthApiScope.PROFILE_READ, HealthApiScope.SETTINGS_READ]],
+    indirect=True,
+)
 @pytest.mark.usefixtures("mock_google_health_client")
 async def test_device_sensor_via_device_id(
     hass: HomeAssistant,
@@ -150,7 +156,12 @@ async def test_device_sensor_via_device_id(
     config_entry: MockConfigEntry,
     integration_setup: Callable[[], Awaitable[bool]],
 ) -> None:
-    """Test a paired device is linked to the account device via via_device_id."""
+    """Test a paired device is linked to the account device via via_device_id.
+
+    Only the profile and settings scopes are granted so the account device
+    can only come from the up-front registration, not from account-level
+    sensors that scopes outside of this test would also create.
+    """
     with patch("homeassistant.components.google_health._PLATFORMS", [Platform.SENSOR]):
         assert await integration_setup()
 

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -7,9 +7,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.google_health.const import DOMAIN
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.unit_system import (
     METRIC_SYSTEM,
     US_CUSTOMARY_SYSTEM,
@@ -140,3 +141,26 @@ async def test_sensor_unit_conversions(
         assert state is not None
         assert float(state.state) == expected_state
         assert state.attributes.get("unit_of_measurement") == expected_unit
+
+
+@pytest.mark.usefixtures("mock_google_health_client")
+async def test_device_sensor_via_device_id(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test a paired device is linked to the account device via via_device_id."""
+    with patch("homeassistant.components.google_health._PLATFORMS", [Platform.SENSOR]):
+        assert await integration_setup()
+
+    account_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry.entry_id), config_entry.entry_id
+    )
+    assert account_device is not None
+
+    paired_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "watch_123"), config_entry.entry_id
+    )
+    assert paired_device is not None
+    assert paired_device.via_device_id == account_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `google_health`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
