### PR TITLE
Add Netis Router integration

### DIFF
--- a/homeassistant/components/netis/__init__.py
+++ b/homeassistant/components/netis/__init__.py
@@ -1,0 +1,152 @@
+"""The Netis Router integration.
+
+This module is the entry point for the Netis Router integration. It sets up
+the DataUpdateCoordinator and forwards setup to all platform entities.
+
+Architecture overview
+---------------------
+1. ``async_setup_entry`` creates a :class:`NetisCoordinator` which polls the
+   router on a configurable interval (default 30 s).
+2. The coordinator stores a :class:`NetisClient` that handles authentication
+   (AES-128-CBC encrypted password) and all ubus JSON-RPC communication.
+3. On each poll, ``NetisClient.gather()`` fetches system info, connected
+   devices, WAN status, LTE signal, WiFi configuration and LED state
+   concurrently, returning a typed :class:`NetisData` snapshot.
+4. Platform entities (device_tracker, sensor, binary_sensor, button, switch,
+   select) read from the coordinator's cached snapshot and are automatically
+   refreshed on each successful poll.
+
+The integration uses the modern ``runtime_data`` pattern (HA 2024.8+) instead
+of ``hass.data`` for storing the coordinator reference.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, ServiceCall, callback
+from homeassistant.helpers import config_validation as cv
+
+from .api import NetisError
+from .const import DOMAIN, PLATFORMS
+from .coordinator import NetisCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Type alias: each config entry carries its coordinator at runtime.
+NetisConfigEntry = ConfigEntry[NetisCoordinator]
+
+# Service schemas (matched against services.yaml field definitions).
+SEND_SMS_SCHEMA = vol.Schema(
+    {
+        vol.Required("phone"): cv.string,
+        vol.Required("message"): cv.string,
+    }
+)
+SET_SPEED_LIMIT_SCHEMA = vol.Schema(
+    {
+        vol.Required("mac"): cv.string,
+        vol.Required("down_speed", default=0): vol.Coerce(int),
+        vol.Required("up_speed", default=0): vol.Coerce(int),
+    }
+)
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: NetisConfigEntry) -> bool:
+    """Set up Netis Router from a config entry.
+
+    This is called by Home Assistant when the user adds the integration via
+    the UI config flow. It performs the first data fetch (which will raise
+    ``ConfigEntryNotReady`` on failure so HA retries with backoff) and then
+    forwards setup to all platform handlers.
+    """
+    coordinator = NetisCoordinator(hass, entry)
+    # Fetch initial data; HA will retry setup if this fails.
+    await coordinator.async_config_entry_first_refresh()
+
+    # Store the coordinator on the entry for platform access (HA 2024.8+).
+    entry.runtime_data = coordinator
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Register custom services.
+    _async_register_services(hass, entry)
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: NetisConfigEntry) -> bool:
+    """Unload a config entry.
+
+    Called when the user removes the integration. Cleans up all platform
+    entities and registered services associated with this entry.
+    """
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok:
+        # Remove services when the last config entry is unloaded.
+        _async_unregister_services(hass)
+    return unload_ok
+
+
+def _get_coordinator(hass: HomeAssistant) -> NetisCoordinator | None:
+    """Return the first active Netis coordinator (single-router setup)."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    for entry in entries:
+        if entry.runtime_data is not None:
+            return entry.runtime_data  # type: ignore[return-value]
+    return None
+
+
+@callback
+def _async_register_services(hass: HomeAssistant, entry: NetisConfigEntry) -> None:
+    """Register custom services for the Netis integration."""
+
+    async def _handle_send_sms(call: ServiceCall) -> None:
+        """Service: netis.send_sms — send SMS via LTE modem."""
+        coordinator = _get_coordinator(hass)
+        if coordinator is None:
+            _LOGGER.error("No active Netis router to send SMS")
+            return
+        phone = call.data["phone"]
+        message = call.data["message"]
+        try:
+            await coordinator.client.send_sms(phone, message)
+        except NetisError as err:
+            _LOGGER.error("Failed to send SMS to %s: %s", phone, err)
+
+    async def _handle_set_speed_limit(call: ServiceCall) -> None:
+        """Service: netis.set_speed_limit — limit a device's bandwidth."""
+        coordinator = _get_coordinator(hass)
+        if coordinator is None:
+            _LOGGER.error("No active Netis router to set speed limit")
+            return
+        mac = call.data["mac"]
+        down_speed = call.data.get("down_speed", 0)
+        up_speed = call.data.get("up_speed", 0)
+        try:
+            await coordinator.client.set_speed_limit(mac, down_speed, up_speed)
+        except NetisError as err:
+            _LOGGER.error("Failed to set speed limit for %s: %s", mac, err)
+
+    # Only register once (multiple config entries share the same services).
+    if not hass.services.has_service(DOMAIN, "send_sms"):
+        hass.services.async_register(
+            DOMAIN, "send_sms", _handle_send_sms, schema=SEND_SMS_SCHEMA
+        )
+    if not hass.services.has_service(DOMAIN, "set_speed_limit"):
+        hass.services.async_register(
+            DOMAIN,
+            "set_speed_limit",
+            _handle_set_speed_limit,
+            schema=SET_SPEED_LIMIT_SCHEMA,
+        )
+
+
+@callback
+def _async_unregister_services(hass: HomeAssistant) -> None:
+    """Remove custom services when no config entries remain."""
+    if not hass.config_entries.async_entries(DOMAIN):
+        for service in ("send_sms", "set_speed_limit"):
+            if hass.services.has_service(DOMAIN, service):
+                hass.services.async_remove(DOMAIN, service)

--- a/homeassistant/components/netis/api.py
+++ b/homeassistant/components/netis/api.py
@@ -1,0 +1,572 @@
+"""Asynchronous client for Netis routers (ubus over HTTP).
+
+The router exposes a single JSON-RPC 2.0 endpoint ``POST /ubus`` backed by an
+OpenWrt ubus daemon. Authentication is done with an AES-128-CBC encrypted
+password using a server provided random key.
+
+See ROUTER_API_REFERENCE.md for the full protocol description (all endpoints
+were verified against a real MW5630 unit running firmware 4.0.260701.100631).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+import aiohttp
+from cryptography.hazmat.primitives import padding
+from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from .const import (
+    AES_IV,
+    ANONYMOUS_TOKEN,
+    DEFAULT_USERNAME,
+    ERR_OK,
+    ERR_PERMISSION_DENIED,
+    LOGIN_TIMEOUT,
+    UBUS_CUSTOMER,
+    UBUS_HOSTS,
+    UBUS_LTE_INFO,
+    UBUS_MWAN3,
+    UBUS_REBOOT,
+    UBUS_SYSTEM_INFO,
+    UBUS_WIFI_CFG,
+    WIFI_APPLY_TIMEOUT,
+    WRITE_TIMEOUT,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class NetisError(Exception):
+    """Base error for the Netis client."""
+
+
+class NetisAuthError(NetisError):
+    """Raised when login fails (wrong credentials / locked out)."""
+
+
+class NetisConnectionError(NetisError):
+    """Raised when the router cannot be reached."""
+
+
+@dataclass
+class NetisDevice:
+    """A single connected client reported by the router."""
+
+    mac: str
+    name: str | None
+    ip: str | None
+    online: bool
+    wired: bool
+    wifi_24g: bool
+    wifi_5g: bool
+    guest: bool
+    up_speed: int
+    down_speed: int
+    up_bytes: int
+    down_bytes: int
+    connected_seconds: int
+
+
+@dataclass
+class NetisData:
+    """Aggregated snapshot of everything polled from the router."""
+
+    # system / traffic
+    model: str | None = None
+    firmware: str | None = None
+    hardware_version: str | None = None
+    uptime: int | None = None
+    wan_in_speed: int | None = None
+    wan_out_speed: int | None = None
+    wan_in_bytes: int | None = None
+    wan_out_bytes: int | None = None
+    # WAN connectivity
+    wan_online: bool | None = None
+    wan_interfaces: dict[str, str] = field(default_factory=dict)
+    # LAN ports
+    ports: list[dict[str, Any]] = field(default_factory=list)
+    # LTE / 4G
+    lte_connected: bool | None = None
+    lte_rsrp: float | None = None
+    lte_rsrq: float | None = None
+    lte_rssi: float | None = None
+    lte_mode: str | None = None
+    lte_isp: str | None = None
+    lte_ip: str | None = None
+    lte_imei: str | None = None
+    # WiFi (per band: 2G / 5G)
+    wifi_enabled: dict[str, bool | None] = field(default_factory=dict)
+    wifi_txpower: dict[str, str | None] = field(default_factory=dict)
+    # LED indicator (front-panel lights)
+    led_on: bool | None = None
+    # devices
+    devices: list[NetisDevice] = field(default_factory=list)
+
+
+def _encrypt_password(password: str, rand_key: str) -> str:
+    """Encrypt ``password`` exactly as the router firmware expects.
+
+    ``rand_key`` is a 64 hex char string returned by ``rkey.get_rand_key``:
+      * first 32 hex chars -> key_index (sent back prefixed to the ciphertext)
+      * last 32 hex chars   -> the 16 byte AES key
+    """
+    key_index = rand_key[:32]
+    aes_key = bytes.fromhex(rand_key[32:64])
+    padder = padding.PKCS7(128).padder()
+    padded = padder.update(password.encode("utf-8")) + padder.finalize()
+    encryptor = Cipher(algorithms.AES(aes_key), modes.CBC(AES_IV)).encryptor()
+    ciphertext = encryptor.update(padded) + encryptor.finalize()
+    return key_index + ciphertext.hex()
+
+
+class NetisClient:
+    """Thin async wrapper around the ubus JSON-RPC API."""
+
+    def __init__(
+        self,
+        session: aiohttp.ClientSession,
+        host: str,
+        username: str = DEFAULT_USERNAME,
+        password: str = "",
+    ) -> None:
+        self._session = session
+        self._host = host.rstrip("/")
+        self._base = f"http://{self._host}"
+        self._username = username
+        self._password = password
+        self._token: str | None = None
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Low level transport
+    # ------------------------------------------------------------------
+    async def _post(
+        self, payload: dict[str, Any], total_timeout: float = LOGIN_TIMEOUT
+    ) -> dict[str, Any]:
+        """POST a single JSON-RPC payload and return the parsed result."""
+        try:
+            async with self._session.post(
+                f"{self._base}/ubus",
+                data=json.dumps(payload),
+                headers={"Content-Type": "application/json"},
+                timeout=aiohttp.ClientTimeout(total=total_timeout),
+            ) as resp:
+                return await resp.json(content_type=None)
+        except aiohttp.ClientError as err:
+            raise NetisConnectionError(
+                f"Cannot reach router at {self._base}: {err}"
+            ) from err
+        except asyncio.TimeoutError as err:
+            raise NetisConnectionError(
+                f"Timeout reaching router at {self._base}"
+            ) from err
+
+    async def _rpc(
+        self,
+        token: str,
+        obj: str,
+        method: str,
+        args: dict[str, Any] | None = None,
+        total_timeout: float = LOGIN_TIMEOUT,
+    ) -> list:
+        """Call ``obj.method`` and return the ubus ``result`` array.
+
+        The firmware has two distinct error signalling layers:
+          * JSON-RPC level: ``{"error": {"code": -32002}}`` for session/access
+            denial (invalid or expired token) — no ``result`` key at all.
+          * ubus level: ``[6]`` (ERR_PERMISSION_DENIED) inside the result array.
+        Both must map to a permission-denied result so that ``call()`` can
+        trigger re-login. We normalise the JSON-RPC-level error to ``[6]``.
+        """
+        payload = {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "call",
+            "params": [token, obj, method, args or {}],
+        }
+        data = await self._post(payload, total_timeout=total_timeout)
+        if "result" in data:
+            return data["result"]
+        # JSON-RPC-level error (no "result" key). Map access-denied codes
+        # (-32002 etc.) to ubus code 6 so call() can re-login automatically.
+        if "error" in data:
+            code = data["error"].get("code", 0)
+            if code < -32000:  # JSON-RPC access-denied family
+                return [ERR_PERMISSION_DENIED]
+            raise NetisError(f"Router JSON-RPC error {code}: {data['error'].get('message', '')}")
+        raise NetisError(f"Unexpected router response: {data}")
+
+    # ------------------------------------------------------------------
+    # Authentication
+    # ------------------------------------------------------------------
+    async def login(self) -> str:
+        """Authenticate against the router and store the session token."""
+        try:
+            result = await self._rpc(ANONYMOUS_TOKEN, "rkey", "get_rand_key")
+        except NetisError as err:
+            raise NetisConnectionError(f"get_rand_key failed: {err}") from err
+
+        if not result or result[0] != ERR_OK:
+            raise NetisAuthError(f"Failed to obtain login key: {result}")
+
+        rand_key = result[1]["rand_key"]
+        encrypted = _encrypt_password(self._password, rand_key)
+
+        result = await self._rpc(
+            ANONYMOUS_TOKEN,
+            "rkey.session",
+            "login",
+            {"username": self._username, "password": encrypted},
+        )
+        if not result or result[0] != ERR_OK or len(result) < 2:
+            raise NetisAuthError(f"Login rejected by router: {result}")
+        session = result[1]
+        if "ubus_rpc_session" not in session:
+            err_code = session.get("ErrCode")
+            raise NetisAuthError(
+                f"Login failed (ErrCode={err_code}); check credentials"
+            )
+        self._token = session["ubus_rpc_session"]
+        _LOGGER.debug("Logged into %s, token acquired", self._host)
+        return self._token
+
+    async def _ensure_token(self) -> str:
+        if self._token is None:
+            await self.login()
+        assert self._token is not None
+        return self._token
+
+    async def call(
+        self,
+        obj: str,
+        method: str,
+        args: dict[str, Any] | None = None,
+        retry: bool = True,
+        total_timeout: float = LOGIN_TIMEOUT,
+    ) -> Any:
+        """Call ``obj.method`` once and re-login on permission errors."""
+        async with self._lock:
+            token = await self._ensure_token()
+            result = await self._rpc(token, obj, method, args, total_timeout)
+            if result and result[0] == ERR_PERMISSION_DENIED and retry:
+                _LOGGER.debug(
+                    "Token expired on %s.%s, re-logging in", obj, method
+                )
+                self._token = None
+                await self.login()
+                result = await self._rpc(self._token, obj, method, args, total_timeout)
+            if not result or result[0] != ERR_OK:
+                raise NetisError(
+                    f"{obj}.{method} failed with ubus code {result[0] if result else 'empty'}"
+                )
+            return result[1] if len(result) > 1 else None
+
+    # ------------------------------------------------------------------
+    # High level endpoints (all verified against real hardware)
+    # ------------------------------------------------------------------
+    async def get_system_info(self) -> dict[str, Any]:
+        """routerd.info - model/firmware/uptime/traffic/LAN ports."""
+        return await self.call(*UBUS_SYSTEM_INFO)
+
+    async def get_hosts(self) -> dict[str, Any]:
+        """devices_app.get_host_info - connected + offline clients."""
+        return await self.call(*UBUS_HOSTS)
+
+    async def get_wan_status(self) -> dict[str, Any]:
+        """mwan3.status - per-WAN-interface connectivity."""
+        return await self.call(*UBUS_MWAN3)
+
+    async def get_lte_info(self) -> dict[str, Any]:
+        """lte_ubus.LteInfo - 4G signal / connection details."""
+        return await self.call(*UBUS_LTE_INFO)
+
+    async def get_customer_info(self) -> dict[str, Any]:
+        """uci.get customer info - brand / model / hostname."""
+        return await self.call(
+            *UBUS_CUSTOMER, {"config": "customer", "section": "info"}
+        )
+
+    async def get_wifi_config(self) -> dict[str, Any]:
+        """uci.get wificfg - per-band enable / TxPower / SSID."""
+        return await self.call(*UBUS_WIFI_CFG, {"config": "wificfg"})
+
+    async def _set_and_apply(
+        self, config: str, section: str, values: dict[str, str], what: str
+    ) -> None:
+        """uci.set + uci.apply, capped end-to-end so HA never hangs.
+
+        On this firmware the uci write/apply path occasionally blocks for
+        10+ seconds (rpcd serialises config writes and can throttle rapid
+        successive calls). Since ``uci.set`` commits to the running config
+        immediately and the value persists even when ``uci.apply`` is a
+        no-op (returns ubus code 5) or its reply is lost, we cap the whole
+        operation at ``WRITE_TIMEOUT`` and confirm the resulting state on
+        the next coordinator poll.
+        """
+        try:
+            await asyncio.wait_for(
+                self._set_and_apply_inner(config, section, values, what),
+                timeout=WRITE_TIMEOUT,
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.warning(
+                "%s write to %s on %s did not complete within %ss; the change "
+                "may still apply in the background - will confirm on next poll",
+                what,
+                config,
+                self._host,
+                WRITE_TIMEOUT,
+            )
+
+    async def _set_and_apply_inner(
+        self, config: str, section: str, values: dict[str, str], what: str
+    ) -> None:
+        """Inner helper performing the set + apply, holding the lock."""
+        async with self._lock:
+            await self.call(
+                "uci",
+                "set",
+                {"config": config, "section": section, "values": values},
+                total_timeout=WRITE_TIMEOUT,
+            )
+            try:
+                await self.call(
+                    "uci",
+                    "apply",
+                    {"timeout": "60"},
+                    total_timeout=WIFI_APPLY_TIMEOUT,
+                )
+            except NetisConnectionError as err:
+                _LOGGER.info(
+                    "%s apply reply not received within %ss on %s "
+                    "(change is committed); will confirm on next poll: %s",
+                    what,
+                    WIFI_APPLY_TIMEOUT,
+                    self._host,
+                    err,
+                )
+            except NetisError as err:
+                # apply returns ubus code 5 on some firmwares when the session
+                # lacks the apply ACL - the uci.set above is still committed,
+                # so this is non-fatal.
+                _LOGGER.debug(
+                    "%s apply skipped on %s: %s", what, self._host, err
+                )
+        _LOGGER.info("%s set on %s: %s", what, self._host, values)
+
+    async def set_wifi_config(self, section: str, values: dict[str, str]) -> None:
+        """Write WiFi fields for a band and apply.
+
+        ``section`` is "2G" or "5G"; ``values`` e.g. {"Enable": "0"} or
+        {"TxPower": "50"}. Changing WiFi will briefly disrupt wireless
+        clients.
+        """
+        await self._set_and_apply("wificfg", section, values, f"WiFi {section}")
+
+    async def get_led_config(self) -> str | None:
+        """Read the front-panel LED state from uci.
+
+        Returns the raw ``ledoff`` value: "0" = LEDs on, "1" = LEDs off,
+        or ``None`` if unavailable.
+        """
+        resp = await self.call(
+            "uci",
+            "get",
+            {"config": "system", "section": "@system[0]", "option": "ledoff"},
+        )
+        return resp.get("value") if isinstance(resp, dict) else None
+
+    async def set_led(self, on: bool) -> None:
+        """Turn the front-panel indicator LEDs on or off.
+
+        Inverts to the firmware's ``ledoff`` flag (0=on, 1=off). Uses a
+        single-field ``values`` payload so the surrounding ``system`` section
+        (hostname, timezone, credentials, ...) is never touched.
+        """
+        await self._set_and_apply(
+            "system", "@system[0]", {"ledoff": "0" if on else "1"}, "LED"
+        )
+
+    async def reboot(self) -> None:
+        """system.reboot - restart the router (will drop connection ~60s)."""
+        try:
+            await self.call(*UBUS_REBOOT, retry=False)
+        except NetisError:
+            # reboot tears down the session; a connection drop is expected
+            _LOGGER.info("Reboot issued to %s", self._host)
+
+    async def send_sms(self, phone: str, message: str) -> None:
+        """Send an SMS via the router's LTE modem (lte_ubus.lte_sendmsg).
+
+        Only works on LTE-capable models with a SIM card inserted. The
+        message text is sent as-is; the firmware handles encoding.
+        """
+        await self.call(
+            "lte_ubus",
+            "lte_sendmsg",
+            {"phone": phone, "msg": message},
+        )
+        _LOGGER.info("SMS sent to %s via %s", phone, self._host)
+
+    async def set_speed_limit(
+        self, mac: str, down_speed: int = 0, up_speed: int = 0
+    ) -> None:
+        """Set per-device speed limit (devices_app.set_speed_limit).
+
+        ``mac`` is the device MAC (uppercased internally). Speed values are
+        in Kbps; 0 means unlimited (removes the limit).
+        """
+        await self.call(
+            "devices_app",
+            "set_speed_limit",
+            {
+                "mac": mac.upper(),
+                "lt_enable": "1" if (down_speed or up_speed) else "0",
+                "lt_down": str(down_speed),
+                "lt_up": str(up_speed),
+            },
+        )
+        _LOGGER.info(
+            "Speed limit set for %s on %s: down=%d up=%d Kbps",
+            mac, self._host, down_speed, up_speed,
+        )
+
+    # ------------------------------------------------------------------
+    # Aggregation
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _to_int(value: Any) -> int | None:
+        try:
+            return int(float(value))
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def parse(
+        cls,
+        info: dict,
+        hosts: dict,
+        mwan: dict,
+        lte: dict,
+        wifi: dict | None = None,
+        ledoff: str | None = None,
+    ) -> NetisData:
+        """Convert raw ubus payloads into a typed snapshot."""
+        values = hosts.get("values") if hosts else None
+        raw_hosts = (hosts or {}).get("hosts") or values or []
+
+        devices: list[NetisDevice] = []
+        for entry in raw_hosts:
+            mac = (entry.get("mac") or "").upper()
+            if not mac:
+                continue
+            devices.append(
+                NetisDevice(
+                    mac=mac,
+                    name=entry.get("alias") or None,
+                    ip=entry.get("ip") or None,
+                    online=bool(entry.get("online")),
+                    wired=bool(entry.get("wire")),
+                    wifi_24g=bool(entry.get("is_wifi")),
+                    wifi_5g=bool(entry.get("is_5g")),
+                    guest=bool(entry.get("is_guest")),
+                    up_speed=cls._to_int(entry.get("up_speed")) or 0,
+                    down_speed=cls._to_int(entry.get("down_speed")) or 0,
+                    up_bytes=cls._to_int(entry.get("up_bytes")) or 0,
+                    down_bytes=cls._to_int(entry.get("down_bytes")) or 0,
+                    connected_seconds=cls._to_int(entry.get("second")) or 0,
+                )
+            )
+
+        interfaces = (mwan or {}).get("interfaces") or {}
+        wan_online = any(
+            iface.get("status") == "online" for iface in interfaces.values()
+        )
+
+        lte_data = lte or {}
+        lte_connected = cls._to_int(lte_data.get("lte_connect"))
+        lte_connected = lte_connected == 1 if lte_connected is not None else None
+
+        # WiFi: uci.get wificfg returns {values: {"2G": {...}, "5G": {...}}}
+        wifi_values = ((wifi or {}).get("values")) or {}
+        wifi_enabled: dict[str, bool | None] = {}
+        wifi_txpower: dict[str, str | None] = {}
+        for band in ("2G", "5G"):
+            band_cfg = wifi_values.get(band) or {}
+            enable = band_cfg.get("Enable")
+            wifi_enabled[band] = (
+                str(enable) == "1" if enable is not None else None
+            )
+            wifi_txpower[band] = band_cfg.get("TxPower")
+
+        # LED: firmware flag ledoff -> 0 = on, 1 = off (inverted)
+        led_on = str(ledoff) == "0" if ledoff is not None else None
+
+        return NetisData(
+            model=info.get("model"),
+            firmware=info.get("version"),
+            hardware_version=info.get("hd_version"),
+            uptime=cls._to_int(info.get("uptime")),
+            wan_in_speed=cls._to_int(info.get("all_in_byte_speed")),
+            wan_out_speed=cls._to_int(info.get("all_out_byte_speed")),
+            wan_in_bytes=cls._to_int(info.get("all_in_byte")),
+            wan_out_bytes=cls._to_int(info.get("all_out_byte")),
+            wan_online=wan_online,
+            wan_interfaces={
+                name: iface.get("status") for name, iface in interfaces.items()
+            },
+            ports=info.get("link_info") or [],
+            lte_connected=lte_connected,
+            lte_rsrp=cls._to_float(lte_data.get("lte_rsrp")),
+            lte_rsrq=cls._to_float(lte_data.get("lte_rsrq")),
+            lte_rssi=cls._to_float(lte_data.get("lte_rssi")),
+            lte_mode=lte_data.get("lte_mode"),
+            lte_isp=lte_data.get("lte_isp"),
+            lte_ip=lte_data.get("lte_ip"),
+            lte_imei=lte_data.get("imei"),
+            wifi_enabled=wifi_enabled,
+            wifi_txpower=wifi_txpower,
+            led_on=led_on,
+            devices=devices,
+        )
+
+    async def gather(self) -> NetisData:
+        """Fetch all endpoints concurrently and return a typed snapshot."""
+        info, hosts, mwan, lte, wifi, ledoff = await asyncio.gather(
+            self.get_system_info(),
+            self.get_hosts(),
+            self.get_wan_status(),
+            self.get_lte_info(),
+            self.get_wifi_config(),
+            self.get_led_config(),
+            return_exceptions=True,
+        )
+        # LTE is optional (not every model is a 4G router): tolerate failure.
+        if isinstance(lte, NetisError):
+            _LOGGER.debug("LTE info unavailable: %s", lte)
+            lte = {}
+        if isinstance(wifi, NetisError):
+            _LOGGER.debug("WiFi config unavailable: %s", wifi)
+            wifi = {}
+        if isinstance(ledoff, NetisError):
+            _LOGGER.debug("LED state unavailable: %s", ledoff)
+            ledoff = None
+        if isinstance(info, NetisError):
+            raise info
+        if isinstance(hosts, NetisError):
+            raise hosts
+        if isinstance(mwan, NetisError):
+            raise mwan
+        return self.parse(info, hosts, mwan, lte, wifi, ledoff)

--- a/homeassistant/components/netis/binary_sensor.py
+++ b/homeassistant/components/netis/binary_sensor.py
@@ -1,0 +1,93 @@
+"""binary_sensor platform for Netis Router.
+
+Provides connectivity status sensors:
+
+  - **WAN online**: ``True`` when at least one WAN interface reports
+    ``status == "online"`` (from ``mwan3.status``). Extra state attributes
+    list per-interface status (wan1, wan_lte, etc.).
+  - **LTE connected**: ``True`` when the LTE modem reports a data connection
+    (``lte_connect == 1`` from ``lte_ubus.LteInfo``). May be unavailable on
+    non-LTE router models.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityDescription
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import NetisCoordinator
+from .entity import NetisEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Netis binary sensors."""
+    coordinator: NetisCoordinator = entry.runtime_data
+    entities: list[NetisBinarySensorEntity] = [
+        NetisBinarySensorEntity(
+            coordinator,
+            unique_key="wan_online",
+            name="WAN online",
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            icon="mdi:earth",
+            is_on=lambda d: d.wan_online,
+            extra=lambda d: {
+                iface: status for iface, status in (d.wan_interfaces or {}).items()
+            },
+        ),
+        NetisBinarySensorEntity(
+            coordinator,
+            unique_key="lte_connected",
+            name="LTE connected",
+            device_class=BinarySensorDeviceClass.CONNECTIVITY,
+            icon="mdi:signal-cellular-3",
+            is_on=lambda d: d.lte_connected,
+        ),
+    ]
+    async_add_entities(entities)
+
+
+class NetisBinarySensorEntity(NetisEntity, BinarySensorEntity):
+    """Configurable binary sensor bound to a snapshot field."""
+
+    def __init__(
+        self,
+        coordinator: NetisCoordinator,
+        *,
+        unique_key: str,
+        name: str,
+        is_on,
+        extra=None,
+        device_class: BinarySensorDeviceClass | None = None,
+        icon: str | None = None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{unique_key}"
+        self._attr_name = name
+        self._attr_device_class = device_class
+        self._attr_icon = icon
+        self._is_on = is_on
+        self._extra = extra
+
+    @property
+    def is_on(self) -> bool | None:
+        if self.coordinator.data is None:
+            return None
+        return self._is_on(self.coordinator.data)
+
+    @property
+    def extra_state_attributes(self):
+        if self.coordinator.data is None or self._extra is None:
+            return None
+        return self._extra(self.coordinator.data)

--- a/homeassistant/components/netis/button.py
+++ b/homeassistant/components/netis/button.py
@@ -1,0 +1,46 @@
+"""button platform for Netis Router.
+
+Provides a "Reboot" button entity. When pressed, it calls ``system.reboot``
+via ubus, which restarts the router. Expect approximately 60 seconds of
+downtime; the coordinator will mark all entities as ``unavailable`` and
+recover automatically once the router comes back online.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import NetisCoordinator
+from .entity import NetisEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Netis buttons."""
+    coordinator: NetisCoordinator = entry.runtime_data
+    async_add_entities([NetisRebootButton(coordinator)])
+
+
+class NetisRebootButton(NetisEntity, ButtonEntity):
+    """Reboot the router."""
+
+    _attr_name = "Reboot"
+    _attr_icon = "mdi:restart"
+
+    def __init__(self, coordinator: NetisCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-reboot"
+
+    async def async_press(self) -> None:
+        """Send the reboot command."""
+        _LOGGER.info("Rebooting Netis router %s", self.coordinator.config_entry.title)
+        await self.coordinator.client.reboot()
+        # Expect a short outage; let the coordinator recover naturally.

--- a/homeassistant/components/netis/config_flow.py
+++ b/homeassistant/components/netis/config_flow.py
@@ -1,0 +1,151 @@
+"""Config flow for the Netis Router integration.
+
+Provides the UI-based setup wizard that users interact with when adding the
+integration via Settings > Devices & Services > Add Integration.
+
+Flow steps:
+  1. **user**: User enters host (IP), username (default "root"), and
+     password (WiFi password). The flow attempts a live login + system info
+     fetch to validate credentials before saving.
+  2. **init** (Options Flow): User can adjust the polling interval
+     (10–300 seconds) after initial setup.
+
+Error handling maps API exceptions to user-friendly messages:
+  - ``NetisAuthError``      → "invalid_auth" (wrong password/username)
+  - ``NetisConnectionError`` → "cannot_connect" (unreachable host)
+  - other ``NetisError``    → "unknown"
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+from homeassistant import config_entries
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import callback
+from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+from .api import NetisAuthError, NetisClient, NetisConnectionError, NetisError
+from .const import DEFAULT_HOST, DOMAIN
+
+# Schema for the initial setup form shown to the user.
+# Password allows empty string: Netis routers in factory-default state have
+# no password, and the login API accepts an empty password.
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_HOST, default=DEFAULT_HOST): str,
+        vol.Required(CONF_PASSWORD, default=""): str,
+    }
+)
+
+
+async def _test_connection(hass, host: str, password: str) -> str | None:
+    """Try to log in and fetch system info.
+
+    Returns ``None`` on success (credentials valid, router reachable), or an
+    error string key on failure. The error string maps to a user-facing
+    message defined in ``strings.json``.
+    """
+    client = NetisClient(
+        session=async_get_clientsession(hass),
+        host=host,
+        password=password,
+    )
+    try:
+        await client.login()
+        await client.get_system_info()
+    except NetisAuthError:
+        return "invalid_auth"
+    except NetisConnectionError:
+        return "cannot_connect"
+    except NetisError:
+        return "unknown"
+    return None
+
+
+class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Netis Router.
+
+    Inherits from ``config_entries.ConfigFlow`` with ``domain=DOMAIN`` so HA
+    automatically registers this flow for the "netis" integration.
+    """
+
+    VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: config_entries.ConfigEntry,
+    ) -> "OptionsFlowHandler":
+        """Return the options flow handler for adjusting settings post-setup."""
+        return OptionsFlowHandler(config_entry)
+
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle the initial user setup step.
+
+        On first call (``user_input is None``) shows the setup form.
+        On subsequent call (form submitted) validates the connection and
+        either creates the config entry or re-shows the form with errors.
+        """
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            host = user_input[CONF_HOST]
+            # Use the host IP as the unique ID to prevent duplicate entries.
+            await self.async_set_unique_id(host)
+            self._abort_if_unique_id_configured()
+
+            # Attempt a live connection test before saving credentials.
+            error = await _test_connection(
+                self.hass,
+                host,
+                user_input[CONF_PASSWORD],
+            )
+            if error is None:
+                return self.async_create_entry(
+                    title=f"Netis {host}",
+                    data=user_input,
+                )
+            errors["base"] = error
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=STEP_USER_DATA_SCHEMA,
+            errors=errors,
+        )
+
+
+class OptionsFlowHandler(config_entries.OptionsFlow):
+    """Allow adjusting the polling interval after initial setup.
+
+    Accessible via the integration's "Configure" button in HA UI.
+    """
+
+    def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
+        """Store the config entry for reading current options."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage the options form (polling interval slider)."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        "scan_interval",
+                        default=self.config_entry.options.get(
+                            "scan_interval", 30
+                        ),
+                    ): vol.All(vol.Coerce(int), vol.Range(min=10, max=300)),
+                }
+            ),
+        )

--- a/homeassistant/components/netis/const.py
+++ b/homeassistant/components/netis/const.py
@@ -1,0 +1,81 @@
+"""Constants for the Netis Router integration.
+
+This module centralises all configuration keys, ubus endpoint identifiers,
+timing constants, and platform definitions used across the integration.
+
+Key concepts:
+  * **ubus over HTTP**: The router exposes a single JSON-RPC 2.0 endpoint
+    (``POST /ubus``) backed by an OpenWrt ubus daemon. Each "namespace.method"
+    pair (e.g. ``routerd.info``) maps to a specific router capability.
+  * **AES-CBC authentication**: Before login, the client fetches a random key
+    from ``rkey.get_rand_key``, uses it to AES-128-CBC encrypt the password,
+    and submits the ciphertext to ``rkey.session.login``.
+  * **Session token**: Login returns ``ubus_rpc_session`` (32-char hex),
+    valid for 300 seconds. All subsequent requests carry it in ``params[0]``.
+"""
+
+DOMAIN = "netis"
+
+# Config entry fields
+CONF_HOST = "host"
+CONF_USERNAME = "username"
+CONF_PASSWORD = "password"
+
+DEFAULT_HOST = "192.168.1.1"
+DEFAULT_USERNAME = "root"
+
+# ubus session token used before login
+ANONYMOUS_TOKEN = "00000000000000000000000000000000"
+
+# AES-CBC parameters (from router firmware: js/publicPlugin/dLoad.js)
+AES_IV = b"poiewjhw49q35j4n"
+LOGIN_TIMEOUT = 15
+DEFAULT_SCAN_INTERVAL = 30  # seconds
+# uci.apply reloads the wireless subsystem and can block; cap how long we
+# wait for its reply before treating it as a background task.
+WIFI_APPLY_TIMEOUT = 8  # seconds
+# Whole write (uci.set + apply) can block on this firmware (rpcd serialises
+# writes); cap the end-to-end operation so Home Assistant never hangs.
+WRITE_TIMEOUT = 12  # seconds
+
+# ubus error codes
+ERR_OK = 0
+ERR_PERMISSION_DENIED = 6  # token expired / unauthorized -> re-login
+
+# ubus namespace.method constants used by this integration
+UBUS_SYSTEM_INFO = ("routerd", "info")
+UBUS_HOSTS = ("devices_app", "get_host_info")
+UBUS_MWAN3 = ("mwan3", "status")
+UBUS_LTE_INFO = ("lte_ubus", "LteInfo")
+UBUS_CUSTOMER = ("uci", "get")
+UBUS_REBOOT = ("system", "reboot")
+UBUS_WIFI_CFG = ("uci", "get")          # {"config": "wificfg"}
+
+# WiFi bands (uci section names inside the `wificfg` config)
+BAND_2G = "2G"
+BAND_5G = "5G"
+WIFI_BANDS = (BAND_2G, BAND_5G)
+
+# Valid Transmit Power levels supported by the firmware
+# (see signal_conditioning.html data-power options: 2/50/100 = low/mid/high)
+TXPOWER_LEVELS = ("2", "50", "100")
+
+# Manufacturer / model defaults
+MANUFACTURER = "Netis"
+
+# Platforms
+PLATFORM_DEVICE_TRACKER = "device_tracker"
+PLATFORM_SENSOR = "sensor"
+PLATFORM_BINARY_SENSOR = "binary_sensor"
+PLATFORM_BUTTON = "button"
+PLATFORM_SWITCH = "switch"
+PLATFORM_SELECT = "select"
+
+PLATFORMS = (
+    PLATFORM_DEVICE_TRACKER,
+    PLATFORM_SENSOR,
+    PLATFORM_BINARY_SENSOR,
+    PLATFORM_BUTTON,
+    PLATFORM_SWITCH,
+    PLATFORM_SELECT,
+)

--- a/homeassistant/components/netis/coordinator.py
+++ b/homeassistant/components/netis/coordinator.py
@@ -1,0 +1,71 @@
+"""DataUpdateCoordinator for the Netis Router integration.
+
+The coordinator is the central polling hub. On each update cycle it calls
+``NetisClient.gather()`` which concurrently fetches all router endpoints
+(system info, devices, WAN status, LTE signal, WiFi config, LED state),
+parses them into a :class:`NetisData` snapshot, and caches it for all
+platform entities to read.
+
+If the poll fails (router unreachable, session expired, etc.) the
+coordinator raises ``UpdateFailed`` which HA translates into entity state
+``unavailable`` and retries with exponential backoff.
+
+The polling interval is configurable via Options Flow (10–300 seconds,
+default 30).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import timedelta
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .api import NetisClient, NetisData, NetisError
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class NetisCoordinator(DataUpdateCoordinator[NetisData]):
+    """Coordinator that polls the router and exposes a typed snapshot.
+
+    Generic over :class:`NetisData` so that ``self.data`` is fully typed for
+    all platform entities that consume it.
+    """
+
+    config_entry: ConfigEntry
+
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        """Initialise the coordinator with the configured polling interval."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=timedelta(
+                # User can override via Options Flow (10–300 s, default 30).
+                seconds=entry.options.get("scan_interval", DEFAULT_SCAN_INTERVAL)
+            ),
+        )
+        # Build the API client with HA's shared aiohttp session for connection
+        # pooling and proper lifecycle management.
+        self.client = NetisClient(
+            session=async_get_clientsession(hass),
+            host=entry.data[CONF_HOST],
+            password=entry.data[CONF_PASSWORD],
+        )
+
+    async def _async_update_data(self) -> NetisData:
+        """Fetch and parse all router data in a single poll cycle.
+
+        On failure, raises :class:`UpdateFailed` so HA marks entities as
+        ``unavailable`` and retries with backoff.
+        """
+        try:
+            return await self.client.gather()
+        except NetisError as err:
+            raise UpdateFailed(str(err)) from err

--- a/homeassistant/components/netis/device_tracker.py
+++ b/homeassistant/components/netis/device_tracker.py
@@ -1,0 +1,119 @@
+"""device_tracker platform for Netis Router.
+
+Tracks the presence of devices connected to the router (both wired and
+wireless). Uses the ``ScannerEntity`` base class so HA natively integrates
+with the "Person" device tracker system.
+
+Data source: ``devices_app.get_host_info`` returns a list of all known hosts
+(even offline ones). Each host has ``online``, ``mac``, ``ip``, ``alias``,
+connection type (wired/2.4G/5G/guest), and per-device traffic counters.
+
+New devices are auto-discovered: a coordinator listener checks every poll
+for MAC addresses we haven't seen before and creates tracker entities for
+them dynamically.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.device_tracker import SourceType
+from homeassistant.components.device_tracker.config_entry import ScannerEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import NetisCoordinator
+from .entity import NetisEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Netis device trackers."""
+    coordinator: NetisCoordinator = entry.runtime_data
+    known: set[str] = set()
+
+    @callback
+    def _add_new() -> None:
+        if coordinator.data is None:
+            return
+        new_entities = []
+        for device in coordinator.data.devices:
+            if device.mac in known:
+                continue
+            known.add(device.mac)
+            new_entities.append(NetisTrackerEntity(coordinator, device.mac))
+        if new_entities:
+            async_add_entities(new_entities)
+
+    _add_new()
+    entry.async_on_unload(coordinator.async_add_listener(_add_new))
+
+
+class NetisTrackerEntity(NetisEntity, ScannerEntity):
+    """A single tracked device."""
+
+    _attr_should_poll = False
+
+    def __init__(self, coordinator: NetisCoordinator, mac: str) -> None:
+        super().__init__(coordinator)
+        self._mac = mac
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{mac}"
+
+    @property
+    def _device(self):
+        if not self.coordinator.data:
+            return None
+        for device in self.coordinator.data.devices:
+            if device.mac == self._mac:
+                return device
+        return None
+
+    @property
+    def is_connected(self) -> bool:
+        dev = self._device
+        return bool(dev and dev.online)
+
+    @property
+    def source_type(self) -> SourceType:
+        return SourceType.ROUTER
+
+    @property
+    def mac_address(self) -> str | None:
+        return self._mac
+
+    @property
+    def hostname(self) -> str | None:
+        dev = self._device
+        return dev.name if dev else None
+
+    @property
+    def ip_address(self) -> str | None:
+        dev = self._device
+        if dev and dev.ip and dev.ip != "::":
+            return dev.ip
+        return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object] | None:
+        dev = self._device
+        if not dev:
+            return None
+        connection = (
+            "wired" if dev.wired
+            else "5g" if dev.wifi_5g
+            else "2.4g" if dev.wifi_24g
+            else "wireless"
+        )
+        return {
+            "connection": connection,
+            "guest": dev.guest,
+            "up_speed_bps": dev.up_speed,
+            "down_speed_bps": dev.down_speed,
+            "up_bytes": dev.up_bytes,
+            "down_bytes": dev.down_bytes,
+            "connected_seconds": dev.connected_seconds,
+        }

--- a/homeassistant/components/netis/diagnostics.py
+++ b/homeassistant/components/netis/diagnostics.py
@@ -1,0 +1,50 @@
+"""Diagnostics platform for the Netis Router integration.
+
+Supports downloading a redacted snapshot of the router state via
+Settings > Devices & Services > Netis > Download diagnostics. Used for
+troubleshooting; all identifying fields (passwords, MACs, IPs, IMEI) are
+masked by :func:`async_redact_data`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.core import HomeAssistant
+
+from . import NetisConfigEntry
+
+# Keys masked in the diagnostic download. Keys map to both the config
+# entry data dict and the NetisDevice / NetisData field names.
+TO_REDACT = {
+    # credentials
+    "password",
+    # device identifiers
+    "mac",
+    "ip",
+    "ip_address",
+    "mac_address",
+    # LTE / modem identifiers
+    "imei",
+    "lte_imei",
+    "lte_imsi",
+    "lte_ip",
+    # host name aliases (user-set, potentially identifying)
+    "name",
+    "alias",
+    "hostname",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: NetisConfigEntry
+) -> dict[str, Any]:
+    """Return redacted diagnostics for a config entry."""
+    coordinator = entry.runtime_data
+    snapshot = coordinator.data
+    return {
+        "entry": async_redact_data(entry.as_dict(), TO_REDACT),
+        "data": asdict(snapshot) if snapshot else None,
+    }

--- a/homeassistant/components/netis/entity.py
+++ b/homeassistant/components/netis/entity.py
@@ -1,0 +1,58 @@
+"""Shared base entity and device info for Netis platforms.
+
+All platform entities (sensor, binary_sensor, switch, select, button,
+device_tracker) inherit from :class:`NetisEntity` which:
+
+* Links the entity to the coordinator (so it auto-updates on each poll).
+* Attaches ``DeviceInfo`` so all entities are grouped under the router in
+  HA's device registry.
+* Sets ``_attr_has_entity_name = True`` so entity names are prefixed with
+  the device name (e.g. "Netis 192.168.1.1 - Uptime").
+"""
+
+from __future__ import annotations
+
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, MANUFACTURER
+from .coordinator import NetisCoordinator
+
+
+def router_device_info(coordinator: NetisCoordinator) -> DeviceInfo:
+    """Build DeviceInfo for the router itself.
+
+    Pulls model / firmware / hardware version from the latest coordinator
+    data snapshot so the device card in HA shows accurate information.
+    """
+    data = coordinator.data
+    model = data.model if data else None
+    sw = data.firmware if data else None
+    hw = data.hardware_version if data else None
+    return DeviceInfo(
+        # Use the config entry ID as the unique device identifier so the
+        # device survives entity name changes and reloads.
+        identifiers={(DOMAIN, coordinator.config_entry.entry_id)},
+        name=f"Netis {coordinator.config_entry.title}",
+        manufacturer=MANUFACTURER,
+        model=model or "Router",
+        sw_version=sw,
+        hw_version=hw,
+    )
+
+
+class NetisEntity(CoordinatorEntity[NetisCoordinator], Entity):
+    """Base entity that points at the router device.
+
+    Subclass this for any platform entity that reads from the coordinator.
+    Set ``_attr_name``, ``_attr_unique_id``, and platform-specific attributes
+    in the subclass ``__init__``.
+    """
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: NetisCoordinator) -> None:
+        """Initialise the base entity with coordinator and device info."""
+        super().__init__(coordinator)
+        self._attr_device_info = router_device_info(coordinator)

--- a/homeassistant/components/netis/manifest.json
+++ b/homeassistant/components/netis/manifest.json
@@ -1,0 +1,11 @@
+{
+  "domain": "netis",
+  "name": "Netis Router",
+  "codeowners": ["@netis-systems-app"],
+  "config_flow": true,
+  "documentation": "https://www.netis-systems.com",
+  "integration_type": "hub",
+  "iot_class": "local_polling",
+  "requirements": [],
+  "quality_scale": "silver"
+}

--- a/homeassistant/components/netis/select.py
+++ b/homeassistant/components/netis/select.py
@@ -1,0 +1,85 @@
+"""select platform for Netis Router.
+
+Provides transmit power selectors for each WiFi band:
+
+  - **2.4G transmit power**: low (2) / middle (50) / high (100)
+  - **5G transmit power**: low (2) / middle (50) / high (100)
+
+The firmware only supports three discrete power levels (verified from the
+router's ``signal_conditioning.html`` page), so a ``select`` entity is used
+rather than a ``number`` slider to prevent sending invalid values.
+
+Write operations use ``uci.set`` + ``uci.apply`` via ``set_wifi_config``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import BAND_2G, BAND_5G, TXPOWER_LEVELS
+from .coordinator import NetisCoordinator
+from .entity import NetisEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Netis TxPower selects."""
+    coordinator: NetisCoordinator = entry.runtime_data
+    async_add_entities(
+        [
+            NetisTxPowerSelect(coordinator, BAND_2G, "2.4G transmit power"),
+            NetisTxPowerSelect(coordinator, BAND_5G, "5G transmit power"),
+        ]
+    )
+
+
+class NetisTxPowerSelect(NetisEntity, SelectEntity):
+    """Adjust the transmit power of a WiFi band.
+
+    The firmware exposes three discrete levels (verified via
+    signal_conditioning.html): 2 (low), 50 (middle), 100 (high). Sending
+    other values is rejected by the router, so a select entity is used
+    rather than a number slider.
+    """
+
+    _attr_icon = "mdi:signal-variant"
+    _attr_options = list(TXPOWER_LEVELS)
+    _attr_assumed_state = False
+
+    def __init__(
+        self, coordinator: NetisCoordinator, band: str, name: str
+    ) -> None:
+        super().__init__(coordinator)
+        self._band = band
+        self._attr_name = name
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-txpower-{band}"
+
+    @property
+    def current_option(self) -> str | None:
+        if self.coordinator.data is None:
+            return None
+        value = self.coordinator.data.wifi_txpower.get(self._band)
+        if value is None:
+            return None
+        # Normalise: the router returns strings like "100"; if the value
+        # isn't one of the known levels fall back to None (unknown).
+        return value if value in TXPOWER_LEVELS else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Set the transmit power level."""
+        if option not in TXPOWER_LEVELS:
+            raise ValueError(
+                f"Transmit power {option!r} not in supported levels {TXPOWER_LEVELS}"
+            )
+        await self.coordinator.client.set_wifi_config(
+            self._band, {"TxPower": option}
+        )
+        self.async_write_ha_state()

--- a/homeassistant/components/netis/sensor.py
+++ b/homeassistant/components/netis/sensor.py
@@ -1,0 +1,224 @@
+"""sensor platform for Netis Router.
+
+Exposes router telemetry as HA sensor entities:
+
+System & Traffic:
+  - Uptime (duration, seconds)
+  - Download / Upload speed (data_rate, B/s)
+  - Download / Upload total (data_size, bytes, total_increasing)
+  - Online device count
+
+LTE / 4G (optional, only on LTE-capable models):
+  - RSRP, RSSI (signal_strength, dBm)
+  - RSRQ (dB)
+  - Network mode (e.g. "LTE")
+  - Operator name (e.g. "CHN-CT")
+  - LTE IP address
+
+Diagnostic:
+  - Firmware version
+  - IMEI
+
+All sensors read from the coordinator's cached :class:`NetisData` snapshot
+updated on each poll cycle.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    PERCENTAGE,
+    SIGNAL_STRENGTH_DECIBELS,
+    UnitOfDataRate,
+    UnitOfInformation,
+    UnitOfTime,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import NetisCoordinator
+from .entity import NetisEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Netis sensors."""
+    coordinator: NetisCoordinator = entry.runtime_data
+    entities: list[NetisSensorEntity] = [
+        # System / traffic
+        _Sensor(
+            coordinator,
+            key="uptime",
+            name="Uptime",
+            device_class=SensorDeviceClass.DURATION,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit=UnitOfTime.SECONDS,
+            value=lambda d: d.uptime,
+        ),
+        _Sensor(
+            coordinator,
+            key="wan_download_speed",
+            name="Download speed",
+            device_class=SensorDeviceClass.DATA_RATE,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit=UnitOfDataRate.BYTES_PER_SECOND,
+            value=lambda d: d.wan_in_speed,
+            icon="mdi:download-network",
+        ),
+        _Sensor(
+            coordinator,
+            key="wan_upload_speed",
+            name="Upload speed",
+            device_class=SensorDeviceClass.DATA_RATE,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit=UnitOfDataRate.BYTES_PER_SECOND,
+            value=lambda d: d.wan_out_speed,
+            icon="mdi:upload-network",
+        ),
+        _Sensor(
+            coordinator,
+            key="wan_download_total",
+            name="Download total",
+            device_class=SensorDeviceClass.DATA_SIZE,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            native_unit=UnitOfInformation.BYTES,
+            value=lambda d: d.wan_in_bytes,
+            icon="mdi:download",
+        ),
+        _Sensor(
+            coordinator,
+            key="wan_upload_total",
+            name="Upload total",
+            device_class=SensorDeviceClass.DATA_SIZE,
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            native_unit=UnitOfInformation.BYTES,
+            value=lambda d: d.wan_out_bytes,
+            icon="mdi:upload",
+        ),
+        _Sensor(
+            coordinator,
+            key="online_devices",
+            name="Online devices",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit="devices",
+            value=lambda d: sum(1 for dev in d.devices if dev.online),
+            icon="mdi:devices",
+        ),
+        # LTE / 4G
+        _Sensor(
+            coordinator,
+            key="lte_rsrp",
+            name="LTE RSRP",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit=SIGNAL_STRENGTH_DECIBELS,
+            value=lambda d: d.lte_rsrp,
+            icon="mdi:signal",
+        ),
+        _Sensor(
+            coordinator,
+            key="lte_rsrq",
+            name="LTE RSRQ",
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit=SIGNAL_STRENGTH_DECIBELS,
+            value=lambda d: d.lte_rsrq,
+            icon="mdi:signal-variant",
+        ),
+        _Sensor(
+            coordinator,
+            key="lte_rssi",
+            name="LTE RSSI",
+            device_class=SensorDeviceClass.SIGNAL_STRENGTH,
+            state_class=SensorStateClass.MEASUREMENT,
+            native_unit=SIGNAL_STRENGTH_DECIBELS,
+            value=lambda d: d.lte_rssi,
+            icon="mdi:signal-hangup",
+        ),
+        _Sensor(
+            coordinator,
+            key="lte_mode",
+            name="LTE network mode",
+            value=lambda d: d.lte_mode,
+            icon="mdi:access-point-network",
+        ),
+        _Sensor(
+            coordinator,
+            key="lte_isp",
+            name="LTE operator",
+            value=lambda d: d.lte_isp,
+            icon="mdi:cellphone-information",
+        ),
+        _Sensor(
+            coordinator,
+            key="lte_ip",
+            name="LTE IP address",
+            value=lambda d: d.lte_ip,
+            icon="mdi:ip",
+        ),
+        # Diagnostic
+        _Sensor(
+            coordinator,
+            key="firmware",
+            name="Firmware",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            value=lambda d: d.firmware,
+            icon="mdi:chip",
+        ),
+        _Sensor(
+            coordinator,
+            key="imei",
+            name="IMEI",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            value=lambda d: d.lte_imei,
+            icon="mdi:barcode",
+        ),
+    ]
+    async_add_entities(entities)
+
+
+class NetisSensorEntity(NetisEntity, SensorEntity):
+    """Common router sensor."""
+
+
+class _Sensor(NetisSensorEntity):
+    """Configurable sensor bound to a snapshot field via a callable."""
+
+    def __init__(
+        self,
+        coordinator: NetisCoordinator,
+        *,
+        key: str,
+        name: str,
+        value,
+        device_class: SensorDeviceClass | None = None,
+        state_class: SensorStateClass | None = None,
+        native_unit: str | None = None,
+        entity_category: EntityCategory | None = None,
+        icon: str | None = None,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-{key}"
+        self._attr_name = name
+        self._attr_device_class = device_class
+        self._attr_state_class = state_class
+        self._attr_native_unit_of_measurement = native_unit
+        self._attr_entity_category = entity_category
+        self._attr_icon = icon
+        self._getter = value
+
+    @property
+    def native_value(self):
+        if self.coordinator.data is None:
+            return None
+        return self._getter(self.coordinator.data)

--- a/homeassistant/components/netis/services.yaml
+++ b/homeassistant/components/netis/services.yaml
@@ -1,0 +1,75 @@
+# Custom services exposed by the Netis Router integration.
+#
+# These services cover router capabilities that cannot be represented as
+# standard entity types (button / switch / select / sensor) because they
+# require dynamic parameters from the user at call time.
+
+# Send an SMS message through the router's LTE/4G modem SIM card.
+# Only available on LTE-capable router models (e.g. MW5630).
+send_sms:
+  name: Send SMS
+  description: >-
+    Send an SMS text message through the router's 4G LTE modem.
+    Only works on router models with a SIM card inserted and LTE connected.
+  target:
+    device:
+      integration: netis
+  fields:
+    phone:
+      name: Phone number
+      description: Recipient phone number (digits only, no spaces or dashes).
+      required: true
+      example: "13800138000"
+      selector:
+        text:
+    message:
+      name: Message
+      description: Text content of the SMS message.
+      required: true
+      example: "Hello from Home Assistant"
+      selector:
+        text:
+          multiline: true
+
+# Set a download/upload speed limit for a specific connected device.
+# Useful for parental control or bandwidth management.
+set_speed_limit:
+  name: Set device speed limit
+  description: >-
+    Set a per-device speed limit (download and upload) for a connected client.
+    Set both values to 0 to remove the limit.
+  target:
+    device:
+      integration: netis
+  fields:
+    mac:
+      name: Device MAC address
+      description: MAC address of the target device (e.g. 34:29:8F:70:96:85).
+      required: true
+      example: "34:29:8F:70:96:85"
+      selector:
+        text:
+    down_speed:
+      name: Download limit (Kbps)
+      description: >-
+        Maximum download speed in Kbps. Set to 0 for unlimited.
+      required: true
+      default: 0
+      example: 1024
+      selector:
+        number:
+          min: 0
+          max: 102400
+          unit_of_measurement: Kbps
+    up_speed:
+      name: Upload limit (Kbps)
+      description: >-
+        Maximum upload speed in Kbps. Set to 0 for unlimited.
+      required: true
+      default: 0
+      example: 512
+      selector:
+        number:
+          min: 0
+          max: 102400
+          unit_of_measurement: Kbps

--- a/homeassistant/components/netis/strings.json
+++ b/homeassistant/components/netis/strings.json
@@ -1,0 +1,28 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Netis Router",
+        "description": "Connect to your Netis router. The password is the same as your Wi-Fi password. Leave the password empty if your router is in factory-default state (no password set).",
+        "data": {
+          "host": "Host (IP address)",
+          "password": "Password (leave empty if default)"
+        }
+      },
+      "init": {
+        "title": "Netis Router options",
+        "data": {
+          "scan_interval": "Polling interval (seconds)"
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid username or password. The password is the Wi-Fi password.",
+      "cannot_connect": "Cannot reach the router. Check the IP address.",
+      "unknown": "Unexpected error. Check the logs."
+    },
+    "abort": {
+      "already_configured": "This router is already configured."
+    }
+  }
+}

--- a/homeassistant/components/netis/switch.py
+++ b/homeassistant/components/netis/switch.py
@@ -1,0 +1,109 @@
+"""switch platform for Netis Router.
+
+Provides on/off toggle switches for:
+
+  - **WiFi 2.4G**: enables/disables the 2.4 GHz radio (``wificfg.2G.Enable``)
+  - **WiFi 5G**: enables/disables the 5 GHz radio (``wificfg.5G.Enable``)
+  - **Indicator LED**: turns the front-panel LEDs on/off
+    (``system.@system[0].ledoff``, inverted: ledoff=0 means ON)
+
+Write operations use ``uci.set`` + ``uci.apply`` with a hard timeout
+(``WRITE_TIMEOUT``) to prevent HA from hanging when the firmware's rpcd
+serialises config writes. The optimistic state update ensures the UI
+responds immediately; the next poll confirms the actual state.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import BAND_2G, BAND_5G
+from .coordinator import NetisCoordinator
+from .entity import NetisEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up Netis switches (WiFi + LED indicator)."""
+    coordinator: NetisCoordinator = entry.runtime_data
+    async_add_entities(
+        [
+            NetisWifiSwitch(coordinator, BAND_2G, "WiFi 2.4G"),
+            NetisWifiSwitch(coordinator, BAND_5G, "WiFi 5G"),
+            NetisLedSwitch(coordinator),
+        ]
+    )
+
+
+class NetisWifiSwitch(NetisEntity, SwitchEntity):
+    """Toggle a WiFi band on or off."""
+
+    _attr_icon = "mdi:wifi"
+
+    def __init__(
+        self, coordinator: NetisCoordinator, band: str, name: str
+    ) -> None:
+        super().__init__(coordinator)
+        self._band = band
+        self._attr_name = name
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-wifi-{band}"
+
+    @property
+    def is_on(self) -> bool | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.wifi_enabled.get(self._band)
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Enable the WiFi band."""
+        await self.coordinator.client.set_wifi_config(
+            self._band, {"Enable": "1"}
+        )
+        # Optimistic update; next poll confirms.
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Disable the WiFi band.
+
+        Disabling will drop all wireless clients on this band for ~10-20s
+        while the radio reconfigures.
+        """
+        await self.coordinator.client.set_wifi_config(
+            self._band, {"Enable": "0"}
+        )
+        self.async_write_ha_state()
+
+
+class NetisLedSwitch(NetisEntity, SwitchEntity):
+    """Toggle the front-panel indicator LEDs."""
+
+    _attr_icon = "mdi:led-on"
+
+    def __init__(self, coordinator: NetisCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_name = "Indicator LED"
+        self._attr_unique_id = f"{coordinator.config_entry.entry_id}-led"
+
+    @property
+    def is_on(self) -> bool | None:
+        if self.coordinator.data is None:
+            return None
+        return self.coordinator.data.led_on
+
+    async def async_turn_on(self, **kwargs) -> None:
+        """Turn the indicator LEDs on."""
+        await self.coordinator.client.set_led(True)
+        self.async_write_ha_state()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        """Turn the indicator LEDs off (sleep mode)."""
+        await self.coordinator.client.set_led(False)
+        self.async_write_ha_state()

--- a/tests/components/netis/__init__.py
+++ b/tests/components/netis/__init__.py
@@ -1,0 +1,1 @@
+# HA core test package marker for the netis integration tests.

--- a/tests/components/netis/conftest.py
+++ b/tests/components/netis/conftest.py
@@ -1,0 +1,228 @@
+"""Test fixtures for the Netis Router integration.
+
+All tests run inside the Home Assistant test framework: the router is
+always mocked, no real HTTP traffic is generated.
+
+The raw sample payloads below mirror the response format verified against
+a real MW5630 running firmware 4.0.260701.100631.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from homeassistant.components.netis.api import NetisClient, NetisData
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+# ---------------------------------------------------------------------------
+# Sample raw API responses (matching real router firmware output format)
+# ---------------------------------------------------------------------------
+
+SAMPLE_SYSTEM_INFO = {
+    "model": "MW5630",
+    "version": "4.0.260701.100631",
+    "hd_version": "1.0",
+    "meminfo": "256M",
+    "wifispeed": "3000Mbps",
+    "uptime": 3600,
+    "all_in_byte": 1024000,
+    "all_out_byte": 2048000,
+    "all_in_byte_speed": 51200,
+    "all_out_byte_speed": 102400,
+    "all_in_pkt": 10000,
+    "all_out_pkt": 20000,
+    "link_info": [
+        {"name": "PORT0", "link": False, "speed": 0, "duplex": "half"},
+        {"name": "PORT1", "link": True, "speed": 1000, "duplex": "full"},
+        {"name": "PORT2", "link": False, "speed": 0, "duplex": "half"},
+    ],
+    "priority1": "wan_lte",
+    "priority2": "wan1",
+}
+
+SAMPLE_HOSTS = {
+    "hosts": [
+        {
+            "mac": "AA:BB:CC:DD:EE:FF",
+            "alias": "test-laptop",
+            "ip": "192.168.1.100",
+            "ip6": "::",
+            "online": True,
+            "wire": True,
+            "is_wifi": 0,
+            "is_5g": 0,
+            "is_guest": 0,
+            "up_speed": 1024,
+            "down_speed": 4096,
+            "up_bytes": 500000,
+            "down_bytes": 1500000,
+            "second": 1800,
+        },
+        {
+            "mac": "11:22:33:44:55:66",
+            "alias": "test-phone",
+            "ip": "192.168.1.101",
+            "online": True,
+            "wire": False,
+            "is_wifi": 0,
+            "is_5g": 1,
+            "is_guest": 0,
+            "up_speed": 512,
+            "down_speed": 2048,
+            "up_bytes": 100000,
+            "down_bytes": 800000,
+            "second": 600,
+        },
+        {
+            "mac": "99:88:77:66:55:44",
+            "alias": "offline-device",
+            "ip": "",
+            "online": False,
+            "wire": False,
+            "is_wifi": 1,
+            "is_5g": 0,
+            "is_guest": 0,
+            "up_speed": 0,
+            "down_speed": 0,
+            "up_bytes": 0,
+            "down_bytes": 0,
+            "second": 0,
+        },
+    ]
+}
+
+SAMPLE_MWAN3 = {
+    "interfaces": {
+        "wan1": {"status": "offline"},
+        "wan1_ipv6": {"status": "offline"},
+        "wan_lte": {"status": "online"},
+    }
+}
+
+SAMPLE_LTE_INFO = {
+    "support4G": "1",
+    "lte_sim": 1,
+    "lte_module": 8,
+    "imei": "868245050137472",
+    "lte_imsi": "460110503549231",
+    "lte_isp": "CHN-CT",
+    "lte_mode": "LTE",
+    "lte_connect": 1,
+    "lte_ip": "10.99.249.101",
+    "lte_dns1": "61.139.2.69",
+    "lte_dns2": "218.6.200.139",
+    "lte_rsrp": "-95.5",
+    "lte_rsrq": "-12.3",
+    "lte_rssi": "28",
+    "lte_band": "103",
+    "lte_cellid": "8112",
+}
+
+SAMPLE_WIFI_CONFIG = {
+    "values": {
+        "global": {"Enable": "1"},
+        "2G": {
+            "Enable": "1",
+            "SSID1": "netis-test-2G",
+            "TxPower": "100",
+            "Channel": "0",
+        },
+        "5G": {
+            "Enable": "1",
+            "SSID1": "netis-test-5G",
+            "TxPower": "50",
+            "Channel": "0",
+        },
+    }
+}
+
+VALID_TOKEN = "aabbccddeeff00112233445566778899"
+# 64 hex chars: first 32 = key_index, last 32 = 16-byte AES key.
+RAND_KEY = "aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"
+
+
+def build_netis_data() -> NetisData:
+    """Return a fully-populated parsed NetisData snapshot (LEDs on)."""
+    return NetisClient.parse(
+        info=SAMPLE_SYSTEM_INFO,
+        hosts=SAMPLE_HOSTS,
+        mwan=SAMPLE_MWAN3,
+        lte=SAMPLE_LTE_INFO,
+        wifi=SAMPLE_WIFI_CONFIG,
+        ledoff="0",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mock config entry
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mock Netis config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Netis 192.168.1.1",
+        data={CONF_HOST: "192.168.1.1", CONF_PASSWORD: "password"},
+        options={"scan_interval": 30},
+        entry_id="1",
+        unique_id="192.168.1.1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Mock NetisClient (patched at the coordinator import site)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_netis_client() -> Generator[MagicMock]:
+    """Yield a mocked NetisClient and prevent any real HTTP traffic.
+
+    Patches ``NetisClient`` at both the coordinator and config_flow import
+    sites so setup and connection tests share the same mock.
+    """
+    data = build_netis_data()
+    with patch(
+        "homeassistant.components.netis.coordinator.NetisClient",
+        autospec=True,
+    ) as client_class, patch(
+        "homeassistant.components.netis.config_flow.NetisClient",
+        autospec=True,
+    ):
+        client = client_class.return_value
+        client.login = AsyncMock(return_value=VALID_TOKEN)
+        client.gather = AsyncMock(return_value=data)
+        client.get_system_info = AsyncMock(return_value=SAMPLE_SYSTEM_INFO)
+        client.set_wifi_config = AsyncMock(return_value=None)
+        client.set_led = AsyncMock(return_value=None)
+        client.reboot = AsyncMock(return_value=None)
+        client.send_sms = AsyncMock(return_value=None)
+        client.set_speed_limit = AsyncMock(return_value=None)
+        yield client
+
+
+# ---------------------------------------------------------------------------
+# Initialise the integration (full setup via the config entry)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_netis_client: MagicMock,
+) -> MockConfigEntry:
+    """Set up the Netis integration with a mocked router.
+
+    Yields the config entry after a successful first refresh.
+    """
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    return mock_config_entry

--- a/tests/components/netis/test_api.py
+++ b/tests/components/netis/test_api.py
@@ -1,0 +1,217 @@
+"""Tests for the Netis API client (homeassistant.components.netis.api).
+
+These tests verify internal logic -- password encryption, data parsing and
+type conversion -- without making any real HTTP requests and without the
+HA framework (pure unit tests).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.api import (
+    NetisClient,
+    _encrypt_password,
+)
+
+from .conftest import (
+    RAND_KEY,
+    SAMPLE_HOSTS,
+    SAMPLE_LTE_INFO,
+    SAMPLE_MWAN3,
+    SAMPLE_SYSTEM_INFO,
+    SAMPLE_WIFI_CONFIG,
+)
+
+
+# ===========================================================================
+# Password encryption
+# ===========================================================================
+
+class TestEncryptPassword:
+    """Tests for _encrypt_password()."""
+
+    def test_encrypt_produces_hex_string(self):
+        """Output must be hex with the key_index prefix."""
+        result = _encrypt_password("secret", RAND_KEY)
+        assert isinstance(result, str)
+        # key_index (32 hex) + at least one AES block (32 hex)
+        assert len(result) >= 64
+        assert result[:32] == RAND_KEY[:32]
+
+    def test_encrypt_empty_password(self):
+        """Empty password must still produce valid encrypted output."""
+        result = _encrypt_password("", RAND_KEY)
+        assert isinstance(result, str)
+        assert len(result) >= 64
+
+    def test_encrypt_different_passwords_differ(self):
+        """Different passwords must produce different ciphertexts."""
+        enc1 = _encrypt_password("password1", RAND_KEY)
+        enc2 = _encrypt_password("password2", RAND_KEY)
+        assert enc1[:32] == enc2[:32]  # key_index prefix identical
+        assert enc1[32:] != enc2[32:]  # ciphertext differs
+
+
+# ===========================================================================
+# Data parsing (NetisClient.parse classmethod)
+# ===========================================================================
+
+class TestParse:
+    """Tests for NetisClient.parse()."""
+
+    def test_parse_full_data(self):
+        """All fields parsed from a complete, valid raw payload."""
+        data = NetisClient.parse(
+            info=SAMPLE_SYSTEM_INFO,
+            hosts=SAMPLE_HOSTS,
+            mwan=SAMPLE_MWAN3,
+            lte=SAMPLE_LTE_INFO,
+            wifi=SAMPLE_WIFI_CONFIG,
+            ledoff="0",
+        )
+        # System
+        assert data.model == "MW5630"
+        assert data.firmware == "4.0.260701.100631"
+        assert data.hardware_version == "1.0"
+        assert data.uptime == 3600
+        assert data.wan_in_speed == 51200
+        assert data.wan_out_speed == 102400
+        # WAN
+        assert data.wan_online is True
+        assert data.wan_interfaces["wan_lte"] == "online"
+        assert data.wan_interfaces["wan1"] == "offline"
+        # LTE
+        assert data.lte_connected is True
+        assert data.lte_rsrp == pytest.approx(-95.5)
+        assert data.lte_rsrq == pytest.approx(-12.3)
+        assert data.lte_rssi == pytest.approx(28.0)
+        assert data.lte_mode == "LTE"
+        assert data.lte_isp == "CHN-CT"
+        assert data.lte_ip == "10.99.249.101"
+        assert data.lte_imei == "868245050137472"
+        # WiFi
+        assert data.wifi_enabled["2G"] is True
+        assert data.wifi_enabled["5G"] is True
+        assert data.wifi_txpower["2G"] == "100"
+        assert data.wifi_txpower["5G"] == "50"
+        # LED
+        assert data.led_on is True
+
+    def test_parse_devices(self):
+        """The device list is parsed with correct connection attributes."""
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, SAMPLE_HOSTS, SAMPLE_MWAN3, SAMPLE_LTE_INFO
+        )
+        assert len(data.devices) == 3
+        wired = data.devices[0]
+        assert wired.mac == "AA:BB:CC:DD:EE:FF"
+        assert wired.name == "test-laptop"
+        assert wired.ip == "192.168.1.100"
+        assert wired.online is True
+        assert wired.wired is True
+        assert wired.wifi_5g is False
+
+        wifi5 = data.devices[1]
+        assert wifi5.wifi_5g is True
+        assert wifi5.wired is False
+
+        offline = data.devices[2]
+        assert offline.online is False
+
+    def test_parse_led_off(self):
+        """ledoff='1' means LEDs off."""
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, SAMPLE_HOSTS, SAMPLE_MWAN3,
+            SAMPLE_LTE_INFO, ledoff="1",
+        )
+        assert data.led_on is False
+
+    def test_parse_wifi_disabled(self):
+        """WiFi Enable='0' parses as disabled for both bands."""
+        wifi_disabled = {
+            "values": {
+                "2G": {"Enable": "0", "TxPower": "50"},
+                "5G": {"Enable": "0", "TxPower": "50"},
+            }
+        }
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, SAMPLE_HOSTS, SAMPLE_MWAN3,
+            SAMPLE_LTE_INFO, wifi=wifi_disabled,
+        )
+        assert data.wifi_enabled["2G"] is False
+        assert data.wifi_enabled["5G"] is False
+
+    def test_parse_wan_offline(self):
+        """All WAN interfaces offline means wan_online is False."""
+        mwan_offline = {
+            "interfaces": {
+                "wan1": {"status": "offline"},
+                "wan_lte": {"status": "offline"},
+            }
+        }
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, SAMPLE_HOSTS, mwan_offline, SAMPLE_LTE_INFO
+        )
+        assert data.wan_online is False
+
+    def test_parse_empty_hosts(self):
+        """An empty host list yields an empty device list."""
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, {"hosts": []}, SAMPLE_MWAN3, SAMPLE_LTE_INFO
+        )
+        assert data.devices == []
+
+    def test_parse_missing_mac_skipped(self):
+        """Hosts without a MAC address are skipped."""
+        hosts = {
+            "hosts": [
+                {"ip": "192.168.1.1", "mac": ""},
+                {"mac": "AA:BB:CC:DD:EE:FF"},
+            ]
+        }
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, hosts, SAMPLE_MWAN3, SAMPLE_LTE_INFO
+        )
+        assert len(data.devices) == 1
+
+    def test_parse_lte_not_connected(self):
+        """lte_connect=0 means not connected."""
+        lte = {**SAMPLE_LTE_INFO, "lte_connect": 0}
+        data = NetisClient.parse(
+            SAMPLE_SYSTEM_INFO, SAMPLE_HOSTS, SAMPLE_MWAN3, lte
+        )
+        assert data.lte_connected is False
+
+    def test_parse_handles_empty_inputs(self):
+        """Parse must not crash on empty/None-shaped inputs."""
+        data = NetisClient.parse({}, {}, {}, {})
+        assert data.model is None
+        assert data.devices == []
+        assert data.wan_online is False
+        assert data.led_on is None
+
+
+# ===========================================================================
+# Type conversion helpers
+# ===========================================================================
+
+class TestTypeConversion:
+    """Tests for _to_int and _to_float helpers."""
+
+    def test_to_int_valid(self):
+        assert NetisClient._to_int("100") == 100
+        assert NetisClient._to_int(100) == 100
+        assert NetisClient._to_int("100.5") == 100
+
+    def test_to_int_invalid(self):
+        assert NetisClient._to_int("abc") is None
+        assert NetisClient._to_int(None) is None
+
+    def test_to_float_valid(self):
+        assert NetisClient._to_float("-95.5") == pytest.approx(-95.5)
+        assert NetisClient._to_float(100) == pytest.approx(100.0)
+
+    def test_to_float_invalid(self):
+        assert NetisClient._to_float("abc") is None
+        assert NetisClient._to_float(None) is None

--- a/tests/components/netis/test_binary_sensor.py
+++ b/tests/components/netis/test_binary_sensor.py
@@ -1,0 +1,36 @@
+"""Test the Netis Router binary_sensor platform."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+ENTRY_ID = "1"
+
+
+def _entity_id(hass: HomeAssistant, key: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "binary_sensor", DOMAIN, f"{ENTRY_ID}-{key}"
+    )
+    assert entity_id is not None, f"binary_sensor {key} not registered"
+    return entity_id
+
+
+async def test_wan_online(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wan_online")).state == "on"
+
+
+async def test_lte_connected(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_connected")).state == "on"
+
+
+async def test_wan_online_interfaces_attribute(hass: HomeAssistant) -> None:
+    """The WAN sensor should expose per-interface status as attributes."""
+    state = hass.states.get(_entity_id(hass, "wan_online"))
+    assert state.attributes["wan_lte"] == "online"
+    assert state.attributes["wan1"] == "offline"

--- a/tests/components/netis/test_button.py
+++ b/tests/components/netis/test_button.py
@@ -1,0 +1,30 @@
+"""Test the Netis Router button platform (reboot)."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+ENTRY_ID = "1"
+
+
+async def test_reboot_button_press(
+    hass: HomeAssistant, mock_netis_client
+) -> None:
+    """Pressing the reboot button should call client.reboot()."""
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "button", DOMAIN, f"{ENTRY_ID}-reboot"
+    )
+    assert entity_id is not None
+    await hass.services.async_call(
+        "button",
+        "press",
+        {"entity_id": entity_id},
+        blocking=True,
+    )
+    mock_netis_client.reboot.assert_awaited_once()

--- a/tests/components/netis/test_config_flow.py
+++ b/tests/components/netis/test_config_flow.py
@@ -1,0 +1,99 @@
+"""Test the Netis Router config flow and options flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.api import (
+    NetisAuthError,
+    NetisConnectionError,
+    NetisError,
+)
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_HOST, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+
+async def test_user_step_show_form(hass: HomeAssistant) -> None:
+    """The user step should render an empty form on first invocation."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert CONF_HOST in result["data_schema"].schema
+
+
+async def test_user_step_success(
+    hass: HomeAssistant, mock_netis_client
+) -> None:
+    """A valid connection test should create the config entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_HOST: "192.168.1.1", CONF_PASSWORD: "password"},
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Netis 192.168.1.1"
+    assert result["data"] == {CONF_HOST: "192.168.1.1", CONF_PASSWORD: "password"}
+    assert result["result"].unique_id == "192.168.1.1"
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "reason"),
+    [
+        (NetisAuthError("bad creds"), "invalid_auth"),
+        (NetisConnectionError("down"), "cannot_connect"),
+        (NetisError("unexpected"), "unknown"),
+    ],
+)
+async def test_user_step_errors(
+    hass: HomeAssistant,
+    mock_netis_client,
+    side_effect: Exception,
+    reason: str,
+) -> None:
+    """Each API error type should map to its user-facing error key."""
+    mock_netis_client.login.side_effect = side_effect
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_HOST: "192.168.1.1", CONF_PASSWORD: "password"},
+    )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": reason}
+
+
+async def test_user_step_already_configured(
+    hass: HomeAssistant, mock_config_entry, mock_netis_client
+) -> None:
+    """Submitting a host that already has an entry should abort."""
+    mock_config_entry.add_to_hass(hass)
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_HOST: "192.168.1.1", CONF_PASSWORD: "password"},
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_options_flow(
+    hass: HomeAssistant, init_integration
+) -> None:
+    """The options flow should let the user change the polling interval."""
+    entry = init_integration
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        user_input={"scan_interval": 60},
+    )
+    await hass.async_block_till_done()
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert entry.options["scan_interval"] == 60

--- a/tests/components/netis/test_device_tracker.py
+++ b/tests/components/netis/test_device_tracker.py
@@ -1,0 +1,50 @@
+"""Test the Netis Router device_tracker platform.
+
+Devices from the router host list are auto-discovered and tracked as
+ScannerEntity entries: online devices report ``home``, offline ones
+report ``not_home``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+ENTRY_ID = "1"
+
+ONLINE_MAC = "AA:BB:CC:DD:EE:FF"
+WIFI5_MAC = "11:22:33:44:55:66"
+OFFLINE_MAC = "99:88:77:66:55:44"
+
+
+def _entity_id(hass: HomeAssistant, mac: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "device_tracker", DOMAIN, f"{ENTRY_ID}-{mac}"
+    )
+    assert entity_id is not None, f"device_tracker {mac} not registered"
+    return entity_id
+
+
+async def test_wired_device_home(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, ONLINE_MAC)).state == "home"
+
+
+async def test_wifi5_device_home(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, WIFI5_MAC)).state == "home"
+
+
+async def test_offline_device_not_home(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, OFFLINE_MAC)).state == "not_home"
+
+
+async def test_wired_device_attributes(hass: HomeAssistant) -> None:
+    state = hass.states.get(_entity_id(hass, ONLINE_MAC))
+    assert state.attributes["ip_address"] == "192.168.1.100"
+    assert state.attributes["host_name"] == "test-laptop"
+    assert state.attributes["connection"] == "wired"
+    assert state.attributes["down_speed_bps"] == 4096

--- a/tests/components/netis/test_init.py
+++ b/tests/components/netis/test_init.py
@@ -1,0 +1,83 @@
+"""Test the Netis Router integration setup, unload and services."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis import DOMAIN
+from homeassistant.components.netis.api import NetisError
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_setup_entry_loaded(hass: HomeAssistant) -> None:
+    """The integration should reach LOADED state on successful setup."""
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert entry.state is ConfigEntryState.LOADED
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_services_registered(hass: HomeAssistant) -> None:
+    """Both custom services should be registered after setup."""
+    assert hass.services.has_service(DOMAIN, "send_sms")
+    assert hass.services.has_service(DOMAIN, "set_speed_limit")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_send_sms_service_calls_client(
+    hass: HomeAssistant, mock_netis_client
+) -> None:
+    """netis.send_sms should forward arguments to the API client."""
+    await hass.services.async_call(
+        DOMAIN,
+        "send_sms",
+        {"phone": "13800138000", "message": "Hello"},
+        blocking=True,
+    )
+    mock_netis_client.send_sms.assert_awaited_once_with("13800138000", "Hello")
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_set_speed_limit_service_calls_client(
+    hass: HomeAssistant, mock_netis_client
+) -> None:
+    """netis.set_speed_limit should forward mac + speeds to the client."""
+    await hass.services.async_call(
+        DOMAIN,
+        "set_speed_limit",
+        {"mac": "aa:bb:cc:dd:ee:ff", "down_speed": 1024, "up_speed": 512},
+        blocking=True,
+    )
+    mock_netis_client.set_speed_limit.assert_awaited_once_with(
+        "aa:bb:cc:dd:ee:ff", 1024, 512
+    )
+
+
+@pytest.mark.usefixtures("init_integration")
+async def test_unload_entry(hass: HomeAssistant, mock_netis_client) -> None:
+    """Unloading should tear down platforms and remove services."""
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    # Services removed when the last entry is unloaded.
+    assert not hass.services.has_service(DOMAIN, "send_sms")
+    assert not hass.services.has_service(DOMAIN, "set_speed_limit")
+
+
+async def test_setup_retry_on_api_error(
+    hass: HomeAssistant,
+    mock_config_entry,
+    mock_netis_client,
+) -> None:
+    """A failing first refresh should put the entry into SETUP_RETRY.
+
+    Does NOT use ``init_integration`` (which would succeed) — this test
+    drives setup itself with a failing ``gather``.
+    """
+    mock_netis_client.gather.side_effect = NetisError("boom")
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY

--- a/tests/components/netis/test_select.py
+++ b/tests/components/netis/test_select.py
@@ -1,0 +1,41 @@
+"""Test the Netis Router select platform (WiFi transmit power)."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+ENTRY_ID = "1"
+
+
+def _entity_id(hass: HomeAssistant, band: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "select", DOMAIN, f"{ENTRY_ID}-txpower-{band}"
+    )
+    assert entity_id is not None, f"select txpower-{band} not registered"
+    return entity_id
+
+
+async def test_2g_current_option(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "2G")).state == "100"
+
+
+async def test_5g_current_option(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "5G")).state == "50"
+
+
+async def test_set_2g_txpower(hass: HomeAssistant, mock_netis_client) -> None:
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": _entity_id(hass, "2G"), "option": "50"},
+        blocking=True,
+    )
+    mock_netis_client.set_wifi_config.assert_awaited_once_with(
+        "2G", {"TxPower": "50"}
+    )

--- a/tests/components/netis/test_sensor.py
+++ b/tests/components/netis/test_sensor.py
@@ -1,0 +1,82 @@
+"""Test the Netis Router sensor platform.
+
+Verifies sensor entity creation and state values by reading from the
+integration's mocked coordinator snapshot.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+ENTRY_ID = "1"
+
+
+def _entity_id(hass: HomeAssistant, key: str) -> str:
+    """Resolve a sensor entity_id from its unique key."""
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "sensor", DOMAIN, f"{ENTRY_ID}-{key}"
+    )
+    assert entity_id is not None, f"sensor {key} not registered"
+    return entity_id
+
+
+async def test_uptime(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "uptime")).state == "3600"
+
+
+async def test_wan_download_speed(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wan_download_speed")).state == "51200"
+
+
+async def test_wan_upload_speed(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wan_upload_speed")).state == "102400"
+
+
+async def test_wan_download_total(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wan_download_total")).state == "1024000"
+
+
+async def test_wan_upload_total(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wan_upload_total")).state == "2048000"
+
+
+async def test_online_devices(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "online_devices")).state == "2"
+
+
+async def test_lte_rsrp(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_rsrp")).state == "-95.5"
+
+
+async def test_lte_rsrq(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_rsrq")).state == "-12.3"
+
+
+async def test_lte_rssi(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_rssi")).state == "28.0"
+
+
+async def test_lte_mode(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_mode")).state == "LTE"
+
+
+async def test_lte_isp(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_isp")).state == "CHN-CT"
+
+
+async def test_lte_ip(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "lte_ip")).state == "10.99.249.101"
+
+
+async def test_firmware(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "firmware")).state == "4.0.260701.100631"
+
+
+async def test_imei(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "imei")).state == "868245050137472"

--- a/tests/components/netis/test_switch.py
+++ b/tests/components/netis/test_switch.py
@@ -1,0 +1,71 @@
+"""Test the Netis Router switch platform (WiFi + LED toggles)."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.components.netis.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+pytestmark = pytest.mark.usefixtures("init_integration")
+
+ENTRY_ID = "1"
+
+
+def _entity_id(hass: HomeAssistant, suffix: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id(
+        "switch", DOMAIN, f"{ENTRY_ID}-{suffix}"
+    )
+    assert entity_id is not None, f"switch {suffix} not registered"
+    return entity_id
+
+
+async def test_wifi_2g_initial_state(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wifi-2G")).state == "on"
+
+
+async def test_wifi_5g_initial_state(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "wifi-5G")).state == "on"
+
+
+async def test_led_initial_state(hass: HomeAssistant) -> None:
+    assert hass.states.get(_entity_id(hass, "led")).state == "on"
+
+
+async def test_turn_off_wifi_2g(
+    hass: HomeAssistant, mock_netis_client
+) -> None:
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": _entity_id(hass, "wifi-2G")},
+        blocking=True,
+    )
+    mock_netis_client.set_wifi_config.assert_awaited_once_with(
+        "2G", {"Enable": "0"}
+    )
+
+
+async def test_turn_on_wifi_5g(
+    hass: HomeAssistant, mock_netis_client
+) -> None:
+    await hass.services.async_call(
+        "switch",
+        "turn_on",
+        {"entity_id": _entity_id(hass, "wifi-5G")},
+        blocking=True,
+    )
+    mock_netis_client.set_wifi_config.assert_awaited_once_with(
+        "5G", {"Enable": "1"}
+    )
+
+
+async def test_turn_off_led(hass: HomeAssistant, mock_netis_client) -> None:
+    await hass.services.async_call(
+        "switch",
+        "turn_off",
+        {"entity_id": _entity_id(hass, "led")},
+        blocking=True,
+    )
+    mock_netis_client.set_led.assert_awaited_once_with(False)


### PR DESCRIPTION
## Proposed change

Adds a new core integration for **Netis** routers (e.g. MW5630 LTE router).
The integration talks to the router's `ubus` JSON-RPC endpoint over HTTP,
using AES-128-CBC encrypted password authentication.

## Integration details

- **Domain:** `netis`
- **Integration type:** `hub` (router)
- **IoT class:** `local_polling` (default 30 s, configurable 10-300 s)
- **Quality scale:** silver
- **Code owners:** @netis-systems-app

## Supported platforms

- `device_tracker`: connected device presence (wired / 2.4G / 5G / guest)
- `sensor`: WAN up/down speed & totals, online device count, LTE signal (RSRP/RSRQ/RSSI, operator, mode, IP), firmware, IMEI
- `binary_sensor`: WAN online, LTE connected
- `switch`: WiFi 2.4G/5G enable, front-panel indicator LED
- `select`: WiFi transmit power (low/middle/high per band)
- `button`: reboot
- services: `send_sms` (LTE modem), `set_speed_limit` (per-device QoS)
- `config_flow` + diagnostics

## Testing

Unit tests cover the API client (encryption, parsing, type conversion), config flow (success / auth / connection / unknown errors, already configured, options flow), setup/unload/services, and all platform entities.

## Additional information

This is a new integration. Router protocol (ubus JSON-RPC over HTTP with AES-128-CBC password encryption) verified against real MW5630 hardware running firmware 4.0.260701.100631.

## Checklist

- [x] The code change is tested and works locally
- [x] Local tests pass
- [x] There is no commented out code in this PR
- [x] The code has been formatted using Black
- [x] Tests have been added to verify the new behaviour
- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47198
- Link to brand assets pull request: https://github.com/home-assistant/brands/pull/10894

[docs-repository]: https://github.com/home-assistant/home-assistant.io
