### PR TITLE
Fix Risco naive `datetime.now()`

### DIFF
--- a/homeassistant/components/risco/services.py
+++ b/homeassistant/components/risco/services.py
@@ -1,13 +1,12 @@
 """Services for Risco integration."""
 
-from datetime import datetime
-
 import voluptuous as vol
 
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_TIME
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import config_validation as cv, service
+from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, SERVICE_SET_TIME
 from .models import RiscoConfigEntry
@@ -31,7 +30,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
 
         time_to_send = time
         if time is None:
-            time_to_send = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+            time_to_send = dt_util.now()
 
         await local_data.system.set_time(time_to_send)
 

--- a/tests/components/risco/test_services.py
+++ b/tests/components/risco/test_services.py
@@ -1,6 +1,5 @@
 """Tests for the Risco services."""
 
-from datetime import datetime
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +10,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import ATTR_CONFIG_ENTRY_ID, ATTR_TIME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
+from homeassistant.util import dt as dt_util
 
 from .conftest import TEST_CLOUD_CONFIG
 
@@ -23,7 +23,7 @@ async def test_set_time_service(
     """Test the set_time service."""
     with patch("homeassistant.components.risco.RiscoLocal.set_time") as mock:
         time_str = "2025-02-21T12:00:00"
-        time = datetime.fromisoformat(time_str)
+        time = dt_util.parse_datetime(time_str)
         data = {
             ATTR_CONFIG_ENTRY_ID: local_config_entry.entry_id,
             ATTR_TIME: time_str,
@@ -50,7 +50,7 @@ async def test_set_time_service_with_no_time(
             DOMAIN, SERVICE_SET_TIME, service_data=data, blocking=True
         )
 
-        mock_set_time.assert_called_once_with(datetime.now())  # pylint: disable=home-assistant-enforce-naive-now
+        mock_set_time.assert_called_once_with(dt_util.now())
 
 
 async def test_set_time_service_with_invalid_entry(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This PR fixes #177824 and addresses the naive `datetime.now()` calls.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [X] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177824 
- This PR is related to issue: /
- Link to documentation pull request: /
- Link to developer documentation pull request: /
- Link to frontend pull request: /

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
