### PR TITLE
Fix swallowed exceptions in action handlers for Mailgun

### DIFF
--- a/homeassistant/components/mailgun/notify.py
+++ b/homeassistant/components/mailgun/notify.py
@@ -20,10 +20,11 @@ from homeassistant.components.notify import (
 )
 from homeassistant.const import CONF_API_KEY, CONF_DOMAIN, CONF_RECIPIENT, CONF_SENDER
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 
 from . import CONF_SANDBOX
-from .const import DATA_CONFIG
+from .const import DATA_CONFIG, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -111,6 +112,8 @@ class MailgunNotificationService(BaseNotificationService):
                 files=files,
             )
             _LOGGER.debug("Message sent: %s", resp)
-        # pylint: disable-next=home-assistant-action-swallowed-exception
-        except MailgunError:
-            _LOGGER.exception("Failed to send message")
+        except MailgunError as err:
+            raise HomeAssistantError(
+                translation_domain=DOMAIN,
+                translation_key="send_message_failed",
+            ) from err

--- a/homeassistant/components/mailgun/strings.json
+++ b/homeassistant/components/mailgun/strings.json
@@ -19,5 +19,10 @@
         "title": "Set up the Mailgun webhook"
       }
     }
+  },
+  "exceptions": {
+    "send_message_failed": {
+      "message": "Failed to send the Mailgun notification."
+    }
   }
 }

--- a/tests/components/mailgun/test_notify.py
+++ b/tests/components/mailgun/test_notify.py
@@ -1,0 +1,175 @@
+"""Test Mailgun notifications."""
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from pymailgunner import MailgunCredentialsError, MailgunDomainError, MailgunError
+import pytest
+
+from homeassistant.components.mailgun.const import DOMAIN
+from homeassistant.components.mailgun.notify import MailgunNotificationService
+from homeassistant.components.notify import ATTR_TITLE_DEFAULT, DOMAIN as NOTIFY_DOMAIN
+from homeassistant.const import (
+    CONF_API_KEY,
+    CONF_DOMAIN,
+    CONF_NAME,
+    CONF_PLATFORM,
+    CONF_RECIPIENT,
+    CONF_SENDER,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.setup import async_setup_component
+
+SERVICE_NAME = "mailgun"
+
+
+@pytest.fixture
+def mock_client_class() -> Generator[MagicMock]:
+    """Mock the pymailgunner client class."""
+    with patch(
+        "homeassistant.components.mailgun.notify.Client", autospec=True
+    ) as mock_class:
+        mock_class.return_value.domain = "example.com"
+        yield mock_class
+
+
+@pytest.fixture
+def mock_client(mock_client_class: MagicMock) -> MagicMock:
+    """Return the mocked pymailgunner client."""
+    return mock_client_class.return_value
+
+
+async def setup_notify_platform(hass: HomeAssistant) -> None:
+    """Set up the Mailgun component and the legacy notify platform."""
+    assert await async_setup_component(
+        hass,
+        DOMAIN,
+        {DOMAIN: {CONF_API_KEY: "api-key", CONF_DOMAIN: "example.com"}},
+    )
+    assert await async_setup_component(
+        hass,
+        NOTIFY_DOMAIN,
+        {
+            NOTIFY_DOMAIN: {
+                CONF_NAME: SERVICE_NAME,
+                CONF_PLATFORM: DOMAIN,
+                CONF_RECIPIENT: "recipient@example.com",
+                CONF_SENDER: "sender@example.com",
+            }
+        },
+    )
+    await hass.async_block_till_done()
+
+
+@pytest.mark.parametrize(
+    ("service_data", "expected_subject", "expected_files"),
+    [
+        pytest.param({}, ATTR_TITLE_DEFAULT, None, id="message_only"),
+        pytest.param({"title": "Test"}, "Test", None, id="with_title"),
+        pytest.param(
+            {"data": {"images": ["image.jpg"]}},
+            ATTR_TITLE_DEFAULT,
+            ["image.jpg"],
+            id="with_images",
+        ),
+    ],
+)
+async def test_send_message(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    service_data: dict[str, Any],
+    expected_subject: str,
+    expected_files: list[str] | None,
+) -> None:
+    """Test sending a message."""
+    await setup_notify_platform(hass)
+    assert hass.services.has_service(NOTIFY_DOMAIN, SERVICE_NAME)
+
+    await hass.services.async_call(
+        NOTIFY_DOMAIN,
+        SERVICE_NAME,
+        {"message": "Hello", **service_data},
+        blocking=True,
+    )
+
+    mock_client.send_mail.assert_called_once_with(
+        sender="sender@example.com",
+        to="recipient@example.com",
+        subject=expected_subject,
+        text="Hello",
+        files=expected_files,
+    )
+
+
+def test_send_message_initializes_client(mock_client: MagicMock) -> None:
+    """Test that send_message initializes a missing client and derives the sender.
+
+    This bypasses the registered service because the lazy initialization branch
+    is unreachable through it: get_service always calls connection_is_valid,
+    which already initializes the client.
+    """
+    service = MailgunNotificationService(
+        "example.com", False, "api-key", None, "recipient@example.com"
+    )
+
+    service.send_message("Hello")
+
+    mock_client.send_mail.assert_called_once_with(
+        sender="hass@example.com",
+        to="recipient@example.com",
+        subject=ATTR_TITLE_DEFAULT,
+        text="Hello",
+        files=None,
+    )
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(MailgunError, id="base_error"),
+        pytest.param(MailgunCredentialsError, id="credentials_error"),
+        pytest.param(MailgunDomainError, id="domain_error"),
+    ],
+)
+async def test_send_message_error(
+    hass: HomeAssistant,
+    mock_client: MagicMock,
+    side_effect: type[MailgunError],
+) -> None:
+    """Test that a failing send raises an error with a translation key."""
+    await setup_notify_platform(hass)
+    assert hass.services.has_service(NOTIFY_DOMAIN, SERVICE_NAME)
+    mock_client.send_mail.side_effect = side_effect
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            NOTIFY_DOMAIN,
+            SERVICE_NAME,
+            {"message": "Hello"},
+            blocking=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "send_message_failed"
+
+
+@pytest.mark.parametrize(
+    "side_effect",
+    [
+        pytest.param(MailgunCredentialsError, id="invalid_credentials"),
+        pytest.param(MailgunDomainError, id="invalid_domain"),
+    ],
+)
+async def test_setup_with_connection_error(
+    hass: HomeAssistant,
+    mock_client_class: MagicMock,
+    side_effect: type[MailgunError],
+) -> None:
+    """Test that the notify service is not created when the connection fails."""
+    mock_client_class.side_effect = side_effect
+
+    await setup_notify_platform(hass)
+
+    assert not hass.services.has_service(NOTIFY_DOMAIN, SERVICE_NAME)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

When sending a mail failed, the Mailgun notify action handler only logged the error, so the action reported success and automations continued as if the mail had been sent. The except block now raises `HomeAssistantError` with a translated message (`send_message_failed`) so the failure surfaces to the caller, following the pattern used by `system_bridge` and `playstation_network`. Since `MailgunCredentialsError` and `MailgunDomainError` both subclass `MailgunError` in pymailgunner, the raise also covers failures from the lazy client initialization inside the same try block. The pylint suppression is removed, an `exceptions` section is added to `strings.json`, and a new test module covers the raised error for all three library exceptions plus the happy path through the notify service. The `connection_is_valid` checks in the setup path are unchanged.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes home-assistant/core#170695
- This PR is related to issue: home-assistant/epics#64
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
