### PR TITLE
Relax constraint on counter initial value

### DIFF
--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -125,7 +125,7 @@ async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     component.async_register_entity_service(SERVICE_RESET, None, "async_reset")
     component.async_register_entity_service(
         SERVICE_SET_VALUE,
-        {vol.Required(VALUE): cv.positive_int},
+        {vol.Required(VALUE): vol.Coerce(int)},
         "async_set_value",
     )
 

--- a/homeassistant/components/counter/__init__.py
+++ b/homeassistant/components/counter/__init__.py
@@ -49,7 +49,7 @@ STORAGE_VERSION = 1
 
 STORAGE_FIELDS: VolDictType = {
     vol.Optional(CONF_ICON): cv.icon,
-    vol.Optional(CONF_INITIAL, default=DEFAULT_INITIAL): cv.positive_int,
+    vol.Optional(CONF_INITIAL, default=DEFAULT_INITIAL): vol.Coerce(int),
     vol.Required(CONF_NAME): vol.All(cv.string, vol.Length(min=1)),
     vol.Optional(CONF_MAXIMUM, default=None): vol.Any(None, vol.Coerce(int)),
     vol.Optional(CONF_MINIMUM, default=None): vol.Any(None, vol.Coerce(int)),
@@ -71,9 +71,9 @@ CONFIG_SCHEMA = vol.Schema(
                 _none_to_empty_dict,
                 {
                     vol.Optional(CONF_ICON): cv.icon,
-                    vol.Optional(
-                        CONF_INITIAL, default=DEFAULT_INITIAL
-                    ): cv.positive_int,
+                    vol.Optional(CONF_INITIAL, default=DEFAULT_INITIAL): vol.Coerce(
+                        int
+                    ),
                     vol.Optional(CONF_NAME): cv.string,
                     vol.Optional(CONF_MAXIMUM, default=None): vol.Any(
                         None, vol.Coerce(int)

--- a/homeassistant/components/counter/services.yaml
+++ b/homeassistant/components/counter/services.yaml
@@ -24,6 +24,6 @@ set_value:
       required: true
       selector:
         number:
-          min: 0
+          min: -9223372036854775808
           max: 9223372036854775807
           mode: box

--- a/tests/components/counter/test_init.py
+++ b/tests/components/counter/test_init.py
@@ -285,6 +285,58 @@ async def test_methods_with_config(hass: HomeAssistant) -> None:
     assert state.state == "5"
 
 
+async def test_negative_with_config(hass: HomeAssistant) -> None:
+    """Test increment, decrement, set, and reset methods with negative values."""
+    config = {
+        DOMAIN: {
+            "test": {
+                CONF_NAME: "Hello World",
+                CONF_INITIAL: -10,
+                CONF_STEP: 2,
+                CONF_MINIMUM: -10,
+                CONF_MAXIMUM: -2,
+            }
+        }
+    }
+
+    assert await async_setup_component(hass, DOMAIN, config)
+
+    entity_id = "counter.test"
+
+    state = hass.states.get(entity_id)
+    assert int(state.state) == -10
+
+    async_increment(hass, entity_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert int(state.state) == -8
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_SET_VALUE,
+        {
+            ATTR_ENTITY_ID: entity_id,
+            VALUE: -4,
+        },
+        blocking=True,
+    )
+    state = hass.states.get(entity_id)
+    assert int(state.state) == -4
+
+    async_decrement(hass, entity_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert int(state.state) == -6
+
+    async_reset(hass, entity_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert int(state.state) == -10
+
+
 async def test_initial_state_overrules_restore_state(hass: HomeAssistant) -> None:
     """Ensure states are restored on startup."""
     mock_restore_cache(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The counter helper generally makes no differentiation between positive and negative values. The state can go negative, it can have a negative min, it can have a negative max. 

However the initial value was constrained to be positive, but I see no reason why that must be constrained above zero, it seems inconsistent with the rest of the options. 

Relax this to allow negative values as well. 

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/home-assistant/frontend/issues/53385
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47243
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
