### PR TITLE
Keep a WiiM device available when a command fails

### DIFF
--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -95,7 +95,6 @@ def media_player_exception_wrap[
         try:
             result = await func(self, *args, **kwargs)
         except (WiimDeviceException, WiimRequestException, WiimException) as err:
-            await self._async_handle_critical_error(err)
             raise HomeAssistantError(
                 translation_domain=DOMAIN,
                 translation_key="command_failed",

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -4,7 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from wiim.consts import PlayingStatus
-from wiim.exceptions import WiimRequestException
+from wiim.exceptions import WiimDeviceException, WiimRequestException
 from wiim.models import (
     WiimGroupRole,
     WiimGroupSnapshot,
@@ -54,7 +54,7 @@ from homeassistant.components.media_player import (
 )
 import homeassistant.components.wiim as wiim_component
 from homeassistant.components.wiim.const import DOMAIN
-from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST
+from homeassistant.const import ATTR_ENTITY_ID, CONF_HOST, STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
@@ -321,6 +321,28 @@ async def test_command_error_uses_translation(
         "command": "async_media_play",
         "entity_id": MEDIA_PLAYER_ENTITY_ID,
     }
+
+
+async def test_command_error_keeps_device_available(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    mock_wiim_controller: MagicMock,
+) -> None:
+    """Test a rejected command does not mark the device unavailable."""
+    await setup_integration(hass, mock_config_entry)
+    mock_wiim_device.async_pause.side_effect = WiimDeviceException("not allowed")
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_MEDIA_PAUSE,
+            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+            blocking=True,
+        )
+
+    mock_wiim_device.set_available.assert_not_called()
+    assert hass.states.get(MEDIA_PLAYER_ENTITY_ID).state != STATE_UNAVAILABLE
 
 
 async def test_repeat_and_shuffle_services_update_state_machine(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

A rejected command marked the WiiM device unavailable. Every SDK error raised by a service call was treated as a lost connection, including a device refusing an action it cannot perform in its current state — pausing while stopped, for example, which the device answers with a UPnP error.

Nothing reliably undid it. Availability is restored by the library's polling loop, which skips a cycle whenever a UPnP event arrived within the poll interval, so a device with healthy eventing keeps starving the only path back and the entity stays `unavailable` until the config entry is reloaded. Observed on a WiiM Pro: a `media_play_pause` press while the device was stopped left the entity `unavailable` indefinitely, while the device kept answering its HTTP API normally.

This lets the library own availability. It already marks a device unavailable from its own polling when the device really is unreachable, and that path is unchanged; a single failed command no longer does it. The command still raises a translated `HomeAssistantError`, so the failure is still surfaced to the user.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
