### PR TITLE
Fix ESPHome dashboard adoption locking HA out of provisioned devices

### DIFF
--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -221,7 +221,6 @@ class ESPHomeManager:
     __slots__ = (
         "_cancel_subscribe_logs",
         "_dashboard_key_sync_warned",
-        "_dashboard_key_synced",
         "_log_level",
         "cli",
         "device_id",
@@ -258,7 +257,6 @@ class ESPHomeManager:
         self.entry_data = entry.runtime_data
         self._cancel_subscribe_logs: CALLBACK_TYPE | None = None
         self._dashboard_key_sync_warned = False
-        self._dashboard_key_synced = False
         self._log_level = LogLevel.LOG_LEVEL_NONE
 
     async def on_stop(self, event: Event) -> None:
@@ -939,11 +937,9 @@ class ESPHomeManager:
         if isinstance(result_value, str) and result_value in _DASHBOARD_KEY_SYNC_OK:
             if reason:
                 # Partial success: a duplicate-name sibling refused the
-                # key and flashing it can still lock HA out — warn and
-                # keep retrying instead of latching.
+                # key and flashing it can still lock HA out.
                 self._async_warn_dashboard_key_sync_failed(device_info, reason)
                 return
-            self._dashboard_key_synced = True
             _LOGGER.debug(
                 "Synced encryption key for %s to the ESPHome dashboard: %s",
                 device_info.name,
@@ -981,14 +977,13 @@ class ESPHomeManager:
         """
         noise_psk: str | None = self.entry.data.get(CONF_NOISE_PSK)
         if noise_psk:
-            if self._dashboard_key_synced:
-                # Already delivered this manager's lifetime; a dashboard
-                # change reloads the entry and resets the latch.
-                return
             # We're already connected with this key, so it's proven valid;
             # re-offer it so a dashboard that missed the original handoff
             # (added later, upgraded, or temporarily unreachable) catches
-            # up. The dashboard no-ops when it already has the same key.
+            # up. Deliberately re-offered on every connect (no success
+            # latch): the dashboard no-ops on an identical key, and a
+            # dashboard whose copy was deleted out from under it gets it
+            # back on the next connect.
             # Only keys in our storage are ours to push — a user-authored
             # YAML key is not (mirrors _async_clear_dynamic_encryption_key).
             # Background task: this runs on every connect and must not

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -907,9 +907,9 @@ class ESPHomeManager:
 
         Without this the dashboard has no way to know the key HA set on
         the device, so adopting the device generates a competing key and
-        the next flash locks HA out. Dashboards without the endpoint
-        (or errors) are logged at debug level and never fail the
-        connect flow.
+        the next flash locks HA out. Never fails the connect flow: a
+        dashboard without the endpoint (404/405) logs at debug, any
+        other failure warns once per manager.
         """
         if (dashboard := async_get_dashboard(self.hass)) is None:
             return

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -29,6 +29,7 @@ from aioesphomeapi import (
     ZWaveProxyRequestType,
     parse_log_message,
 )
+import aiohttp
 from awesomeversion import AwesomeVersion
 import voluptuous as vol
 
@@ -882,6 +883,37 @@ class ESPHomeManager:
             await cli.disconnect(force=True)
         return False
 
+    async def _async_sync_encryption_key_to_dashboard(
+        self, device_info: EsphomeDeviceInfo, key: str
+    ) -> None:
+        """Best effort: tell the ESPHome dashboard about the provisioned key.
+
+        Without this the dashboard has no way to know the key HA set on
+        the device, so adopting the device generates a competing key and
+        the next flash locks HA out. Dashboards without the endpoint
+        (or errors) are logged at debug level and never fail the
+        connect flow.
+        """
+        if (dashboard := async_get_dashboard(self.hass)) is None:
+            return
+        try:
+            result = await dashboard.api.post_encryption_key(
+                device_info.name, key, mac=self.entry.unique_id
+            )
+        except (aiohttp.ClientError, TimeoutError) as err:
+            _LOGGER.debug(
+                "Could not sync encryption key for %s to the ESPHome dashboard "
+                "(the dashboard may not support it yet): %s",
+                device_info.name,
+                err,
+            )
+            return
+        _LOGGER.debug(
+            "Synced encryption key for %s to the ESPHome dashboard: %s",
+            device_info.name,
+            result,
+        )
+
     async def _handle_dynamic_encryption_key(
         self, device_info: EsphomeDeviceInfo
     ) -> None:
@@ -961,6 +993,10 @@ class ESPHomeManager:
             self.entry,
             data={**self.entry.data, CONF_NOISE_PSK: new_key_str},
         )
+
+        # The dashboard must learn the key or its next adoption/flash of
+        # this device bakes in a competing key and locks HA out.
+        await self._async_sync_encryption_key_to_dashboard(device_info, new_key_str)
 
         if from_storage:
             _LOGGER.info(

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -886,6 +886,17 @@ class ESPHomeManager:
             await cli.disconnect(force=True)
         return False
 
+    @callback
+    def _async_schedule_dashboard_key_sync(
+        self, device_info: EsphomeDeviceInfo, key: str
+    ) -> None:
+        """Schedule the best-effort dashboard key sync off the connect path."""
+        self.entry.async_create_background_task(
+            self.hass,
+            self._async_sync_encryption_key_to_dashboard(device_info, key),
+            "esphome-sync-encryption-key",
+        )
+
     async def _async_sync_encryption_key_to_dashboard(
         self, device_info: EsphomeDeviceInfo, key: str
     ) -> None:
@@ -951,13 +962,7 @@ class ESPHomeManager:
             if self.entry.unique_id and (
                 await storage.async_get_key(self.entry.unique_id) == noise_psk
             ):
-                self.entry.async_create_background_task(
-                    self.hass,
-                    self._async_sync_encryption_key_to_dashboard(
-                        device_info, noise_psk
-                    ),
-                    "esphome-sync-encryption-key",
-                )
+                self._async_schedule_dashboard_key_sync(device_info, noise_psk)
             return
 
         if not device_info.api_encryption_supported:
@@ -1028,8 +1033,9 @@ class ESPHomeManager:
         )
 
         # The dashboard must learn the key or its next adoption/flash of
-        # this device bakes in a competing key and locks HA out.
-        await self._async_sync_encryption_key_to_dashboard(device_info, new_key_str)
+        # this device bakes in a competing key and locks HA out. Background
+        # task: an unreachable dashboard must not stall entity setup.
+        self._async_schedule_dashboard_key_sync(device_info, new_key_str)
 
         if from_storage:
             _LOGGER.info(

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -221,6 +221,7 @@ class ESPHomeManager:
     __slots__ = (
         "_cancel_subscribe_logs",
         "_dashboard_key_sync_warned",
+        "_dashboard_key_synced",
         "_log_level",
         "cli",
         "device_id",
@@ -256,7 +257,8 @@ class ESPHomeManager:
         self.zeroconf_instance = zeroconf_instance
         self.entry_data = entry.runtime_data
         self._cancel_subscribe_logs: CALLBACK_TYPE | None = None
-        self._dashboard_key_sync_warned = False
+        self._dashboard_key_sync_warned: set[str] = set()
+        self._dashboard_key_synced = False
         self._log_level = LogLevel.LOG_LEVEL_NONE
 
     async def on_stop(self, event: Event) -> None:
@@ -932,25 +934,28 @@ class ESPHomeManager:
             else:
                 self._async_warn_dashboard_key_sync_failed(device_info, err)
             return
-        if result.get("result") in _DASHBOARD_KEY_SYNC_OK:
+        if isinstance(result, dict) and result.get("result") in _DASHBOARD_KEY_SYNC_OK:
+            self._dashboard_key_synced = True
             _LOGGER.debug(
                 "Synced encryption key for %s to the ESPHome dashboard: %s",
                 device_info.name,
                 result,
             )
             return
+        reason = result.get("reason") if isinstance(result, dict) else None
         self._async_warn_dashboard_key_sync_failed(
-            device_info, result.get("reason") or f"unexpected response {result}"
+            device_info, reason or f"unexpected response {result}"
         )
 
     @callback
     def _async_warn_dashboard_key_sync_failed(
         self, device_info: EsphomeDeviceInfo, cause: Exception | str
     ) -> None:
-        """Warn once that the dashboard did not store the key."""
-        if self._dashboard_key_sync_warned:
+        """Warn once per distinct cause that the dashboard did not store the key."""
+        cause_text = str(cause)
+        if cause_text in self._dashboard_key_sync_warned:
             return
-        self._dashboard_key_sync_warned = True
+        self._dashboard_key_sync_warned.add(cause_text)
         _LOGGER.warning(
             "The ESPHome dashboard could not store the encryption key for "
             "%s (%s), so installing that configuration may use a different "
@@ -970,6 +975,10 @@ class ESPHomeManager:
         """
         noise_psk: str | None = self.entry.data.get(CONF_NOISE_PSK)
         if noise_psk:
+            if self._dashboard_key_synced:
+                # Already delivered this manager's lifetime; a dashboard
+                # change reloads the entry and resets the latch.
+                return
             # We're already connected with this key, so it's proven valid;
             # re-offer it so a dashboard that missed the original handoff
             # (added later, upgraded, or temporarily unreachable) catches

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -934,7 +934,14 @@ class ESPHomeManager:
             else:
                 self._async_warn_dashboard_key_sync_failed(device_info, err)
             return
+        reason = result.get("reason") if isinstance(result, dict) else None
         if isinstance(result, dict) and result.get("result") in _DASHBOARD_KEY_SYNC_OK:
+            if reason:
+                # Partial success: a duplicate-name sibling refused the
+                # key and flashing it can still lock HA out — warn and
+                # keep retrying instead of latching.
+                self._async_warn_dashboard_key_sync_failed(device_info, reason)
+                return
             self._dashboard_key_synced = True
             _LOGGER.debug(
                 "Synced encryption key for %s to the ESPHome dashboard: %s",
@@ -942,7 +949,6 @@ class ESPHomeManager:
                 result,
             )
             return
-        reason = result.get("reason") if isinstance(result, dict) else None
         self._async_warn_dashboard_key_sync_failed(
             device_info, reason or f"unexpected response {result}"
         )

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -257,7 +257,7 @@ class ESPHomeManager:
         self.zeroconf_instance = zeroconf_instance
         self.entry_data = entry.runtime_data
         self._cancel_subscribe_logs: CALLBACK_TYPE | None = None
-        self._dashboard_key_sync_warned: set[str] = set()
+        self._dashboard_key_sync_warned = False
         self._dashboard_key_synced = False
         self._log_level = LogLevel.LOG_LEVEL_NONE
 
@@ -934,8 +934,9 @@ class ESPHomeManager:
             else:
                 self._async_warn_dashboard_key_sync_failed(device_info, err)
             return
+        result_value = result.get("result") if isinstance(result, dict) else None
         reason = result.get("reason") if isinstance(result, dict) else None
-        if isinstance(result, dict) and result.get("result") in _DASHBOARD_KEY_SYNC_OK:
+        if isinstance(result_value, str) and result_value in _DASHBOARD_KEY_SYNC_OK:
             if reason:
                 # Partial success: a duplicate-name sibling refused the
                 # key and flashing it can still lock HA out — warn and
@@ -957,11 +958,10 @@ class ESPHomeManager:
     def _async_warn_dashboard_key_sync_failed(
         self, device_info: EsphomeDeviceInfo, cause: Exception | str
     ) -> None:
-        """Warn once per distinct cause that the dashboard did not store the key."""
-        cause_text = str(cause)
-        if cause_text in self._dashboard_key_sync_warned:
+        """Warn once that the dashboard did not store the key."""
+        if self._dashboard_key_sync_warned:
             return
-        self._dashboard_key_sync_warned.add(cause_text)
+        self._dashboard_key_sync_warned = True
         _LOGGER.warning(
             "The ESPHome dashboard could not store the encryption key for "
             "%s (%s), so installing that configuration may use a different "

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -137,6 +137,9 @@ _LOGGER = logging.getLogger(__name__)
 # Max time to wait at startup for a BLE proxy to register its scanner.
 STARTUP_SCANNER_WAIT: Final = 3.0
 
+# Dashboard responses that mean the encryption-key handoff landed.
+_DASHBOARD_KEY_SYNC_OK: Final = frozenset({"stored", "updated", "unchanged"})
+
 LOG_LEVEL_TO_LOGGER = {
     LogLevel.LOG_LEVEL_NONE: logging.DEBUG,
     LogLevel.LOG_LEVEL_ERROR: logging.ERROR,
@@ -915,29 +918,46 @@ class ESPHomeManager:
                 device_info.name, key, mac=self.entry.unique_id
             )
         except (aiohttp.ClientError, TimeoutError, json.JSONDecodeError) as err:
+            if isinstance(err, aiohttp.ClientResponseError) and err.status in (
+                404,
+                405,
+            ):
+                # Endpoint absent — an old dashboard, not a failed store.
+                _LOGGER.debug(
+                    "The ESPHome dashboard does not support the encryption key "
+                    "handoff for %s: %s",
+                    device_info.name,
+                    err,
+                )
+            else:
+                self._async_warn_dashboard_key_sync_failed(device_info, err)
+            return
+        if result.get("result") in _DASHBOARD_KEY_SYNC_OK:
             _LOGGER.debug(
-                "Could not sync encryption key for %s to the ESPHome dashboard "
-                "(the dashboard may not support it yet): %s",
+                "Synced encryption key for %s to the ESPHome dashboard: %s",
                 device_info.name,
-                err,
+                result,
             )
             return
-        if result.get("result") == "not_writable":
-            if not self._dashboard_key_sync_warned:
-                self._dashboard_key_sync_warned = True
-                _LOGGER.warning(
-                    "The ESPHome dashboard could not store the encryption key for "
-                    "%s (%s), so installing that configuration may use a different "
-                    "key and lock Home Assistant out: %s",
-                    device_info.name,
-                    self.entry.unique_id,
-                    result.get("reason", "unknown reason"),
-                )
+        self._async_warn_dashboard_key_sync_failed(
+            device_info, result.get("reason") or f"unexpected response {result}"
+        )
+
+    @callback
+    def _async_warn_dashboard_key_sync_failed(
+        self, device_info: EsphomeDeviceInfo, cause: Exception | str
+    ) -> None:
+        """Warn once that the dashboard did not store the key."""
+        if self._dashboard_key_sync_warned:
             return
-        _LOGGER.debug(
-            "Synced encryption key for %s to the ESPHome dashboard: %s",
+        self._dashboard_key_sync_warned = True
+        _LOGGER.warning(
+            "The ESPHome dashboard could not store the encryption key for "
+            "%s (%s), so installing that configuration may use a different "
+            "key and lock Home Assistant out: %s",
             device_info.name,
-            result,
+            self.entry.unique_id,
+            cause,
         )
 
     async def _handle_dynamic_encryption_key(

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 from functools import partial
+import json
 import logging
 import secrets
 import struct
@@ -216,6 +217,7 @@ class ESPHomeManager:
 
     __slots__ = (
         "_cancel_subscribe_logs",
+        "_dashboard_key_sync_warned",
         "_log_level",
         "cli",
         "device_id",
@@ -251,6 +253,7 @@ class ESPHomeManager:
         self.zeroconf_instance = zeroconf_instance
         self.entry_data = entry.runtime_data
         self._cancel_subscribe_logs: CALLBACK_TYPE | None = None
+        self._dashboard_key_sync_warned = False
         self._log_level = LogLevel.LOG_LEVEL_NONE
 
     async def on_stop(self, event: Event) -> None:
@@ -900,7 +903,7 @@ class ESPHomeManager:
             result = await dashboard.api.post_encryption_key(
                 device_info.name, key, mac=self.entry.unique_id
             )
-        except (aiohttp.ClientError, TimeoutError) as err:
+        except (aiohttp.ClientError, TimeoutError, json.JSONDecodeError) as err:
             _LOGGER.debug(
                 "Could not sync encryption key for %s to the ESPHome dashboard "
                 "(the dashboard may not support it yet): %s",
@@ -909,14 +912,16 @@ class ESPHomeManager:
             )
             return
         if result.get("result") == "not_writable":
-            _LOGGER.warning(
-                "The ESPHome dashboard could not store the encryption key for "
-                "%s (%s), so installing that configuration may use a different "
-                "key and lock Home Assistant out: %s",
-                device_info.name,
-                self.entry.unique_id,
-                result.get("reason", "unknown reason"),
-            )
+            if not self._dashboard_key_sync_warned:
+                self._dashboard_key_sync_warned = True
+                _LOGGER.warning(
+                    "The ESPHome dashboard could not store the encryption key for "
+                    "%s (%s), so installing that configuration may use a different "
+                    "key and lock Home Assistant out: %s",
+                    device_info.name,
+                    self.entry.unique_id,
+                    result.get("reason", "unknown reason"),
+                )
             return
         _LOGGER.debug(
             "Synced encryption key for %s to the ESPHome dashboard: %s",
@@ -938,13 +943,21 @@ class ESPHomeManager:
             # re-offer it so a dashboard that missed the original handoff
             # (added later, upgraded, or temporarily unreachable) catches
             # up. The dashboard no-ops when it already has the same key.
+            # Only keys in our storage are ours to push — a user-authored
+            # YAML key is not (mirrors _async_clear_dynamic_encryption_key).
             # Background task: this runs on every connect and must not
             # delay entity setup.
-            self.entry.async_create_background_task(
-                self.hass,
-                self._async_sync_encryption_key_to_dashboard(device_info, noise_psk),
-                "esphome-sync-encryption-key",
-            )
+            storage = await async_get_encryption_key_storage(self.hass)
+            if self.entry.unique_id and (
+                await storage.async_get_key(self.entry.unique_id) == noise_psk
+            ):
+                self.entry.async_create_background_task(
+                    self.hass,
+                    self._async_sync_encryption_key_to_dashboard(
+                        device_info, noise_psk
+                    ),
+                    "esphome-sync-encryption-key",
+                )
             return
 
         if not device_info.api_encryption_supported:

--- a/homeassistant/components/esphome/manager.py
+++ b/homeassistant/components/esphome/manager.py
@@ -908,6 +908,16 @@ class ESPHomeManager:
                 err,
             )
             return
+        if result.get("result") == "not_writable":
+            _LOGGER.warning(
+                "The ESPHome dashboard could not store the encryption key for "
+                "%s (%s), so installing that configuration may use a different "
+                "key and lock Home Assistant out: %s",
+                device_info.name,
+                self.entry.unique_id,
+                result.get("reason", "unknown reason"),
+            )
+            return
         _LOGGER.debug(
             "Synced encryption key for %s to the ESPHome dashboard: %s",
             device_info.name,
@@ -924,7 +934,17 @@ class ESPHomeManager:
         """
         noise_psk: str | None = self.entry.data.get(CONF_NOISE_PSK)
         if noise_psk:
-            # we're already connected with a noise PSK - nothing to do
+            # We're already connected with this key, so it's proven valid;
+            # re-offer it so a dashboard that missed the original handoff
+            # (added later, upgraded, or temporarily unreachable) catches
+            # up. The dashboard no-ops when it already has the same key.
+            # Background task: this runs on every connect and must not
+            # delay entity setup.
+            self.entry.async_create_background_task(
+                self.hass,
+                self._async_sync_encryption_key_to_dashboard(device_info, noise_psk),
+                "esphome-sync-encryption-key",
+            )
             return
 
         if not device_info.api_encryption_supported:

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -3062,6 +3062,13 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
     assert ("could not store the encryption key" in caplog.text) is expect_warning
 
 
+@pytest.mark.parametrize(
+    "unexpected",
+    [
+        pytest.param({"error": "unknown device"}, id="not_an_outcome"),
+        pytest.param(["valid", "json", "wrong", "shape"], id="not_a_dict"),
+    ],
+)
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
 async def test_dashboard_unexpected_sync_result_logs_warning(
     mock_token_bytes: Mock,
@@ -3071,6 +3078,7 @@ async def test_dashboard_unexpected_sync_result_logs_warning(
     hass_storage: dict[str, Any],
     mock_dashboard: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
+    unexpected: Any,
 ) -> None:
     """Test an unrecognized dashboard response is treated as a failed handoff."""
     mac_address = "11:22:33:44:55:aa"
@@ -3082,7 +3090,7 @@ async def test_dashboard_unexpected_sync_result_logs_warning(
     with patch(
         "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
         new_callable=AsyncMock,
-        return_value={"error": "unknown device"},
+        return_value=unexpected,
     ):
         device = await mock_esphome_device(
             mock_client=mock_client,
@@ -3155,6 +3163,8 @@ async def test_existing_key_resynced_to_dashboard_on_connect(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     mock_post_key.assert_awaited_with("test-device", test_key, mac=mac_address)
+    # The success latch stops the re-offer on subsequent connects.
+    assert mock_post_key.await_count == 1
 
 
 async def test_user_provided_key_not_resynced_to_dashboard(
@@ -3248,6 +3258,51 @@ async def test_dashboard_not_writable_response_logs_warning(
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
     assert caplog.text.count("could not store the encryption key") == 1
+    assert "!secret" in caplog.text
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dashboard_sync_warns_once_per_distinct_cause(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a transient error does not mute a later distinct decline."""
+    mac_address = "11:22:33:44:55:aa"
+    mock_token_bytes.return_value = b"test_key_32_bytes_long_exactly!"
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        side_effect=[
+            aiohttp.ClientError("boom"),
+            {"result": "not_writable", "reason": "the key is provided via !secret"},
+        ],
+    ):
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert caplog.text.count("could not store the encryption key") == 2
+    assert "boom" in caplog.text
     assert "!secret" in caplog.text
 
 

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -3,6 +3,7 @@
 import asyncio
 import base64
 from collections.abc import Generator
+import json
 import logging
 from typing import Any
 from unittest.mock import AsyncMock, Mock, call, patch
@@ -2923,10 +2924,11 @@ async def test_dynamic_encryption_key_synced_to_dashboard(
         )
         await device.mock_disconnect(True)
         await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
-    # The reload after the entry update reconnects and re-offers the
-    # key as a background task; assert on the provisioning-time call.
+    # The test's second connect sees the stored key and re-offers it as
+    # a background task; assert on the provisioning-time call.
     assert mock_post_key.await_args_list[0] == call(
         "test-device", expected_key, mac=mac_address
     )
@@ -2971,6 +2973,7 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
         )
         await device.mock_disconnect(True)
         await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == test_key
     assert mock_post_key.await_args_list[0] == call(
@@ -2984,6 +2987,7 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
         aiohttp.ClientResponseError(request_info=Mock(), history=(), status=404),
         aiohttp.ClientError("boom"),
         TimeoutError(),
+        json.JSONDecodeError("boom", "x", 0),
     ],
 )
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
@@ -3023,6 +3027,7 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
         )
         await device.mock_disconnect(True)
         await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert mock_post_key.await_count >= 1
     assert entry.data[CONF_NOISE_PSK] == expected_key
@@ -3039,9 +3044,16 @@ async def test_existing_key_resynced_to_dashboard_on_connect(
     hass_storage: dict[str, Any],
     mock_dashboard: dict[str, Any],
 ) -> None:
-    """Test a connect with a proven-valid key re-offers it to the dashboard."""
+    """Test a connect with a proven-valid HA-provisioned key re-offers it."""
     mac_address = "11:22:33:44:55:aa"
     test_key = base64.b64encode(b"existing_key_32_bytes_long!!!").decode()
+
+    hass_storage[ENCRYPTION_KEY_STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": ENCRYPTION_KEY_STORAGE_KEY,
+        "data": {"keys": {mac_address: test_key}},
+    }
 
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -3077,6 +3089,52 @@ async def test_existing_key_resynced_to_dashboard_on_connect(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     mock_post_key.assert_awaited_with("test-device", test_key, mac=mac_address)
+
+
+async def test_user_provided_key_not_resynced_to_dashboard(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test a user-authored YAML key (absent from storage) is never pushed."""
+    mac_address = "11:22:33:44:55:aa"
+    test_key = base64.b64encode(b"existing_key_32_bytes_long!!!").decode()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test-device",
+            CONF_NOISE_PSK: test_key,
+        },
+        unique_id=mac_address,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_post_key.assert_not_awaited()
 
 
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
@@ -3120,6 +3178,7 @@ async def test_dashboard_not_writable_response_logs_warning(
         )
         await device.mock_disconnect(True)
         await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
     assert "could not store the encryption key" in caplog.text

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -3030,6 +3030,9 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert mock_post_key.await_count >= 1
+    # The flow must have run to completion — a sync exception escaping
+    # _on_connect would skip everything after the handoff.
+    assert entry.runtime_data.first_connect_done.is_set()
     assert entry.data[CONF_NOISE_PSK] == expected_key
     assert (
         hass_storage[ENCRYPTION_KEY_STORAGE_KEY]["data"]["keys"][mac_address]
@@ -3181,7 +3184,7 @@ async def test_dashboard_not_writable_response_logs_warning(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
-    assert "could not store the encryption key" in caplog.text
+    assert caplog.text.count("could not store the encryption key") == 1
     assert "!secret" in caplog.text
 
 
@@ -3217,6 +3220,7 @@ async def test_dynamic_encryption_key_not_synced_without_dashboard(
         )
         await device.mock_disconnect(True)
         await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] != ""
     mock_post_key.assert_not_awaited()
@@ -3255,6 +3259,7 @@ async def test_dynamic_encryption_key_not_synced_when_provisioning_fails(
         )
         await device.mock_disconnect(True)
         await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
 
     assert CONF_NOISE_PSK not in entry.data or entry.data[CONF_NOISE_PSK] == ""
     mock_post_key.assert_not_awaited()

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -2994,6 +2994,7 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
 async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
     mock_token_bytes: Mock,
     hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
     mock_client: APIClient,
     mock_esphome_device: MockESPHomeDeviceType,
     hass_storage: dict[str, Any],
@@ -3031,8 +3032,13 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
 
     assert mock_post_key.await_count >= 1
     # The flow must have run to completion — a sync exception escaping
-    # _on_connect would skip everything after the handoff.
-    assert entry.runtime_data.first_connect_done.is_set()
+    # _on_connect would skip the device-registry setup after the handoff.
+    assert (
+        device_registry.async_get_device(
+            connections={(dr.CONNECTION_NETWORK_MAC, mac_address)}
+        )
+        is not None
+    )
     assert entry.data[CONF_NOISE_PSK] == expected_key
     assert (
         hass_storage[ENCRYPTION_KEY_STORAGE_KEY]["data"]["keys"][mac_address]

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -2925,7 +2925,11 @@ async def test_dynamic_encryption_key_synced_to_dashboard(
         await device.mock_connect()
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
-    mock_post_key.assert_awaited_once_with("test-device", expected_key, mac=mac_address)
+    # The reload after the entry update reconnects and re-offers the
+    # key as a background task; assert on the provisioning-time call.
+    assert mock_post_key.await_args_list[0] == call(
+        "test-device", expected_key, mac=mac_address
+    )
 
 
 async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
@@ -2969,7 +2973,9 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
         await device.mock_connect()
 
     assert entry.data[CONF_NOISE_PSK] == test_key
-    mock_post_key.assert_awaited_once_with("test-device", test_key, mac=mac_address)
+    assert mock_post_key.await_args_list[0] == call(
+        "test-device", test_key, mac=mac_address
+    )
 
 
 @pytest.mark.parametrize(
@@ -3018,12 +3024,106 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
         await device.mock_disconnect(True)
         await device.mock_connect()
 
-    mock_post_key.assert_awaited_once()
+    assert mock_post_key.await_count >= 1
     assert entry.data[CONF_NOISE_PSK] == expected_key
     assert (
         hass_storage[ENCRYPTION_KEY_STORAGE_KEY]["data"]["keys"][mac_address]
         == expected_key
     )
+
+
+async def test_existing_key_resynced_to_dashboard_on_connect(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test a connect with a proven-valid key re-offers it to the dashboard."""
+    mac_address = "11:22:33:44:55:aa"
+    test_key = base64.b64encode(b"existing_key_32_bytes_long!!!").decode()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_HOST: "192.168.1.100",
+            CONF_PORT: 6053,
+            CONF_PASSWORD: "",
+            CONF_DEVICE_NAME: "test-device",
+            CONF_NOISE_PSK: test_key,
+        },
+        unique_id=mac_address,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        return_value={"result": "unchanged", "configurations": ["test-device.yaml"]},
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    mock_post_key.assert_awaited_with("test-device", test_key, mac=mac_address)
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dashboard_not_writable_response_logs_warning(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test a dashboard that declined the key surfaces an actionable warning."""
+    mac_address = "11:22:33:44:55:aa"
+    test_key_bytes = b"test_key_32_bytes_long_exactly!"
+    mock_token_bytes.return_value = test_key_bytes
+    expected_key = base64.b64encode(test_key_bytes).decode()
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        return_value={
+            "result": "not_writable",
+            "configurations": ["test-device.yaml"],
+            "reason": "the key is provided via !secret or a substitution",
+        },
+    ):
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+
+    assert entry.data[CONF_NOISE_PSK] == expected_key
+    assert "could not store the encryption key" in caplog.text
+    assert "!secret" in caplog.text
 
 
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -31,6 +31,7 @@ from aioesphomeapi import (
     ZWaveProxyRequest,
     ZWaveProxyRequestType,
 )
+import aiohttp
 import pytest
 import voluptuous as vol
 
@@ -2884,6 +2885,220 @@ async def test_dynamic_encryption_key_provisioned_over_zero_psk_from_storage(
     )
     mock_client.noise_encryption_set_key.assert_not_called()
     assert entry.data[CONF_NOISE_PSK] == test_key
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dynamic_encryption_key_synced_to_dashboard(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test a newly generated key is pushed to the dashboard."""
+    mac_address = "11:22:33:44:55:aa"
+    test_key_bytes = b"test_key_32_bytes_long_exactly!"
+    mock_token_bytes.return_value = test_key_bytes
+    expected_key = base64.b64encode(test_key_bytes).decode()
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        return_value={"result": "stored"},
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+
+    assert entry.data[CONF_NOISE_PSK] == expected_key
+    mock_post_key.assert_awaited_once_with("test-device", expected_key, mac=mac_address)
+
+
+async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test a storage-recovered key is pushed to the dashboard too."""
+    mac_address = "11:22:33:44:55:aa"
+    test_key = base64.b64encode(b"existing_key_32_bytes_long!!!").decode()
+
+    hass_storage[ENCRYPTION_KEY_STORAGE_KEY] = {
+        "version": 1,
+        "minor_version": 1,
+        "key": ENCRYPTION_KEY_STORAGE_KEY,
+        "data": {"keys": {mac_address: test_key}},
+    }
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        return_value={"result": "stored"},
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+
+    assert entry.data[CONF_NOISE_PSK] == test_key
+    mock_post_key.assert_awaited_once_with("test-device", test_key, mac=mac_address)
+
+
+@pytest.mark.parametrize(
+    "sync_error",
+    [
+        aiohttp.ClientResponseError(request_info=Mock(), history=(), status=404),
+        aiohttp.ClientError("boom"),
+        TimeoutError(),
+    ],
+)
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+    sync_error: Exception,
+) -> None:
+    """Test an old dashboard (404) or a flaky one never fails the connect flow."""
+    mac_address = "11:22:33:44:55:aa"
+    test_key_bytes = b"test_key_32_bytes_long_exactly!"
+    mock_token_bytes.return_value = test_key_bytes
+    expected_key = base64.b64encode(test_key_bytes).decode()
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        side_effect=sync_error,
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+
+    mock_post_key.assert_awaited_once()
+    assert entry.data[CONF_NOISE_PSK] == expected_key
+    assert (
+        hass_storage[ENCRYPTION_KEY_STORAGE_KEY]["data"]["keys"][mac_address]
+        == expected_key
+    )
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dynamic_encryption_key_not_synced_without_dashboard(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+) -> None:
+    """Test no dashboard registered means no push is attempted."""
+    mac_address = "11:22:33:44:55:aa"
+    mock_token_bytes.return_value = b"test_key_32_bytes_long_exactly!"
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+
+    assert entry.data[CONF_NOISE_PSK] != ""
+    mock_post_key.assert_not_awaited()
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dynamic_encryption_key_not_synced_when_provisioning_fails(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+) -> None:
+    """Test a key the device rejected is never pushed to the dashboard."""
+    mac_address = "11:22:33:44:55:aa"
+    mock_token_bytes.return_value = b"test_key_32_bytes_long_exactly!"
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=False)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+
+    assert CONF_NOISE_PSK not in entry.data or entry.data[CONF_NOISE_PSK] == ""
+    mock_post_key.assert_not_awaited()
 
 
 @pytest.mark.parametrize(

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -2927,8 +2927,10 @@ async def test_dynamic_encryption_key_synced_to_dashboard(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
-    # The success latch makes the provisioning-time push the only one.
-    mock_post_key.assert_awaited_once_with("test-device", expected_key, mac=mac_address)
+    # Provisioning-time push first; the reconnect re-offers the same key.
+    assert mock_post_key.await_args_list[0] == call(
+        "test-device", expected_key, mac=mac_address
+    )
 
 
 async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
@@ -2973,7 +2975,9 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == test_key
-    mock_post_key.assert_awaited_once_with("test-device", test_key, mac=mac_address)
+    assert mock_post_key.await_args_list[0] == call(
+        "test-device", test_key, mac=mac_address
+    )
 
 
 @pytest.mark.parametrize(
@@ -3159,8 +3163,9 @@ async def test_existing_key_resynced_to_dashboard_on_connect(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     mock_post_key.assert_awaited_with("test-device", test_key, mac=mac_address)
-    # The success latch stops the re-offer on subsequent connects.
-    assert mock_post_key.await_count == 1
+    # No success latch: every connect re-offers so a dashboard whose
+    # copy was deleted gets it back; the dashboard no-ops otherwise.
+    assert mock_post_key.await_count == 2
 
 
 async def test_user_provided_key_not_resynced_to_dashboard(
@@ -3299,7 +3304,7 @@ async def test_dashboard_partial_success_warns_and_keeps_retrying(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     # The duplicate-name sibling still carries a competing key: warn
-    # (deduped) and keep the sync unlatched so reconnects retry.
+    # (once) while reconnects keep retrying.
     assert caplog.text.count("could not store the encryption key") == 1
     assert "!secret" in caplog.text
     assert mock_post_key.await_count == 2

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -2982,12 +2982,23 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
 
 
 @pytest.mark.parametrize(
-    "sync_error",
+    ("sync_error", "expect_warning"),
     [
-        aiohttp.ClientResponseError(request_info=Mock(), history=(), status=404),
-        aiohttp.ClientError("boom"),
-        TimeoutError(),
-        json.JSONDecodeError("boom", "x", 0),
+        (
+            aiohttp.ClientResponseError(request_info=Mock(), history=(), status=404),
+            False,
+        ),
+        (
+            aiohttp.ClientResponseError(request_info=Mock(), history=(), status=405),
+            False,
+        ),
+        (
+            aiohttp.ClientResponseError(request_info=Mock(), history=(), status=500),
+            True,
+        ),
+        (aiohttp.ClientError("boom"), True),
+        (TimeoutError(), True),
+        (json.JSONDecodeError("boom", "x", 0), True),
     ],
 )
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
@@ -3000,6 +3011,8 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
     hass_storage: dict[str, Any],
     mock_dashboard: dict[str, Any],
     sync_error: Exception,
+    expect_warning: bool,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test an old dashboard (404) or a flaky one never fails the connect flow."""
     mac_address = "11:22:33:44:55:aa"
@@ -3044,6 +3057,50 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
         hass_storage[ENCRYPTION_KEY_STORAGE_KEY]["data"]["keys"][mac_address]
         == expected_key
     )
+    # Endpoint-absent (404/405) stays debug; real failures warn so the
+    # possible lockout is visible.
+    assert ("could not store the encryption key" in caplog.text) is expect_warning
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dashboard_unexpected_sync_result_logs_warning(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an unrecognized dashboard response is treated as a failed handoff."""
+    mac_address = "11:22:33:44:55:aa"
+    mock_token_bytes.return_value = b"test_key_32_bytes_long_exactly!"
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        return_value={"error": "unknown device"},
+    ):
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert caplog.text.count("could not store the encryption key") == 1
+    assert "unexpected response" in caplog.text
 
 
 async def test_existing_key_resynced_to_dashboard_on_connect(

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -3262,6 +3262,54 @@ async def test_dashboard_not_writable_response_logs_warning(
 
 
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
+async def test_dashboard_partial_success_warns_and_keeps_retrying(
+    mock_token_bytes: Mock,
+    hass: HomeAssistant,
+    mock_client: APIClient,
+    mock_esphome_device: MockESPHomeDeviceType,
+    hass_storage: dict[str, Any],
+    mock_dashboard: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test an updated-with-reason response warns and does not latch success."""
+    mac_address = "11:22:33:44:55:aa"
+    mock_token_bytes.return_value = b"test_key_32_bytes_long_exactly!"
+
+    entry = _make_provisionable_entry(hass, mac_address)
+    mock_client.noise_encryption_set_key = AsyncMock(return_value=True)
+
+    with patch(
+        "esphome_dashboard_api.ESPHomeDashboardAPI.post_encryption_key",
+        new_callable=AsyncMock,
+        return_value={
+            "result": "updated",
+            "configurations": ["test-device.yaml", "test-device (1).yaml"],
+            "reason": "the key is provided via !secret or a substitution",
+        },
+    ) as mock_post_key:
+        device = await mock_esphome_device(
+            mock_client=mock_client,
+            entry=entry,
+            device_info={
+                "uses_password": False,
+                "name": "test-device",
+                "mac_address": mac_address,
+                "esphome_version": "2023.12.0",
+                "api_encryption_supported": True,
+            },
+        )
+        await device.mock_disconnect(True)
+        await device.mock_connect()
+        await hass.async_block_till_done(wait_background_tasks=True)
+
+    # The duplicate-name sibling still carries a competing key: warn
+    # (deduped) and keep the sync unlatched so reconnects retry.
+    assert caplog.text.count("could not store the encryption key") == 1
+    assert "!secret" in caplog.text
+    assert mock_post_key.await_count == 2
+
+
+@patch("homeassistant.components.esphome.manager.secrets.token_bytes")
 async def test_dashboard_sync_warns_once_per_distinct_cause(
     mock_token_bytes: Mock,
     hass: HomeAssistant,

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -2927,11 +2927,8 @@ async def test_dynamic_encryption_key_synced_to_dashboard(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == expected_key
-    # The test's second connect sees the stored key and re-offers it as
-    # a background task; assert on the provisioning-time call.
-    assert mock_post_key.await_args_list[0] == call(
-        "test-device", expected_key, mac=mac_address
-    )
+    # The success latch makes the provisioning-time push the only one.
+    mock_post_key.assert_awaited_once_with("test-device", expected_key, mac=mac_address)
 
 
 async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
@@ -2976,9 +2973,7 @@ async def test_dynamic_encryption_key_from_storage_synced_to_dashboard(
         await hass.async_block_till_done(wait_background_tasks=True)
 
     assert entry.data[CONF_NOISE_PSK] == test_key
-    assert mock_post_key.await_args_list[0] == call(
-        "test-device", test_key, mac=mac_address
-    )
+    mock_post_key.assert_awaited_once_with("test-device", test_key, mac=mac_address)
 
 
 @pytest.mark.parametrize(
@@ -3067,6 +3062,7 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
     [
         pytest.param({"error": "unknown device"}, id="not_an_outcome"),
         pytest.param(["valid", "json", "wrong", "shape"], id="not_a_dict"),
+        pytest.param({"result": ["updated"]}, id="unhashable_result"),
     ],
 )
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
@@ -3310,7 +3306,7 @@ async def test_dashboard_partial_success_warns_and_keeps_retrying(
 
 
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")
-async def test_dashboard_sync_warns_once_per_distinct_cause(
+async def test_dashboard_sync_warns_once_across_causes(
     mock_token_bytes: Mock,
     hass: HomeAssistant,
     mock_client: APIClient,
@@ -3319,7 +3315,7 @@ async def test_dashboard_sync_warns_once_per_distinct_cause(
     mock_dashboard: dict[str, Any],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test a transient error does not mute a later distinct decline."""
+    """Test the handoff warns exactly once regardless of failure causes."""
     mac_address = "11:22:33:44:55:aa"
     mock_token_bytes.return_value = b"test_key_32_bytes_long_exactly!"
 
@@ -3349,9 +3345,9 @@ async def test_dashboard_sync_warns_once_per_distinct_cause(
         await device.mock_connect()
         await hass.async_block_till_done(wait_background_tasks=True)
 
-    assert caplog.text.count("could not store the encryption key") == 2
+    assert caplog.text.count("could not store the encryption key") == 1
     assert "boom" in caplog.text
-    assert "!secret" in caplog.text
+    assert "!secret" not in caplog.text
 
 
 @patch("homeassistant.components.esphome.manager.secrets.token_bytes")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Fixes a lockout dead end with dynamically provisioned encryption keys. When HA provisions a key on a keyless device, the ESPHome dashboard has no way to know about it; adopting the device in the dashboard generates a different key, the next flash bakes that competing key into the firmware, and HA can no longer connect with the key it stored. Reproduced with a CAST-1-W.

After a successful provision the manager now tells the dashboard about the key via `post_encryption_key` (esphome-dashboard-api 1.4.0). The dashboard splices it into an adopted device's YAML or holds it for adoption, so both sides stay on the same key (esphome/device-builder#2496). The push is best effort; a dashboard without the endpoint returns 404 and the connect flow is never failed.

Connects with an already-provisioned key also re-offer it as a background task, so a dashboard that was added later, upgraded, or unreachable at provisioning time catches up; the dashboard treats an identical key as a no-op. The re-sync only fires for keys present in the encryption key storage, meaning keys HA itself provisioned; user-authored YAML keys are never pushed, mirroring the removal path's rule. The re-offer deliberately runs on every connect with no success latch; the dashboard no-ops on an identical key, and a dashboard whose stored copy was deleted out from under it gets the key back on the next connect.

Failure handling is fail-visible: only 404/405 (dashboard without the endpoint) stays at debug; any other transport error, timeout, malformed response, unrecognized result, or a partial success where a duplicate configuration refused the key produces a single warning per manager naming the device and the dashboard's reason. Nothing on this path can fail the connect flow or stall entity setup; both push sites schedule through one background-task helper.

The alternative we considered was to keep the key out of the dashboard entirely: the dynamically provisioned key stays in the device's NVS, known only to HA and the device. We rejected that for two reasons. First, losing either copy loses the key forever; recovery would mean a serial flash, which is a real problem when the device is installed somewhere inaccessible. Sharing the key with the dashboard keeps the usual recovery path where a reachable device can always be rebuilt and reflashed over the air. Second, without the key the dashboard can't control the device or stream logs over the encrypted native API, so the key has to reach it for the dashboard to stay functional at all. The trust model already lets HA fetch keys from the dashboard (`get_encryption_key` via `/json-config`); pushing them the other way is the natural inverse of that existing two way trust.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
