### PR TITLE
Fix entity_description type on EcovacsButtonEntity

### DIFF
--- a/homeassistant/components/ecovacs/button.py
+++ b/homeassistant/components/ecovacs/button.py
@@ -115,7 +115,7 @@ class EcovacsButtonEntity(
 ):
     """Ecovacs button entity."""
 
-    entity_description: EcovacsLifespanButtonEntityDescription
+    entity_description: EcovacsButtonEntityDescription
 
     @override
     async def async_press(self) -> None:


### PR DESCRIPTION
## Proposed change

`EcovacsButtonEntity` declares `entity_description: EcovacsLifespanButtonEntityDescription`, but it never uses that description. It reads `self._capability` and calls `execute()`; the lifespan-specific `component: LifeSpan` field belongs to `EcovacsResetLifespanButtonEntity`.

The two sibling classes each annotate their own description type:

```python
class EcovacsButtonEntity(...):
    entity_description: EcovacsLifespanButtonEntityDescription      # <- this PR

class EcovacsResetLifespanButtonEntity(...):
    entity_description: EcovacsLifespanButtonEntityDescription      # correct

class EcovacsStationActionButtonEntity(...):
    entity_description: EcovacsStationActionButtonEntityDescription # correct
```

so this looks like a copy-paste slip from the class below it.

The annotation has no runtime effect, which is presumably why it has gone unnoticed. It does mislead type checkers and anyone reading the class to understand what a plain button description needs.

One line, no behaviour change.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information

Found while working on a custom integration derived from this component. No linked issue.

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/