### PR TITLE
Avoid naive datetime.now() in smarttub tests

### DIFF
--- a/tests/components/smarttub/test_binary_sensor.py
+++ b/tests/components/smarttub/test_binary_sensor.py
@@ -1,6 +1,5 @@
 """Test the SmartTub binary sensor platform."""
 
-from datetime import datetime
 from unittest.mock import create_autospec
 
 import pytest
@@ -8,6 +7,7 @@ import smarttub
 
 from homeassistant.components.binary_sensor import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
 
 
 async def test_binary_sensors(spa, setup_entry, hass: HomeAssistant) -> None:
@@ -43,8 +43,8 @@ def mock_error(spa):
     error.title = "Flow Switch Stuck Open"
     error.description = None
     error.active = True
-    error.created_at = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
-    error.updated_at = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+    error.created_at = dt_util.utcnow()
+    error.updated_at = dt_util.utcnow()
     error.error_type = "TUB_ERROR"
     return error
 


### PR DESCRIPTION
## Breaking change


## Proposed change

The `smarttub` test suite calls a naive `datetime.now()` directly in the `mock_error` fixture, which trips the `home-assistant-enforce-naive-now` pylint rule. The values are only used as arbitrary timestamps for a mocked `SpaError` (fed into `.isoformat()` when building entity attributes), not for a duration calculation, so a timezone-aware datetime is appropriate. Replaced both calls with `dt_util.utcnow()`.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177827
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)