### PR TITLE
Update integrations to call async_remove_device (part 2)

### DIFF
--- a/homeassistant/components/litterrobot/coordinator.py
+++ b/homeassistant/components/litterrobot/coordinator.py
@@ -85,10 +85,7 @@ class LitterRobotDataUpdateCoordinator(DataUpdateCoordinator[None]):
                     (DOMAIN, device_id), self.config_entry.entry_id
                 )
                 if device:
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
         self.previous_members = current_members
 
     @override

--- a/homeassistant/components/music_assistant/__init__.py
+++ b/homeassistant/components/music_assistant/__init__.py
@@ -183,9 +183,7 @@ async def async_setup_entry(  # noqa: C901
         if hass_device := dev_reg.async_get_device_by_identifier(
             (DOMAIN, player_id), entry.entry_id
         ):
-            dev_reg.async_update_device(
-                hass_device.id, remove_config_entry_id=entry.entry_id
-            )
+            dev_reg.async_remove_device(hass_device.id)
 
     # register listener for new players
     def handle_player_added(event: MassEvent) -> None:

--- a/homeassistant/components/ondilo_ico/coordinator.py
+++ b/homeassistant/components/ondilo_ico/coordinator.py
@@ -98,10 +98,7 @@ class OndiloIcoPoolsCoordinator(DataUpdateCoordinator[dict[str, OndiloIcoPoolDat
                 self.config_entry.entry_id,
             )
             if device_entry:
-                self._device_registry.async_update_device(
-                    device_id=device_entry.id,
-                    remove_config_entry_id=self.config_entry.entry_id,
-                )
+                self._device_registry.async_remove_device(device_entry.id)
 
         for pool_id in current_pools:
             pool_data = data[pool_id]

--- a/homeassistant/components/overkiz/coordinator.py
+++ b/homeassistant/components/overkiz/coordinator.py
@@ -216,11 +216,7 @@ async def on_device_removed(
     if registered_device := registry.async_get_device_by_identifier(
         (DOMAIN, base_device_url), coordinator.config_entry.entry_id
     ):
-        # Detach only this entry; the registry deletes the device once none remain.
-        registry.async_update_device(
-            registered_device.id,
-            remove_config_entry_id=coordinator.config_entry.entry_id,
-        )
+        registry.async_remove_device(registered_device.id)
 
     if event.device_url in coordinator.devices:
         del coordinator.devices[event.device_url]

--- a/homeassistant/components/plugwise/coordinator.py
+++ b/homeassistant/components/plugwise/coordinator.py
@@ -165,9 +165,7 @@ class PlugwiseDataUpdateCoordinator(DataUpdateCoordinator[dict[str, GwEntityData
                     (DOMAIN, device_id), self.config_entry.entry_id
                 )
             ) is not None:
-                device_reg.async_update_device(
-                    device_entry.id, remove_config_entry_id=self.config_entry.entry_id
-                )
+                device_reg.async_remove_device(device_entry.id)
                 LOGGER.debug(
                     "%s %s %s removed from device_registry",
                     DOMAIN,

--- a/homeassistant/components/sensibo/coordinator.py
+++ b/homeassistant/components/sensibo/coordinator.py
@@ -114,10 +114,7 @@ class SensiboDataUpdateCoordinator(DataUpdateCoordinator[SensiboData]):
                     (DOMAIN, _id), self.config_entry.entry_id
                 )
                 if device:
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
         self.previous_devices = current_devices
 
         return data

--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -248,9 +248,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: SmartThingsConfigEntry) 
             (DOMAIN, device_id), entry.entry_id
         )
         if dev_entry is not None:
-            device_registry.async_update_device(
-                dev_entry.id, remove_config_entry_id=entry.entry_id
-            )
+            device_registry.async_remove_device(dev_entry.id)
 
     entry.async_on_unload(
         client.add_device_lifecycle_event_listener(

--- a/homeassistant/components/solarlog/coordinator.py
+++ b/homeassistant/components/solarlog/coordinator.py
@@ -201,10 +201,7 @@ class SolarLogDeviceDataCoordinator(DataUpdateCoordinator[dict[int, InverterData
                     ),
                     self.config_entry.entry_id,
                 ):
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
                     _LOGGER.info("Device removed from device registry: %s", device.id)
 
         # add new devices

--- a/homeassistant/components/tasmota/__init__.py
+++ b/homeassistant/components/tasmota/__init__.py
@@ -122,9 +122,7 @@ async def _remove_device(
         return
 
     _LOGGER.debug("Removing tasmota from device %s", mac)
-    device_registry.async_update_device(
-        device.id, remove_config_entry_id=config_entry.entry_id
-    )
+    device_registry.async_remove_device(device.id)
 
 
 def _update_device(

--- a/homeassistant/components/tedee/coordinator.py
+++ b/homeassistant/components/tedee/coordinator.py
@@ -151,10 +151,7 @@ class TedeeApiCoordinator(DataUpdateCoordinator[dict[int, TedeeLock]]):
                 if device := device_registry.async_get_device_by_identifier(
                     (DOMAIN, str(lock_id)), self.config_entry.entry_id
                 ):
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
 
         # add new locks
         if new_locks := current_locks - self._locks_last_update:

--- a/homeassistant/components/tplink/coordinator.py
+++ b/homeassistant/components/tplink/coordinator.py
@@ -110,10 +110,7 @@ class TPLinkDataUpdateCoordinator(DataUpdateCoordinator[None]):
                     (DOMAIN, device_id), self.config_entry.entry_id
                 )
                 if device:
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
                 child_coordinator = self._child_coordinators.pop(device_id, None)
                 if child_coordinator:
                     await child_coordinator.async_shutdown()

--- a/homeassistant/components/trmnl/coordinator.py
+++ b/homeassistant/components/trmnl/coordinator.py
@@ -62,8 +62,5 @@ class TRMNLCoordinator(DataUpdateCoordinator[dict[int, Device]]):
                 if entry := device_registry.async_get_device_by_identifier(
                     (DOMAIN, str(device_id)), self.config_entry.entry_id
                 ):
-                    device_registry.async_update_device(
-                        device_id=entry.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(entry.id)
         return new_data

--- a/homeassistant/components/uptimerobot/coordinator.py
+++ b/homeassistant/components/uptimerobot/coordinator.py
@@ -72,9 +72,6 @@ class UptimeRobotDataUpdateCoordinator(
                 if device := device_registry.async_get_device_by_identifier(
                     (DOMAIN, str(monitor_id)), self.config_entry.entry_id
                 ):
-                    device_registry.async_update_device(
-                        device_id=device.id,
-                        remove_config_entry_id=self.config_entry.entry_id,
-                    )
+                    device_registry.async_remove_device(device.id)
 
         return new_monitors

--- a/homeassistant/components/watts/coordinator.py
+++ b/homeassistant/components/watts/coordinator.py
@@ -152,10 +152,7 @@ class WattsVisionHubCoordinator(DataUpdateCoordinator[dict[str, Device]]):
                 (DOMAIN, device_id), self.config_entry.entry_id
             )
             if device:
-                device_registry.async_update_device(
-                    device_id=device.id,
-                    remove_config_entry_id=self.config_entry.entry_id,
-                )
+                device_registry.async_remove_device(device.id)
 
     @property
     def device_ids(self) -> list[str]:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Update integrations to call `async_remove_device` instead of passing `remove_config_entry_id` to `async_update_device`

This PR migrates trivial cases where the device to be mutated has been looked up with `async_get_device_by_identifier` or `async_get_device_by_connection`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
