### PR TITLE
Fix feedreader events for unsorted feeds

### DIFF
--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -172,13 +172,14 @@ class FeedReaderCoordinator(
         # Check if the entry has a updated or published date.
         # Start from a updated date because generally `updated` > `published`.
         time_stamp = entry.get("updated_parsed") or entry.get("published_parsed")
-        if time_stamp is not None and time_stamp > self._last_entry_timestamp:
-            self._last_entry_timestamp = time_stamp
-        else:
+        if time_stamp is None:
             _LOGGER.debug(
                 "No updated_parsed or published_parsed info available for entry %s",
                 entry,
             )
+        elif time_stamp and time_stamp > self._last_entry_timestamp:
+            self._last_entry_timestamp = time_stamp
+
         entry["feed_url"] = self.url
         self.hass.bus.async_fire(self._event_type, entry)
         _LOGGER.debug("New event fired for entry %s", entry.get("link"))

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -171,7 +171,7 @@ class FeedReaderCoordinator(
         """Update last_entry_timestamp and fire entry."""
         # Check if the entry has a updated or published date.
         # Start from a updated date because generally `updated` > `published`.
-        time_stamp = entry.get("updated_parsed", entry.get("published_parsed"))
+        time_stamp = entry.get("updated_parsed") or entry.get("published_parsed")
         if time_stamp is not None and time_stamp > self._last_entry_timestamp:
             self._last_entry_timestamp = time_stamp
         else:

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -171,7 +171,8 @@ class FeedReaderCoordinator(
         """Update last_entry_timestamp and fire entry."""
         # Check if the entry has a updated or published date.
         # Start from a updated date because generally `updated` > `published`.
-        if time_stamp := entry.get("updated_parsed") or entry.get("published_parsed"):
+        time_stamp = entry.get("updated_parsed", entry.get("published_parsed"))
+        if time_stamp is not None and time_stamp > self._last_entry_timestamp:
             self._last_entry_timestamp = time_stamp
         else:
             _LOGGER.debug(

--- a/tests/components/feedreader/conftest.py
+++ b/tests/components/feedreader/conftest.py
@@ -75,6 +75,18 @@ def fixture_feed_atom_htmlentities(hass: HomeAssistant) -> bytes:
     return load_fixture_bytes("feedreader10.xml", DOMAIN)
 
 
+@pytest.fixture(name="feed_unsorted")
+def fixture_feed_unsorted(hass: HomeAssistant) -> bytes:
+    """Load test ATOM feed data with HTML Entities."""
+    return load_fixture_bytes("feedreader11.xml", DOMAIN)
+
+
+@pytest.fixture(name="feed_unsorted_update")
+def fixture_feed_unsorted_update(hass: HomeAssistant) -> bytes:
+    """Load test ATOM feed data with HTML Entities."""
+    return load_fixture_bytes("feedreader12.xml", DOMAIN)
+
+
 @pytest.fixture(name="events")
 async def fixture_events(hass: HomeAssistant) -> list[Event]:
     """Fixture that catches alexa events."""

--- a/tests/components/feedreader/fixtures/feedreader11.xml
+++ b/tests/components/feedreader/fixtures/feedreader11.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+        <item>
+            <title>Title 3</title>
+            <pubDate>Mon, 30 Apr 2018 15:02:00 +1000</pubDate>
+            <content>Content 3</content>
+        </item>
+        <item>
+            <title>Title 1</title>
+            <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+            <content>Content 1</content>
+        </item>
+        <item>
+            <title>Title 2</title>
+            <pubDate>Mon, 30 Apr 2018 15:01:00 +1000</pubDate>
+            <content>Content 2</content>
+        </item>
+    </channel>
+</rss>

--- a/tests/components/feedreader/fixtures/feedreader12.xml
+++ b/tests/components/feedreader/fixtures/feedreader12.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+    <channel>
+        <title>RSS Sample</title>
+        <description>This is an example of an RSS feed</description>
+        <link>http://www.example.com/main.html</link>
+        <lastBuildDate>Mon, 30 Apr 2018 12:00:00 +1000 </lastBuildDate>
+        <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+        <ttl>1800</ttl>
+        <item>
+            <title>Title 3</title>
+            <pubDate>Mon, 30 Apr 2018 15:02:00 +1000</pubDate>
+            <content>Content 3</content>
+        </item>
+        <item>
+            <title>Title 4</title>
+            <pubDate>Mon, 30 Apr 2018 15:03:00 +1000</pubDate>
+            <content>Content 4</content>
+        </item>
+        <item>
+            <title>Title 1</title>
+            <pubDate>Mon, 30 Apr 2018 15:00:00 +1000</pubDate>
+            <content>Content 1</content>
+        </item>
+        <item>
+            <title>Title 2</title>
+            <pubDate>Mon, 30 Apr 2018 15:01:00 +1000</pubDate>
+            <content>Content 2</content>
+        </item>
+    </channel>
+</rss>

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -237,6 +237,34 @@ async def test_feed_updates(
         assert len(events) == 2
 
 
+async def test_unsorted_feed_updates(
+    hass: HomeAssistant, events, feed_unsorted, feed_unsorted_update
+) -> None:
+    """Test feed updates."""
+    side_effect = [
+        feed_unsorted,
+        feed_unsorted_update,
+    ]
+
+    entry = create_mock_entry(VALID_CONFIG_DEFAULT)
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.feedreader.coordinator.feedparser.http.get",
+        side_effect=side_effect,
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert len(events) == 3
+
+        # Change time and fetch one more onordered entry
+        future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+        assert len(events) == 4
+
+
 async def test_feed_default_max_length(
     hass: HomeAssistant, events, feed_21_events
 ) -> None:

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -257,7 +257,7 @@ async def test_unsorted_feed_updates(
 
         assert len(events) == 3
 
-        # Change time and fetch one more onordered entry
+        # Change time and fetch one more unordered entry
         future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
         async_fire_time_changed(hass, future)
         await hass.async_block_till_done(wait_background_tasks=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
We only store the newest timestamp now, rather than the timestamp of the last processed feed-entry. This ensures that the order of the entries in the feed doesn't matter.

- This may also fix #156863

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
