### PR TITLE
Fix Philips TV state without powerstate endpoint

### DIFF
--- a/homeassistant/components/philips_js/const.py
+++ b/homeassistant/components/philips_js/const.py
@@ -7,4 +7,7 @@ CONF_ALLOW_NOTIFY = "allow_notify"
 CONST_APP_ID = "homeassistant.io"
 CONST_APP_NAME = "Home Assistant"
 
+TV_STATE_OFF = "Off"
+TV_STATE_ON = "On"
+
 TRIGGER_TYPE_TURN_ON = "turn_on"

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.trigger import PluggableAction
 
 from . import LOGGER as _LOGGER
+from .const import TV_STATE_OFF
 from .coordinator import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
 from .helpers import async_get_turn_on_trigger
@@ -458,14 +459,10 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
     @callback
     def _update_from_coordinator(self):
         if self._tv.on:
-            if self._tv.powerstate in ("Standby", "StandbyKeep"):
+            if self._tv.powerstate in ("Standby", "StandbyKeep") or (
+                self._tv.powerstate is None and self._tv.screenstate == TV_STATE_OFF
+            ):
                 self._attr_state = MediaPlayerState.OFF
-            elif self._tv.powerstate is None and self._tv.screenstate is not None:
-                self._attr_state = (
-                    MediaPlayerState.ON
-                    if self._tv.screenstate == "On"
-                    else MediaPlayerState.OFF
-                )
             else:
                 self._attr_state = MediaPlayerState.ON
         else:

--- a/homeassistant/components/philips_js/media_player.py
+++ b/homeassistant/components/philips_js/media_player.py
@@ -460,6 +460,12 @@ class PhilipsTVMediaPlayer(PhilipsJsEntity, MediaPlayerEntity):
         if self._tv.on:
             if self._tv.powerstate in ("Standby", "StandbyKeep"):
                 self._attr_state = MediaPlayerState.OFF
+            elif self._tv.powerstate is None and self._tv.screenstate is not None:
+                self._attr_state = (
+                    MediaPlayerState.ON
+                    if self._tv.screenstate == "On"
+                    else MediaPlayerState.OFF
+                )
             else:
                 self._attr_state = MediaPlayerState.ON
         else:

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -6,11 +6,9 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import TV_STATE_OFF, TV_STATE_ON
 from .coordinator import PhilipsTVConfigEntry, PhilipsTVDataUpdateCoordinator
 from .entity import PhilipsJsEntity
-
-HUE_POWER_OFF = "Off"
-HUE_POWER_ON = "On"
 
 
 async def async_setup_entry(
@@ -50,23 +48,23 @@ class PhilipsTVScreenSwitch(PhilipsJsEntity, SwitchEntity):
             return False
         if not self.coordinator.api.on:
             return False
-        return self.coordinator.api.powerstate in ("On", None)
+        return self.coordinator.api.powerstate in (TV_STATE_ON, None)
 
     @property
     @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        return self.coordinator.api.screenstate == "On"
+        return self.coordinator.api.screenstate == TV_STATE_ON
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self.coordinator.api.setScreenState("On")
+        await self.coordinator.api.setScreenState(TV_STATE_ON)
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.coordinator.api.setScreenState("Off")
+        await self.coordinator.api.setScreenState(TV_STATE_OFF)
 
 
 class PhilipsTVAmbilightHueSwitch(PhilipsJsEntity, SwitchEntity):
@@ -92,22 +90,22 @@ class PhilipsTVAmbilightHueSwitch(PhilipsJsEntity, SwitchEntity):
             return False
         if not self.coordinator.api.on:
             return False
-        return self.coordinator.api.powerstate in ("On", None)
+        return self.coordinator.api.powerstate in (TV_STATE_ON, None)
 
     @property
     @override
     def is_on(self) -> bool:
         """Return True if entity is on."""
-        return self.coordinator.api.huelamp_power == HUE_POWER_ON
+        return self.coordinator.api.huelamp_power == TV_STATE_ON
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the entity on."""
-        await self.coordinator.api.setHueLampPower(HUE_POWER_ON)
+        await self.coordinator.api.setHueLampPower(TV_STATE_ON)
         self.async_write_ha_state()
 
     @override
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the entity off."""
-        await self.coordinator.api.setHueLampPower(HUE_POWER_OFF)
+        await self.coordinator.api.setHueLampPower(TV_STATE_OFF)
         self.async_write_ha_state()

--- a/homeassistant/components/philips_js/switch.py
+++ b/homeassistant/components/philips_js/switch.py
@@ -50,7 +50,7 @@ class PhilipsTVScreenSwitch(PhilipsJsEntity, SwitchEntity):
             return False
         if not self.coordinator.api.on:
             return False
-        return self.coordinator.api.powerstate == "On"
+        return self.coordinator.api.powerstate in ("On", None)
 
     @property
     @override
@@ -92,7 +92,7 @@ class PhilipsTVAmbilightHueSwitch(PhilipsJsEntity, SwitchEntity):
             return False
         if not self.coordinator.api.on:
             return False
-        return self.coordinator.api.powerstate == "On"
+        return self.coordinator.api.powerstate in ("On", None)
 
     @property
     @override

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -47,7 +47,6 @@ def mock_tv():
     tv.powerstate = None
     tv.screenstate = None
     tv.source_id = None
-    tv.huelamp_power = None
     tv.ambilight_current_configuration = None
     tv.ambilight_styles = {}
     tv.ambilight_cached = {}

--- a/tests/components/philips_js/conftest.py
+++ b/tests/components/philips_js/conftest.py
@@ -45,7 +45,9 @@ def mock_tv():
     tv.notify_change_supported = False
     tv.pairing_type = None
     tv.powerstate = None
+    tv.screenstate = None
     tv.source_id = None
+    tv.huelamp_power = None
     tv.ambilight_current_configuration = None
     tv.ambilight_styles = {}
     tv.ambilight_cached = {}

--- a/tests/components/philips_js/test_media_player.py
+++ b/tests/components/philips_js/test_media_player.py
@@ -1,0 +1,40 @@
+"""Tests for the Philips TV media player."""
+
+from haphilipsjs import PhilipsTV
+import pytest
+
+from homeassistant.const import STATE_OFF, STATE_ON
+from homeassistant.core import HomeAssistant
+
+from . import MOCK_ENTITY_ID
+
+from tests.common import MockConfigEntry
+
+
+@pytest.mark.parametrize(
+    ("powerstate", "screenstate", "expected_state"),
+    [
+        pytest.param("On", "Off", STATE_ON, id="powerstate-on"),
+        pytest.param("Standby", "On", STATE_OFF, id="powerstate-standby"),
+        pytest.param(None, "On", STATE_ON, id="screenstate-on"),
+        pytest.param(None, "Off", STATE_OFF, id="screenstate-off"),
+    ],
+)
+async def test_state(
+    hass: HomeAssistant,
+    mock_tv: PhilipsTV,
+    mock_config_entry: MockConfigEntry,
+    powerstate: str | None,
+    screenstate: str,
+    expected_state: str,
+) -> None:
+    """Test the media player state."""
+    mock_tv.json_feature_supported.return_value = False
+    mock_tv.powerstate = powerstate
+    mock_tv.screenstate = screenstate
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (state := hass.states.get(MOCK_ENTITY_ID))
+    assert state.state == expected_state

--- a/tests/components/philips_js/test_media_player.py
+++ b/tests/components/philips_js/test_media_player.py
@@ -3,6 +3,7 @@
 from haphilipsjs import PhilipsTV
 import pytest
 
+from homeassistant.components.philips_js.const import TV_STATE_OFF, TV_STATE_ON
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 
@@ -14,10 +15,10 @@ from tests.common import MockConfigEntry
 @pytest.mark.parametrize(
     ("powerstate", "screenstate", "expected_state"),
     [
-        pytest.param("On", "Off", STATE_ON, id="powerstate-on"),
-        pytest.param("Standby", "On", STATE_OFF, id="powerstate-standby"),
-        pytest.param(None, "On", STATE_ON, id="screenstate-on"),
-        pytest.param(None, "Off", STATE_OFF, id="screenstate-off"),
+        pytest.param(TV_STATE_ON, TV_STATE_OFF, STATE_ON, id="powerstate-on"),
+        pytest.param("Standby", TV_STATE_ON, STATE_OFF, id="powerstate-standby"),
+        pytest.param(None, TV_STATE_ON, STATE_ON, id="screenstate-on"),
+        pytest.param(None, TV_STATE_OFF, STATE_OFF, id="screenstate-off"),
     ],
 )
 async def test_state(

--- a/tests/components/philips_js/test_switch.py
+++ b/tests/components/philips_js/test_switch.py
@@ -1,0 +1,28 @@
+"""Tests for the Philips TV switches."""
+
+from haphilipsjs import PhilipsTV
+
+from homeassistant.const import STATE_OFF
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_available_without_powerstate(
+    hass: HomeAssistant,
+    mock_tv: PhilipsTV,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test switches are available when the power state endpoint is absent."""
+    mock_tv.json_feature_supported.return_value = True
+    mock_tv.powerstate = None
+    mock_tv.screenstate = "Off"
+    mock_tv.huelamp_power = "Off"
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (screen_state := hass.states.get("switch.philips_tv_screen_state"))
+    assert screen_state.state == STATE_OFF
+    assert (hue_state := hass.states.get("switch.philips_tv_ambilight_hue"))
+    assert hue_state.state == STATE_OFF

--- a/tests/components/philips_js/test_switch.py
+++ b/tests/components/philips_js/test_switch.py
@@ -1,28 +1,48 @@
 """Tests for the Philips TV switches."""
 
 from haphilipsjs import PhilipsTV
+import pytest
 
+from homeassistant.components.philips_js.const import TV_STATE_OFF
 from homeassistant.const import STATE_OFF
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
 
 
+@pytest.mark.parametrize(
+    ("entity_id", "screenstate", "huelamp_power"),
+    [
+        pytest.param(
+            "switch.philips_tv_screen_state",
+            TV_STATE_OFF,
+            None,
+            id="screen",
+        ),
+        pytest.param(
+            "switch.philips_tv_ambilight_hue",
+            None,
+            TV_STATE_OFF,
+            id="ambilight-hue",
+        ),
+    ],
+)
 async def test_available_without_powerstate(
     hass: HomeAssistant,
     mock_tv: PhilipsTV,
     mock_config_entry: MockConfigEntry,
+    entity_id: str,
+    screenstate: str | None,
+    huelamp_power: str | None,
 ) -> None:
     """Test switches are available when the power state endpoint is absent."""
     mock_tv.json_feature_supported.return_value = True
     mock_tv.powerstate = None
-    mock_tv.screenstate = "Off"
-    mock_tv.huelamp_power = "Off"
+    mock_tv.screenstate = screenstate
+    mock_tv.huelamp_power = huelamp_power
 
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    assert (screen_state := hass.states.get("switch.philips_tv_screen_state"))
-    assert screen_state.state == STATE_OFF
-    assert (hue_state := hass.states.get("switch.philips_tv_ambilight_hue"))
-    assert hue_state.state == STATE_OFF
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_OFF


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

None.

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Philips SAPHI TVs do not expose the `powerstate` endpoint, leaving the screen switches permanently unavailable and the media player stuck in the `on` state while the TV is in networked standby.

Allow the switches to remain available when `powerstate` is absent. For the media player, retain `powerstate` as the primary signal and fall back to `screenstate` only when `powerstate` is unavailable. Tests cover both the fallback and the existing `powerstate` precedence.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177542
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

Validation: `uv run pytest -q tests/components/philips_js` (22 passed) and targeted `prek` checks for all changed files.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running: `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet been
  reviewed.
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
