### PR TITLE
Fix swallowed exceptions in action handlers for Simplepush

### DIFF
--- a/homeassistant/components/simplepush/notify.py
+++ b/homeassistant/components/simplepush/notify.py
@@ -13,9 +13,10 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import CONF_EVENT, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
-from .const import ATTR_ATTACHMENTS, ATTR_EVENT, CONF_DEVICE_KEY, CONF_SALT
+from .const import ATTR_ATTACHMENTS, ATTR_EVENT, CONF_DEVICE_KEY, CONF_SALT, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,8 +98,13 @@ class SimplePushNotificationService(BaseNotificationService):
                     event=event,
                 )
 
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except BadRequest:
-            _LOGGER.error("Bad request. Title or message are too long")
-        except UnknownError:
-            _LOGGER.error("Failed to send the notification")
+        except BadRequest as err:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="title_or_message_too_long",
+            ) from err
+        except UnknownError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_message_failed",
+            ) from err

--- a/homeassistant/components/simplepush/strings.json
+++ b/homeassistant/components/simplepush/strings.json
@@ -17,5 +17,13 @@
         }
       }
     }
+  },
+  "exceptions": {
+    "send_message_failed": {
+      "message": "Failed to send the Simplepush notification."
+    },
+    "title_or_message_too_long": {
+      "message": "The notification title or message is too long."
+    }
   }
 }

--- a/tests/components/simplepush/test_notify.py
+++ b/tests/components/simplepush/test_notify.py
@@ -1,0 +1,199 @@
+"""Test Simplepush notifications."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from simplepush import BadRequest, UnknownError
+
+from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
+from homeassistant.components.simplepush.const import CONF_DEVICE_KEY, CONF_SALT, DOMAIN
+from homeassistant.const import CONF_NAME, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.setup import async_setup_component
+
+from tests.common import MockConfigEntry
+
+MOCK_CONFIG = {
+    CONF_DEVICE_KEY: "abc",
+    CONF_NAME: "simplepush",
+}
+
+SERVICE_NAME = "simplepush"
+
+
+@pytest.fixture
+def mock_send() -> Generator[MagicMock]:
+    """Mock the simplepush send call."""
+    with patch("homeassistant.components.simplepush.notify.send") as mock:
+        yield mock
+
+
+async def setup_config_entry(hass: HomeAssistant, data: dict[str, str]) -> None:
+    """Set up the simplepush integration."""
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    assert hass.services.has_service(NOTIFY_DOMAIN, SERVICE_NAME)
+
+
+@pytest.mark.parametrize(
+    ("service_data", "expected_attachments", "expected_event"),
+    [
+        pytest.param({}, None, None, id="message_only"),
+        pytest.param({"data": {"event": "event"}}, None, "event", id="event_in_data"),
+        pytest.param(
+            {"data": {"attachments": "image.jpg"}},
+            None,
+            None,
+            id="attachments_not_a_list",
+        ),
+        pytest.param(
+            {"data": {"attachments": [{"image": "image.jpg"}]}},
+            ["image.jpg"],
+            None,
+            id="image_attachment",
+        ),
+        pytest.param(
+            {"data": {"attachments": [{"video": "video.mp4"}]}},
+            ["video.mp4"],
+            None,
+            id="video_attachment",
+        ),
+        pytest.param(
+            {
+                "data": {
+                    "attachments": [{"video": "video.mp4", "thumbnail": "thumb.jpg"}]
+                }
+            },
+            [{"video": "video.mp4", "thumbnail": "thumb.jpg"}],
+            None,
+            id="video_attachment_with_thumbnail",
+        ),
+    ],
+)
+async def test_send_message(
+    hass: HomeAssistant,
+    mock_send: MagicMock,
+    service_data: dict[str, Any],
+    expected_attachments: list[Any] | None,
+    expected_event: str | None,
+) -> None:
+    """Test sending a message."""
+    await setup_config_entry(hass, MOCK_CONFIG)
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_NAME,
+        {"message": "Hello", **service_data},
+        blocking=True,
+    )
+
+    mock_send.assert_called_once_with(
+        key="abc",
+        title="Home Assistant",
+        message="Hello",
+        attachments=expected_attachments,
+        event=expected_event,
+    )
+
+
+async def test_send_message_with_password(
+    hass: HomeAssistant, mock_send: MagicMock
+) -> None:
+    """Test sending a message with an encryption password."""
+    await setup_config_entry(
+        hass, {**MOCK_CONFIG, CONF_PASSWORD: "password", CONF_SALT: "salt"}
+    )
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_NAME,
+        {"message": "Hello"},
+        blocking=True,
+    )
+
+    mock_send.assert_called_once_with(
+        key="abc",
+        password="password",
+        salt="salt",
+        title="Home Assistant",
+        message="Hello",
+        attachments=None,
+        event=None,
+    )
+
+
+async def test_send_message_with_invalid_attachment(
+    hass: HomeAssistant, mock_send: MagicMock, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that an invalid attachment format sends nothing."""
+    await setup_config_entry(hass, MOCK_CONFIG)
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_NAME,
+        {"message": "Hello", "data": {"attachments": [{"file": "image.jpg"}]}},
+        blocking=True,
+    )
+
+    assert "Attachment format is incorrect" in caplog.text
+    mock_send.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("side_effect", "expected_exception", "translation_key"),
+    [
+        pytest.param(
+            BadRequest,
+            ServiceValidationError,
+            "title_or_message_too_long",
+            id="bad_request",
+        ),
+        pytest.param(
+            UnknownError,
+            HomeAssistantError,
+            "send_message_failed",
+            id="unknown_error",
+        ),
+    ],
+)
+async def test_send_message_error(
+    hass: HomeAssistant,
+    mock_send: MagicMock,
+    side_effect: type[Exception],
+    expected_exception: type[HomeAssistantError],
+    translation_key: str,
+) -> None:
+    """Test that a failing send raises the correct exception."""
+    await setup_config_entry(hass, MOCK_CONFIG)
+    mock_send.side_effect = side_effect
+
+    with pytest.raises(expected_exception) as exc_info:
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            SERVICE_NAME,
+            {"message": "Hello"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == translation_key
+
+
+async def test_no_discovery_info(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test setup of the legacy platform without discovery info."""
+    assert await async_setup_component(
+        hass,
+        NOTIFY_DOMAIN,
+        {NOTIFY_DOMAIN: {"platform": DOMAIN}},
+    )
+    await hass.async_block_till_done()
+
+    assert f"Failed to initialize notification service {DOMAIN}" in caplog.text
+    assert not hass.services.has_service(NOTIFY_DOMAIN, SERVICE_NAME)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Raise instead of swallowing the `BadRequest` and `UnknownError` exceptions in the Simplepush `send_message` action handler, as tracked in #170700 (part of home-assistant/epics#64). `BadRequest` is raised by the library when the user-supplied title or message is too long, so it becomes a `ServiceValidationError`, mirroring the merged Slack fix #177049. `UnknownError` covers any other failed delivery and becomes a `HomeAssistantError`. Both carry translation keys backed by a new `exceptions` section in `strings.json`, and the pylint suppression comment is removed. A new `test_notify.py` covers both failure paths as well as sending with and without encryption, attachment handling, and legacy platform setup without discovery info, bringing the notify platform to full test coverage.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#170700
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
