### PR TITLE
Bump plugwise to v1.14.4

### DIFF
--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -27,9 +27,10 @@ ERROR_NO_SCHEDULE = "set_schedule_first"
 PARALLEL_UPDATES = 0
 
 
-def _check_for_schedule(active: bool, last_active: str) -> None:
+def _check_for_schedule(active: bool, last_active: str | None) -> None:
     """Raise a HAError when no thermostat schedule has been set."""
-    if not active and last_active == STATE_OFF:
+    # last_active can be stored as None from before the plugwise v1.14.3 bump
+    if not active and last_active in (None, STATE_OFF):
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key=ERROR_NO_SCHEDULE,
@@ -107,7 +108,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         self._api = coordinator.api
         gateway_id: str = self._api.gateway_id
         self._gateway_data = coordinator.data[gateway_id]
-        self._last_active_schedule = STATE_OFF
+        self._last_active_schedule: str | None = None
         self._location = device_id
         if (location := self.device.get("location")) is not None:
             self._location = location

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -112,7 +112,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         self._location = device_id
         if (location := self.device.get("location")) is not None:
             self._location = location
-        self._previous_action_mode = HVACAction.HEATING.value
+        self._previous_action_mode = str | None = None
 
         # Determine supported features
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
@@ -144,7 +144,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             plugwise_extra_data = PlugwiseClimateExtraStoredData.from_dict(
                 extra_data.as_dict()
             )
-            self._last_active_schedule = plugwise_extra_data.last_active_schedule
+            self._last_active_schedule = plugwise_extra_data.last_active_schedule or STATE_OFF
             self._previous_action_mode = (
                 plugwise_extra_data.previous_action_mode or HVACAction.HEATING.value
             )

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -294,7 +294,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             await self._api.set_regulation_mode(hvac_mode.value)
             return
 
-        current_schedule = self.device.get("select_schedule")
+        current_schedule = self.device["select_schedule"]
         schedule_is_active = current_schedule != STATE_OFF
         desired_schedule = (
             current_schedule if schedule_is_active else self._last_active_schedule

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -209,7 +209,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         if "regulation_modes" in self._gateway_data:
             hvac_modes.append(HVACMode.OFF)
 
-        if self.device.get("available_schedules"):
+        if (schedules := self.device.get("available_schedules")) and len(schedules) > 1:
             hvac_modes.append(HVACMode.AUTO)
 
         if self._api.cooling_present:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -27,9 +27,9 @@ ERROR_NO_SCHEDULE = "set_schedule_first"
 PARALLEL_UPDATES = 0
 
 
-def _check_for_schedule(active: bool, last_active: str | None) -> None:
+def _check_for_schedule(active: bool, last_active: str) -> None:
     """Raise a HAError when no thermostat schedule has been set."""
-    if not active and last_active is None:
+    if not active and last_active == STATE_OFF:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key=ERROR_NO_SCHEDULE,
@@ -292,7 +292,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             return
 
         current_schedule = self.device.get("select_schedule")
-        schedule_is_active = current_schedule not in (None, "off")
+        schedule_is_active = current_schedule != STATE_OFF
         desired_schedule = (
             current_schedule if schedule_is_active else self._last_active_schedule
         )

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -112,7 +112,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         self._location = device_id
         if (location := self.device.get("location")) is not None:
             self._location = location
-        self._previous_action_mode = str | None = None
+        self._previous_action_mode: str | None = None
 
         # Determine supported features
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
@@ -144,7 +144,9 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
             plugwise_extra_data = PlugwiseClimateExtraStoredData.from_dict(
                 extra_data.as_dict()
             )
-            self._last_active_schedule = plugwise_extra_data.last_active_schedule or STATE_OFF
+            self._last_active_schedule = (
+                plugwise_extra_data.last_active_schedule or STATE_OFF
+            )
             self._previous_action_mode = (
                 plugwise_extra_data.previous_action_mode or HVACAction.HEATING.value
             )

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -107,7 +107,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         self._api = coordinator.api
         gateway_id: str = self._api.gateway_id
         self._gateway_data = coordinator.data[gateway_id]
-        self._last_active_schedule: str | None = None
+        self._last_active_schedule = STATE_OFF
         self._location = device_id
         if (location := self.device.get("location")) is not None:
             self._location = location
@@ -209,7 +209,7 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         if "regulation_modes" in self._gateway_data:
             hvac_modes.append(HVACMode.OFF)
 
-        if (schedules := self.device.get("available_schedules")) and len(schedules) > 1:
+        if self.device["available_schedules"] != [STATE_OFF]:
             hvac_modes.append(HVACMode.AUTO)
 
         if self._api.cooling_present:

--- a/homeassistant/components/plugwise/climate.py
+++ b/homeassistant/components/plugwise/climate.py
@@ -27,10 +27,10 @@ ERROR_NO_SCHEDULE = "set_schedule_first"
 PARALLEL_UPDATES = 0
 
 
-def _check_for_schedule(active: bool, last_active: str | None) -> None:
+def _check_for_schedule(active: bool, last_active: str) -> None:
     """Raise a HAError when no thermostat schedule has been set."""
     # last_active can be stored as None from before the plugwise v1.14.3 bump
-    if not active and last_active in (None, STATE_OFF):
+    if not active and last_active == STATE_OFF:
         raise HomeAssistantError(
             translation_domain=DOMAIN,
             translation_key=ERROR_NO_SCHEDULE,
@@ -108,11 +108,11 @@ class PlugwiseClimateEntity(PlugwiseEntity, ClimateEntity, RestoreEntity):
         self._api = coordinator.api
         gateway_id: str = self._api.gateway_id
         self._gateway_data = coordinator.data[gateway_id]
-        self._last_active_schedule: str | None = None
+        self._last_active_schedule = STATE_OFF
         self._location = device_id
         if (location := self.device.get("location")) is not None:
             self._location = location
-        self._previous_action_mode: str | None = None
+        self._previous_action_mode = HVACAction.HEATING.value
 
         # Determine supported features
         self._attr_supported_features = ClimateEntityFeature.TARGET_TEMPERATURE

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "quality_scale": "platinum",
-  "requirements": ["plugwise==1.14.2"],
+  "requirements": ["plugwise==1.14.3"],
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/homeassistant/components/plugwise/manifest.json
+++ b/homeassistant/components/plugwise/manifest.json
@@ -8,6 +8,6 @@
   "iot_class": "local_polling",
   "loggers": ["plugwise"],
   "quality_scale": "platinum",
-  "requirements": ["plugwise==1.14.3"],
+  "requirements": ["plugwise==1.14.4"],
   "zeroconf": ["_plugwise._tcp.local."]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1869,7 +1869,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.14
 
 # homeassistant.components.plugwise
-plugwise==1.14.2
+plugwise==1.14.3
 
 # homeassistant.components.serial_pm
 pmsensor==0.4

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1869,7 +1869,7 @@ plexauth==0.0.6
 plexwebsocket==0.0.14
 
 # homeassistant.components.plugwise
-plugwise==1.14.3
+plugwise==1.14.4
 
 # homeassistant.components.serial_pm
 pmsensor==0.4

--- a/tests/components/plugwise/fixtures/anna_heatpump_heating/data.json
+++ b/tests/components/plugwise/fixtures/anna_heatpump_heating/data.json
@@ -30,7 +30,10 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "current": 46.3,
@@ -64,7 +67,10 @@
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": ["standaard", "off"],
+    "available_schedules": [
+      "off",
+      "standaard"
+    ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -73,7 +79,13 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+    "preset_modes": [
+      "no_frost",
+      "home",
+      "away",
+      "asleep",
+      "vacation"
+    ],
     "select_schedule": "standaard",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/components/plugwise/fixtures/anna_heatpump_heating/data.json
+++ b/tests/components/plugwise/fixtures/anna_heatpump_heating/data.json
@@ -30,10 +30,7 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "current": 46.3,
@@ -67,10 +64,7 @@
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": [
-      "off",
-      "standaard"
-    ],
+    "available_schedules": ["off", "standaard"],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -79,13 +73,7 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": [
-      "no_frost",
-      "home",
-      "away",
-      "asleep",
-      "vacation"
-    ],
+    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
     "select_schedule": "standaard",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/components/plugwise/fixtures/anna_loria_cooling_active/data.json
+++ b/tests/components/plugwise/fixtures/anna_loria_cooling_active/data.json
@@ -1,11 +1,7 @@
 {
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
-    "available_schedules": [
-      "off",
-      "Winter",
-      "Test "
-    ],
+    "available_schedules": ["off", "Winter", "Test "],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -14,13 +10,7 @@
     "location": "15da035090b847e7a21f93e08c015ebc",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": [
-      "away",
-      "vacation",
-      "no_frost",
-      "home",
-      "asleep"
-    ],
+    "preset_modes": ["away", "vacation", "no_frost", "home", "asleep"],
     "select_schedule": "Winter",
     "sensors": {
       "illuminance": 45.0,
@@ -72,13 +62,7 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
-    "dhw_modes": [
-      "off",
-      "auto",
-      "boost",
-      "eco",
-      "comfort"
-    ],
+    "dhw_modes": ["off", "auto", "boost", "eco", "comfort"],
     "location": "674b657c138a41a291d315d7471deb06",
     "max_dhw_temperature": {
       "current": 52.9,

--- a/tests/components/plugwise/fixtures/anna_loria_cooling_active/data.json
+++ b/tests/components/plugwise/fixtures/anna_loria_cooling_active/data.json
@@ -1,7 +1,11 @@
 {
   "582dfbdace4d4aeb832923ce7d1ddda0": {
     "active_preset": "home",
-    "available_schedules": ["Winter", "Test ", "off"],
+    "available_schedules": [
+      "off",
+      "Winter",
+      "Test "
+    ],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -10,7 +14,13 @@
     "location": "15da035090b847e7a21f93e08c015ebc",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "vacation", "no_frost", "home", "asleep"],
+    "preset_modes": [
+      "away",
+      "vacation",
+      "no_frost",
+      "home",
+      "asleep"
+    ],
     "select_schedule": "Winter",
     "sensors": {
       "illuminance": 45.0,
@@ -62,7 +72,13 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "auto",
-    "dhw_modes": ["off", "auto", "boost", "eco", "comfort"],
+    "dhw_modes": [
+      "off",
+      "auto",
+      "boost",
+      "eco",
+      "comfort"
+    ],
     "location": "674b657c138a41a291d315d7471deb06",
     "max_dhw_temperature": {
       "current": 52.9,

--- a/tests/components/plugwise/fixtures/anna_p1/data.json
+++ b/tests/components/plugwise/fixtures/anna_p1/data.json
@@ -1,10 +1,7 @@
 {
   "1e5e55b958ac445583602f767cb45942": {
     "active_preset": "home",
-    "available_schedules": [
-      "off",
-      "Thermostat schedule"
-    ],
+    "available_schedules": ["off", "Thermostat schedule"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -13,13 +10,7 @@
     "location": "5b13651d79c4454684fd268850b1bff8",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 2.0,
@@ -48,10 +39,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",
     "model_id": "HR24",

--- a/tests/components/plugwise/fixtures/anna_p1/data.json
+++ b/tests/components/plugwise/fixtures/anna_p1/data.json
@@ -1,7 +1,10 @@
 {
   "1e5e55b958ac445583602f767cb45942": {
     "active_preset": "home",
-    "available_schedules": ["Thermostat schedule", "off"],
+    "available_schedules": [
+      "off",
+      "Thermostat schedule"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "thermostat",
@@ -10,7 +13,13 @@
     "location": "5b13651d79c4454684fd268850b1bff8",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 2.0,
@@ -39,7 +48,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "da7be222ab3b420c927f3e49fade0304",
     "model": "Generic heater",
     "model_id": "HR24",

--- a/tests/components/plugwise/fixtures/legacy_anna/data.json
+++ b/tests/components/plugwise/fixtures/legacy_anna/data.json
@@ -36,9 +36,7 @@
   },
   "0d266432d64443e283b5d708ae98b455": {
     "active_preset": "home",
-    "available_schedules": [
-      "off"
-    ],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -47,13 +45,7 @@
     "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": [
-      "away",
-      "vacation",
-      "asleep",
-      "home",
-      "no_frost"
-    ],
+    "preset_modes": ["away", "vacation", "asleep", "home", "no_frost"],
     "select_schedule": "off",
     "sensors": {
       "illuminance": 150.8,

--- a/tests/components/plugwise/fixtures/legacy_anna/data.json
+++ b/tests/components/plugwise/fixtures/legacy_anna/data.json
@@ -36,7 +36,9 @@
   },
   "0d266432d64443e283b5d708ae98b455": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "heating",
     "dev_class": "thermostat",
@@ -45,8 +47,14 @@
     "location": "0000aaaa0000aaaa0000aaaa0000aa00",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["away", "vacation", "asleep", "home", "no_frost"],
-    "select_schedule": null,
+    "preset_modes": [
+      "away",
+      "vacation",
+      "asleep",
+      "home",
+      "no_frost"
+    ],
+    "select_schedule": "off",
     "sensors": {
       "illuminance": 150.8,
       "setpoint": 20.5,

--- a/tests/components/plugwise/fixtures/m_adam_cooling/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_cooling/data.json
@@ -8,10 +8,7 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "maximum_boiler_temperature": {
       "current": 19.0,
@@ -119,11 +116,7 @@
     },
     "dev_class": "gateway",
     "firmware": "3.9.0",
-    "gateway_modes": [
-      "away",
-      "full",
-      "vacation"
-    ],
+    "gateway_modes": ["away", "full", "vacation"],
     "hardware": "AME Smile 2.0 board",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "mac_address": "D40FB201CBA0",
@@ -224,13 +217,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": [
-      "vacation",
-      "no_frost",
-      "asleep",
-      "home",
-      "away"
-    ],
+    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -253,11 +240,7 @@
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
@@ -273,13 +256,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": [
-      "vacation",
-      "no_frost",
-      "asleep",
-      "home",
-      "away"
-    ],
+    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -294,18 +271,10 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": [
-        "e2f4322d57924fa090fbbc48b3a140dc"
-      ],
-      "secondary": [
-        "1772a4ea304041adb83f357b751341ff"
-      ]
+      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
+      "secondary": ["1772a4ea304041adb83f357b751341ff"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   }
 }

--- a/tests/components/plugwise/fixtures/m_adam_cooling/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_cooling/data.json
@@ -8,7 +8,10 @@
       "heating_state": false
     },
     "dev_class": "heater_central",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "maximum_boiler_temperature": {
       "current": 19.0,
@@ -116,7 +119,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.9.0",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "mac_address": "D40FB201CBA0",
@@ -206,18 +213,24 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "cool",
     "control_state": "cooling",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "asleep",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -240,23 +253,33 @@
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "asleep",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -271,10 +294,18 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
-      "secondary": ["1772a4ea304041adb83f357b751341ff"]
+      "primary": [
+        "e2f4322d57924fa090fbbc48b3a140dc"
+      ],
+      "secondary": [
+        "1772a4ea304041adb83f357b751341ff"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   }
 }

--- a/tests/components/plugwise/fixtures/m_adam_heating/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_heating/data.json
@@ -8,10 +8,7 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "max_dhw_temperature": {
       "current": 37.0,
@@ -125,11 +122,7 @@
     },
     "dev_class": "gateway",
     "firmware": "3.9.0",
-    "gateway_modes": [
-      "away",
-      "full",
-      "vacation"
-    ],
+    "gateway_modes": ["away", "full", "vacation"],
     "hardware": "AME Smile 2.0 board",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "mac_address": "D40FB201CBA0",
@@ -137,12 +130,7 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": [
-      "bleeding_cold",
-      "heating",
-      "off",
-      "bleeding_hot"
-    ],
+    "regulation_modes": ["bleeding_cold", "heating", "off", "bleeding_hot"],
     "select_gateway_mode": "full",
     "select_regulation_mode": "heating",
     "sensors": {
@@ -229,13 +217,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": [
-      "vacation",
-      "no_frost",
-      "asleep",
-      "home",
-      "away"
-    ],
+    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -258,11 +240,7 @@
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
@@ -278,13 +256,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": [
-      "vacation",
-      "no_frost",
-      "asleep",
-      "home",
-      "away"
-    ],
+    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -299,18 +271,10 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": [
-        "e2f4322d57924fa090fbbc48b3a140dc"
-      ],
-      "secondary": [
-        "1772a4ea304041adb83f357b751341ff"
-      ]
+      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
+      "secondary": ["1772a4ea304041adb83f357b751341ff"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   }
 }

--- a/tests/components/plugwise/fixtures/m_adam_heating/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_heating/data.json
@@ -8,7 +8,10 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "max_dhw_temperature": {
       "current": 37.0,
@@ -122,7 +125,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.9.0",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "mac_address": "D40FB201CBA0",
@@ -130,7 +137,12 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": ["bleeding_cold", "heating", "off", "bleeding_hot"],
+    "regulation_modes": [
+      "bleeding_cold",
+      "heating",
+      "off",
+      "bleeding_hot"
+    ],
     "select_gateway_mode": "full",
     "select_regulation_mode": "heating",
     "sensors": {
@@ -206,18 +218,24 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "heat",
     "control_state": "preheating",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "asleep",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -240,23 +258,33 @@
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "asleep",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "passive",
     "sensors": {
@@ -271,10 +299,18 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
-      "secondary": ["1772a4ea304041adb83f357b751341ff"]
+      "primary": [
+        "e2f4322d57924fa090fbbc48b3a140dc"
+      ],
+      "secondary": [
+        "1772a4ea304041adb83f357b751341ff"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   }
 }

--- a/tests/components/plugwise/fixtures/m_adam_heating_off_schedule/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_heating_off_schedule/data.json
@@ -8,10 +8,7 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "max_dhw_temperature": {
       "current": 37.0,
@@ -125,11 +122,7 @@
     },
     "dev_class": "gateway",
     "firmware": "3.9.0",
-    "gateway_modes": [
-      "away",
-      "full",
-      "vacation"
-    ],
+    "gateway_modes": ["away", "full", "vacation"],
     "hardware": "AME Smile 2.0 board",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "mac_address": "D40FB201CBA0",
@@ -137,12 +130,7 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": [
-      "bleeding_cold",
-      "heating",
-      "off",
-      "bleeding_hot"
-    ],
+    "regulation_modes": ["bleeding_cold", "heating", "off", "bleeding_hot"],
     "select_gateway_mode": "full",
     "select_regulation_mode": "off",
     "sensors": {
@@ -229,13 +217,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": [
-      "vacation",
-      "no_frost",
-      "asleep",
-      "home",
-      "away"
-    ],
+    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -258,11 +240,7 @@
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
@@ -278,13 +256,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": [
-      "vacation",
-      "no_frost",
-      "asleep",
-      "home",
-      "away"
-    ],
+    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
     "select_schedule": "Badkamer",
     "select_zone_profile": "passive",
     "sensors": {
@@ -299,18 +271,10 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": [
-        "e2f4322d57924fa090fbbc48b3a140dc"
-      ],
-      "secondary": [
-        "1772a4ea304041adb83f357b751341ff"
-      ]
+      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
+      "secondary": ["1772a4ea304041adb83f357b751341ff"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   }
 }

--- a/tests/components/plugwise/fixtures/m_adam_heating_off_schedule/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_heating_off_schedule/data.json
@@ -8,7 +8,10 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "max_dhw_temperature": {
       "current": 37.0,
@@ -122,7 +125,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.9.0",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "bc93488efab249e5bc54fd7e175a6f91",
     "mac_address": "D40FB201CBA0",
@@ -130,7 +137,12 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": ["bleeding_cold", "heating", "off", "bleeding_hot"],
+    "regulation_modes": [
+      "bleeding_cold",
+      "heating",
+      "off",
+      "bleeding_hot"
+    ],
     "select_gateway_mode": "full",
     "select_regulation_mode": "off",
     "sensors": {
@@ -206,18 +218,24 @@
   "f2bf9048bef64cc5b6d5110154e33c81": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "off",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Living room",
-    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "asleep",
+      "home",
+      "away"
+    ],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -240,23 +258,33 @@
       "secondary": []
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "f871b8c4d63549319221e294e4f88074": {
     "active_preset": "vacation",
     "available_schedules": [
+      "off",
       "Badkamer",
       "Vakantie",
       "Weekschema",
-      "Test",
-      "off"
+      "Test"
     ],
     "climate_mode": "off",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bathroom",
-    "preset_modes": ["vacation", "no_frost", "asleep", "home", "away"],
+    "preset_modes": [
+      "vacation",
+      "no_frost",
+      "asleep",
+      "home",
+      "away"
+    ],
     "select_schedule": "Badkamer",
     "select_zone_profile": "passive",
     "sensors": {
@@ -271,10 +299,18 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["e2f4322d57924fa090fbbc48b3a140dc"],
-      "secondary": ["1772a4ea304041adb83f357b751341ff"]
+      "primary": [
+        "e2f4322d57924fa090fbbc48b3a140dc"
+      ],
+      "secondary": [
+        "1772a4ea304041adb83f357b751341ff"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   }
 }

--- a/tests/components/plugwise/fixtures/m_adam_jip/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_jip/data.json
@@ -1,20 +1,12 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
-    "available_schedules": [
-      "off"
-    ],
+    "available_schedules": ["off"],
     "climate_mode": "off",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -27,37 +19,21 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": [
-        "1346fbd8498d4dbcab7e18d51b771f3d"
-      ],
-      "secondary": [
-        "356b65335e274d769c338223e7af9c33"
-      ]
+      "primary": ["1346fbd8498d4dbcab7e18d51b771f3d"],
+      "secondary": ["356b65335e274d769c338223e7af9c33"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
-    "available_schedules": [
-      "off"
-    ],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -70,19 +46,11 @@
       "upper_bound": 30.0
     },
     "thermostats": {
-      "primary": [
-        "f61f1a2535f54f52ad006a3d18e459ca"
-      ],
-      "secondary": [
-        "833de10f269c4deab58fb9df69901b4e"
-      ]
+      "primary": ["f61f1a2535f54f52ad006a3d18e459ca"],
+      "secondary": ["833de10f269c4deab58fb9df69901b4e"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "1346fbd8498d4dbcab7e18d51b771f3d": {
     "available": true,
@@ -257,11 +225,7 @@
     },
     "dev_class": "gateway",
     "firmware": "3.2.8",
-    "gateway_modes": [
-      "away",
-      "full",
-      "vacation"
-    ],
+    "gateway_modes": ["away", "full", "vacation"],
     "hardware": "AME Smile 2.0 board",
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "mac_address": "012345670001",
@@ -269,12 +233,7 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": [
-      "heating",
-      "off",
-      "bleeding_cold",
-      "bleeding_hot"
-    ],
+    "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
     "select_gateway_mode": "full",
     "select_regulation_mode": "heating",
     "sensors": {
@@ -285,21 +244,13 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
-    "available_schedules": [
-      "off"
-    ],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Kinderkamer",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -312,19 +263,11 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": [
-        "6f3e9d7084214c21b9dfa46f6eeb8700"
-      ],
-      "secondary": [
-        "d4496250d0e942cfa7aea3476e9070d5"
-      ]
+      "primary": ["6f3e9d7084214c21b9dfa46f6eeb8700"],
+      "secondary": ["d4496250d0e942cfa7aea3476e9070d5"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "d4496250d0e942cfa7aea3476e9070d5": {
     "available": true,
@@ -352,21 +295,13 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
-    "available_schedules": [
-      "off"
-    ],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Logeerkamer",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
@@ -379,19 +314,11 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": [
-        "a6abc6a129ee499c88a4d420cc413b47"
-      ],
-      "secondary": [
-        "1da4d325838e4ad8aac12177214505c9"
-      ]
+      "primary": ["a6abc6a129ee499c88a4d420cc413b47"],
+      "secondary": ["1da4d325838e4ad8aac12177214505c9"]
     },
     "vendor": "Plugwise",
-    "zone_profiles": [
-      "active",
-      "off",
-      "passive"
-    ]
+    "zone_profiles": ["active", "off", "passive"]
   },
   "e4684553153b44afbef2200885f379dc": {
     "available": true,
@@ -402,10 +329,7 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "max_dhw_temperature": {
       "current": 37.3,

--- a/tests/components/plugwise/fixtures/m_adam_jip/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_jip/data.json
@@ -1,13 +1,21 @@
 {
   "06aecb3d00354375924f50c47af36bd2": {
     "active_preset": "no_frost",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "off",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Slaapkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-    "select_schedule": null,
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 24.2
@@ -19,22 +27,38 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["1346fbd8498d4dbcab7e18d51b771f3d"],
-      "secondary": ["356b65335e274d769c338223e7af9c33"]
+      "primary": [
+        "1346fbd8498d4dbcab7e18d51b771f3d"
+      ],
+      "secondary": [
+        "356b65335e274d769c338223e7af9c33"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "13228dab8ce04617af318a2888b3c548": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-    "select_schedule": null,
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 27.4
@@ -46,11 +70,19 @@
       "upper_bound": 30.0
     },
     "thermostats": {
-      "primary": ["f61f1a2535f54f52ad006a3d18e459ca"],
-      "secondary": ["833de10f269c4deab58fb9df69901b4e"]
+      "primary": [
+        "f61f1a2535f54f52ad006a3d18e459ca"
+      ],
+      "secondary": [
+        "833de10f269c4deab58fb9df69901b4e"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "1346fbd8498d4dbcab7e18d51b771f3d": {
     "available": true,
@@ -225,7 +257,11 @@
     },
     "dev_class": "gateway",
     "firmware": "3.2.8",
-    "gateway_modes": ["away", "full", "vacation"],
+    "gateway_modes": [
+      "away",
+      "full",
+      "vacation"
+    ],
     "hardware": "AME Smile 2.0 board",
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "mac_address": "012345670001",
@@ -233,7 +269,12 @@
     "model_id": "smile_open_therm",
     "name": "Adam",
     "notifications": {},
-    "regulation_modes": ["heating", "off", "bleeding_cold", "bleeding_hot"],
+    "regulation_modes": [
+      "heating",
+      "off",
+      "bleeding_cold",
+      "bleeding_hot"
+    ],
     "select_gateway_mode": "full",
     "select_regulation_mode": "heating",
     "sensors": {
@@ -244,14 +285,22 @@
   },
   "d27aede973b54be484f6842d1b2802ad": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Kinderkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-    "select_schedule": null,
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0
@@ -263,11 +312,19 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["6f3e9d7084214c21b9dfa46f6eeb8700"],
-      "secondary": ["d4496250d0e942cfa7aea3476e9070d5"]
+      "primary": [
+        "6f3e9d7084214c21b9dfa46f6eeb8700"
+      ],
+      "secondary": [
+        "d4496250d0e942cfa7aea3476e9070d5"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "d4496250d0e942cfa7aea3476e9070d5": {
     "available": true,
@@ -295,14 +352,22 @@
   },
   "d58fec52899f4f1c92e4f8fad6d8c48c": {
     "active_preset": "home",
-    "available_schedules": [],
+    "available_schedules": [
+      "off"
+    ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Logeerkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-    "select_schedule": null,
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
+    "select_schedule": "off",
     "select_zone_profile": "active",
     "sensors": {
       "temperature": 30.0
@@ -314,11 +379,19 @@
       "upper_bound": 99.9
     },
     "thermostats": {
-      "primary": ["a6abc6a129ee499c88a4d420cc413b47"],
-      "secondary": ["1da4d325838e4ad8aac12177214505c9"]
+      "primary": [
+        "a6abc6a129ee499c88a4d420cc413b47"
+      ],
+      "secondary": [
+        "1da4d325838e4ad8aac12177214505c9"
+      ]
     },
     "vendor": "Plugwise",
-    "zone_profiles": ["active", "off", "passive"]
+    "zone_profiles": [
+      "active",
+      "off",
+      "passive"
+    ]
   },
   "e4684553153b44afbef2200885f379dc": {
     "available": true,
@@ -329,7 +402,10 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "9e4433a9d69f40b3aefd15e74395eaec",
     "max_dhw_temperature": {
       "current": 37.3,

--- a/tests/components/plugwise/fixtures/m_adam_multiple_devices_per_zone/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_multiple_devices_per_zone/data.json
@@ -35,13 +35,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Badkamer",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "Badkamer Schema",
     "sensors": {
       "temperature": 18.9
@@ -76,13 +70,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bios",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "off",
     "sensors": {
       "electricity_consumed": 0.0,
@@ -96,12 +84,8 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": [
-        "df4a4a8169904cdb9c03d61a21f42140"
-      ],
-      "secondary": [
-        "a2c3583e0a6349358998b760cea82d2a"
-      ]
+      "primary": ["df4a4a8169904cdb9c03d61a21f42140"],
+      "secondary": ["a2c3583e0a6349358998b760cea82d2a"]
     },
     "vendor": "Plugwise"
   },
@@ -134,13 +118,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Garage",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": null,
     "sensors": {
       "temperature": 15.6
@@ -152,9 +130,7 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": [
-        "e7693eb9582644e5b865dba8d4447cf1"
-      ],
+      "primary": ["e7693eb9582644e5b865dba8d4447cf1"],
       "secondary": []
     },
     "vendor": "Plugwise"
@@ -290,13 +266,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Jessie",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "CV Jessie",
     "sensors": {
       "temperature": 17.2
@@ -308,12 +278,8 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": [
-        "6a3bf693d05e48e0b460c815a4fdd09d"
-      ],
-      "secondary": [
-        "d3da73bde12a47d5a6b8f9dad971f2ec"
-      ]
+      "primary": ["6a3bf693d05e48e0b460c815a4fdd09d"],
+      "secondary": ["d3da73bde12a47d5a6b8f9dad971f2ec"]
     },
     "vendor": "Plugwise"
   },
@@ -445,13 +411,7 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": [
-      "home",
-      "asleep",
-      "away",
-      "vacation",
-      "no_frost"
-    ],
+    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
     "select_schedule": "GF7  Woonkamer",
     "sensors": {
       "electricity_consumed": 35.6,
@@ -465,12 +425,8 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": [
-        "b59bcebaf94b499ea7d46e4a66fb62d8"
-      ],
-      "secondary": [
-        "b310b72a0e354bfab43089919b9a88bf"
-      ]
+      "primary": ["b59bcebaf94b499ea7d46e4a66fb62d8"],
+      "secondary": ["b310b72a0e354bfab43089919b9a88bf"]
     },
     "vendor": "Plugwise"
   },

--- a/tests/components/plugwise/fixtures/m_adam_multiple_devices_per_zone/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_multiple_devices_per_zone/data.json
@@ -112,14 +112,14 @@
   },
   "446ac08dd04d4eff8ac57489757b7314": {
     "active_preset": "no_frost",
-    "available_schedules": [],
+    "available_schedules": ["off"],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Garage",
     "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
-    "select_schedule": null,
+    "select_schedule": "off",
     "sensors": {
       "temperature": 15.6
     },

--- a/tests/components/plugwise/fixtures/m_adam_multiple_devices_per_zone/data.json
+++ b/tests/components/plugwise/fixtures/m_adam_multiple_devices_per_zone/data.json
@@ -23,19 +23,25 @@
   "08963fec7c53423ca5680aa4cb502c63": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Badkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "Badkamer Schema",
     "sensors": {
       "temperature": 18.9
@@ -58,19 +64,25 @@
   "12493538af164a409c6a1c79e38afe1c": {
     "active_preset": "away",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "heat",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Bios",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "off",
     "sensors": {
       "electricity_consumed": 0.0,
@@ -84,8 +96,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["df4a4a8169904cdb9c03d61a21f42140"],
-      "secondary": ["a2c3583e0a6349358998b760cea82d2a"]
+      "primary": [
+        "df4a4a8169904cdb9c03d61a21f42140"
+      ],
+      "secondary": [
+        "a2c3583e0a6349358998b760cea82d2a"
+      ]
     },
     "vendor": "Plugwise"
   },
@@ -118,7 +134,13 @@
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Garage",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": null,
     "sensors": {
       "temperature": 15.6
@@ -130,7 +152,9 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["e7693eb9582644e5b865dba8d4447cf1"],
+      "primary": [
+        "e7693eb9582644e5b865dba8d4447cf1"
+      ],
       "secondary": []
     },
     "vendor": "Plugwise"
@@ -254,19 +278,25 @@
   "82fa13f017d240daa0d0ea1775420f24": {
     "active_preset": "asleep",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "idle",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Jessie",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "CV Jessie",
     "sensors": {
       "temperature": 17.2
@@ -278,8 +308,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["6a3bf693d05e48e0b460c815a4fdd09d"],
-      "secondary": ["d3da73bde12a47d5a6b8f9dad971f2ec"]
+      "primary": [
+        "6a3bf693d05e48e0b460c815a4fdd09d"
+      ],
+      "secondary": [
+        "d3da73bde12a47d5a6b8f9dad971f2ec"
+      ]
     },
     "vendor": "Plugwise"
   },
@@ -399,19 +433,25 @@
   "c50f167537524366a5af7aa3942feb1e": {
     "active_preset": "home",
     "available_schedules": [
+      "off",
       "CV Roan",
       "Bios Schema met Film Avond",
       "GF7  Woonkamer",
       "Badkamer Schema",
-      "CV Jessie",
-      "off"
+      "CV Jessie"
     ],
     "climate_mode": "auto",
     "control_state": "heating",
     "dev_class": "climate",
     "model": "ThermoZone",
     "name": "Woonkamer",
-    "preset_modes": ["home", "asleep", "away", "vacation", "no_frost"],
+    "preset_modes": [
+      "home",
+      "asleep",
+      "away",
+      "vacation",
+      "no_frost"
+    ],
     "select_schedule": "GF7  Woonkamer",
     "sensors": {
       "electricity_consumed": 35.6,
@@ -425,8 +465,12 @@
       "upper_bound": 100.0
     },
     "thermostats": {
-      "primary": ["b59bcebaf94b499ea7d46e4a66fb62d8"],
-      "secondary": ["b310b72a0e354bfab43089919b9a88bf"]
+      "primary": [
+        "b59bcebaf94b499ea7d46e4a66fb62d8"
+      ],
+      "secondary": [
+        "b310b72a0e354bfab43089919b9a88bf"
+      ]
     },
     "vendor": "Plugwise"
   },

--- a/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/data.json
+++ b/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/data.json
@@ -30,10 +30,7 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": [
-      "comfort",
-      "eco"
-    ],
+    "dhw_modes": ["comfort", "eco"],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "current": 41.5,
@@ -67,10 +64,7 @@
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": [
-      "off",
-      "standaard"
-    ],
+    "available_schedules": ["off", "standaard"],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -79,13 +73,7 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": [
-      "no_frost",
-      "home",
-      "away",
-      "asleep",
-      "vacation"
-    ],
+    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
     "select_schedule": "standaard",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/data.json
+++ b/tests/components/plugwise/fixtures/m_anna_heatpump_cooling/data.json
@@ -30,7 +30,10 @@
     },
     "dev_class": "heater_central",
     "dhw_mode": "eco",
-    "dhw_modes": ["comfort", "eco"],
+    "dhw_modes": [
+      "comfort",
+      "eco"
+    ],
     "location": "a57efe5f145f498c9be62a9b63626fbf",
     "max_dhw_temperature": {
       "current": 41.5,
@@ -64,7 +67,10 @@
   },
   "3cb70739631c4d17a86b8b12e8a5161b": {
     "active_preset": "home",
-    "available_schedules": ["standaard", "off"],
+    "available_schedules": [
+      "off",
+      "standaard"
+    ],
     "climate_mode": "auto",
     "control_state": "cooling",
     "dev_class": "thermostat",
@@ -73,7 +79,13 @@
     "location": "c784ee9fdab44e1395b8dee7d7a497d5",
     "model": "ThermoTouch",
     "name": "Anna",
-    "preset_modes": ["no_frost", "home", "away", "asleep", "vacation"],
+    "preset_modes": [
+      "no_frost",
+      "home",
+      "away",
+      "asleep",
+      "vacation"
+    ],
     "select_schedule": "standaard",
     "sensors": {
       "cooling_activation_outdoor_temperature": 21.0,

--- a/tests/components/plugwise/snapshots/test_diagnostics.ambr
+++ b/tests/components/plugwise/snapshots/test_diagnostics.ambr
@@ -25,12 +25,12 @@
     '08963fec7c53423ca5680aa4cb502c63': dict({
       'active_preset': 'away',
       'available_schedules': list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
       'climate_mode': 'auto',
       'control_state': 'idle',
@@ -67,12 +67,12 @@
     '12493538af164a409c6a1c79e38afe1c': dict({
       'active_preset': 'away',
       'available_schedules': list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
       'climate_mode': 'heat',
       'control_state': 'idle',
@@ -283,12 +283,12 @@
     '82fa13f017d240daa0d0ea1775420f24': dict({
       'active_preset': 'asleep',
       'available_schedules': list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
       'climate_mode': 'auto',
       'control_state': 'idle',
@@ -438,12 +438,12 @@
     'c50f167537524366a5af7aa3942feb1e': dict({
       'active_preset': 'home',
       'available_schedules': list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
       'climate_mode': 'auto',
       'control_state': 'heating',

--- a/tests/components/plugwise/snapshots/test_diagnostics.ambr
+++ b/tests/components/plugwise/snapshots/test_diagnostics.ambr
@@ -132,6 +132,7 @@
     '446ac08dd04d4eff8ac57489757b7314': dict({
       'active_preset': 'no_frost',
       'available_schedules': list([
+        'off',
       ]),
       'climate_mode': 'heat',
       'control_state': 'idle',
@@ -145,7 +146,7 @@
         'vacation',
         'no_frost',
       ]),
-      'select_schedule': None,
+      'select_schedule': 'off',
       'sensors': dict({
         'temperature': 15.6,
       }),

--- a/tests/components/plugwise/snapshots/test_select.ambr
+++ b/tests/components/plugwise/snapshots/test_select.ambr
@@ -133,11 +133,11 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'Badkamer',
         'Vakantie',
         'Weekschema',
         'Test',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -175,11 +175,11 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bathroom Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'Badkamer',
         'Vakantie',
         'Weekschema',
         'Test',
-        'off',
       ]),
     }),
     'context': <ANY>,
@@ -259,11 +259,11 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'Badkamer',
         'Vakantie',
         'Weekschema',
         'Test',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -301,11 +301,11 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Living room Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'Badkamer',
         'Vakantie',
         'Weekschema',
         'Test',
-        'off',
       ]),
     }),
     'context': <ANY>,
@@ -385,12 +385,12 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -428,12 +428,12 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Badkamer Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'context': <ANY>,
@@ -452,12 +452,12 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -495,12 +495,12 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Bios Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'context': <ANY>,
@@ -519,12 +519,12 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -562,12 +562,12 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Jessie Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'context': <ANY>,
@@ -586,12 +586,12 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -629,12 +629,12 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Woonkamer Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'CV Roan',
         'Bios Schema met Film Avond',
         'GF7  Woonkamer',
         'Badkamer Schema',
         'CV Jessie',
-        'off',
       ]),
     }),
     'context': <ANY>,
@@ -653,9 +653,9 @@
     'area_id': None,
     'capabilities': dict({
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'Winter',
         'Test ',
-        'off',
       ]),
     }),
     'config_entry_id': <ANY>,
@@ -693,9 +693,9 @@
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Anna Thermostat schedule',
       <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
         'Winter',
         'Test ',
-        'off',
       ]),
     }),
     'context': <ANY>,

--- a/tests/components/plugwise/snapshots/test_select.ambr
+++ b/tests/components/plugwise/snapshots/test_select.ambr
@@ -511,6 +511,63 @@
     'state': 'off',
   })
 # ---
+# name: test_adam_select_entities[platforms0][select.garage_thermostat_schedule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
+      ]),
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'select',
+    'entity_category': None,
+    'entity_id': 'select.garage_thermostat_schedule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Thermostat schedule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Thermostat schedule',
+    'platform': 'plugwise',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'select_schedule',
+    'unique_id': '446ac08dd04d4eff8ac57489757b7314-select_schedule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_adam_select_entities[platforms0][select.garage_thermostat_schedule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'Garage Thermostat schedule',
+      <SelectEntityCapabilityAttribute.OPTIONS: 'options'>: list([
+        'off',
+      ]),
+    }),
+    'context': <ANY>,
+    'entity_id': 'select.garage_thermostat_schedule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'off',
+  })
+# ---
 # name: test_adam_select_entities[platforms0][select.jessie_thermostat_schedule-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -169,7 +169,7 @@ async def test_adam_restore_state_climate(
             (
                 State("climate.living_room", "heat"),
                 PlugwiseClimateExtraStoredData(
-                    last_active_schedule=None,
+                    last_active_schedule="off",
                     previous_action_mode="heating",
                 ).as_dict(),
             ),
@@ -191,7 +191,7 @@ async def test_adam_restore_state_climate(
     assert state.state == "heat"
 
     # Verify a HomeAssistantError is raised setting a schedule
-    # with last_active_schedule = None
+    # with last_active_schedule = "off" and not schedules defined
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -300,7 +300,7 @@ async def test_adam_off_regulation_mode_change(
             (
                 State("climate.living_room", "heat"),
                 PlugwiseClimateExtraStoredData(
-                    last_active_schedule=None,
+                    last_active_schedule="off",
                     previous_action_mode="heating",
                 ).as_dict(),
             ),
@@ -321,7 +321,8 @@ async def test_adam_off_regulation_mode_change(
     assert (state := hass.states.get("climate.living_room"))
     assert state.state == "off"
 
-    # Verify a HomeAssistantError is raised setting a schedule from regulation-off-mode with last_active_schedule = None
+    # Verify a HomeAssistantError is raised setting a schedule from regulation-off-mode
+    # with last_active_schedule = "off" and no schedule defined
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -377,13 +377,16 @@ async def test_adam_off_regulation_mode_change(
 
 @pytest.mark.parametrize("chosen_env", ["m_adam_cooling"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
-async def test_adam_4_climate_entity_attributes(
+async def test_adam_climate_entity_attributes(
     hass: HomeAssistant,
     mock_smile_adam_heat_cool: MagicMock,
     mock_config_entry: MockConfigEntry,
     freezer: FrozenDateTimeFactory,
 ) -> None:
-    """Test creation of adam climate device environment."""
+    """Test creation of adam climate device environment.
+
+    Restored data is according to the plugwise v1.14.3 updated format.
+    """
     mock_restore_cache_with_extra_data(
         hass,
         [

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -190,12 +190,14 @@ async def test_adam_restore_state_climate(
     assert (state := hass.states.get("climate.living_room"))
     assert state.state == "heat"
 
-    await hass.services.async_call(
-        CLIMATE_DOMAIN,
-        SERVICE_SET_HVAC_MODE,
-        {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.AUTO},
-        blocking=True,
-    )
+    # Verify a HomeAssistantError is raised setting a schedule with last_active_schedule == "off"
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.AUTO},
+            blocking=True,
+        )
 
     data = mock_smile_adam_heat_cool.async_update.return_value
     data["f2bf9048bef64cc5b6d5110154e33c81"]["climate_mode"] = "off"
@@ -243,7 +245,7 @@ async def test_adam_restore_state_climate(
             "Badkamer",
             STATE_ON,
         )
-        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
+        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 1
 
     data = mock_smile_adam_heat_cool.async_update.return_value
     data["f871b8c4d63549319221e294e4f88074"]["climate_mode"] = "heat"
@@ -263,7 +265,7 @@ async def test_adam_restore_state_climate(
             {ATTR_ENTITY_ID: "climate.bathroom", ATTR_HVAC_MODE: HVACMode.AUTO},
             blocking=True,
         )
-        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 3
+        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
 
 
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -289,7 +289,6 @@ async def test_adam_none_restore(
     hass: HomeAssistant,
     mock_smile_adam_heat_cool: MagicMock,
     mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test last_active_schedule restored as None from before the plugwise v1.14.3 bump."""
     mock_restore_cache_with_extra_data(
@@ -333,7 +332,6 @@ async def test_adam_off_regulation_mode_change(
     hass: HomeAssistant,
     mock_smile_adam_heat_cool: MagicMock,
     mock_config_entry: MockConfigEntry,
-    freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test changing from regulation off mode."""
     mock_restore_cache_with_extra_data(

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -282,7 +282,6 @@ async def test_adam_2_climate_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
-
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating_off_schedule"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -315,14 +314,14 @@ async def test_adam_none_restore(
 
     mock_config_entry.add_to_hass(hass)
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
-    await hass.async_block_till_done()  
+    await hass.async_block_till_done()
 
     # Verify that setting a schedule with last_active_schedule=None fails
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
-            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.HEAT},
+            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.AUTO},
             blocking=True,
         )
 

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -190,15 +190,12 @@ async def test_adam_restore_state_climate(
     assert (state := hass.states.get("climate.living_room"))
     assert state.state == "heat"
 
-    # Verify a HomeAssistantError is raised setting a schedule
-    # with last_active_schedule = "off" and not schedules defined
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_HVAC_MODE,
-            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.AUTO},
-            blocking=True,
-        )
+    await hass.services.async_call(
+        CLIMATE_DOMAIN,
+        SERVICE_SET_HVAC_MODE,
+        {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.AUTO},
+        blocking=True,
+    )
 
     data = mock_smile_adam_heat_cool.async_update.return_value
     data["f2bf9048bef64cc5b6d5110154e33c81"]["climate_mode"] = "off"
@@ -233,7 +230,7 @@ async def test_adam_restore_state_climate(
         assert (state := hass.states.get("climate.bathroom"))
         assert state.state == "heat"
 
-        # Verify restoration is used when setting the schedule, schedule == "off"
+        # Verify restoration is used when setting the schedule, from "off"
         await hass.services.async_call(
             CLIMATE_DOMAIN,
             SERVICE_SET_HVAC_MODE,
@@ -246,7 +243,7 @@ async def test_adam_restore_state_climate(
             "Badkamer",
             STATE_ON,
         )
-        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 1
+        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
 
     data = mock_smile_adam_heat_cool.async_update.return_value
     data["f871b8c4d63549319221e294e4f88074"]["climate_mode"] = "heat"
@@ -266,7 +263,7 @@ async def test_adam_restore_state_climate(
             {ATTR_ENTITY_ID: "climate.bathroom", ATTR_HVAC_MODE: HVACMode.AUTO},
             blocking=True,
         )
-        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 2
+        assert mock_smile_adam_heat_cool.set_schedule_state.call_count == 3
 
 
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating"], indirect=True)
@@ -320,16 +317,6 @@ async def test_adam_off_regulation_mode_change(
 
     assert (state := hass.states.get("climate.living_room"))
     assert state.state == "off"
-
-    # Verify a HomeAssistantError is raised setting a schedule from regulation-off-mode
-    # with last_active_schedule = "off" and no schedule defined
-    with pytest.raises(HomeAssistantError):
-        await hass.services.async_call(
-            CLIMATE_DOMAIN,
-            SERVICE_SET_HVAC_MODE,
-            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.AUTO},
-            blocking=True,
-        )
 
     # Verify that the active schedule is turned off when transitioning from regulation-off-mode to a manual mode
     await hass.services.async_call(
@@ -711,3 +698,18 @@ async def test_tom_without_temperature_measurement(
     assert (state := hass.states.get("climate.bathroom")) is not None
     assert state.state != STATE_UNAVAILABLE
     assert state.attributes[ATTR_CURRENT_TEMPERATURE] is None
+
+
+async def test_legacy_anna_no_schedule(
+    hass: HomeAssistant,
+    mock_smile_legacy_anna: MagicMock,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test failing to set a schedule with no schedule defined."""
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: "climate.anna", ATTR_HVAC_MODE: HVACMode.AUTO},
+            blocking=True,
+        )

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -190,7 +190,6 @@ async def test_adam_restore_state_climate(
     assert (state := hass.states.get("climate.living_room"))
     assert state.state == "heat"
 
-    # Verify a HomeAssistantError is raised setting a schedule with last_active_schedule == "off"
     with pytest.raises(HomeAssistantError):
         await hass.services.async_call(
             CLIMATE_DOMAIN,
@@ -283,6 +282,51 @@ async def test_adam_2_climate_snapshot(
     await snapshot_platform(hass, entity_registry, snapshot, setup_platform.entry_id)
 
 
+
+@pytest.mark.parametrize("chosen_env", ["m_adam_heating_off_schedule"], indirect=True)
+@pytest.mark.parametrize("cooling_present", [False], indirect=True)
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_adam_none_restore(
+    hass: HomeAssistant,
+    mock_smile_adam_heat_cool: MagicMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test last_active_schedule restored as None from before the plugwise v1.14.3 bump."""
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State("climate.living_room", "heat"),
+                PlugwiseClimateExtraStoredData(
+                    last_active_schedule=None,
+                    previous_action_mode="heating",
+                ).as_dict(),
+            ),
+            (
+                State("climate.bathroom", "heat"),
+                PlugwiseClimateExtraStoredData(
+                    last_active_schedule="Badkamer",
+                    previous_action_mode="heating",
+                ).as_dict(),
+            ),
+        ],
+    )
+
+    mock_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()  
+
+    # Verify that setting a schedule with last_active_schedule=None fails
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            CLIMATE_DOMAIN,
+            SERVICE_SET_HVAC_MODE,
+            {ATTR_ENTITY_ID: "climate.living_room", ATTR_HVAC_MODE: HVACMode.HEAT},
+            blocking=True,
+        )
+
+
 @pytest.mark.parametrize("chosen_env", ["m_adam_heating_off_schedule"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [False], indirect=True)
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
@@ -336,7 +380,7 @@ async def test_adam_off_regulation_mode_change(
 
 @pytest.mark.parametrize("chosen_env", ["m_adam_cooling"], indirect=True)
 @pytest.mark.parametrize("cooling_present", [True], indirect=True)
-async def test_adam_3_climate_entity_attributes(
+async def test_adam_4_climate_entity_attributes(
     hass: HomeAssistant,
     mock_smile_adam_heat_cool: MagicMock,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/plugwise/test_climate.py
+++ b/tests/components/plugwise/test_climate.py
@@ -652,8 +652,8 @@ async def test_anna_climate_entity_climate_changes(
 
     # Mock user deleting last schedule from app or browser
     data = mock_smile_anna.async_update.return_value
-    data["3cb70739631c4d17a86b8b12e8a5161b"]["available_schedules"] = []
-    data["3cb70739631c4d17a86b8b12e8a5161b"]["select_schedule"] = None
+    data["3cb70739631c4d17a86b8b12e8a5161b"]["available_schedules"] = ["off"]
+    data["3cb70739631c4d17a86b8b12e8a5161b"]["select_schedule"] = "off"
     data["3cb70739631c4d17a86b8b12e8a5161b"]["climate_mode"] = "heat_cool"
     with patch(HA_PLUGWISE_SMILE_ASYNC_UPDATE, return_value=data):
         freezer.tick(timedelta(minutes=1))

--- a/tests/components/plugwise/test_select.py
+++ b/tests/components/plugwise/test_select.py
@@ -153,7 +153,7 @@ async def test_legacy_anna_select_entities(
     mock_smile_legacy_anna: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
-    """Test "off" to be the selected option for legacy Anna without schedule."""
+    """Test that "off" is the selected option for legacy Anna without schedule."""
     assert (state := hass.states.get("select.anna_thermostat_schedule"))
     assert state.state == "off"
 

--- a/tests/components/plugwise/test_select.py
+++ b/tests/components/plugwise/test_select.py
@@ -153,7 +153,7 @@ async def test_legacy_anna_select_entities(
     mock_smile_legacy_anna: MagicMock,
     init_integration: MockConfigEntry,
 ) -> None:
-    """Test no select-entity for legacy Anna without schedule."""
+    """Test "off" to be the selected option for legacy Anna without schedule."""
     assert (state := hass.states.get("select.anna_thermostat_schedule"))
     assert state.state == "off"
 

--- a/tests/components/plugwise/test_select.py
+++ b/tests/components/plugwise/test_select.py
@@ -154,7 +154,8 @@ async def test_legacy_anna_select_entities(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test no select-entity for legacy Anna without schedule."""
-    assert not hass.states.get("select.anna_thermostat_schedule")
+    assert (state := hass.states.get("select.anna_thermostat_schedule"))
+    assert state.state == "off"
 
 
 @pytest.mark.parametrize("chosen_env", ["anna_heatpump_heating"], indirect=True)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update plugwise to v1.14.4

This update changes the output for thermostat schedules; when no schedule has been defined the backend library outputs a single `"off"` option instead of `null`. This enables live detection of any changes, like creating a new/first or adding an extra thermostat schedule, the user might perform in the future.

https://github.com/plugwise/python-plugwise/releases/tag/v1.14.3
https://github.com/plugwise/python-plugwise/releases/tag/v1.14.4

https://github.com/plugwise/python-plugwise/compare/v1.14.2...v1.14.3
https://github.com/plugwise/python-plugwise/compare/v1.14.3...v1.14.4

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47204
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
