### PR TITLE
Migrate knocki dhcp flow to call async_get_devices

### DIFF
--- a/homeassistant/components/knocki/config_flow.py
+++ b/homeassistant/components/knocki/config_flow.py
@@ -70,11 +70,11 @@ class KnockiConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> ConfigFlowResult:
         """Handle a DHCP discovery."""
         device_registry = dr.async_get(self.hass)
-        if device_entry := device_registry.async_get_device(
+        for device in device_registry.async_get_devices(
             identifiers={(DOMAIN, discovery_info.hostname)}
         ):
             device_registry.async_update_device(
-                device_entry.id,
+                device.id,
                 new_connections={
                     (dr.CONNECTION_NETWORK_MAC, discovery_info.macaddress)
                 },

--- a/tests/components/knocki/test_config_flow.py
+++ b/tests/components/knocki/test_config_flow.py
@@ -17,9 +17,12 @@ from . import setup_integration
 
 from tests.common import MockConfigEntry
 
+DEVICE_ID = "KNC1-W-00000214"
+FORMATTED_MAC = "aa:bb:cc:dd:ee:ff"
+
 DHCP_DISCOVERY = DhcpServiceInfo(
     ip="1.1.1.1",
-    hostname="KNC1-W-00000214",
+    hostname=DEVICE_ID,
     macaddress="aabbccddeeff",
 )
 
@@ -166,6 +169,56 @@ async def test_dhcp_mac(
     device = device_registry.async_get_device(identifiers={(DOMAIN, "KNC1-W-00000214")})
     assert device
     assert device.connections == {(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:dd:ee:ff")}
+
+
+async def test_dhcp_mac_multiple_entries(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the DHCP discovery updates the mac on every matching device.
+
+    Two config entries each own a device sharing the discovered identifier. The
+    migration to async_get_devices must update both devices; the deprecated
+    async_get_device would only have resolved to a single one.
+    """
+    mock_config_entry.add_to_hass(hass)
+    second_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Knocki 2",
+        unique_id="test-id-2",
+        data={CONF_TOKEN: "test-token"},
+    )
+    second_config_entry.add_to_hass(hass)
+
+    device_1 = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, DEVICE_ID)},
+    )
+    device_2 = device_registry.async_get_or_create(
+        config_entry_id=second_config_entry.entry_id,
+        identifiers={(DOMAIN, DEVICE_ID)},
+    )
+    assert device_1.id != device_2.id
+    assert device_1.connections == set()
+    assert device_2.connections == set()
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_DHCP}, data=DHCP_DISCOVERY
+    )
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+    device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+    )
+    device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), second_config_entry.entry_id
+    )
+    assert device_1
+    assert device_2
+    assert device_1.connections == {(dr.CONNECTION_NETWORK_MAC, FORMATTED_MAC)}
+    assert device_2.connections == {(dr.CONNECTION_NETWORK_MAC, FORMATTED_MAC)}
 
 
 async def test_dhcp_already_setup(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate `knocki` dhcp flow to call `async_get_devices` instead of the deprecated `async_get_device`

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
