### PR TITLE
Bump KNX dependencies (xknx 3.18.0, xknxproject 3.10.0, knx-telegram-…

### DIFF
--- a/homeassistant/components/knx/manifest.json
+++ b/homeassistant/components/knx/manifest.json
@@ -11,10 +11,10 @@
   "loggers": ["xknx", "xknxproject"],
   "quality_scale": "platinum",
   "requirements": [
-    "xknx==3.17.0",
-    "xknxproject==3.9.0",
+    "xknx==3.18.0",
+    "xknxproject==3.10.0",
     "knx-frontend==2026.7.23.145751",
-    "knx-telegram-store[sqlite,postgres]==0.11.1"
+    "knx-telegram-store[sqlite,postgres]==0.11.2"
   ],
   "single_config_entry": true
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -1438,7 +1438,7 @@ knocki==0.4.2
 knx-frontend==2026.7.23.145751
 
 # homeassistant.components.knx
-knx-telegram-store[sqlite,postgres]==0.11.1
+knx-telegram-store[sqlite,postgres]==0.11.2
 
 # homeassistant.components.kraken
 krakenex==2.2.2
@@ -3406,10 +3406,10 @@ wyoming==1.10.0
 xiaomi-ble==1.11.0
 
 # homeassistant.components.knx
-xknx==3.17.0
+xknx==3.18.0
 
 # homeassistant.components.knx
-xknxproject==3.9.0
+xknxproject==3.10.0
 
 # homeassistant.components.fritz
 # homeassistant.components.rest


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
Update the KNX integration's core libraries to their latest releases:

### Dependency Updates
- **xknx** (`3.17.0` -> `3.18.0`) - [Release 3.18.0](https://github.com/XKNX/xknx/releases/tag/3.18.0) | [Changelog](https://github.com/XKNX/xknx/blob/main/docs/changelog.md) | [Compare](https://github.com/XKNX/xknx/compare/3.17.0...3.18.0)
- **xknxproject** (`3.9.0` -> `3.10.0`) - [Release 3.10.0](https://github.com/XKNX/xknxproject/releases/tag/3.10.0) | [Compare](https://github.com/XKNX/xknxproject/compare/3.9.0...3.10.0)
- **knx-telegram-store** (`0.11.1` -> `0.11.2`) - [Release v0.11.2](https://github.com/XKNX/knx-telegram-store/releases/tag/v0.11.2) | [Compare](https://github.com/XKNX/knx-telegram-store/compare/v0.11.1...v0.11.2)
### Summary of Changes
#### `xknx` 3.18.0
* **L_Data_Extended Support**: Automatically encodes APDUs longer than 15 octets as `L_Data_Extended` frames. Fixes sending KNX Data Secure telegrams with payloads $\ge 2$ octets (e.g., DPT 9.x or DPT 232.600) where Data Secure overhead exceeds standard frame limits.
* **APCI Safety & Defense-in-Depth**: Added explicit payload length checks to all APCI frame decoders (`from_knx`). Raises `ConversionError` on malformed or truncated bus telegrams instead of unhandled unpacking errors.
* **Host-Agnostic MCP Module**: Introduced `xknx.mcp` subpackage containing host-agnostic tool functions (`list_dpts`, `describe_dpt`, `encode_value`, `decode_payload`, etc.) and dataclass types with field metadata.
#### `xknxproject` 3.10.0
* **Pyzipper Bump**: Upgraded `pyzipper` from `0.3.6` to `0.4.0` for compressed/encrypted ETS project archive extraction (`.knxproj`).
* **Host-Agnostic MCP Module**: Added `xknxproject.mcp` subpackage for inspecting ETS project topologies, group addresses, devices, functions, and communication objects.
#### `knx-telegram-store` 0.11.2
* **Self-Describing Pagination**: Added `offset` and `next_offset` fields to `QueryTelegramsResult` to simplify iterative log history queries.
* **MCP Field Metadata**: Added human-readable parameter descriptions to input schemas in `knx_telegram_store.mcp.types` using `dataclasses.field` metadata.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
