### PR TITLE
Update integrations to call async_remove_device (part 1)

### DIFF
--- a/homeassistant/components/alexa_devices/coordinator.py
+++ b/homeassistant/components/alexa_devices/coordinator.py
@@ -240,10 +240,7 @@ class AmazonDevicesCoordinator(DataUpdateCoordinator[dict[str, AmazonDevice]]):
                 (DOMAIN, serial_num), self.config_entry.entry_id
             )
             if device:
-                device_registry.async_update_device(
-                    device_id=device.id,
-                    remove_config_entry_id=self.config_entry.entry_id,
-                )
+                device_registry.async_remove_device(device.id)
 
     async def _async_remove_routine_stale(
         self,

--- a/homeassistant/components/aqvify/coordinator.py
+++ b/homeassistant/components/aqvify/coordinator.py
@@ -131,10 +131,7 @@ class AqvifyCoordinator(DataUpdateCoordinator[AqvifyCoordinatorData]):
                     self.config_entry.entry_id,
                 )
                 if device:
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
         self.previous_devices = current_devices
 
         device_data = {}

--- a/homeassistant/components/bosch_shc/entity.py
+++ b/homeassistant/components/bosch_shc/entity.py
@@ -21,7 +21,7 @@ async def async_remove_devices(
         (DOMAIN, entity.device_id), entry_id
     )
     if device is not None:
-        dev_registry.async_update_device(device.id, remove_config_entry_id=entry_id)
+        dev_registry.async_remove_device(device.id)
 
 
 class SHCBaseEntity(Entity):

--- a/homeassistant/components/comelit/coordinator.py
+++ b/homeassistant/components/comelit/coordinator.py
@@ -153,10 +153,7 @@ class ComelitBaseCoordinator(DataUpdateCoordinator[T]):
                     (DOMAIN, identifier), self.config_entry.entry_id
                 )
                 if device:
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
 
 
 class ComelitSerialBridge(ComelitBaseCoordinator[T]):

--- a/homeassistant/components/comelit/utils.py
+++ b/homeassistant/components/comelit/utils.py
@@ -68,13 +68,13 @@ async def cleanup_stale_entity(
             identifiers.append(f"{config_entry.entry_id}-{device.type}-{device.index}")
 
     if len(identifiers) > 0:
-        _async_remove_state_config_entry_from_devices(hass, identifiers, config_entry)
+        _async_remove_stale_devices(hass, identifiers, config_entry)
 
 
-def _async_remove_state_config_entry_from_devices(
+def _async_remove_stale_devices(
     hass: HomeAssistant, identifiers: list[str], config_entry: ConfigEntry
 ) -> None:
-    """Remove config entry from device."""
+    """Remove stale devices."""
 
     device_registry = dr.async_get(hass)
     for identifier in identifiers:
@@ -82,15 +82,8 @@ def _async_remove_state_config_entry_from_devices(
             (DOMAIN, identifier), config_entry.entry_id
         )
         if device:
-            LOGGER.info(
-                "Removing config entry %s from device %s",
-                config_entry.title,
-                device.name,
-            )
-            device_registry.async_update_device(
-                device_id=device.id,
-                remove_config_entry_id=config_entry.entry_id,
-            )
+            LOGGER.info("Removing device %s", device.name)
+            device_registry.async_remove_device(device.id)
 
 
 def bridge_api_call[_T: ComelitBridgeBaseEntity, **_P](

--- a/homeassistant/components/duco/sensor.py
+++ b/homeassistant/components/duco/sensor.py
@@ -262,10 +262,7 @@ async def async_setup_entry(
                     (DOMAIN, f"{mac}_{node_id}"), entry.entry_id
                 )
                 if device:
-                    device_reg.async_update_device(
-                        device.id,
-                        remove_config_entry_id=entry.entry_id,
-                    )
+                    device_reg.async_remove_device(device.id)
             known_nodes.difference_update(stale_node_ids)
             known_box_sensors.difference_update(
                 {

--- a/homeassistant/components/freshr/coordinator.py
+++ b/homeassistant/components/freshr/coordinator.py
@@ -88,10 +88,7 @@ class FreshrDevicesCoordinator(DataUpdateCoordinator[dict[str, DeviceSummary]]):
                     if device := device_registry.async_get_device_by_identifier(
                         (DOMAIN, device_id), self.config_entry.entry_id
                     ):
-                        device_registry.async_update_device(
-                            device.id,
-                            remove_config_entry_id=self.config_entry.entry_id,
-                        )
+                        device_registry.async_remove_device(device.id)
 
         return current
 

--- a/homeassistant/components/fyta/coordinator.py
+++ b/homeassistant/components/fyta/coordinator.py
@@ -101,10 +101,7 @@ class FytaCoordinator(DataUpdateCoordinator[dict[int, Plant]]):
                     (DOMAIN, f"{self.config_entry.entry_id}-{plant_id}"),
                     self.config_entry.entry_id,
                 ):
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
                     _LOGGER.debug("Device removed from device registry: %s", device.id)
 
         # add new devices

--- a/homeassistant/components/home_connect/coordinator.py
+++ b/homeassistant/components/home_connect/coordinator.py
@@ -368,10 +368,7 @@ class HomeConnectApplianceCoordinator(DataUpdateCoordinator[HomeConnectAppliance
                     (DOMAIN, self.data.info.ha_id), self._config_entry.entry_id
                 )
                 if device:
-                    self.device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self._config_entry.entry_id,
-                    )
+                    self.device_registry.async_remove_device(device.id)
                 for (
                     listener,
                     context,

--- a/homeassistant/components/homee/__init__.py
+++ b/homeassistant/components/homee/__init__.py
@@ -117,10 +117,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: HomeeConfigEntry) -> boo
         )
         if device:
             _LOGGER.info("Removing device %s", device.name)
-            device_registry.async_update_device(
-                device_id=device.id,
-                remove_config_entry_id=entry.entry_id,
-            )
+            device_registry.async_remove_device(device.id)
 
     homee.add_nodes_listener(_remove_node_callback)
 

--- a/homeassistant/components/hue/v1/helpers.py
+++ b/homeassistant/components/hue/v1/helpers.py
@@ -25,9 +25,7 @@ async def remove_devices(bridge, api_ids, current):
             (DOMAIN, entity.device_id), bridge.config_entry.entry_id
         )
         if device is not None:
-            dev_registry.async_update_device(
-                device.id, remove_config_entry_id=bridge.config_entry.entry_id
-            )
+            dev_registry.async_remove_device(device.id)
 
     for item_id in removed_items:
         del current[item_id]

--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -234,10 +234,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
                     (DOMAIN, mower_id), self.config_entry.entry_id
                 )
                 if dev is not None:
-                    device_registry.async_update_device(
-                        device_id=dev.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(dev.id)
 
         new_devices = current_devices - registered_devices
         if new_devices:

--- a/homeassistant/components/imou/coordinator.py
+++ b/homeassistant/components/imou/coordinator.py
@@ -152,10 +152,7 @@ class ImouDataUpdateCoordinator(DataUpdateCoordinator[None]):
                 if device := device_registry.async_get_device_by_identifier(
                     (DOMAIN, device_key), self.config_entry.entry_id
                 ):
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
 
         if new_keys := current_keys - known_keys:
             _LOGGER.debug("New Imou device(s) found: %s", ", ".join(new_keys))

--- a/homeassistant/components/libre_hardware_monitor/coordinator.py
+++ b/homeassistant/components/libre_hardware_monitor/coordinator.py
@@ -136,9 +136,6 @@ class LibreHardwareMonitorCoordinator(DataUpdateCoordinator[LibreHardwareMonitor
                     _LOGGER.debug(
                         "Removing device: %s", self._previous_devices[device_id]
                     )
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self._entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
 
         self._previous_devices = detected_devices


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update integrations to call `async_remove_device` instead of passing `remove_config_entry_id` to `async_update_device`

This PR migrates trivial cases where the device to be mutated has been looked up with `async_get_device_by_identifier` or `async_get_device_by_connection`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
