### PR TITLE
Promote HomeKit camera to Video Doorbell category when a doorbell sensor is linked

### DIFF
--- a/homeassistant/components/homekit/type_cameras.py
+++ b/homeassistant/components/homekit/type_cameras.py
@@ -12,7 +12,7 @@ from pyhap.camera import (
     VIDEO_CODEC_PARAM_PROFILE_ID_TYPES,
     Camera as PyhapCamera,
 )
-from pyhap.const import CATEGORY_CAMERA
+from pyhap.const import CATEGORY_CAMERA, CATEGORY_VIDEO_DOOR_BELL
 from pyhap.util import callback as pyhap_callback
 
 from homeassistant.components import camera
@@ -38,6 +38,7 @@ from .const import (
     CONF_AUDIO_CODEC,
     CONF_AUDIO_MAP,
     CONF_AUDIO_PACKET_SIZE,
+    CONF_LINKED_DOORBELL_SENSOR,
     CONF_LINKED_MOTION_SENSOR,
     CONF_MAX_FPS,
     CONF_MAX_HEIGHT,
@@ -205,6 +206,7 @@ class Camera(HomeDoorbellAccessory, PyhapCamera):  # type: ignore[misc]
             "stream_count": config[CONF_STREAM_COUNT],
         }
 
+        linked_doorbell_sensor = config.get(CONF_LINKED_DOORBELL_SENSOR)
         super().__init__(
             hass,
             driver,
@@ -212,7 +214,15 @@ class Camera(HomeDoorbellAccessory, PyhapCamera):  # type: ignore[misc]
             entity_id,
             aid,
             config,
-            category=CATEGORY_CAMERA,
+            # A camera is only promoted to the Video Doorbell category when
+            # its linked doorbell sensor actually exists; HomeDoorbellAccessory
+            # only adds the Doorbell service in that same case (see doorbell.py),
+            # so category and services stay consistent.
+            category=(
+                CATEGORY_VIDEO_DOOR_BELL
+                if linked_doorbell_sensor and hass.states.get(linked_doorbell_sensor)
+                else CATEGORY_CAMERA
+            ),
             options=options,
         )
 

--- a/tests/components/homekit/test_type_cameras.py
+++ b/tests/components/homekit/test_type_cameras.py
@@ -1111,7 +1111,7 @@ async def test_camera_with_linked_doorbell_sensor(
     acc.run()
 
     assert acc.aid == 2
-    assert acc.category == 17  # Camera
+    assert acc.category == 18  # Video Doorbell
 
     service = acc.get_service(SERV_DOORBELL)
     assert service
@@ -1227,7 +1227,7 @@ async def test_camera_with_linked_doorbell_event(
     acc.run()
 
     assert acc.aid == 2
-    assert acc.category == 17  # Camera
+    assert acc.category == 18  # Video Doorbell
 
     service = acc.get_service(SERV_DOORBELL)
     assert service


### PR DESCRIPTION
## Proposed change

`homeassistant.components.homekit.type_cameras.Camera` has always built bridged cameras with `category=CATEGORY_CAMERA`, even when `linked_doorbell_sensor` is configured and `HomeDoorbellAccessory` adds a real Doorbell service (`SERV_DOORBELL`) to the accessory. Apple's Home app only treats an accessory as a video doorbell (distinct tile, ring chime, and Face Recognition/Apple TV notification eligibility once a Home Hub is present) when the HAP accessory category itself is Video Doorbell (18) — the ring service alone isn't enough. Today these cameras only ever appear as plain cameras in the Home app, with no ring notification, regardless of configuration.

This promotes the category to `CATEGORY_VIDEO_DOOR_BELL` exactly when `HomeDoorbellAccessory` will actually add the Doorbell service for this accessory (linked sensor configured AND its state currently exists), keeping category and services consistent rather than checking config presence alone.

Validated live against a real UniFi Protect doorbell bridged through the `unifiprotect` + `homekit` integrations: after the category promotion and a full re-pair in the Home app, the accessory now shows as a proper Video Doorbell (ring notifications, doorbell-specific settings) instead of a plain camera tile.

**Note for reviewers:** this is a behavior change for any existing camera accessory that already has a working `linked_doorbell_sensor` configured — its HAP category will change on upgrade. In our own testing this required a full `homekit.reset_accessory` + re-pair in the Home app for the new category to actually reach an already-paired client (pyhap persists accessory state, including data derived from category, to avoid disrupting existing pairings). Happy to add a repair/breaking change note if that's the right way to communicate this — wanted to flag it explicitly rather than have it be a surprise.

This is a narrower change than the regression in #78541 (cameras with no doorbell configuration at all were incorrectly appearing as doorbells for all users) — this only promotes the category when the user has explicitly configured a `linked_doorbell_sensor` that resolves to a real, existing entity.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (which adds functionality to an existing integration)

## Additional information

- This PR fixes or fixes part of #78541
- This PR is related to the `homekit` integration

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works (updated `test_camera_with_linked_doorbell_sensor` and `test_camera_with_linked_doorbell_event` to expect category 18; `test_camera_with_a_missing_linked_doorbell_sensor` unchanged since the Doorbell service isn't added in that case either).

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/