### PR TITLE
Migrate google_mail off hass.data[DOMAIN] to entry.runtime_data / typed storage

### DIFF
--- a/homeassistant/components/google_mail/__init__.py
+++ b/homeassistant/components/google_mail/__init__.py
@@ -25,8 +25,6 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Google Mail integration."""
-    # Root HA config for legacy notify discovery (domain-level, not per-entry).
-    # Per-entry auth lives on entry.runtime_data.
     hass.data[DATA_HASS_CONFIG] = config
 
     async_setup_services(hass)

--- a/homeassistant/components/google_mail/__init__.py
+++ b/homeassistant/components/google_mail/__init__.py
@@ -1,5 +1,4 @@
 """Support for Google Mail."""
-# pylint: disable=home-assistant-use-runtime-data  # Uses legacy hass.data[DOMAIN] pattern
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_NAME, Platform
@@ -26,7 +25,9 @@ CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the Google Mail integration."""
-    hass.data.setdefault(DOMAIN, {})[DATA_HASS_CONFIG] = config
+    # Root HA config for legacy notify discovery (domain-level, not per-entry).
+    # Per-entry auth lives on entry.runtime_data.
+    hass.data[DATA_HASS_CONFIG] = config
 
     async_setup_services(hass)
 
@@ -53,9 +54,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoogleMailConfigEntry) -
             Platform.NOTIFY,
             DOMAIN,
             {DATA_AUTH: auth, CONF_NAME: entry.title},
-            # Uses legacy hass.data[DOMAIN] pattern
-            # pylint: disable-next=home-assistant-use-runtime-data
-            hass.data[DOMAIN][DATA_HASS_CONFIG],
+            hass.data[DATA_HASS_CONFIG],
         )
     )
 

--- a/homeassistant/components/google_mail/const.py
+++ b/homeassistant/components/google_mail/const.py
@@ -1,5 +1,9 @@
 """Constants for Google Mail integration."""
 
+from typing import Any
+
+from homeassistant.util.hass_dict import HassKey
+
 ATTR_BCC = "bcc"
 ATTR_CC = "cc"
 ATTR_ENABLED = "enabled"
@@ -16,7 +20,9 @@ ATTR_START = "start"
 ATTR_TITLE = "title"
 
 DATA_AUTH = "auth"
-DATA_HASS_CONFIG = "hass_config"
+# Domain-level root HA config for legacy notify platform discovery.
+# Not per config entry — entries store auth on entry.runtime_data.
+DATA_HASS_CONFIG: HassKey[dict[str, Any]] = HassKey("google_mail_hass_config")
 DEFAULT_ACCESS = [
     "https://www.googleapis.com/auth/gmail.compose",
     "https://www.googleapis.com/auth/gmail.settings.basic",


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Migrate `google_mail` off the legacy `hass.data[DOMAIN]` pattern tracked in #168772 (part of home-assistant/epics#43).

Per-entry auth was already stored on `entry.runtime_data` (`GoogleMailConfigEntry = ConfigEntry[AsyncConfigEntryAuth]`) and consumed by sensors/services that way. The remaining `hass.data[DOMAIN]` usage only held the **root HA config** for legacy notify platform discovery (`discovery.async_load_platform`). That is domain-level, not per-entry.

Changes:
- Store root config under typed `DATA_HASS_CONFIG: HassKey[...] = HassKey("google_mail_hass_config")` (same approach as slack / pushover / tibber notify discovery, with HassKey typing as in mailgun)
- Read it via `hass.data[DATA_HASS_CONFIG]` when loading the notify platform
- Remove both `home-assistant-use-runtime-data` pylint suppressions

No user-facing behavior changes. Existing tests already cover setup, notify, sensor, and services; they do not assert on `hass.data` keys.

### Validation
- AST scan of `homeassistant/components/google_mail/` confirms no remaining `hass.data[DOMAIN]` / `hass.data.setdefault(DOMAIN, …)` / `hass.data.get(DOMAIN)` usage (matches `hass-use-runtime-data` / W7405).
- Full `pytest tests/components/google_mail/` not run locally (Home Assistant test environment / deps not installed in this workspace).

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #168772
- This PR is related to issue: home-assistant/epics#43
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!

  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.

  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

### AI/LLM disclosure

- AI coding tools (including Grok and/or Codex agent-assisted editing) were used to help draft or modify code and this PR description.
- I reviewed the complete change, understand the reasoning, and ran the reported local tests before submitting.
- This submission is original work of authorship under the project CLA / contributor terms; AI output was not pasted unreviewed.