### PR TITLE
Eheimdigital revamp

### DIFF
--- a/homeassistant/components/eheimdigital/__init__.py
+++ b/homeassistant/components/eheimdigital/__init__.py
@@ -1,17 +1,11 @@
 """The EHEIM Digital integration."""
 
-from typing import TYPE_CHECKING
-
-from eheimdigital.device import EheimDigitalDevice
-
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
-from .entity import async_device_info
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -33,17 +27,6 @@ async def async_setup_entry(
     coordinator = EheimDigitalUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
-
-    main = coordinator.hub.main
-    if TYPE_CHECKING:
-        # After the first refresh at least one device is found and so there is
-        # always a main device set.
-        assert isinstance(main, EheimDigitalDevice)
-    # Register the main device up front so child devices can resolve their
-    # via_device_id link during concurrent platform setup.
-    dr.async_get(hass).async_get_or_create(
-        config_entry_id=entry.entry_id, **async_device_info(coordinator, main)
-    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/eheimdigital/__init__.py
+++ b/homeassistant/components/eheimdigital/__init__.py
@@ -1,11 +1,17 @@
 """The EHEIM Digital integration."""
 
+from typing import TYPE_CHECKING
+
+from eheimdigital.device import EheimDigitalDevice
+
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry
 
 from .const import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .entity import async_main_device_info
 
 PLATFORMS = [
     Platform.BINARY_SENSOR,
@@ -27,6 +33,17 @@ async def async_setup_entry(
     coordinator = EheimDigitalUpdateCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     entry.runtime_data = coordinator
+
+    main = coordinator.hub.main
+    if TYPE_CHECKING:
+        # After the first refresh at least one device is found and so there is
+        # always a main device set.
+        assert isinstance(main, EheimDigitalDevice)
+    # Register the main device up front so child devices can resolve their
+    # via_device_id link during concurrent platform setup.
+    dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id, **async_main_device_info(coordinator)
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/eheimdigital/binary_sensor.py
+++ b/homeassistant/components/eheimdigital/binary_sensor.py
@@ -16,7 +16,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity
 
 # Coordinator is used to centralize the data updates
@@ -60,23 +60,23 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the binary sensor entities for one or multiple devices."""
         entities: list[EheimDigitalBinarySensor[Any]] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalReeflexUV):
-                entities += [
-                    EheimDigitalBinarySensor[EheimDigitalReeflexUV](
-                        coordinator, device, description
-                    )
-                    for description in REEFLEX_DESCRIPTIONS
-                ]
+        if isinstance(device_coordinator.data, EheimDigitalReeflexUV):
+            entities += [
+                EheimDigitalBinarySensor[EheimDigitalReeflexUV](
+                    device_coordinator, description
+                )
+                for description in REEFLEX_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            ]
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalBinarySensor[_DeviceT: EheimDigitalDevice](
@@ -88,12 +88,11 @@ class EheimDigitalBinarySensor[_DeviceT: EheimDigitalDevice](
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
         description: EheimDigitalBinarySensorDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital binary sensor entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{self._device_address}_{description.key}"
 

--- a/homeassistant/components/eheimdigital/climate.py
+++ b/homeassistant/components/eheimdigital/climate.py
@@ -2,9 +2,8 @@
 
 from typing import Any, override
 
-from eheimdigital.device import EheimDigitalDevice
 from eheimdigital.heater import EheimDigitalHeater
-from eheimdigital.types import HeaterMode, HeaterUnit
+from eheimdigital.types import HeaterMode, HeaterUnit, MsgTitle
 
 from homeassistant.components.climate import (
     PRESET_NONE,
@@ -23,7 +22,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import HEATER_BIO_MODE, HEATER_PRESET_TO_HEATER_MODE, HEATER_SMART_MODE
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
 # Coordinator is used to centralize the data updates
@@ -39,20 +38,19 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the climate entities for one or multiple devices."""
         entities: list[EheimDigitalHeaterClimate] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalHeater):
-                entities.append(EheimDigitalHeaterClimate(coordinator, device))
-                coordinator.known_devices.add(device.mac_address)
+        if (
+            isinstance(device_coordinator.data, EheimDigitalHeater)
+            and device_coordinator.msg_title == MsgTitle.HEATER_DATA
+        ):
+            entities.append(EheimDigitalHeaterClimate(device_coordinator))
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalHeaterClimate(EheimDigitalEntity[EheimDigitalHeater], ClimateEntity):
@@ -75,10 +73,11 @@ class EheimDigitalHeaterClimate(EheimDigitalEntity[EheimDigitalHeater], ClimateE
     _attr_name = None
 
     def __init__(
-        self, coordinator: EheimDigitalUpdateCoordinator, device: EheimDigitalHeater
+        self,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[EheimDigitalHeater],
     ) -> None:
         """Initialize an EHEIM Digital thermocontrol climate entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self._attr_unique_id = self._device_address
         self._async_update_attrs()
 

--- a/homeassistant/components/eheimdigital/coordinator.py
+++ b/homeassistant/components/eheimdigital/coordinator.py
@@ -67,6 +67,9 @@ class EheimDigitalUpdateCoordinator(DataUpdateCoordinator[None]):
     ) -> None:
         """Add the setup callbacks from a specific platform."""
         self.platform_callbacks.add(async_setup_device_entities)
+        for device in self.device_coordinators.values():
+            for coordinator in device.values():
+                async_setup_device_entities(coordinator)
 
     async def _async_device_found(
         self, device_address: str, device_type: EheimDeviceType
@@ -122,6 +125,12 @@ class EheimDigitalUpdateCoordinator(DataUpdateCoordinator[None]):
     async def _async_setup(self) -> None:
         try:
             await self.hub.connect()
+            async with asyncio.timeout(2):
+                # This event gets triggered when the first message is received from
+                # the device, it contains the data necessary to create the main device.
+                # This removes the race condition where the main device is accessed
+                # before the response from the device is parsed.
+                await self.main_device_added_event.wait()
             await self.hub.update()
             self.async_add_listener(lambda: None, None)
         except (TimeoutError, EheimDigitalClientError) as err:

--- a/homeassistant/components/eheimdigital/coordinator.py
+++ b/homeassistant/components/eheimdigital/coordinator.py
@@ -7,7 +7,7 @@ from typing import override
 from aiohttp import ClientError
 from eheimdigital.device import EheimDigitalDevice
 from eheimdigital.hub import EheimDigitalHub
-from eheimdigital.types import EheimDeviceType, EheimDigitalClientError
+from eheimdigital.types import EheimDeviceType, EheimDigitalClientError, MsgTitle
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_HOST
@@ -19,17 +19,22 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 
 from .const import DOMAIN, LOGGER
 
-type AsyncSetupDeviceEntitiesCallback = Callable[[dict[str, EheimDigitalDevice]], None]
+type AsyncSetupDeviceEntitiesCallback = Callable[
+    [EheimDigitalDeviceUpdateCoordinator[EheimDigitalDevice]], None
+]
 
 type EheimDigitalConfigEntry = ConfigEntry[EheimDigitalUpdateCoordinator]
 
 
-class EheimDigitalUpdateCoordinator(
-    DataUpdateCoordinator[dict[str, EheimDigitalDevice]]
-):
-    """The EHEIM Digital data update coordinator."""
+class EheimDigitalUpdateCoordinator(DataUpdateCoordinator[None]):
+    """The EHEIM Digital main data update coordinator."""
 
     config_entry: EheimDigitalConfigEntry
+    device_coordinators: dict[
+        str, dict[MsgTitle, EheimDigitalDeviceUpdateCoordinator[EheimDigitalDevice]]
+    ]
+    main_device_added_event: asyncio.Event
+    hub: EheimDigitalHub
 
     def __init__(
         self, hass: HomeAssistant, config_entry: EheimDigitalConfigEntry
@@ -54,6 +59,7 @@ class EheimDigitalUpdateCoordinator(
         self.known_devices: set[str] = set()
         self.incomplete_devices: set[str] = set()
         self.platform_callbacks: set[AsyncSetupDeviceEntitiesCallback] = set()
+        self.device_coordinators = {}
 
     def add_platform_callback(
         self,
@@ -75,41 +81,87 @@ class EheimDigitalUpdateCoordinator(
             return
 
         if (
-            device_address not in self.known_devices
+            device_address not in self.device_coordinators
             or device_address in self.incomplete_devices
         ):
-            for platform_callback in self.platform_callbacks:
-                platform_callback({device_address: self.hub.devices[device_address]})
+            if device_address not in self.device_coordinators:
+                self.device_coordinators[device_address] = {}
+                for title in self.hub.devices[device_address].packet_mapping:
+                    self.device_coordinators[device_address][title] = (
+                        EheimDigitalDeviceUpdateCoordinator(
+                            self.hass,
+                            self.config_entry,
+                            self,
+                            self.hub.devices[device_address],
+                            title,
+                        )
+                    )
+                    for platform_callback in self.platform_callbacks:
+                        platform_callback(
+                            self.device_coordinators[device_address][title]
+                        )
             if device_address in self.incomplete_devices:
                 self.incomplete_devices.remove(device_address)
 
-    async def _async_receive_callback(self) -> None:
+    async def _async_receive_callback(self, device: str, msg_title: MsgTitle) -> None:
         if any(self.incomplete_devices):
             for device_address in self.incomplete_devices.copy():
                 if not self.hub.devices[device_address].is_missing_data:
                     await self._async_device_found(
                         device_address, EheimDeviceType.VERSION_UNDEFINED
                     )
-        self.async_set_updated_data(self.hub.devices)
+        if (
+            device in self.device_coordinators
+            and msg_title in self.device_coordinators[device]
+        ):
+            self.device_coordinators[device][msg_title].async_set_updated_data(
+                self.hub.devices[device]
+            )
 
     @override
     async def _async_setup(self) -> None:
         try:
             await self.hub.connect()
-            async with asyncio.timeout(2):
-                # This event gets triggered when the first message is received from
-                # the device, it contains the data necessary to create the main device.
-                # This removes the race condition where the main device is accessed
-                # before the response from the device is parsed.
-                await self.main_device_added_event.wait()
             await self.hub.update()
+            self.async_add_listener(lambda: None, None)
         except (TimeoutError, EheimDigitalClientError) as err:
             raise ConfigEntryNotReady from err
 
     @override
-    async def _async_update_data(self) -> dict[str, EheimDigitalDevice]:
+    async def _async_update_data(self) -> None:
         try:
             await self.hub.update()
         except ClientError as ex:
+            for a in self.device_coordinators.values():
+                for coordinator in a.values():
+                    coordinator.async_set_update_error(ex)
             raise UpdateFailed from ex
-        return self.data
+
+
+class EheimDigitalDeviceUpdateCoordinator[_DeviceT: EheimDigitalDevice](
+    DataUpdateCoordinator[_DeviceT]
+):
+    """An EHEIM Digital device update coordinator."""
+
+    main_coordinator: EheimDigitalUpdateCoordinator
+    msg_title: MsgTitle
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        config_entry: EheimDigitalConfigEntry,
+        main_coordinator: EheimDigitalUpdateCoordinator,
+        device: _DeviceT,
+        msg_title: MsgTitle,
+    ) -> None:
+        """Initialize an EHEIM Digital device update coordinator."""
+        super().__init__(
+            hass,
+            LOGGER,
+            config_entry=config_entry,
+            name=f"{DOMAIN}_{device.mac_address}_{msg_title}",
+            update_interval=None,
+        )
+        self.main_coordinator = main_coordinator
+        self.data = device
+        self.msg_title = msg_title

--- a/homeassistant/components/eheimdigital/diagnostics.py
+++ b/homeassistant/components/eheimdigital/diagnostics.py
@@ -15,5 +15,15 @@ async def async_get_config_entry_diagnostics(
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
     return async_redact_data(
-        {"entry": entry.as_dict(), "data": entry.runtime_data.data}, TO_REDACT
+        {
+            "entry": entry.as_dict(),
+            "data": {
+                addr: {
+                    title.lower(): coordinator.data.as_dict()[title.lower()]
+                    for title, coordinator in item.items()
+                }
+                for addr, item in entry.runtime_data.device_coordinators.items()
+            },
+        },
+        TO_REDACT,
     )

--- a/homeassistant/components/eheimdigital/entity.py
+++ b/homeassistant/components/eheimdigital/entity.py
@@ -2,7 +2,7 @@
 
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Coroutine
-from typing import TYPE_CHECKING, Any, Concatenate, override
+from typing import TYPE_CHECKING, Any, Concatenate, cast, override
 
 from eheimdigital.device import EheimDigitalDevice
 from eheimdigital.types import EheimDigitalClientError, MsgTitle
@@ -15,7 +15,25 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import EheimDigitalDeviceUpdateCoordinator
+from .coordinator import (
+    EheimDigitalDeviceUpdateCoordinator,
+    EheimDigitalUpdateCoordinator,
+)
+
+
+def async_main_device_info(coordinator: EheimDigitalUpdateCoordinator) -> DeviceInfo:
+    """Return the base device info for the main EHEIM Digital device."""
+    device = cast(EheimDigitalDevice, coordinator.hub.main)
+    return DeviceInfo(
+        configuration_url=f"http://{coordinator.config_entry.data[CONF_HOST]}",
+        name=device.name,
+        connections={(CONNECTION_NETWORK_MAC, device.mac_address)},
+        manufacturer="EHEIM",
+        model=device.model_name,
+        identifiers={(DOMAIN, device.mac_address)},
+        suggested_area=device.aquarium_name,
+        sw_version=device.sw_version,
+    )
 
 
 def async_device_info[_DeviceT: EheimDigitalDevice](
@@ -63,7 +81,7 @@ class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
             except ValueError:
                 # If for some reason the main device is not yet created in the registry, create it here
                 main_device = (
-                    dr.async_get(self.hass)
+                    dr.async_get(coordinator.hass)
                     .async_get_or_create(
                         config_entry_id=coordinator.main_coordinator.config_entry.entry_id,
                         **async_device_info(

--- a/homeassistant/components/eheimdigital/entity.py
+++ b/homeassistant/components/eheimdigital/entity.py
@@ -5,7 +5,7 @@ from collections.abc import Callable, Coroutine
 from typing import TYPE_CHECKING, Any, Concatenate, override
 
 from eheimdigital.device import EheimDigitalDevice
-from eheimdigital.types import EheimDigitalClientError
+from eheimdigital.types import EheimDigitalClientError, MsgTitle
 
 from homeassistant.const import CONF_HOST
 from homeassistant.core import callback
@@ -19,7 +19,7 @@ from .coordinator import EheimDigitalDeviceUpdateCoordinator
 
 
 def async_device_info[_DeviceT: EheimDigitalDevice](
-    coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT]
+    coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
 ) -> DeviceInfo:
     """Return the base device info for an EHEIM Digital device."""
     return DeviceInfo(
@@ -53,15 +53,30 @@ class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
             assert isinstance(main, EheimDigitalDevice)
         self._attr_device_info = async_device_info(coordinator)
         if coordinator.data.mac_address != main.mac_address:
-            # The main device is registered during setup, before the platforms
-            # are forwarded, so this link always resolves deterministically.
-            self._attr_device_info["via_device_id"] = (
-                dr.async_get_device_id_by_identifier(
+            main_device = None
+            try:
+                main_device = dr.async_get_device_id_by_identifier(
                     coordinator.hass,
                     (DOMAIN, main.mac_address),
                     config_entry_id=coordinator.main_coordinator.config_entry.entry_id,
                 )
-            )
+            except ValueError:
+                # If for some reason the main device is not yet created in the registry, create it here
+                main_device = (
+                    dr.async_get(self.hass)
+                    .async_get_or_create(
+                        config_entry_id=coordinator.main_coordinator.config_entry.entry_id,
+                        **async_device_info(
+                            coordinator.main_coordinator.device_coordinators[
+                                main.mac_address
+                            ][MsgTitle.USRDTA]
+                        ),
+                    )
+                    .id
+                )
+            finally:
+                if main_device is not None:
+                    self._attr_device_info["via_device_id"] = main_device
         self._device = coordinator.data
         self._device_address = coordinator.data.mac_address
 

--- a/homeassistant/components/eheimdigital/entity.py
+++ b/homeassistant/components/eheimdigital/entity.py
@@ -98,6 +98,11 @@ class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
         self._device = coordinator.data
         self._device_address = coordinator.data.mac_address
 
+    @override
+    async def async_update(self) -> None:
+        """Request an update from the hub."""
+        await self.coordinator.main_coordinator.async_request_refresh()
+
     @abstractmethod
     def _async_update_attrs(self) -> None: ...
 

--- a/homeassistant/components/eheimdigital/entity.py
+++ b/homeassistant/components/eheimdigital/entity.py
@@ -15,55 +15,55 @@ from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, Device
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
-from .coordinator import EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalDeviceUpdateCoordinator
 
 
-def async_device_info(
-    coordinator: EheimDigitalUpdateCoordinator, device: EheimDigitalDevice
+def async_device_info[_DeviceT: EheimDigitalDevice](
+    coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT]
 ) -> DeviceInfo:
     """Return the base device info for an EHEIM Digital device."""
     return DeviceInfo(
-        configuration_url=f"http://{coordinator.config_entry.data[CONF_HOST]}",
-        name=device.name,
-        connections={(CONNECTION_NETWORK_MAC, device.mac_address)},
+        configuration_url=f"http://{coordinator.main_coordinator.config_entry.data[CONF_HOST]}",
+        name=coordinator.data.name,
+        connections={(CONNECTION_NETWORK_MAC, coordinator.data.mac_address)},
         manufacturer="EHEIM",
-        model=device.model_name,
-        identifiers={(DOMAIN, device.mac_address)},
-        suggested_area=device.aquarium_name,
-        sw_version=device.sw_version,
+        model=coordinator.data.model_name,
+        identifiers={(DOMAIN, coordinator.data.mac_address)},
+        suggested_area=coordinator.data.aquarium_name,
+        sw_version=coordinator.data.sw_version,
     )
 
 
 class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
-    CoordinatorEntity[EheimDigitalUpdateCoordinator], ABC
+    CoordinatorEntity[EheimDigitalDeviceUpdateCoordinator[_DeviceT]], ABC
 ):
     """Represent a EHEIM Digital entity."""
 
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: EheimDigitalUpdateCoordinator, device: _DeviceT
+        self, coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT]
     ) -> None:
         """Initialize a EHEIM Digital entity."""
         super().__init__(coordinator)
-        main = coordinator.hub.main
+        main = coordinator.main_coordinator.hub.main
         if TYPE_CHECKING:
             # At this point at least one device is found
             # and so there is always a main device set
             assert isinstance(main, EheimDigitalDevice)
-        self._attr_device_info = async_device_info(coordinator, device)
-        if device.mac_address != main.mac_address:
+        self._attr_device_info = async_device_info(coordinator)
+        if coordinator.data.mac_address != main.mac_address:
             # The main device is registered during setup, before the platforms
             # are forwarded, so this link always resolves deterministically.
             self._attr_device_info["via_device_id"] = (
                 dr.async_get_device_id_by_identifier(
                     coordinator.hass,
                     (DOMAIN, main.mac_address),
-                    config_entry_id=coordinator.config_entry.entry_id,
+                    config_entry_id=coordinator.main_coordinator.config_entry.entry_id,
                 )
             )
-        self._device = device
-        self._device_address = device.mac_address
+        self._device = coordinator.data
+        self._device_address = coordinator.data.mac_address
 
     @abstractmethod
     def _async_update_attrs(self) -> None: ...
@@ -76,7 +76,7 @@ class EheimDigitalEntity[_DeviceT: EheimDigitalDevice](
         super()._handle_coordinator_update()
 
 
-def exception_handler[_EntityT: EheimDigitalEntity[EheimDigitalDevice], **_P](
+def exception_handler[_EntityT: EheimDigitalEntity[Any], **_P](
     func: Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, Any]],
 ) -> Callable[Concatenate[_EntityT, _P], Coroutine[Any, Any, None]]:
     """Decorate eheimdigital calls to handle exceptions.

--- a/homeassistant/components/eheimdigital/icons.json
+++ b/homeassistant/components/eheimdigital/icons.json
@@ -27,7 +27,7 @@
       "night_temperature_offset": {
         "default": "mdi:thermometer"
       },
-      "system_led": {
+      "sys_led": {
         "default": "mdi:led-on",
         "state": {
           "0": "mdi:led-off"

--- a/homeassistant/components/eheimdigital/light.py
+++ b/homeassistant/components/eheimdigital/light.py
@@ -3,8 +3,7 @@
 from typing import Any, override
 
 from eheimdigital.classic_led_ctrl import EheimDigitalClassicLEDControl
-from eheimdigital.device import EheimDigitalDevice
-from eheimdigital.types import LightMode
+from eheimdigital.types import LightMode, MsgTitle
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -19,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.color import brightness_to_value, value_to_brightness
 
 from .const import EFFECT_DAYCL_MODE, EFFECT_TO_LIGHT_MODE
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
 BRIGHTNESS_SCALE = (1, 100)
@@ -37,25 +36,23 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the light entities for one or multiple devices."""
         entities: list[EheimDigitalClassicLEDControlLight] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalClassicLEDControl):
-                for channel in range(2):
-                    if len(device.tankconfig[channel]) > 0:
-                        entities.append(
-                            EheimDigitalClassicLEDControlLight(
-                                coordinator, device, channel
-                            )
-                        )
-                        coordinator.known_devices.add(device.mac_address)
+        if (
+            isinstance(device_coordinator.data, EheimDigitalClassicLEDControl)
+            and device_coordinator.msg_title == MsgTitle.CCV
+        ):
+            entities.extend(
+                EheimDigitalClassicLEDControlLight(device_coordinator, channel)
+                for channel in range(2)
+                if len(device_coordinator.data.tankconfig[channel]) > 0
+            )
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalClassicLEDControlLight(
@@ -71,12 +68,11 @@ class EheimDigitalClassicLEDControlLight(
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: EheimDigitalClassicLEDControl,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[EheimDigitalClassicLEDControl],
         channel: int,
     ) -> None:
         """Initialize an EHEIM Digital classicLEDcontrol light entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self._channel = channel
         self._attr_translation_placeholders = {"channel_id": str(channel)}
         self._attr_unique_id = f"{self._device_address}_{channel}"

--- a/homeassistant/components/eheimdigital/number.py
+++ b/homeassistant/components/eheimdigital/number.py
@@ -22,12 +22,15 @@ from homeassistant.const import (
     PRECISION_TENTHS,
     PRECISION_WHOLE,
     EntityCategory,
+    Platform,
     UnitOfTemperature,
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+import homeassistant.helpers.entity_registry as er
 
+from . import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
@@ -196,6 +199,18 @@ GENERAL_DESCRIPTIONS: tuple[EheimDigitalNumberDescription[EheimDigitalDevice], .
 )
 
 
+def _async_migrate_entities(hass: HomeAssistant, device_address: str) -> None:
+    registry = er.async_get(hass)
+    if (
+        old_id := registry.async_get_entity_id(
+            Platform.NUMBER, DOMAIN, f"{device_address}_system_led"
+        )
+    ) is not None:
+        registry.async_update_entity(
+            old_id, new_unique_id=old_id.replace("system_led", "sys_led")
+        )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EheimDigitalConfigEntry,
@@ -209,6 +224,7 @@ async def async_setup_entry(
     ) -> None:
         """Set up the number entities for one or multiple devices."""
         entities: list[EheimDigitalNumber[Any]] = []
+        _async_migrate_entities(hass, device_coordinator.data.mac_address)
         if isinstance(device_coordinator.data, EheimDigitalClassicVario):
             entities.extend(
                 EheimDigitalNumber[EheimDigitalClassicVario](

--- a/homeassistant/components/eheimdigital/number.py
+++ b/homeassistant/components/eheimdigital/number.py
@@ -30,7 +30,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 import homeassistant.helpers.entity_registry as er
 
-from . import DOMAIN
+from .const import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 

--- a/homeassistant/components/eheimdigital/number.py
+++ b/homeassistant/components/eheimdigital/number.py
@@ -206,9 +206,7 @@ def _async_migrate_entities(hass: HomeAssistant, device_address: str) -> None:
             Platform.NUMBER, DOMAIN, f"{device_address}_system_led"
         )
     ) is not None:
-        registry.async_update_entity(
-            old_id, new_unique_id=old_id.replace("system_led", "sys_led")
-        )
+        registry.async_update_entity(old_id, new_unique_id=f"{device_address}_sys_led")
 
 
 async def async_setup_entry(

--- a/homeassistant/components/eheimdigital/number.py
+++ b/homeassistant/components/eheimdigital/number.py
@@ -215,6 +215,8 @@ async def async_setup_entry(
                     device_coordinator, description
                 )
                 for description in CLASSICVARIO_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
             )
         if isinstance(device_coordinator.data, EheimDigitalFilter):
             entities.extend(

--- a/homeassistant/components/eheimdigital/number.py
+++ b/homeassistant/components/eheimdigital/number.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
 PARALLEL_UPDATES = 0
@@ -183,8 +183,8 @@ HEATER_DESCRIPTIONS: tuple[EheimDigitalNumberDescription[EheimDigitalHeater], ..
 
 GENERAL_DESCRIPTIONS: tuple[EheimDigitalNumberDescription[EheimDigitalDevice], ...] = (
     EheimDigitalNumberDescription[EheimDigitalDevice](
-        key="system_led",
-        translation_key="system_led",
+        key="sys_led",
+        translation_key="sys_led",
         entity_category=EntityCategory.CONFIG,
         native_min_value=0,
         native_max_value=100,
@@ -205,48 +205,50 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the number entities for one or multiple devices."""
         entities: list[EheimDigitalNumber[Any]] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalClassicVario):
-                entities.extend(
-                    EheimDigitalNumber[EheimDigitalClassicVario](
-                        coordinator, device, description
-                    )
-                    for description in CLASSICVARIO_DESCRIPTIONS
-                )
-            if isinstance(device, EheimDigitalFilter):
-                entities.extend(
-                    EheimDigitalNumber[EheimDigitalFilter](
-                        coordinator, device, description
-                    )
-                    for description in FILTER_DESCRIPTIONS
-                )
-            if isinstance(device, EheimDigitalHeater):
-                entities.extend(
-                    EheimDigitalNumber[EheimDigitalHeater](
-                        coordinator, device, description
-                    )
-                    for description in HEATER_DESCRIPTIONS
-                )
-            if isinstance(device, EheimDigitalReeflexUV):
-                entities.extend(
-                    EheimDigitalNumber[EheimDigitalReeflexUV](
-                        coordinator, device, description
-                    )
-                    for description in REEFLEX_DESCRIPTIONS
-                )
+        if isinstance(device_coordinator.data, EheimDigitalClassicVario):
             entities.extend(
-                EheimDigitalNumber[EheimDigitalDevice](coordinator, device, description)
-                for description in GENERAL_DESCRIPTIONS
+                EheimDigitalNumber[EheimDigitalClassicVario](
+                    device_coordinator, description
+                )
+                for description in CLASSICVARIO_DESCRIPTIONS
             )
+        if isinstance(device_coordinator.data, EheimDigitalFilter):
+            entities.extend(
+                EheimDigitalNumber[EheimDigitalFilter](device_coordinator, description)
+                for description in FILTER_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalHeater):
+            entities.extend(
+                EheimDigitalNumber[EheimDigitalHeater](device_coordinator, description)
+                for description in HEATER_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalReeflexUV):
+            entities.extend(
+                EheimDigitalNumber[EheimDigitalReeflexUV](
+                    device_coordinator, description
+                )
+                for description in REEFLEX_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        entities.extend(
+            EheimDigitalNumber[EheimDigitalDevice](device_coordinator, description)
+            for description in GENERAL_DESCRIPTIONS
+            if description.key
+            in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+        )
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalNumber[_DeviceT: EheimDigitalDevice](
@@ -258,12 +260,11 @@ class EheimDigitalNumber[_DeviceT: EheimDigitalDevice](
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
         description: EheimDigitalNumberDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital number entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{self._device_address}_{description.key}"
 

--- a/homeassistant/components/eheimdigital/select.py
+++ b/homeassistant/components/eheimdigital/select.py
@@ -26,7 +26,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 import homeassistant.helpers.entity_registry as er
 
-from . import DOMAIN
+from .const import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 

--- a/homeassistant/components/eheimdigital/select.py
+++ b/homeassistant/components/eheimdigital/select.py
@@ -16,10 +16,17 @@ from eheimdigital.types import (
 )
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.const import EntityCategory, UnitOfFrequency, UnitOfVolumeFlowRate
+from homeassistant.const import (
+    EntityCategory,
+    Platform,
+    UnitOfFrequency,
+    UnitOfVolumeFlowRate,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+import homeassistant.helpers.entity_registry as er
 
+from . import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
@@ -166,6 +173,18 @@ CLASSICVARIO_DESCRIPTIONS: tuple[
 )
 
 
+def _async_migrate_entities(hass: HomeAssistant, device_address: str) -> None:
+    registry = er.async_get(hass)
+    if (
+        old_id := registry.async_get_entity_id(
+            Platform.SELECT, DOMAIN, f"{device_address}_const_flow_speed"
+        )
+    ) is not None:
+        registry.async_update_entity(
+            old_id, new_unique_id=old_id.replace("const_flow_speed", "const_flow")
+        )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EheimDigitalConfigEntry,
@@ -179,6 +198,7 @@ async def async_setup_entry(
     ) -> None:
         """Set up the number entities for one or multiple devices."""
         entities: list[EheimDigitalSelect[Any]] = []
+        _async_migrate_entities(hass, device_coordinator.data.mac_address)
         if isinstance(device_coordinator.data, EheimDigitalClassicVario):
             entities.extend(
                 EheimDigitalSelect[EheimDigitalClassicVario](

--- a/homeassistant/components/eheimdigital/select.py
+++ b/homeassistant/components/eheimdigital/select.py
@@ -181,7 +181,7 @@ def _async_migrate_entities(hass: HomeAssistant, device_address: str) -> None:
         )
     ) is not None:
         registry.async_update_entity(
-            old_id, new_unique_id=old_id.replace("const_flow_speed", "const_flow")
+            old_id, new_unique_id=f"{device_address}_const_flow"
         )
 
 

--- a/homeassistant/components/eheimdigital/select.py
+++ b/homeassistant/components/eheimdigital/select.py
@@ -20,7 +20,7 @@ from homeassistant.const import EntityCategory, UnitOfFrequency, UnitOfVolumeFlo
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
 PARALLEL_UPDATES = 0
@@ -73,8 +73,8 @@ FILTER_DESCRIPTIONS: tuple[EheimDigitalSelectDescription[EheimDigitalFilter], ..
         set_value_fn=lambda device, value: device.set_manual_speed(float(value)),
     ),
     EheimDigitalSelectDescription[EheimDigitalFilter](
-        key="const_flow_speed",
-        translation_key="const_flow_speed",
+        key="const_flow",
+        translation_key="const_flow",
         entity_category=EntityCategory.CONFIG,
         use_api_unit=True,
         unit_of_measurement=UnitOfVolumeFlowRate.LITERS_PER_HOUR,
@@ -175,35 +175,39 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the number entities for one or multiple devices."""
         entities: list[EheimDigitalSelect[Any]] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalClassicVario):
-                entities.extend(
-                    EheimDigitalSelect[EheimDigitalClassicVario](
-                        coordinator, device, description
-                    )
-                    for description in CLASSICVARIO_DESCRIPTIONS
+        if isinstance(device_coordinator.data, EheimDigitalClassicVario):
+            entities.extend(
+                EheimDigitalSelect[EheimDigitalClassicVario](
+                    device_coordinator, description
                 )
-            if isinstance(device, EheimDigitalFilter):
-                entities.extend(
-                    EheimDigitalFilterSelect(coordinator, device, description)
-                    for description in FILTER_DESCRIPTIONS
+                for description in CLASSICVARIO_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalFilter):
+            entities.extend(
+                EheimDigitalFilterSelect(device_coordinator, description)
+                for description in FILTER_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalReeflexUV):
+            entities.extend(
+                EheimDigitalSelect[EheimDigitalReeflexUV](
+                    device_coordinator, description
                 )
-            if isinstance(device, EheimDigitalReeflexUV):
-                entities.extend(
-                    EheimDigitalSelect[EheimDigitalReeflexUV](
-                        coordinator, device, description
-                    )
-                    for description in REEFLEX_DESCRIPTIONS
-                )
+                for description in REEFLEX_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalSelect[_DeviceT: EheimDigitalDevice](
@@ -217,15 +221,14 @@ class EheimDigitalSelect[_DeviceT: EheimDigitalDevice](
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
         description: EheimDigitalSelectDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital select entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self.entity_description = description
         if description.options_fn is not None:
-            self._attr_options = description.options_fn(device)
+            self._attr_options = description.options_fn(self._device)
         elif description.options is not None:
             self._attr_options = description.options
         self._attr_unique_id = f"{self._device_address}_{description.key}"

--- a/homeassistant/components/eheimdigital/sensor.py
+++ b/homeassistant/components/eheimdigital/sensor.py
@@ -2,6 +2,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Any, override
 
 from eheimdigital.classic_vario import EheimDigitalClassicVario
@@ -18,7 +19,7 @@ from homeassistant.const import PERCENTAGE, EntityCategory, UnitOfFrequency, Uni
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity
 
 # Coordinator is used to centralize the data updates
@@ -31,7 +32,7 @@ class EheimDigitalSensorDescription[_DeviceT: EheimDigitalDevice](
 ):
     """Class describing EHEIM Digital sensor entities."""
 
-    value_fn: Callable[[_DeviceT], float | str | None]
+    value_fn: Callable[[_DeviceT], float | str | datetime | None]
 
 
 FILTER_DESCRIPTIONS: tuple[EheimDigitalSensorDescription[EheimDigitalFilter], ...] = (
@@ -93,30 +94,30 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the light entities for one or multiple devices."""
         entities: list[EheimDigitalSensor[Any]] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalFilter):
-                entities += [
-                    EheimDigitalSensor[EheimDigitalFilter](
-                        coordinator, device, description
-                    )
-                    for description in FILTER_DESCRIPTIONS
-                ]
-            if isinstance(device, EheimDigitalClassicVario):
-                entities += [
-                    EheimDigitalSensor[EheimDigitalClassicVario](
-                        coordinator, device, description
-                    )
-                    for description in CLASSICVARIO_DESCRIPTIONS
-                ]
+        if isinstance(device_coordinator.data, EheimDigitalFilter):
+            entities += [
+                EheimDigitalSensor[EheimDigitalFilter](device_coordinator, description)
+                for description in FILTER_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            ]
+        if isinstance(device_coordinator.data, EheimDigitalClassicVario):
+            entities += [
+                EheimDigitalSensor[EheimDigitalClassicVario](
+                    device_coordinator, description
+                )
+                for description in CLASSICVARIO_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            ]
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalSensor[_DeviceT: EheimDigitalDevice](
@@ -128,12 +129,11 @@ class EheimDigitalSensor[_DeviceT: EheimDigitalDevice](
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
         description: EheimDigitalSensorDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital number entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{self._device_address}_{description.key}"
 

--- a/homeassistant/components/eheimdigital/strings.json
+++ b/homeassistant/components/eheimdigital/strings.json
@@ -94,7 +94,7 @@
         "name": "Night temperature offset"
       },
       "pause_time": { "name": "Pause duration" },
-      "system_led": {
+      "sys_led": {
         "name": "System LED brightness"
       },
       "temperature_offset": {
@@ -102,7 +102,7 @@
       }
     },
     "select": {
-      "const_flow_speed": {
+      "const_flow": {
         "name": "Constant flow speed"
       },
       "day_speed": {

--- a/homeassistant/components/eheimdigital/switch.py
+++ b/homeassistant/components/eheimdigital/switch.py
@@ -11,10 +11,12 @@ from eheimdigital.reeflex import EheimDigitalReeflexUV
 from eheimdigital.types import MsgTitle
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+import homeassistant.helpers.entity_registry as er
 
+from .const import DOMAIN
 from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
@@ -66,6 +68,18 @@ REEFLEX_DESCRIPTIONS: tuple[
 )
 
 
+def _async_migrate_entities(hass: HomeAssistant, device_address: str) -> None:
+    registry = er.async_get(hass)
+    if (
+        old_id := registry.async_get_entity_id(
+            Platform.SWITCH, DOMAIN, f"{device_address}_active"
+        )
+    ) is not None:
+        registry.async_update_entity(
+            old_id, new_unique_id=old_id.replace("active", "is_active")
+        )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EheimDigitalConfigEntry,
@@ -79,6 +93,7 @@ async def async_setup_entry(
     ) -> None:
         """Set up the switch entities for one or multiple devices."""
         entities: list[SwitchEntity] = []
+        _async_migrate_entities(hass, device_coordinator.data.mac_address)
         if (
             isinstance(device_coordinator.data, EheimDigitalFilter)
             and device_coordinator.msg_title == MsgTitle.FILTER_DATA

--- a/homeassistant/components/eheimdigital/switch.py
+++ b/homeassistant/components/eheimdigital/switch.py
@@ -76,7 +76,7 @@ def _async_migrate_entities(hass: HomeAssistant, device_address: str) -> None:
         )
     ) is not None:
         registry.async_update_entity(
-            old_id, new_unique_id=old_id.replace("active", "is_active")
+            old_id, new_unique_id=f"{device_address}_is_active"
         )
 
 

--- a/homeassistant/components/eheimdigital/switch.py
+++ b/homeassistant/components/eheimdigital/switch.py
@@ -8,6 +8,7 @@ from eheimdigital.classic_vario import EheimDigitalClassicVario
 from eheimdigital.device import EheimDigitalDevice
 from eheimdigital.filter import EheimDigitalFilter
 from eheimdigital.reeflex import EheimDigitalReeflexUV
+from eheimdigital.types import MsgTitle
 
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
 from homeassistant.const import EntityCategory
@@ -78,8 +79,12 @@ async def async_setup_entry(
     ) -> None:
         """Set up the switch entities for one or multiple devices."""
         entities: list[SwitchEntity] = []
-        if isinstance(
-            device_coordinator.data, (EheimDigitalClassicVario, EheimDigitalFilter)
+        if (
+            isinstance(device_coordinator.data, EheimDigitalFilter)
+            and device_coordinator.msg_title == MsgTitle.FILTER_DATA
+        ) or (
+            isinstance(device_coordinator.data, EheimDigitalClassicVario)
+            and device_coordinator.msg_title == MsgTitle.CLASSIC_VARIO_DATA
         ):
             entities.append(EheimDigitalFilterSwitch(device_coordinator))
         if isinstance(device_coordinator.data, EheimDigitalReeflexUV):

--- a/homeassistant/components/eheimdigital/switch.py
+++ b/homeassistant/components/eheimdigital/switch.py
@@ -14,7 +14,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
 # Coordinator is used to centralize the data updates
@@ -35,7 +35,7 @@ REEFLEX_DESCRIPTIONS: tuple[
     EheimDigitalSwitchDescription[EheimDigitalReeflexUV], ...
 ] = (
     EheimDigitalSwitchDescription[EheimDigitalReeflexUV](
-        key="active",
+        key="is_active",
         name=None,
         entity_category=EntityCategory.CONFIG,
         is_on_fn=lambda device: device.is_active,
@@ -74,25 +74,27 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the switch entities for one or multiple devices."""
         entities: list[SwitchEntity] = []
-        for device in device_address.values():
-            if isinstance(device, (EheimDigitalClassicVario, EheimDigitalFilter)):
-                entities.append(EheimDigitalFilterSwitch(coordinator, device))
-            if isinstance(device, EheimDigitalReeflexUV):
-                entities.extend(
-                    EheimDigitalSwitch[EheimDigitalReeflexUV](
-                        coordinator, device, description
-                    )
-                    for description in REEFLEX_DESCRIPTIONS
+        if isinstance(
+            device_coordinator.data, (EheimDigitalClassicVario, EheimDigitalFilter)
+        ):
+            entities.append(EheimDigitalFilterSwitch(device_coordinator))
+        if isinstance(device_coordinator.data, EheimDigitalReeflexUV):
+            entities.extend(
+                EheimDigitalSwitch[EheimDigitalReeflexUV](
+                    device_coordinator, description
                 )
+                for description in REEFLEX_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 class EheimDigitalSwitch[_DeviceT: EheimDigitalDevice](
@@ -104,12 +106,11 @@ class EheimDigitalSwitch[_DeviceT: EheimDigitalDevice](
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
         description: EheimDigitalSwitchDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital switch entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self.entity_description = description
         self._attr_unique_id = f"{self._device_address}_{description.key}"
 
@@ -140,12 +141,13 @@ class EheimDigitalFilterSwitch(
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: EheimDigitalClassicVario | EheimDigitalFilter,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[
+            EheimDigitalClassicVario | EheimDigitalFilter
+        ],
     ) -> None:
         """Initialize an EHEIM Digital classicVARIO or filter switch entity."""
-        super().__init__(coordinator, device)
-        self._attr_unique_id = device.mac_address
+        super().__init__(coordinator)
+        self._attr_unique_id = self._device_address
         self._async_update_attrs()
 
     @override

--- a/homeassistant/components/eheimdigital/time.py
+++ b/homeassistant/components/eheimdigital/time.py
@@ -16,7 +16,7 @@ from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .coordinator import EheimDigitalConfigEntry, EheimDigitalUpdateCoordinator
+from .coordinator import EheimDigitalConfigEntry, EheimDigitalDeviceUpdateCoordinator
 from .entity import EheimDigitalEntity, exception_handler
 
 PARALLEL_UPDATES = 0
@@ -103,44 +103,44 @@ async def async_setup_entry(
     coordinator = entry.runtime_data
 
     def async_setup_device_entities(
-        device_address: dict[str, EheimDigitalDevice],
+        device_coordinator: EheimDigitalDeviceUpdateCoordinator[Any],
     ) -> None:
         """Set up the time entities for one or multiple devices."""
         entities: list[EheimDigitalTime[Any]] = []
-        for device in device_address.values():
-            if isinstance(device, EheimDigitalFilter):
-                entities.extend(
-                    EheimDigitalTime[EheimDigitalFilter](
-                        coordinator, device, description
-                    )
-                    for description in FILTER_DESCRIPTIONS
+        if isinstance(device_coordinator.data, EheimDigitalFilter):
+            entities.extend(
+                EheimDigitalTime[EheimDigitalFilter](device_coordinator, description)
+                for description in FILTER_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalClassicVario):
+            entities.extend(
+                EheimDigitalTime[EheimDigitalClassicVario](
+                    device_coordinator, description
                 )
-            if isinstance(device, EheimDigitalClassicVario):
-                entities.extend(
-                    EheimDigitalTime[EheimDigitalClassicVario](
-                        coordinator, device, description
-                    )
-                    for description in CLASSICVARIO_DESCRIPTIONS
-                )
-            if isinstance(device, EheimDigitalHeater):
-                entities.extend(
-                    EheimDigitalTime[EheimDigitalHeater](
-                        coordinator, device, description
-                    )
-                    for description in HEATER_DESCRIPTIONS
-                )
-            if isinstance(device, EheimDigitalReeflexUV):
-                entities.extend(
-                    EheimDigitalTime[EheimDigitalReeflexUV](
-                        coordinator, device, description
-                    )
-                    for description in REEFLEX_DESCRIPTIONS
-                )
+                for description in CLASSICVARIO_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalHeater):
+            entities.extend(
+                EheimDigitalTime[EheimDigitalHeater](device_coordinator, description)
+                for description in HEATER_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
+        if isinstance(device_coordinator.data, EheimDigitalReeflexUV):
+            entities.extend(
+                EheimDigitalTime[EheimDigitalReeflexUV](device_coordinator, description)
+                for description in REEFLEX_DESCRIPTIONS
+                if description.key
+                in device_coordinator.data.packet_mapping[device_coordinator.msg_title]
+            )
 
         async_add_entities(entities)
 
     coordinator.add_platform_callback(async_setup_device_entities)
-    async_setup_device_entities(coordinator.hub.devices)
 
 
 @final
@@ -153,14 +153,13 @@ class EheimDigitalTime[_DeviceT: EheimDigitalDevice](
 
     def __init__(
         self,
-        coordinator: EheimDigitalUpdateCoordinator,
-        device: _DeviceT,
+        coordinator: EheimDigitalDeviceUpdateCoordinator[_DeviceT],
         description: EheimDigitalTimeDescription[_DeviceT],
     ) -> None:
         """Initialize an EHEIM Digital time entity."""
-        super().__init__(coordinator, device)
+        super().__init__(coordinator)
         self.entity_description = description
-        self._attr_unique_id = f"{device.mac_address}_{description.key}"
+        self._attr_unique_id = f"{self._device_address}_{description.key}"
 
     @override
     @exception_handler

--- a/tests/components/eheimdigital/snapshots/test_climate.ambr
+++ b/tests/components/eheimdigital/snapshots/test_climate.ambr
@@ -79,7 +79,7 @@
     'state': 'auto',
   })
 # ---
-# name: test_setup_heater[climate.mock_aquarium_mock_heater-entry]
+# name: test_setup[climate.mock_aquarium_mock_heater-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -129,7 +129,7 @@
     'unit_of_measurement': None,
   })
 # ---
-# name: test_setup_heater[climate.mock_aquarium_mock_heater-state]
+# name: test_setup[climate.mock_aquarium_mock_heater-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <ClimateEntityStateAttribute.CURRENT_TEMPERATURE: 'current_temperature'>: 24.2,

--- a/tests/components/eheimdigital/snapshots/test_diagnostics.ambr
+++ b/tests/components/eheimdigital/snapshots/test_diagnostics.ambr
@@ -341,8 +341,8 @@
           'version': 8,
         }),
         'usrdta': dict({
-          'api_password': 'admin',
-          'api_usrName': 'api',
+          'api_password': '**REDACTED**',
+          'api_usrName': '**REDACTED**',
           'aqName': 'Mock Aquarium',
           'build': list([
             '1765358332000',
@@ -350,7 +350,7 @@
           ]),
           'demoUse': 0,
           'dst': 1,
-          'emailAddr': 'xxx',
+          'emailAddr': '**REDACTED**',
           'firmwareAvailable': 0,
           'firstStart': 0,
           'from': '00:00:00:00:00:05',
@@ -384,7 +384,7 @@
           'title': 'USRDTA',
           'to': 'USER',
           'unit': 0,
-          'usrName': 'xxx',
+          'usrName': '**REDACTED**',
           'version': 11,
         }),
       }),

--- a/tests/components/eheimdigital/snapshots/test_number.ambr
+++ b/tests/components/eheimdigital/snapshots/test_number.ambr
@@ -36,8 +36,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'system_led',
-    'unique_id': '00:00:00:00:00:01_system_led',
+    'translation_key': 'sys_led',
+    'unique_id': '00:00:00:00:00:01_sys_led',
     'unit_of_measurement': '%',
   })
 # ---
@@ -56,7 +56,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '20',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_classicvario_day_speed-entry]
@@ -116,7 +116,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '80',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_classicvario_manual_speed-entry]
@@ -176,7 +176,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '75',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_classicvario_night_speed-entry]
@@ -236,7 +236,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '20',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_classicvario_system_led_brightness-entry]
@@ -276,8 +276,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'system_led',
-    'unique_id': '00:00:00:00:00:03_system_led',
+    'translation_key': 'sys_led',
+    'unique_id': '00:00:00:00:00:03_sys_led',
     'unit_of_measurement': '%',
   })
 # ---
@@ -296,7 +296,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '100',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_filter_high_pulse_duration-entry]
@@ -357,7 +357,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '10',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_filter_low_pulse_duration-entry]
@@ -418,7 +418,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '10',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_filter_system_led_brightness-entry]
@@ -458,8 +458,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'system_led',
-    'unique_id': '00:00:00:00:00:04_system_led',
+    'translation_key': 'sys_led',
+    'unique_id': '00:00:00:00:00:04_sys_led',
     'unit_of_measurement': '%',
   })
 # ---
@@ -478,7 +478,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '45',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_heater_night_temperature_offset-entry]
@@ -532,13 +532,14 @@
       <NumberEntityCapabilityAttribute.MIN: 'min'>: -5,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
       <NumberEntityCapabilityAttribute.STEP: 'step'>: 0.5,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'number.mock_aquarium_mock_heater_night_temperature_offset',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '-0.2',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_heater_system_led_brightness-entry]
@@ -578,8 +579,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'system_led',
-    'unique_id': '00:00:00:00:00:02_system_led',
+    'translation_key': 'sys_led',
+    'unique_id': '00:00:00:00:00:02_sys_led',
     'unit_of_measurement': '%',
   })
 # ---
@@ -598,7 +599,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '20',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_heater_temperature_offset-entry]
@@ -652,13 +653,14 @@
       <NumberEntityCapabilityAttribute.MIN: 'min'>: -3,
       <NumberEntityCapabilityAttribute.MODE: 'mode'>: <NumberMode.AUTO: 'auto'>,
       <NumberEntityCapabilityAttribute.STEP: 'step'>: 0.1,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
     }),
     'context': <ANY>,
     'entity_id': 'number.mock_aquarium_mock_heater_temperature_offset',
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0.1',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_reeflex_booster_duration-entry]
@@ -719,7 +721,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_reeflex_daily_burn_duration-entry]
@@ -780,7 +782,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '720',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_reeflex_pause_duration-entry]
@@ -841,7 +843,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '0',
   })
 # ---
 # name: test_setup[number.mock_aquarium_mock_reeflex_system_led_brightness-entry]
@@ -881,8 +883,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'system_led',
-    'unique_id': '00:00:00:00:00:05_system_led',
+    'translation_key': 'sys_led',
+    'unique_id': '00:00:00:00:00:05_sys_led',
     'unit_of_measurement': '%',
   })
 # ---
@@ -901,6 +903,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '100',
   })
 # ---

--- a/tests/components/eheimdigital/snapshots/test_select.ambr
+++ b/tests/components/eheimdigital/snapshots/test_select.ambr
@@ -57,7 +57,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'manual',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_filter_constant_flow_speed-entry]
@@ -110,8 +110,8 @@
     'previous_unique_id': None,
     'suggested_object_id': None,
     'supported_features': 0,
-    'translation_key': 'const_flow_speed',
-    'unique_id': '00:00:00:00:00:04_const_flow_speed',
+    'translation_key': 'const_flow',
+    'unique_id': '00:00:00:00:00:04_const_flow',
     'unit_of_measurement': <UnitOfVolumeFlowRate.LITERS_PER_HOUR: 'L/h'>,
   })
 # ---
@@ -143,7 +143,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '860',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_filter_day_speed-entry]
@@ -229,7 +229,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '740',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_filter_filter_mode-entry]
@@ -292,7 +292,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'manual',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_filter_high_pulse_speed-entry]
@@ -378,7 +378,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '740',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_filter_low_pulse_speed-entry]
@@ -464,7 +464,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '440',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_filter_manual_speed-entry]
@@ -636,7 +636,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '550',
   })
 # ---
 # name: test_setup[select.mock_aquarium_mock_reeflex_operation_mode-entry]
@@ -695,6 +695,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'daycycle',
   })
 # ---

--- a/tests/components/eheimdigital/snapshots/test_sensor.ambr
+++ b/tests/components/eheimdigital/snapshots/test_sensor.ambr
@@ -47,7 +47,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '75',
   })
 # ---
 # name: test_setup[sensor.mock_aquarium_mock_classicvario_error_code-entry]
@@ -109,7 +109,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'no_error',
   })
 # ---
 # name: test_setup[sensor.mock_aquarium_mock_classicvario_remaining_hours_until_service-entry]
@@ -167,7 +167,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '15.0',
   })
 # ---
 # name: test_setup[sensor.mock_aquarium_mock_filter_current_speed-entry]
@@ -222,7 +222,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '72.0',
   })
 # ---
 # name: test_setup[sensor.mock_aquarium_mock_filter_remaining_hours_until_service-entry]
@@ -280,6 +280,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '1532.25',
   })
 # ---

--- a/tests/components/eheimdigital/snapshots/test_switch.ambr
+++ b/tests/components/eheimdigital/snapshots/test_switch.ambr
@@ -132,7 +132,7 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': '00:00:00:00:00:05_active',
+    'unique_id': '00:00:00:00:00:05_is_active',
     'unit_of_measurement': None,
   })
 # ---
@@ -146,7 +146,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_setup[switch.mock_aquarium_mock_reeflex_booster-entry]
@@ -196,7 +196,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---
 # name: test_setup[switch.mock_aquarium_mock_reeflex_expert_mode-entry]
@@ -246,7 +246,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'on',
   })
 # ---
 # name: test_setup[switch.mock_aquarium_mock_reeflex_pause-entry]
@@ -296,6 +296,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': 'off',
   })
 # ---

--- a/tests/components/eheimdigital/snapshots/test_time.ambr
+++ b/tests/components/eheimdigital/snapshots/test_time.ambr
@@ -46,7 +46,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '08:00:00+01:00',
   })
 # ---
 # name: test_setup[time.mock_aquarium_mock_classicvario_night_start_time-entry]
@@ -96,7 +96,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '20:00:00+01:00',
   })
 # ---
 # name: test_setup[time.mock_aquarium_mock_filter_day_start_time-entry]
@@ -146,7 +146,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '07:00:00+01:00',
   })
 # ---
 # name: test_setup[time.mock_aquarium_mock_filter_night_start_time-entry]
@@ -196,7 +196,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '19:00:00+01:00',
   })
 # ---
 # name: test_setup[time.mock_aquarium_mock_heater_day_start_time-entry]
@@ -246,7 +246,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '08:00:00+01:00',
   })
 # ---
 # name: test_setup[time.mock_aquarium_mock_heater_night_start_time-entry]
@@ -296,7 +296,7 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '20:00:00+01:00',
   })
 # ---
 # name: test_setup[time.mock_aquarium_mock_reeflex_start_time-entry]
@@ -346,6 +346,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': 'unknown',
+    'state': '06:30:00+01:00',
   })
 # ---

--- a/tests/components/eheimdigital/test_binary_sensor.py
+++ b/tests/components/eheimdigital/test_binary_sensor.py
@@ -36,10 +36,14 @@ async def test_setup(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device, eheimdigital_hub_mock.return_value.devices[device].device_type
+            device, device_obj.device_type
         )
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
 
         await hass.async_block_till_done()
 
@@ -100,10 +104,17 @@ async def test_state_update(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
     for item in entity_list:
         getattr(device, item[1])[item[2]] = item[3]
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, item[1].upper()
+        )
+        await hass.async_block_till_done()
         assert get_sensor_display_state(hass, entity_registry, item[0]) == str(item[4])

--- a/tests/components/eheimdigital/test_climate.py
+++ b/tests/components/eheimdigital/test_climate.py
@@ -8,6 +8,7 @@ from eheimdigital.types import (
     EheimDigitalClientError,
     HeaterMode,
     HeaterUnit,
+    MsgTitle,
 )
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -37,15 +38,14 @@ from .conftest import init_integration
 from tests.common import MockConfigEntry, snapshot_platform
 
 
-@pytest.mark.usefixtures("heater_mock")
-async def test_setup_heater(
+async def test_setup(
     hass: HomeAssistant,
     eheimdigital_hub_mock: MagicMock,
     mock_config_entry: MockConfigEntry,
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test climate platform setup for heater."""
+    """Test climate platform setup."""
     mock_config_entry.add_to_hass(hass)
 
     with (
@@ -57,10 +57,17 @@ async def test_setup_heater(
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-        "00:00:00:00:00:02", EheimDeviceType.VERSION_EHEIM_EXT_HEATER
-    )
-    await hass.async_block_till_done()
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device, device_obj.device_type
+        )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -273,7 +280,10 @@ async def test_state_update(
     heater_mock.heater_data["active"] = int(False)
     heater_mock.heater_data["mode"] = int(HeaterMode.SMART)
 
-    await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+    await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+        "00:00:00:00:00:02", MsgTitle.HEATER_DATA
+    )
+    await hass.async_block_till_done()
 
     assert (state := hass.states.get("climate.mock_aquarium_mock_heater"))
     assert state.state == HVACMode.OFF

--- a/tests/components/eheimdigital/test_diagnostics.py
+++ b/tests/components/eheimdigital/test_diagnostics.py
@@ -37,8 +37,6 @@ async def test_entry_diagnostics(
 
         await hass.async_block_till_done()
 
-    mock_config_entry.runtime_data.data = eheimdigital_hub_mock.return_value.devices
-
     result = await get_diagnostics_for_config_entry(
         hass, hass_client, mock_config_entry
     )

--- a/tests/components/eheimdigital/test_diagnostics.py
+++ b/tests/components/eheimdigital/test_diagnostics.py
@@ -25,10 +25,17 @@ async def test_entry_diagnostics(
 
     await init_integration(hass, mock_config_entry)
 
-    for device in eheimdigital_hub_mock.return_value.devices.values():
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device.mac_address, device.device_type
+            device, device_obj.device_type
         )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
 
     mock_config_entry.runtime_data.data = eheimdigital_hub_mock.return_value.devices
 

--- a/tests/components/eheimdigital/test_init.py
+++ b/tests/components/eheimdigital/test_init.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from eheimdigital.types import EheimDeviceType, EheimDigitalClientError
+from eheimdigital.types import EheimDeviceType, EheimDigitalClientError, MsgTitle
 
 from homeassistant.components.eheimdigital.const import DOMAIN
 from homeassistant.config_entries import ConfigEntryState
@@ -54,7 +54,9 @@ async def test_dynamic_entities(
         "00:00:00:00:00:02"
     ].heater_data = heater_data
 
-    await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+    await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+        "00:00:00:00:00:02", MsgTitle.HEATER_DATA
+    )
 
     assert hass.states.get(
         "number.mock_aquarium_mock_heater_night_temperature_offset"

--- a/tests/components/eheimdigital/test_light.py
+++ b/tests/components/eheimdigital/test_light.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aiohttp import ClientError
 from eheimdigital.classic_led_ctrl import EheimDigitalClassicLEDControl
-from eheimdigital.types import EheimDeviceType, EheimDigitalClientError
+from eheimdigital.types import EheimDeviceType, EheimDigitalClientError, MsgTitle
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -64,10 +64,17 @@ async def test_setup_classic_led_ctrl(
     ):
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
-    await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-        "00:00:00:00:00:01", EheimDeviceType.VERSION_EHEIM_CLASSIC_LED_CTRL_PLUS_E
-    )
-    await hass.async_block_till_done()
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device, device_obj.device_type
+        )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -107,10 +114,17 @@ async def test_dynamic_new_devices(
         "00:00:00:00:00:01": classic_led_ctrl_mock
     }
 
-    await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-        "00:00:00:00:00:01", EheimDeviceType.VERSION_EHEIM_CLASSIC_LED_CTRL_PLUS_E
-    )
-    await hass.async_block_till_done()
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device, device_obj.device_type
+        )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -272,7 +286,9 @@ async def test_state_update(
 
     classic_led_ctrl_mock.ccv["currentValues"] = [30, 20]
 
-    await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+    await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+        classic_led_ctrl_mock.mac_address, MsgTitle.CCV
+    )
 
     assert (
         state := hass.states.get(

--- a/tests/components/eheimdigital/test_number.py
+++ b/tests/components/eheimdigital/test_number.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.eheimdigital.const import DOMAIN
 from homeassistant.components.number import (
     ATTR_VALUE,
     DOMAIN as NUMBER_DOMAIN,
@@ -51,6 +52,57 @@ async def test_setup(
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_migrate_entities(
+    hass: HomeAssistant,
+    eheimdigital_hub_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the migration of entity ids."""
+    mock_config_entry.add_to_hass(hass)
+
+    entity_registry.async_get_or_create(
+        Platform.NUMBER,
+        DOMAIN,
+        "00:00:00:00:00:01_system_led",
+        config_entry=mock_config_entry,
+    )
+
+    with (
+        patch("homeassistant.components.eheimdigital.PLATFORMS", [Platform.NUMBER]),
+        patch(
+            "homeassistant.components.eheimdigital.coordinator.asyncio.Event",
+            new=AsyncMock,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device, device_obj.device_type
+        )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.NUMBER, DOMAIN, "00:00:00:00:00:01_system_led"
+        )
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.NUMBER, DOMAIN, "00:00:00:00:00:01_sys_led"
+        )
+        is not None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/eheimdigital/test_number.py
+++ b/tests/components/eheimdigital/test_number.py
@@ -39,9 +39,15 @@ async def test_setup(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device, eheimdigital_hub_mock.return_value.devices[device].device_type
+            device, device_obj.device_type
         )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
@@ -165,6 +171,10 @@ async def test_set_value(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
@@ -317,11 +327,17 @@ async def test_state_update(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
     for item in entity_list:
         getattr(device, item[1])[item[2]] = item[3]
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, item[1].upper()
+        )
         assert (state := hass.states.get(item[0]))
         assert state.state == str(item[4])

--- a/tests/components/eheimdigital/test_select.py
+++ b/tests/components/eheimdigital/test_select.py
@@ -6,6 +6,7 @@ from eheimdigital.types import FilterMode, FilterModeProf, ReeflexMode
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.eheimdigital.const import DOMAIN
 from homeassistant.components.select import (
     ATTR_OPTION,
     DOMAIN as SELECT_DOMAIN,
@@ -51,6 +52,57 @@ async def test_setup(
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_migrate_entities(
+    hass: HomeAssistant,
+    eheimdigital_hub_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the migration of entity ids."""
+    mock_config_entry.add_to_hass(hass)
+
+    entity_registry.async_get_or_create(
+        Platform.SELECT,
+        DOMAIN,
+        "00:00:00:00:00:04_const_flow_speed",
+        config_entry=mock_config_entry,
+    )
+
+    with (
+        patch("homeassistant.components.eheimdigital.PLATFORMS", [Platform.SELECT]),
+        patch(
+            "homeassistant.components.eheimdigital.coordinator.asyncio.Event",
+            new=AsyncMock,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device, device_obj.device_type
+        )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.SELECT, DOMAIN, "00:00:00:00:00:04_const_flow_speed"
+        )
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.SELECT, DOMAIN, "00:00:00:00:00:04_const_flow"
+        )
+        is not None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/eheimdigital/test_select.py
+++ b/tests/components/eheimdigital/test_select.py
@@ -40,9 +40,14 @@ async def test_setup(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device, eheimdigital_hub_mock.return_value.devices[device].device_type
+            device, device_obj.device_type
         )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
@@ -137,6 +142,10 @@ async def test_set_value(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
@@ -250,11 +259,17 @@ async def test_state_update(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
     for item in entity_list:
         getattr(device, item[1])[item[2]] = item[3]
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, item[1].upper()
+        )
         assert (state := hass.states.get(item[0]))
         assert state.state == item[4]

--- a/tests/components/eheimdigital/test_sensor.py
+++ b/tests/components/eheimdigital/test_sensor.py
@@ -22,7 +22,7 @@ async def test_setup(
     entity_registry: er.EntityRegistry,
     snapshot: SnapshotAssertion,
 ) -> None:
-    """Test sensor platform setup for the filter."""
+    """Test sensor platform setup."""
     mock_config_entry.add_to_hass(hass)
 
     with (
@@ -35,9 +35,14 @@ async def test_setup(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device, eheimdigital_hub_mock.return_value.devices[device].device_type
+            device, device_obj.device_type
         )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
@@ -109,10 +114,15 @@ async def test_state_update(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
-
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
     await hass.async_block_till_done()
 
     for item in entity_list:
         getattr(device, item[1])[item[2]] = item[3]
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, item[1].upper()
+        )
         assert get_sensor_display_state(hass, entity_registry, item[0]) == str(item[4])

--- a/tests/components/eheimdigital/test_switch.py
+++ b/tests/components/eheimdigital/test_switch.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components.eheimdigital.const import DOMAIN
 from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
@@ -52,6 +53,57 @@ async def test_setup(
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_migrate_entities(
+    hass: HomeAssistant,
+    eheimdigital_hub_mock: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the migration of entity ids."""
+    mock_config_entry.add_to_hass(hass)
+
+    entity_registry.async_get_or_create(
+        Platform.SWITCH,
+        DOMAIN,
+        "00:00:00:00:00:05_active",
+        config_entry=mock_config_entry,
+    )
+
+    with (
+        patch("homeassistant.components.eheimdigital.PLATFORMS", [Platform.SWITCH]),
+        patch(
+            "homeassistant.components.eheimdigital.coordinator.asyncio.Event",
+            new=AsyncMock,
+        ),
+    ):
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
+        await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
+            device, device_obj.device_type
+        )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
+        await hass.async_block_till_done()
+
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.SWITCH, DOMAIN, "00:00:00:00:00:05_active"
+        )
+        is None
+    )
+    assert (
+        entity_registry.async_get_entity_id(
+            Platform.SWITCH, DOMAIN, "00:00:00:00:00:05_is_active"
+        )
+        is not None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/eheimdigital/test_switch.py
+++ b/tests/components/eheimdigital/test_switch.py
@@ -40,9 +40,15 @@ async def test_setup(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device, eheimdigital_hub_mock.return_value.devices[device].device_type
+            device, device_obj.device_type
         )
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
+
         await hass.async_block_till_done()
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
@@ -84,6 +90,10 @@ async def test_turn_on_off(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
     await hass.async_block_till_done()
 
     await hass.services.async_call(
@@ -217,11 +227,17 @@ async def test_state_update(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
     for item in entity_list:
         getattr(device, item[1])[item[2]] = item[3]
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, item[1].upper()
+        )
         assert (state := hass.states.get(item[0]))
         assert state.state == str(item[4])

--- a/tests/components/eheimdigital/test_time.py
+++ b/tests/components/eheimdigital/test_time.py
@@ -40,10 +40,14 @@ async def test_setup(
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     for device in eheimdigital_hub_mock.return_value.devices:
+        device_obj = eheimdigital_hub_mock.return_value.devices[device]
         await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
-            device, eheimdigital_hub_mock.return_value.devices[device].device_type
+            device, device_obj.device_type
         )
-        await hass.async_block_till_done()
+        for packet in device_obj.packet_mapping:
+            await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+                device_obj.mac_address, packet
+            )
 
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
@@ -130,6 +134,10 @@ async def test_set_value(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
@@ -233,11 +241,17 @@ async def test_state_update(
     await eheimdigital_hub_mock.call_args.kwargs["device_found_callback"](
         device.mac_address, device.device_type
     )
+    for packet in device.packet_mapping:
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, packet
+        )
 
     await hass.async_block_till_done()
 
     for item in entity_list:
         getattr(device, item[1])[item[2]] = item[3]
-        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"]()
+        await eheimdigital_hub_mock.call_args.kwargs["receive_callback"](
+            device.mac_address, item[1].upper()
+        )
         assert (state := hass.states.get(item[0]))
         assert state.state == item[4]


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

This is quite a big revamp of the eheimdigital integration to make it more stable and reliable.

+ Instead of a single data update coordinator, it now has a data update coordinator per device message type (for example the heater has two coordinators; for `HEATER_DATA` and `USRDTA`)
  + This allows entity updates to be independent of each other and removes race conditions based on not yet received data from devices (due to the WebSocket connection being asynchronous)
  + It also removes unnecessary entity updates (an entity is now only updated when it actually receives a new message belonging to them, instead of all being updated)
    + This is especially important for the time sensors which will follow, where the devices sends a remaining minutes/seconds and the integration needing converting into a timestamp, the unnecessary updates had the problem that the time jumped around.

The test snapshots now also work correctly. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [ ] ~~Any generated code has been carefully reviewed for correctness and compliance with project standards.~~ No generated code

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
