### PR TITLE
Fix via_device race in lyric

### DIFF
--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import (
     aiohttp_client,
     config_entry_oauth2_flow,
     config_validation as cv,
+    device_registry as dr,
 )
 
 from .api import (
@@ -18,6 +19,7 @@ from .api import (
 )
 from .const import DOMAIN
 from .coordinator import LyricConfigEntry, LyricDataUpdateCoordinator
+from .entity import create_thermostat_device_info
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -58,6 +60,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: LyricConfigEntry) -> boo
     # Fetch initial data so we have data when entities subscribe
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+
+    # Register the thermostat devices up front so the accessory (room sensor)
+    # entities can resolve them as their via_device parent regardless of the
+    # order the platforms are set up in.
+    device_registry = dr.async_get(hass)
+    for location in coordinator.data.locations:
+        for device in location.devices:
+            device_registry.async_get_or_create(
+                config_entry_id=entry.entry_id,
+                **create_thermostat_device_info(device),
+            )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/lyric/entity.py
+++ b/homeassistant/components/lyric/entity.py
@@ -50,6 +50,17 @@ class LyricEntity(CoordinatorEntity[LyricDataUpdateCoordinator]):
         return self.location.devices_dict[self._mac_id]
 
 
+def create_thermostat_device_info(device: LyricDevice) -> DeviceInfo:
+    """Return the device info for a Lyric thermostat."""
+    return DeviceInfo(
+        identifiers={(dr.CONNECTION_NETWORK_MAC, device.mac_id)},
+        connections={(dr.CONNECTION_NETWORK_MAC, device.mac_id)},
+        manufacturer="Honeywell",
+        model=device.device_model,
+        name=f"{device.name} Thermostat",
+    )
+
+
 class LyricDeviceEntity(LyricEntity):
     """Defines a Honeywell Lyric device entity."""
 
@@ -57,13 +68,7 @@ class LyricDeviceEntity(LyricEntity):
     @override
     def device_info(self) -> DeviceInfo:
         """Return device information about this Honeywell Lyric instance."""
-        return DeviceInfo(
-            identifiers={(dr.CONNECTION_NETWORK_MAC, self._mac_id)},
-            connections={(dr.CONNECTION_NETWORK_MAC, self._mac_id)},
-            manufacturer="Honeywell",
-            model=self.device.device_model,
-            name=f"{self.device.name} Thermostat",
-        )
+        return create_thermostat_device_info(self.device)
 
 
 class LyricAccessoryEntity(LyricDeviceEntity):
@@ -97,7 +102,11 @@ class LyricAccessoryEntity(LyricDeviceEntity):
             manufacturer="Honeywell",
             model="RCHTSENSOR",
             name=f"{self.room.room_name} Sensor",
-            via_device=(dr.CONNECTION_NETWORK_MAC, self._mac_id),
+            via_device_id=dr.async_get_device_id_by_identifier(
+                self.hass,
+                (dr.CONNECTION_NETWORK_MAC, self._mac_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            ),
         )
 
     @property

--- a/tests/components/lyric/test_sensor.py
+++ b/tests/components/lyric/test_sensor.py
@@ -3,6 +3,7 @@
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiolyric import Lyric
 from aiolyric.objects.location import LyricLocation
 from aiolyric.objects.priority import LyricRoom
 
@@ -36,7 +37,7 @@ def test_get_datetime_from_future_time_valid() -> None:
 
 
 def _mock_lyric() -> MagicMock:
-    """Build a mock Lyric client with one thermostat and one room accessory."""
+    """Build a fake aiolyric Lyric client with one thermostat and one room accessory."""
     client = MagicMock()
     location = LyricLocation(
         client,
@@ -67,7 +68,9 @@ def _mock_lyric() -> MagicMock:
         }
     )
 
-    lyric = MagicMock()
+    lyric = MagicMock(spec=Lyric)
+    lyric.get_locations = AsyncMock()
+    lyric.get_thermostat_rooms = AsyncMock()
     lyric.locations = [location]
     lyric.locations_dict = {1234: location}
     lyric.rooms_dict = {_MAC: {1: room}}
@@ -77,12 +80,7 @@ def _mock_lyric() -> MagicMock:
 async def test_accessory_links_to_thermostat_via_device(
     hass: HomeAssistant, device_registry: dr.DeviceRegistry
 ) -> None:
-    """Test room accessory devices resolve the thermostat as their via_device.
-
-    The accessory device_info resolves the thermostat by identifier through the
-    (raising) via_device_id helper, so setup only succeeds because the thermostat
-    device is registered up front, before the platforms are forwarded.
-    """
+    """Test room accessory devices resolve the thermostat as their via_device."""
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -107,10 +105,7 @@ async def test_accessory_links_to_thermostat_via_device(
             return_value=implementation,
         ),
         patch("homeassistant.components.lyric.PLATFORMS", [Platform.SENSOR]),
-        patch(
-            "homeassistant.components.lyric.coordinator.LyricDataUpdateCoordinator._async_update_data",
-            new=AsyncMock(return_value=_mock_lyric()),
-        ),
+        patch("homeassistant.components.lyric.Lyric", return_value=_mock_lyric()),
     ):
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()

--- a/tests/components/lyric/test_sensor.py
+++ b/tests/components/lyric/test_sensor.py
@@ -1,8 +1,22 @@
 """Tests for the Honeywell Lyric sensor platform."""
 
 from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from aiolyric.objects.location import LyricLocation
+from aiolyric.objects.priority import LyricRoom
+
+from homeassistant.components.lyric.api import LyricLocalOAuth2Implementation
+from homeassistant.components.lyric.const import DOMAIN
 from homeassistant.components.lyric.sensor import get_datetime_from_future_time
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+_MAC = "AABBCCDDEEFF"
 
 
 def test_get_datetime_from_future_time_none() -> None:
@@ -19,3 +33,98 @@ def test_get_datetime_from_future_time_valid() -> None:
     """Test that a valid time string returns a datetime."""
     result = get_datetime_from_future_time("13:30:00")
     assert isinstance(result, datetime)
+
+
+def _mock_lyric() -> MagicMock:
+    """Build a mock Lyric client with one thermostat and one room accessory."""
+    client = MagicMock()
+    location = LyricLocation(
+        client,
+        {
+            "locationID": 1234,
+            "name": "Home",
+            "devices": [
+                # A thermostat with no device-level sensors: the sensor platform
+                # creates no thermostat entity, so the thermostat device can only
+                # come from the up-front registration in async_setup_entry.
+                {
+                    "deviceID": f"LCC-{_MAC}",
+                    "deviceClass": "Thermostat",
+                    "macID": _MAC,
+                    "name": "Thermostat",
+                    "deviceModel": "T5-T6",
+                }
+            ],
+        },
+    )
+    room = LyricRoom(
+        {
+            "id": 1,
+            "roomName": "Living Room",
+            "roomAvgTemp": 21,
+            "roomAvgHumidity": 40,
+            "accessories": [{"id": 1, "type": "IndoorAirSensor", "temperature": 21}],
+        }
+    )
+
+    lyric = MagicMock()
+    lyric.locations = [location]
+    lyric.locations_dict = {1234: location}
+    lyric.rooms_dict = {_MAC: {1: room}}
+    return lyric
+
+
+async def test_accessory_links_to_thermostat_via_device(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test room accessory devices resolve the thermostat as their via_device.
+
+    The accessory device_info resolves the thermostat by identifier through the
+    (raising) via_device_id helper, so setup only succeeds because the thermostat
+    device is registered up front, before the platforms are forwarded.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "auth_implementation": DOMAIN,
+            "token": {
+                "access_token": "mock-access-token",
+                "refresh_token": "mock-refresh-token",
+                "expires_at": 9999999999,
+                "token_type": "Bearer",
+            },
+        },
+    )
+    entry.add_to_hass(hass)
+
+    implementation = MagicMock(spec=LyricLocalOAuth2Implementation)
+    implementation.client_id = "client-id"
+
+    with (
+        patch(
+            "homeassistant.helpers.config_entry_oauth2_flow."
+            "async_get_config_entry_implementation",
+            return_value=implementation,
+        ),
+        patch("homeassistant.components.lyric.PLATFORMS", [Platform.SENSOR]),
+        patch(
+            "homeassistant.components.lyric.coordinator.LyricDataUpdateCoordinator._async_update_data",
+            new=AsyncMock(return_value=_mock_lyric()),
+        ),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+
+    thermostat = device_registry.async_get_device_by_identifier(
+        (dr.CONNECTION_NETWORK_MAC, _MAC), entry.entry_id
+    )
+    assert thermostat is not None
+
+    accessory = device_registry.async_get_device_by_identifier(
+        (f"{dr.CONNECTION_NETWORK_MAC}_room_accessory", f"{_MAC}_room1_accessory1"),
+        entry.entry_id,
+    )
+    assert accessory is not None
+    assert accessory.via_device_id == thermostat.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `lyric`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
