### PR TITLE
Fix duplicate coordinator creation in SwitchBot Cloud

### DIFF
--- a/homeassistant/components/switchbot_cloud/__init__.py
+++ b/homeassistant/components/switchbot_cloud/__init__.py
@@ -93,10 +93,12 @@ async def coordinator_for_device(
     manageable_by_webhook: bool = False,
 ) -> SwitchBotCoordinator:
     """Instantiate coordinator and adds to list for gathering."""
-    coordinator = coordinators_by_id.setdefault(
-        device.device_id,
-        SwitchBotCoordinator(hass, entry, api, device, manageable_by_webhook),
-    )
+    coordinator = coordinators_by_id.get(device.device_id)
+    if coordinator is None:
+        coordinator = SwitchBotCoordinator(
+            hass, entry, api, device, manageable_by_webhook
+        )
+        coordinators_by_id[device.device_id] = coordinator
 
     if coordinator.data is None:
         await coordinator.async_config_entry_first_refresh()

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -750,14 +750,7 @@ async def test_remove_entry_with_cloud_unavailable(
 async def test_single_coordinator_for_multi_platform_device(
     hass: HomeAssistant, mock_list_devices: AsyncMock, mock_get_status: AsyncMock
 ) -> None:
-    """Test a device matching multiple platforms creates only one coordinator.
-
-    A Relay Switch 1PM matches both the switch and sensor platform branches,
-    each of which requests a coordinator. Only one coordinator may be
-    constructed per device: every constructed coordinator registers an unload
-    callback on the config entry, so a discarded duplicate would stay
-    registered (and retained) until the entry is unloaded.
-    """
+    """Test that a multi-platform device creates only one coordinator."""
     mock_list_devices.return_value = [
         Device(
             version="V1.0",

--- a/tests/components/switchbot_cloud/test_init.py
+++ b/tests/components/switchbot_cloud/test_init.py
@@ -1,6 +1,6 @@
 """Tests for the SwitchBot Cloud integration init."""
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -20,6 +20,7 @@ from homeassistant.components.switchbot_cloud.const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
 )
+from homeassistant.components.switchbot_cloud.coordinator import SwitchBotCoordinator
 from homeassistant.components.webhook import DOMAIN as WEBHOOK_DOMAIN
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import (
@@ -744,3 +745,35 @@ async def test_remove_entry_with_cloud_unavailable(
         await hass.async_block_till_done()
 
         assert not hass.config_entries.async_entries("switchbot_cloud")
+
+
+async def test_single_coordinator_for_multi_platform_device(
+    hass: HomeAssistant, mock_list_devices: AsyncMock, mock_get_status: AsyncMock
+) -> None:
+    """Test a device matching multiple platforms creates only one coordinator.
+
+    A Relay Switch 1PM matches both the switch and sensor platform branches,
+    each of which requests a coordinator. Only one coordinator may be
+    constructed per device: every constructed coordinator registers an unload
+    callback on the config entry, so a discarded duplicate would stay
+    registered (and retained) until the entry is unloaded.
+    """
+    mock_list_devices.return_value = [
+        Device(
+            version="V1.0",
+            deviceId="relay-switch-pm-id-1",
+            deviceName="relay-switch-pm-1",
+            deviceType="Relay Switch 1PM",
+            hubDeviceId="test-hub-id",
+        ),
+    ]
+    mock_get_status.return_value = {"switchStatus": 0}
+
+    with patch(
+        "homeassistant.components.switchbot_cloud.SwitchBotCoordinator",
+        wraps=SwitchBotCoordinator,
+    ) as coordinator_cls:
+        entry = await configure_integration(hass)
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert coordinator_cls.call_count == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
`coordinator_for_device()` eagerly constructs a `SwitchBotCoordinator` as the default argument to `dict.setdefault()`. Python evaluates that default before `setdefault()` checks the key, so a second call for the same device constructs a duplicate coordinator that is immediately discarded.

The platform branches in `make_device_data()` are not mutually exclusive, so a single device can request a coordinator more than once: a Relay Switch 1PM matches both the switch and sensor branches, and a Plug Mini matches the `startswith("Plug")` and plug sensor branches. Each duplicate call constructs and discards a coordinator.

The discarded duplicate is not simply wasted construction: `DataUpdateCoordinator.__init__()` registers `config_entry.async_on_unload(self.async_shutdown)`, so every duplicate stays referenced by the entry's unload callbacks until the entry is unloaded, and also has `async_shutdown()` invoked on it at unload despite never having served any data.

This change constructs the coordinator only when the device id is not already registered. First-call-wins behavior for `manageable_by_webhook` is unchanged (the previous `setdefault()` also kept the first-constructed coordinator when call sites disagreed on the flag).

The regression test sets up a Relay Switch 1PM (a device matching two platform branches), and asserts that exactly one coordinator is constructed. Without the fix it fails with `assert 2 == 1`.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request:

I was not able to find any issues referencing this bug. I discovered this bug while testing a prototype lint rule for eagerly-constructed, but discarded `setdefault()` defaults over a local clone of this repo; I then started digging deeper and manually traced the coordinator lifecycle registration.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
