### PR TITLE
Migrate insteon to lookup devices scoped to config entry

### DIFF
--- a/homeassistant/components/insteon/api/aldb.py
+++ b/homeassistant/components/insteon/api/aldb.py
@@ -12,6 +12,7 @@ from homeassistant.helpers import device_registry as dr
 
 from ..const import DEVICE_ADDRESS, ID, INSTEON_DEVICE_NOT_FOUND, TYPE
 from ..utils import async_device_name
+from .config import get_insteon_config_entry
 from .device import notify_device_not_found
 
 ALDB_RECORD = "record"
@@ -32,7 +33,7 @@ ALDB_RECORD_SCHEMA = vol.Schema(
 )
 
 
-async def async_aldb_record_to_dict(dev_registry, record, dirty=False):
+async def async_aldb_record_to_dict(dev_registry, record, config_entry_id, dirty=False):
     """Convert an ALDB record to a dict."""
     return ALDB_RECORD_SCHEMA(
         {
@@ -42,7 +43,9 @@ async def async_aldb_record_to_dict(dev_registry, record, dirty=False):
             "highwater": record.is_high_water_mark,
             "group": record.group,
             "target": str(record.target),
-            "target_name": await async_device_name(dev_registry, record.target),
+            "target_name": await async_device_name(
+                dev_registry, record.target, config_entry_id
+            ),
             "data1": record.data1,
             "data2": record.data2,
             "data3": record.data3,
@@ -88,10 +91,11 @@ async def websocket_get_aldb(
     changed_records = list(device.aldb.pending_changes.keys())
 
     dev_registry = dr.async_get(hass)
+    config_entry_id = get_insteon_config_entry(hass).entry_id
 
     records = [
         await async_aldb_record_to_dict(
-            dev_registry, aldb[mem_addr], mem_addr in changed_records
+            dev_registry, aldb[mem_addr], config_entry_id, mem_addr in changed_records
         )
         for mem_addr in aldb
     ]

--- a/homeassistant/components/insteon/api/config.py
+++ b/homeassistant/components/insteon/api/config.py
@@ -137,12 +137,16 @@ def remove_device_override(hass: HomeAssistant, address: Address):
 
 
 async def async_link_to_dict(
-    address: Address, record: ALDBRecord, dev_registry: dr.DeviceRegistry, status=None
+    address: Address,
+    record: ALDBRecord,
+    dev_registry: dr.DeviceRegistry,
+    config_entry_id: str,
+    status=None,
 ) -> dict[str, str | int]:
     """Convert a link to a dictionary."""
     link_dict: dict[str, str | int] = {}
-    device_name = await async_device_name(dev_registry, address)
-    target_name = await async_device_name(dev_registry, record.target)
+    device_name = await async_device_name(dev_registry, address, config_entry_id)
+    target_name = await async_device_name(dev_registry, record.target, config_entry_id)
     link_dict["address"] = str(address)
     link_dict["device_name"] = device_name or str(address)
     link_dict["mem_addr"] = record.mem_addr
@@ -311,8 +315,9 @@ async def websocket_get_broken_links(
     """Get any broken links between devices."""
     broken_links = get_broken_links(devices=devices)
     dev_registry = dr.async_get(hass)
+    config_entry_id = get_insteon_config_entry(hass).entry_id
     broken_links_list = [
-        await async_link_to_dict(address, record, dev_registry, status)
+        await async_link_to_dict(address, record, dev_registry, config_entry_id, status)
         for address, record, status in broken_links
         if status != LinkStatus.MISSING_TARGET
     ]

--- a/homeassistant/components/insteon/services.py
+++ b/homeassistant/components/insteon/services.py
@@ -217,7 +217,10 @@ def async_setup_services(hass: HomeAssistant) -> None:  # noqa: C901
         signal = f"{address.id}_{SIGNAL_REMOVE_ENTITY}"
         async_dispatcher_send(hass, signal)
         dev_registry = dr.async_get(hass)
-        device = dev_registry.async_get_device(identifiers={(DOMAIN, str(address))})
+        config_entry = hass.config_entries.async_entries(DOMAIN)[0]
+        device = dev_registry.async_get_device_by_identifier(
+            (DOMAIN, str(address)), config_entry.entry_id
+        )
         if device:
             dev_registry.async_remove_device(device.id)
 

--- a/homeassistant/components/insteon/utils.py
+++ b/homeassistant/components/insteon/utils.py
@@ -190,9 +190,13 @@ def compute_device_name(ha_device) -> str:
     return ha_device.name_by_user or ha_device.name
 
 
-async def async_device_name(dev_registry: dr.DeviceRegistry, address: Address) -> str:
+async def async_device_name(
+    dev_registry: dr.DeviceRegistry, address: Address, config_entry_id: str
+) -> str:
     """Get the Insteon device name from a device registry id."""
-    ha_device = dev_registry.async_get_device(identifiers={(DOMAIN, str(address))})
+    ha_device = dev_registry.async_get_device_by_identifier(
+        (DOMAIN, str(address)), config_entry_id
+    )
     if not ha_device:
         if device := devices[address]:
             return f"{device.description} ({device.model})"

--- a/tests/components/insteon/test_api_aldb.py
+++ b/tests/components/insteon/test_api_aldb.py
@@ -20,11 +20,13 @@ from homeassistant.components.insteon.api.aldb import (
     TYPE,
 )
 from homeassistant.components.insteon.api.device import INSTEON_DEVICE_NOT_FOUND
+from homeassistant.components.insteon.const import DOMAIN
 from homeassistant.core import HomeAssistant
 
+from .const import MOCK_USER_INPUT_PLM
 from .mock_devices import MockDevices
 
-from tests.common import load_fixture
+from tests.common import MockConfigEntry, load_fixture
 from tests.typing import MockHAClientWebSocket, WebSocketGenerator
 
 
@@ -38,6 +40,13 @@ async def _setup(
     hass: HomeAssistant, hass_ws_client: WebSocketGenerator, aldb_data: dict[str, Any]
 ) -> tuple[MockHAClientWebSocket, MockDevices]:
     """Set up tests."""
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        entry_id="abcde12345",
+        data=MOCK_USER_INPUT_PLM,
+        options={},
+    )
+    config_entry.add_to_hass(hass)
     ws_client = await hass_ws_client(hass)
     devices = MockDevices()
     await devices.async_load()

--- a/tests/components/insteon/test_api_device.py
+++ b/tests/components/insteon/test_api_device.py
@@ -125,10 +125,28 @@ async def test_get_ha_device_name(
     _, devices, _, device_reg = await async_mock_setup(hass, hass_ws_client)
     config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
 
+    # Register a colliding device sharing the same identifier but owned by a second
+    # config entry. The lookup must be scoped to the supplied config entry: an
+    # unscoped lookup could return either device, so returning the correct name for
+    # each config entry proves the config entry controls the lookup.
+    other_config_entry = MockConfigEntry(domain=DOMAIN, data=MOCK_USER_INPUT_PLM)
+    other_config_entry.add_to_hass(hass)
+    device_reg.async_get_or_create(
+        config_entry_id=other_config_entry.entry_id,
+        identifiers={(DOMAIN, "11.11.11")},
+        name="Device 11.11.11 second entry",
+    )
+
     with patch.object(insteon.api.device, "devices", devices):
-        # Test a real HA and Insteon device
+        # The scoped lookup returns the device owned by the supplied config entry
         name = await async_device_name(device_reg, "11.11.11", config_entry_id)
         assert name == "Device 11.11.11"
+
+        # The same identifier scoped to the second config entry returns its device
+        name = await async_device_name(
+            device_reg, "11.11.11", other_config_entry.entry_id
+        )
+        assert name == "Device 11.11.11 second entry"
 
         # Test no HA or Insteon device
         name = await async_device_name(device_reg, "BB.BB.BB", config_entry_id)

--- a/tests/components/insteon/test_api_device.py
+++ b/tests/components/insteon/test_api_device.py
@@ -123,14 +123,15 @@ async def test_get_ha_device_name(
     """Test getting the HA device name from an Insteon address."""
 
     _, devices, _, device_reg = await async_mock_setup(hass, hass_ws_client)
+    config_entry_id = hass.config_entries.async_entries(DOMAIN)[0].entry_id
 
     with patch.object(insteon.api.device, "devices", devices):
         # Test a real HA and Insteon device
-        name = await async_device_name(device_reg, "11.11.11")
+        name = await async_device_name(device_reg, "11.11.11", config_entry_id)
         assert name == "Device 11.11.11"
 
         # Test no HA or Insteon device
-        name = await async_device_name(device_reg, "BB.BB.BB")
+        name = await async_device_name(device_reg, "BB.BB.BB", config_entry_id)
         assert name == ""
 
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate `insteon` to lookup devices scoped to its own config entry by calling `async_get_device_by_identifier` instead of `async_get_device`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
