### PR TITLE
Add gateway health availability to zhong_hong

### DIFF
--- a/homeassistant/components/zhong_hong/climate.py
+++ b/homeassistant/components/zhong_hong/climate.py
@@ -1,5 +1,6 @@
 """Support for ZhongHong HVAC Controller."""
 
+from datetime import timedelta
 import logging
 from typing import Any, override
 
@@ -26,6 +27,7 @@ from homeassistant.const import (
     UnitOfTemperature,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.dispatcher import (
     async_dispatcher_connect,
@@ -40,6 +42,7 @@ CONF_GATEWAY_ADDRRESS = "gateway_address"
 
 DEFAULT_PORT = 9999
 DEFAULT_GATEWAY_ADDRRESS = 1
+SCAN_INTERVAL = timedelta(seconds=60)
 
 SIGNAL_DEVICE_ADDED = "zhong_hong_device_added"
 SIGNAL_ZHONG_HONG_HUB_START = "zhong_hong_hub_start"
@@ -77,6 +80,15 @@ FAN_MODE_MAP = {
     "medium_low": "MIDLOW",
 }
 FAN_MODE_REVERSE_MAP = {v: k for k, v in FAN_MODE_MAP.items()}
+
+
+def _send_failed(command: str) -> HomeAssistantError:
+    """Return the error raised when a command cannot be sent."""
+    return HomeAssistantError(
+        translation_domain="zhong_hong",
+        translation_key="send_command_failed",
+        translation_placeholders={"command": command},
+    )
 
 
 def setup_platform(
@@ -140,7 +152,7 @@ class ZhongHongClimate(ClimateEntity):
         HVACMode.FAN_ONLY,
         HVACMode.OFF,
     ]
-    _attr_should_poll = False
+    _attr_should_poll = True
     _attr_supported_features = (
         ClimateEntityFeature.TARGET_TEMPERATURE
         | ClimateEntityFeature.FAN_MODE
@@ -182,6 +194,17 @@ class ZhongHongClimate(ClimateEntity):
         if self._device.target_temperature:
             self._attr_target_temperature = self._device.target_temperature
         self.schedule_update_ha_state()
+
+    def update(self) -> None:
+        """Poll the gateway for fresh status when the connection is healthy."""
+        if self._hub.connected:
+            self._device.update()
+
+    @property
+    @override
+    def available(self) -> bool:
+        """Return False when the gateway connection is unhealthy."""
+        return self._hub.connected
 
     @property
     @override
@@ -227,18 +250,21 @@ class ZhongHongClimate(ClimateEntity):
     @override
     def turn_on(self) -> None:
         """Turn on ac."""
-        return self._device.turn_on()
+        if not self._device.turn_on():
+            raise _send_failed("turn-on")
 
     @override
     def turn_off(self) -> None:
         """Turn off ac."""
-        return self._device.turn_off()
+        if not self._device.turn_off():
+            raise _send_failed("turn-off")
 
     @override
     def set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature."""
         if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
-            self._device.set_temperature(temperature)
+            if not self._device.set_temperature(temperature):
+                raise _send_failed("temperature")
 
         if (operation_mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
             self.set_hvac_mode(operation_mode)
@@ -254,7 +280,8 @@ class ZhongHongClimate(ClimateEntity):
         if not self.is_on:
             self.turn_on()
 
-        self._device.set_operation_mode(hvac_mode.upper())
+        if not self._device.set_operation_mode(hvac_mode.upper()):
+            raise _send_failed("mode")
 
     @override
     def set_fan_mode(self, fan_mode: str) -> None:
@@ -262,4 +289,6 @@ class ZhongHongClimate(ClimateEntity):
         mapped_mode = FAN_MODE_MAP.get(fan_mode)
         if not mapped_mode:
             _LOGGER.error("Unsupported fan mode: %s", fan_mode)
-        self._device.set_fan_mode(mapped_mode)
+            return
+        if not self._device.set_fan_mode(mapped_mode):
+            raise _send_failed("fan")

--- a/homeassistant/components/zhong_hong/strings.json
+++ b/homeassistant/components/zhong_hong/strings.json
@@ -1,0 +1,7 @@
+{
+  "exceptions": {
+    "send_command_failed": {
+      "message": "Failed to send {command} command to the ZhongHong gateway."
+    }
+  }
+}

--- a/tests/components/zhong_hong/__init__.py
+++ b/tests/components/zhong_hong/__init__.py
@@ -1,0 +1,1 @@
+"""zhong_hong tests."""

--- a/tests/components/zhong_hong/test_climate.py
+++ b/tests/components/zhong_hong/test_climate.py
@@ -1,7 +1,9 @@
 """Test the zhong_hong climate platform."""
 
+from datetime import timedelta
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.climate import (
@@ -26,8 +28,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.setup import async_setup_component
 
+from tests.common import async_fire_time_changed
+
 ENTITY_ID = "climate.zhong_hong_hvac_1_1"
 HOST = "1.2.3.4"
+# Spelled out instead of importing SCAN_INTERVAL, so that changing the poll
+# interval in the platform makes these tests fail instead of following along.
+POLL_INTERVAL = timedelta(seconds=60)
 
 
 class FakeGateway:
@@ -37,6 +44,8 @@ class FakeGateway:
         """Initialize the fake gateway."""
         self.connected = True
         self.send_result = True
+        self.send_results: list[bool] = []
+        self.send_calls = 0
         self.query_status_calls = 0
 
     @property
@@ -69,7 +78,14 @@ class FakeGateway:
         return self.send_result
 
     def send(self, ac_data) -> bool:
-        """Send a command to the gateway."""
+        """Send a command to the gateway.
+
+        Results queued in ``send_results`` are returned in order, so a test can
+        let one command succeed and the next one fail.
+        """
+        self.send_calls += 1
+        if self.send_results:
+            return self.send_results.pop(0)
         return self.send_result
 
 
@@ -120,29 +136,29 @@ async def test_unavailable_when_gateway_disconnected(
     assert state.state == STATE_UNAVAILABLE
 
 
-async def test_update_queries_gateway_when_connected(
-    hass: HomeAssistant, gateway: FakeGateway
+async def test_scheduled_poll_queries_gateway_when_connected(
+    hass: HomeAssistant, gateway: FakeGateway, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test update polls the gateway when the connection is healthy."""
+    """Test the scheduled poll queries the gateway when the connection is healthy."""
     await _setup_climate(hass, gateway)
 
-    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
-    assert entity is not None
-    await entity.async_device_update()
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     assert gateway.query_status_calls == 1
 
 
-async def test_update_skips_gateway_when_disconnected(
-    hass: HomeAssistant, gateway: FakeGateway
+async def test_scheduled_poll_skips_gateway_when_disconnected(
+    hass: HomeAssistant, gateway: FakeGateway, freezer: FrozenDateTimeFactory
 ) -> None:
-    """Test update does not poll the gateway when the connection is unhealthy."""
+    """Test the scheduled poll skips the gateway when the connection is unhealthy."""
     gateway.connected = False
     await _setup_climate(hass, gateway)
 
-    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
-    assert entity is not None
-    await entity.async_device_update()
+    freezer.tick(POLL_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
 
     assert gateway.query_status_calls == 0
 
@@ -220,14 +236,10 @@ async def test_set_hvac_mode_send_failure_raises(
     hass: HomeAssistant, gateway: FakeGateway
 ) -> None:
     """Test set_hvac_mode raises when the command cannot be sent."""
-    gateway.send_result = False
+    # The device is off, so set_hvac_mode turns it on first. Let that command
+    # succeed and fail only the mode command that follows it.
+    gateway.send_results = [True, False]
     await _setup_climate(hass, gateway)
-
-    # The device must already be on, otherwise turn_on() fails first
-    # and the mode command is never attempted.
-    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
-    assert entity is not None
-    entity._device.switch_status = "ON"
 
     with pytest.raises(HomeAssistantError) as exc_info:
         await hass.services.async_call(
@@ -259,12 +271,15 @@ async def test_set_fan_mode_unsupported_logs_error(
     """Test set_fan_mode with an unsupported mode logs an error and sends nothing."""
     await _setup_climate(hass, gateway)
 
+    # The service call is not usable here: climate rejects a fan mode outside
+    # fan_modes before it ever reaches the entity, so the guard under test can
+    # only be exercised by calling the entity method directly.
     entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
     assert entity is not None
     await entity.async_set_fan_mode("unknown")
 
     assert "Unsupported fan mode: unknown" in caplog.text
-    assert "failed to send" not in caplog.text
+    assert gateway.send_calls == 0
 
 
 async def test_set_fan_mode_send_failure_raises(

--- a/tests/components/zhong_hong/test_climate.py
+++ b/tests/components/zhong_hong/test_climate.py
@@ -1,0 +1,298 @@
+"""Test the zhong_hong climate platform."""
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.components.climate import (
+    ATTR_FAN_MODE,
+    ATTR_HVAC_MODE,
+    DOMAIN as CLIMATE_DOMAIN,
+    FAN_LOW,
+    SERVICE_SET_FAN_MODE,
+    SERVICE_SET_HVAC_MODE,
+    SERVICE_SET_TEMPERATURE,
+    SERVICE_TURN_OFF,
+    SERVICE_TURN_ON,
+    HVACMode,
+)
+from homeassistant.const import (
+    ATTR_ENTITY_ID,
+    ATTR_TEMPERATURE,
+    STATE_OFF,
+    STATE_UNAVAILABLE,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
+
+ENTITY_ID = "climate.zhong_hong_hvac_1_1"
+HOST = "1.2.3.4"
+
+
+class FakeGateway:
+    """Test double for the zhong_hong_hvac gateway."""
+
+    def __init__(self) -> None:
+        """Initialize the fake gateway."""
+        self.connected = True
+        self.send_result = True
+        self.query_status_calls = 0
+
+    @property
+    def gw_addr(self) -> int:
+        """Return the gateway address."""
+        return 1
+
+    def add_status_callback(self, ac_addr, callback) -> None:
+        """Register a status callback (no-op)."""
+
+    def add_device(self, device) -> None:
+        """Register a device (no-op)."""
+
+    def discovery_ac(self) -> list[tuple[int, int]]:
+        """Return the discovered device addresses."""
+        return [(1, 1)]
+
+    def start_listen(self) -> None:
+        """Start listening (no-op)."""
+
+    def query_all_status(self) -> None:
+        """Query all devices (no-op)."""
+
+    def stop_listen(self) -> None:
+        """Stop listening (no-op)."""
+
+    def query_status(self, ac_addr) -> bool:
+        """Query the status of a device."""
+        self.query_status_calls += 1
+        return self.send_result
+
+    def send(self, ac_data) -> bool:
+        """Send a command to the gateway."""
+        return self.send_result
+
+
+@pytest.fixture
+def gateway() -> FakeGateway:
+    """Return a fake gateway."""
+    return FakeGateway()
+
+
+async def _setup_climate(hass: HomeAssistant, gateway: FakeGateway) -> None:
+    """Set up the zhong_hong climate platform with a fake gateway."""
+    with patch(
+        "homeassistant.components.zhong_hong.climate.ZhongHongGateway",
+        return_value=gateway,
+    ):
+        assert await async_setup_component(
+            hass,
+            CLIMATE_DOMAIN,
+            {CLIMATE_DOMAIN: {"platform": "zhong_hong", "host": HOST}},
+        )
+        # Platform setup runs in a fire-and-forget task, so the patch must
+        # stay active until it completes.
+        await hass.async_block_till_done()
+
+
+async def test_setup_creates_entity(hass: HomeAssistant, gateway: FakeGateway) -> None:
+    """Test the entity is created and polling is enabled."""
+    await _setup_climate(hass, gateway)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_OFF
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
+    assert entity is not None
+    assert entity.should_poll is True
+
+
+async def test_unavailable_when_gateway_disconnected(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test the entity is unavailable when the gateway connection is unhealthy."""
+    gateway.connected = False
+    await _setup_climate(hass, gateway)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+
+async def test_update_queries_gateway_when_connected(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test update polls the gateway when the connection is healthy."""
+    await _setup_climate(hass, gateway)
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
+    assert entity is not None
+    await entity.async_device_update()
+
+    assert gateway.query_status_calls == 1
+
+
+async def test_update_skips_gateway_when_disconnected(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test update does not poll the gateway when the connection is unhealthy."""
+    gateway.connected = False
+    await _setup_climate(hass, gateway)
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
+    assert entity is not None
+    await entity.async_device_update()
+
+    assert gateway.query_status_calls == 0
+
+
+async def test_turn_on_success(hass: HomeAssistant, gateway: FakeGateway) -> None:
+    """Test turn_on does not raise when the command is sent."""
+    await _setup_climate(hass, gateway)
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: ENTITY_ID},
+        blocking=True,
+    )
+
+
+async def test_turn_on_send_failure_raises(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test turn_on raises when the command cannot be sent."""
+    gateway.send_result = False
+    await _setup_climate(hass, gateway)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "send_command_failed"
+    assert exc_info.value.translation_placeholders == {"command": "turn-on"}
+
+
+async def test_turn_off_send_failure_raises(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test turn_off raises when the command cannot be sent."""
+    gateway.send_result = False
+    await _setup_climate(hass, gateway)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: ENTITY_ID},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "send_command_failed"
+    assert exc_info.value.translation_placeholders == {"command": "turn-off"}
+
+
+async def test_set_temperature_send_failure_raises(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test set_temperature raises when the command cannot be sent."""
+    gateway.send_result = False
+    await _setup_climate(hass, gateway)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_TEMPERATURE,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_TEMPERATURE: 25},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "send_command_failed"
+    assert exc_info.value.translation_placeholders == {"command": "temperature"}
+
+
+async def test_set_hvac_mode_send_failure_raises(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test set_hvac_mode raises when the command cannot be sent."""
+    gateway.send_result = False
+    await _setup_climate(hass, gateway)
+
+    # The device must already be on, otherwise turn_on() fails first
+    # and the mode command is never attempted.
+    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
+    assert entity is not None
+    entity._device.switch_status = "ON"
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.COOL},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "send_command_failed"
+    assert exc_info.value.translation_placeholders == {"command": "mode"}
+
+
+async def test_set_hvac_mode_success(hass: HomeAssistant, gateway: FakeGateway) -> None:
+    """Test set_hvac_mode does not raise when the command is sent."""
+    await _setup_climate(hass, gateway)
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_HVAC_MODE: HVACMode.COOL},
+        blocking=True,
+    )
+
+
+async def test_set_fan_mode_unsupported_logs_error(
+    hass: HomeAssistant, gateway: FakeGateway, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test set_fan_mode with an unsupported mode logs an error and sends nothing."""
+    await _setup_climate(hass, gateway)
+
+    entity = hass.data[CLIMATE_DOMAIN].get_entity(ENTITY_ID)
+    assert entity is not None
+    await entity.async_set_fan_mode("unknown")
+
+    assert "Unsupported fan mode: unknown" in caplog.text
+    assert "failed to send" not in caplog.text
+
+
+async def test_set_fan_mode_send_failure_raises(
+    hass: HomeAssistant, gateway: FakeGateway
+) -> None:
+    """Test set_fan_mode raises when the command cannot be sent."""
+    gateway.send_result = False
+    await _setup_climate(hass, gateway)
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_FAN_MODE,
+            {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_key == "send_command_failed"
+    assert exc_info.value.translation_placeholders == {"command": "fan"}
+
+
+async def test_set_fan_mode_success(hass: HomeAssistant, gateway: FakeGateway) -> None:
+    """Test set_fan_mode does not raise when the command is sent."""
+    await _setup_climate(hass, gateway)
+
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_FAN_MODE,
+        {ATTR_ENTITY_ID: ENTITY_ID, ATTR_FAN_MODE: FAN_LOW},
+        blocking=True,
+    )


### PR DESCRIPTION
## Breaking change

None.

## Proposed change

The gateway connection in `zhong-hong-hvac` can die silently: a status frame with an undefined fan speed value (`0x00`, observed after an indoor unit is switched off) crashes the library listener thread, and nothing restarts it. Entities then keep showing stale state forever with no health signal.

The library fix is in `zhong-hong-hvac` 1.0.16, bumped separately in #178412 (merged). This PR adds the component-side handling:

- polls every entity every 60 s so state self-heals even when the gateway stops pushing
- marks entities unavailable when the gateway connection is unhealthy (via `ZhongHongGateway.connected`)
- raises a translated `HomeAssistantError` when a control command cannot be sent, so a service call or automation no longer reports success for a command that never reached the gateway
- stops sending an invalid fan mode to the library when an unsupported value is requested

Rebased onto `dev` now that #178412 is merged, so this PR no longer touches the manifest or `requirements_all.txt` — the diff is the component change plus its tests.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Dependency upgrade
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Suggested changelog entry

`zhong_hong` entities are now marked unavailable when the gateway connection is unhealthy, are polled every 60 seconds, and raise an error when a command cannot be sent to the gateway.

## Testing

- SDK changes covered by unit tests in `crhan/ZhongHongHVAC` (12 passed, 1 skipped hardware test) and published as `zhong-hong-hvac` 1.0.16 on PyPI.
- Component test suite added (`tests/components/zhong_hong/`, 13 tests): setup, availability, scheduled polling, command-failure errors, unsupported fan mode.
- This component version has been running on a production Home Assistant 2026.7.2 container since 2026-08-01: entities report fresh status, fan modes map to HA standard values, and the connection self-recovers.
- `ruff`/`mypy`/`pylint` pass locally.

## Additional information

- This PR fixes or closes issue: fixes #(none)
- This PR is related to issue: none
- Link to documentation pull request: none
- Link to developer documentation pull request: none
- Link to frontend pull request: none

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
- [x] The manifest file includes all dependencies (these are listed in the [dependency docs][dependency-docs]).
- [x] New dependencies are fully documented in the [manifest file][manifest-docs] and the [dependency docs][dependency-docs].

If the code communicates with devices, web services, or third-party tools:

- [x] New or updated dependencies have been added to `requirements_all.txt`.
- [x] New or updated dependencies have been added to `requirements_test_all.txt`.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/development_catching_up/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[dependency-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/#dependencies




