### PR TITLE
Stop using naive now in here_travel_time

### DIFF
--- a/homeassistant/components/here_travel_time/coordinator.py
+++ b/homeassistant/components/here_travel_time/coordinator.py
@@ -388,7 +388,8 @@ def build_hass_attribution(sections: list[dict[str, Any]]) -> str | None:
 
 def next_datetime(simple_time: time) -> datetime:
     """Take a time like 08:00:00 and combine it with the current date."""
-    combined = datetime.combine(dt_util.start_of_local_day(), simple_time)
-    if combined < datetime.now():  # pylint: disable=home-assistant-enforce-naive-now
+    start_of_day = dt_util.start_of_local_day()
+    combined = datetime.combine(start_of_day, simple_time, start_of_day.tzinfo)
+    if combined < dt_util.now():
         combined = combined + timedelta(days=1)
     return combined

--- a/tests/components/here_travel_time/test_init.py
+++ b/tests/components/here_travel_time/test_init.py
@@ -19,7 +19,6 @@ from homeassistant.components.here_travel_time.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
-from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_CONFIG
 
@@ -33,11 +32,11 @@ from tests.common import MockConfigEntry
         DEFAULT_OPTIONS,
         {
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-            CONF_DEPARTURE_TIME: dt_util.now(),
+            CONF_DEPARTURE_TIME: "08:00:00",
         },
         {
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-            CONF_ARRIVAL_TIME: dt_util.now(),
+            CONF_ARRIVAL_TIME: "08:00:00",
         },
         {
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,

--- a/tests/components/here_travel_time/test_init.py
+++ b/tests/components/here_travel_time/test_init.py
@@ -1,6 +1,6 @@
 """The test for the HERE Travel Time integration."""
 
-from datetime import datetime
+from typing import Any
 
 import pytest
 
@@ -19,6 +19,7 @@ from homeassistant.components.here_travel_time.const import (
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import issue_registry as ir
+from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_CONFIG
 
@@ -32,18 +33,18 @@ from tests.common import MockConfigEntry
         DEFAULT_OPTIONS,
         {
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-            CONF_DEPARTURE_TIME: datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+            CONF_DEPARTURE_TIME: dt_util.now(),
         },
         {
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
-            CONF_ARRIVAL_TIME: datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+            CONF_ARRIVAL_TIME: dt_util.now(),
         },
         {
             CONF_ROUTE_MODE: ROUTE_MODE_FASTEST,
         },
     ],
 )
-async def test_unload_entry(hass: HomeAssistant, options) -> None:
+async def test_unload_entry(hass: HomeAssistant, options: dict[str, Any]) -> None:
     """Test that unloading an entry works."""
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
SSIA

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177807
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
