### PR TITLE
Fix via_device race in matter

### DIFF
--- a/homeassistant/components/matter/adapter.py
+++ b/homeassistant/components/matter/adapter.py
@@ -70,7 +70,12 @@ class MatterAdapter:
         def endpoint_added_callback(event: EventType, data: dict[str, int]) -> None:
             """Handle endpoint added event."""
             node = self.matter_client.get_node(data["node_id"])
-            self._setup_endpoint(node.endpoints[data["endpoint_id"]])
+            endpoint = node.endpoints[data["endpoint_id"]]
+            # Ensure the bridge device (endpoint 0) is registered before a
+            # bridged child endpoint resolves it as its via_device.
+            if endpoint.is_bridged_device and node.endpoints[0] != endpoint:
+                self._setup_endpoint(node.endpoints[0])
+            self._setup_endpoint(endpoint)
 
         def endpoint_removed_callback(event: EventType, data: dict[str, int]) -> None:
             """Handle endpoint removed event."""
@@ -136,9 +141,12 @@ class MatterAdapter:
         """Set up an node."""
         LOGGER.debug("Setting up entities for node %s", node.node_id)
         try:
-            for endpoint in node.endpoints.values():
+            # Process endpoints in order so the bridge device (endpoint 0) is
+            # registered before any bridged child endpoint resolves it as its
+            # via_device.
+            for endpoint_id in sorted(node.endpoints):
                 # Node endpoints are translated into HA devices
-                self._setup_endpoint(endpoint)
+                self._setup_endpoint(node.endpoints[endpoint_id])
         except Exception as err:  # noqa: BLE001
             # We don't want to crash the whole setup when a single node fails to setup
             # for whatever reason, so we catch all exceptions here.
@@ -172,14 +180,20 @@ class MatterAdapter:
             or (device_type.__name__ if device_type else None)
         )
 
+        device_registry = dr.async_get(self.hass)
+
         # handle bridged devices
-        bridge_device_id = None
+        via_device_id: str | None = None
         if endpoint.is_bridged_device and endpoint.node.endpoints[0] != endpoint:
             bridge_device_id = get_device_id(
                 server_info,
                 endpoint.node.endpoints[0],
             )
-            bridge_device_id = f"{ID_TYPE_DEVICE_ID}_{bridge_device_id}"
+            via_device_id = dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{bridge_device_id}"),
+                config_entry_id=self.config_entry.entry_id,
+            )
 
         node_device_id = get_device_id(
             server_info,
@@ -214,7 +228,7 @@ class MatterAdapter:
         else:
             model_id = str(product_id) if (product_id := basic_info.productID) else None
 
-        dr.async_get(self.hass).async_get_or_create(
+        device_registry.async_get_or_create(
             name=name,
             config_entry_id=self.config_entry.entry_id,
             identifiers=identifiers,
@@ -224,7 +238,7 @@ class MatterAdapter:
             model=model_name,
             model_id=model_id,
             serial_number=serial_number,
-            via_device=(DOMAIN, bridge_device_id) if bridge_device_id else None,
+            via_device_id=via_device_id,
         )
 
     def _setup_endpoint(self, endpoint: MatterEndpoint) -> None:

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -195,6 +195,49 @@ async def test_endpoint_added_sets_up_bridge_before_child(
     assert child_entry.via_device_id == bridge_entry.id
 
 
+async def test_setup_node_sorts_bridge_before_child(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test initial node setup registers the bridge before a bridged child.
+
+    Endpoints must be processed in endpoint-id order on the startup path
+    (`_setup_node`), even when the bridged child endpoint precedes endpoint 0
+    in the node's raw endpoint order, otherwise resolving the child's
+    via_device_id would raise.
+    """
+    node = create_node_from_fixture("atios_knx_bridge")
+    node.endpoints = {
+        endpoint_id: node.endpoints[endpoint_id] for endpoint_id in (29, 1, 0)
+    }
+
+    def identifier_for(endpoint_id: int) -> tuple[str, str]:
+        endpoint = node.endpoints[endpoint_id]
+        device_id = get_device_id(matter_client.server_info, endpoint)
+        return (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{device_id}")
+
+    matter_client.get_nodes.return_value = [node]
+    config_entry = MockConfigEntry(
+        domain=DOMAIN, data={"url": "ws://localhost:5580/ws"}
+    )
+    config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        identifier_for(0), config_entry.entry_id
+    )
+    assert bridge_entry is not None
+
+    child_entry = device_registry.async_get_device_by_identifier(
+        identifier_for(29), config_entry.entry_id
+    )
+    assert child_entry is not None
+    assert child_entry.via_device_id == bridge_entry.id
+
+
 @pytest.mark.usefixtures("matter_node")
 @pytest.mark.parametrize("node_fixture", ["mock_air_purifier"])
 async def test_device_registry_single_node_composed_device(

--- a/tests/components/matter/test_adapter.py
+++ b/tests/components/matter/test_adapter.py
@@ -6,7 +6,8 @@ from matter_server.common.models import EventType
 import pytest
 
 from homeassistant.components.matter.adapter import get_clean_name
-from homeassistant.components.matter.const import DOMAIN
+from homeassistant.components.matter.const import DOMAIN, ID_TYPE_DEVICE_ID
+from homeassistant.components.matter.helpers import get_device_id
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 
@@ -142,6 +143,56 @@ async def test_node_added_subscription(
 
     entity_state = hass.states.get("light.mock_onoff_light")
     assert entity_state
+
+
+async def test_endpoint_added_sets_up_bridge_before_child(
+    hass: HomeAssistant,
+    matter_client: MagicMock,
+    device_registry: dr.DeviceRegistry,
+    integration: MockConfigEntry,
+) -> None:
+    """Test a bridged child endpoint resolves via_device_id set up out of order.
+
+    The bridge device (endpoint 0) must be registered before a bridged child
+    endpoint, even if the child's ENDPOINT_ADDED event is the only one that
+    arrives (the bridge itself was never separately set up).
+    """
+    node = create_node_from_fixture("atios_knx_bridge")
+    matter_client.get_node.return_value = node
+
+    def identifier_for(endpoint_id: int) -> tuple[str, str]:
+        endpoint = node.endpoints[endpoint_id]
+        device_id = get_device_id(matter_client.server_info, endpoint)
+        return (DOMAIN, f"{ID_TYPE_DEVICE_ID}_{device_id}")
+
+    endpoint_added_callback = next(
+        call.kwargs["callback"]
+        for call in matter_client.subscribe_events.call_args_list
+        if call.kwargs["event_filter"] == EventType.ENDPOINT_ADDED
+    )
+
+    assert (
+        device_registry.async_get_device_by_identifier(
+            identifier_for(0), integration.entry_id
+        )
+        is None
+    )
+
+    endpoint_added_callback(
+        EventType.ENDPOINT_ADDED, {"node_id": node.node_id, "endpoint_id": 29}
+    )
+    await hass.async_block_till_done()
+
+    bridge_entry = device_registry.async_get_device_by_identifier(
+        identifier_for(0), integration.entry_id
+    )
+    assert bridge_entry is not None
+
+    child_entry = device_registry.async_get_device_by_identifier(
+        identifier_for(29), integration.entry_id
+    )
+    assert child_entry is not None
+    assert child_entry.via_device_id == bridge_entry.id
 
 
 @pytest.mark.usefixtures("matter_node")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `matter`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
