### PR TITLE
Add Tuya KTKZQ child-lock switch entity description

### DIFF
--- a/homeassistant/components/tuya/switch.py
+++ b/homeassistant/components/tuya/switch.py
@@ -493,6 +493,13 @@ SWITCHES: dict[DeviceCategory, tuple[SwitchEntityDescription, ...]] = {
             translation_key="ionizer",
         ),
     ),
+    DeviceCategory.KTKZQ: (
+        SwitchEntityDescription(
+            key=DPCode.CHILD_LOCK,
+            translation_key="child_lock",
+            entity_category=EntityCategory.CONFIG,
+        ),
+    ),
     DeviceCategory.MAL: (
         SwitchEntityDescription(
             key=DPCode.SWITCH_ALARM_SOUND,

--- a/tests/components/tuya/snapshots/test_init.ambr
+++ b/tests/components/tuya/snapshots/test_init.ambr
@@ -8240,7 +8240,7 @@
     'labels': set({
     }),
     'manufacturer': 'Tuya',
-    'model': 'VITAL+ (unsupported)',
+    'model': 'VITAL+',
     'model_id': 'urzivdhumrwfakie',
     'name': 'VITAL+',
     'name_by_user': None,

--- a/tests/components/tuya/snapshots/test_switch.ambr
+++ b/tests/components/tuya/snapshots/test_switch.ambr
@@ -11803,6 +11803,56 @@
     'state': 'on',
   })
 # ---
+# name: test_platform_setup_and_discovery[switch.vital_child_lock-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'switch',
+    'entity_category': <EntityCategory.CONFIG: 'config'>,
+    'entity_id': 'switch.vital_child_lock',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Child lock',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Child lock',
+    'platform': 'tuya',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'child_lock',
+    'unique_id': 'tuya.eikafwrmuhdvizruqzktkchild_lock',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_platform_setup_and_discovery[switch.vital_child_lock-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'VITAL+ Child lock',
+    }),
+    'context': <ANY>,
+    'entity_id': 'switch.vital_child_lock',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'on',
+  })
+# ---
 # name: test_platform_setup_and_discovery[switch.wallwasher_front_child_lock-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/tuya/test_switch.py
+++ b/tests/components/tuya/test_switch.py
@@ -13,7 +13,7 @@ from homeassistant.components.switch import (
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
-from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, Platform
+from homeassistant.const import ATTR_ENTITY_ID, STATE_UNKNOWN, EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
@@ -165,3 +165,23 @@ async def test_state(
     state = hass.states.get(entity_id)
     assert state is not None, f"{entity_id} does not exist"
     assert state.state == expected_state
+
+
+@pytest.mark.parametrize("mock_device_code", ["ktkzq_urzivdhumrwfakie"])
+async def test_ktkzq_child_lock_switch(
+    hass: HomeAssistant,
+    mock_manager: Manager,
+    mock_config_entry: MockConfigEntry,
+    mock_device: CustomerDevice,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the KTKZQ (Vital+ Ice Bath) child_lock switch entity."""
+    await initialize_entry(hass, mock_manager, mock_config_entry, mock_device)
+
+    state = hass.states.get("switch.vital_child_lock")
+    assert state is not None, "switch.vital_child_lock entity was not created"
+    assert state.state == "on"
+
+    entry = entity_registry.async_get("switch.vital_child_lock")
+    assert entry is not None
+    assert entry.entity_category is EntityCategory.CONFIG


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to the issue in the
  additional information section.
-->

This PR adds a native Home Assistant Core switch entity-description mapping for `DeviceCategory.KTKZQ` (Air conditioner controller), following the merged fixture PR #176865 which added the Vital+ Ice Bath Pro chiller fixture (`ktkzq_urzivdhumrwfakie`).

**What this PR adds:**

- **Switch** (`switch.py`): Maps `DeviceCategory.KTKZQ` to a `child_lock` switch entity (`DPCode.CHILD_LOCK`) with `entity_category=EntityCategory.CONFIG`, matching the existing pattern used by other Tuya categories.

This is partial native support for the KTKZQ category. The climate entity mapping (COOL mode via `power_switch`) is deferred to a separate Core follow-up PR, because the currently pinned `tuya-device-handlers` 0.0.26 does not select `power_switch` as the climate `switch_wrapper`. The climate mapping will return after tuya-device-handlers#413 is merged and available in a released/pinned version.

**Repository boundary rationale:** The fixture (device data) lives in Core (merged #176865), the generic `power_switch` dpcode lookup fix belongs in the tuya-device-handlers library (#413), and the entity-description mappings belong here in Core. This follows the architecture @epenet suggested in #176803: fixture+snapshots first, then code mappings as a follow-up.

**What was rejected (superseded):**
- tuya-device-handlers#405 proposed a device-specific quirk that disguised the category as `wk` (thermostat). This was closed as superseded by the cleaner architecture: native Core entity descriptions (#176865 fixture + this PR) + a generic library fix (#413).

**No changes to:**
- The fixture file (already merged in #176865)
- The tuya-device-handlers library (separate repo, #413)
- Generic dpcode names or category classifications
- Any other Tuya category or platform

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you will most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue:
- This PR is related to issue: #176803
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you are unsure about any of them, do not hesitate to ask.
  We are here to help! This is simply a reminder of the things that we are
  going to look for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code they are submitting. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so we is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that has not yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

### Test details

**Focused tests run locally (all pass):**
- `test_ktkzq_child_lock_switch` — verifies `switch.vital_child_lock` is created with `state=on` and `entity_category=EntityCategory.CONFIG`
- `test_platform_setup_and_discovery` (switch) — 506 snapshots passed including the new `switch.vital_child_lock` entry/state
- `test_device_registry` — VITAL+ model correctly updated from `(unsupported)` to supported

**Pre-existing issues (not caused by this PR):**
All tests in `tests/components/tuya/test_switch.py` show an `ERROR at teardown` ("Async generator fixture did not stop") on the unmodified `dev` branch as well. A pre-existing snapshot failure for `Smart Kettle` in `test_device_registry` was also confirmed on the unmodified `dev` branch.

**Ruff / format:** All changed Python files pass `ruff check` and `ruff format --check`. `git diff --check` is clean.

### Related PRs

| PR | Repo | Status | Role |
|---|---|---|---|
| #176865 | home-assistant/core | **Merged** | Fixture + initial snapshots |
| #176803 | home-assistant/core | Closed | Original combined PR (closed in favour of #176865 fixture-first approach, per @epenet) |
| #413 | tuya-device-handlers | Open | Generic library fix: accept `power_switch` in climate `switch_wrapper` lookup (prerequisite for climate follow-up) |
| #405 | tuya-device-handlers | Closed (superseded) | Device-specific quirk that disguised category as `wk` |
