### PR TITLE
Fix assist capability in Open Router when using Web Search

### DIFF
--- a/homeassistant/components/open_router/entity.py
+++ b/homeassistant/components/open_router/entity.py
@@ -237,52 +237,65 @@ class OpenRouterEntity(Entity):
 
         extra_body: dict[str, Any] = {"require_parameters": True}
 
+        tools: list[ChatCompletionFunctionToolParam | dict[str, Any]] = []
+        if chat_log.llm_api:
+            tools.extend(
+                [
+                    _format_tool(tool, chat_log.llm_api.custom_serializer)
+                    for tool in chat_log.llm_api.tools
+                ]
+            )
+
         match self.subentry.data.get(CONF_WEB_SEARCH):
             case "plugin":
                 model += ":online"
                 LOGGER.debug("Using plugin web search mode: %s", model)
             case "tool":
-                extra_body["tools"] = [
+                tools.append(
                     {"type": "openrouter:web_search", "parameters": {"engine": "auto"}}
-                ]
+                )
                 LOGGER.debug("Using auto tool web search mode: %s", model)
             case "tool_native":
-                extra_body["tools"] = [
+                tools.append(
                     {
                         "type": "openrouter:web_search",
                         "parameters": {"engine": "native"},
                     }
-                ]
+                )
                 LOGGER.debug("Using native tool web search mode: %s", model)
             case "tool_exa":
-                extra_body["tools"] = [
+                tools.append(
                     {"type": "openrouter:web_search", "parameters": {"engine": "exa"}}
-                ]
+                )
                 LOGGER.debug("Using Exa tool web search mode: %s", model)
             case "tool_firecrawl":
-                extra_body["tools"] = [
+                tools.append(
                     {
                         "type": "openrouter:web_search",
                         "parameters": {"engine": "firecrawl"},
                     }
-                ]
+                )
                 LOGGER.debug("Using Firecrawl tool web search mode: %s", model)
             case "tool_parallel":
-                extra_body["tools"] = [
+                tools.append(
                     {
                         "type": "openrouter:web_search",
                         "parameters": {"engine": "parallel"},
                     }
-                ]
+                )
                 LOGGER.debug("Using Parallel tool web search mode: %s", model)
             case "tool_perplexity":
-                extra_body["tools"] = [
+                tools.append(
                     {
                         "type": "openrouter:web_search",
                         "parameters": {"engine": "perplexity"},
                     }
-                ]
+                )
                 LOGGER.debug("Using Perplexity tool web search mode: %s", model)
+
+        if tools:
+            extra_body["tools"] = tools
+
         model_args = {
             "model": model,
             "user": chat_log.conversation_id,
@@ -292,16 +305,6 @@ class OpenRouterEntity(Entity):
             },
             "extra_body": extra_body,
         }
-
-        tools: list[ChatCompletionFunctionToolParam] | None = None
-        if chat_log.llm_api:
-            tools = [
-                _format_tool(tool, chat_log.llm_api.custom_serializer)
-                for tool in chat_log.llm_api.tools
-            ]
-
-        if tools:
-            model_args["tools"] = tools
 
         model_args["messages"] = [
             m

--- a/tests/components/open_router/test_conversation.py
+++ b/tests/components/open_router/test_conversation.py
@@ -80,17 +80,27 @@ async def test_default_prompt(
 
 
 @pytest.mark.parametrize(
-    ("web_search", "expected_server_tools", "expected_model_suffix"),
+    ("web_search", "expected_model_suffix", "enable_assist"),
     [
-        ("plugin", None, ":online"),
+        ("plugin", ":online", False),
         (
             "tool",
-            [{"type": "openrouter:web_search", "parameters": {"engine": "auto"}}],
             "",
+            False,
         ),
-        ("off", None, ""),
+        (
+            "tool",
+            "",
+            True,
+        ),
+        ("off", "", False),
     ],
-    ids=["web_search_plugin_enabled", "web_search_enabled", "web_search_disabled"],
+    ids=[
+        "web_search_plugin_enabled",
+        "web_search_enabled",
+        "web_search_enabled_with_assist",
+        "web_search_disabled",
+    ],
 )
 async def test_web_search(
     hass: HomeAssistant,
@@ -98,7 +108,7 @@ async def test_web_search(
     mock_openai_client: AsyncMock,
     mock_chat_log: MockChatLog,  # noqa: F811
     web_search: str,
-    expected_server_tools: dict[str, str] | None,
+    enable_assist: bool,
     expected_model_suffix: str,
 ) -> None:
     """Test that web search adds :online suffix to model."""
@@ -113,7 +123,16 @@ async def test_web_search(
     call = mock_openai_client.chat.completions.create.call_args_list[0][1]
     expected_model = "openai/gpt-3.5-turbo" + expected_model_suffix
     assert call["model"] == expected_model
-    assert call["extra_body"].get("tools") == expected_server_tools
+    if web_search == "tool":
+        assert {
+            "type": "openrouter:web_search",
+            "parameters": {"engine": "auto"},
+        } in call["extra_body"]["tools"]
+    if enable_assist:
+        assert any(
+            tool.get("function", {}).get("name") == "GetDateTime"
+            for tool in call["extra_body"]["tools"]
+        )
 
 
 async def test_empty_api_response(

--- a/tests/components/open_router/test_conversation.py
+++ b/tests/components/open_router/test_conversation.py
@@ -80,27 +80,17 @@ async def test_default_prompt(
 
 
 @pytest.mark.parametrize(
-    ("web_search", "expected_model_suffix", "enable_assist"),
+    ("web_search", "expected_server_tools", "expected_model_suffix"),
     [
-        ("plugin", ":online", False),
+        ("plugin", None, ":online"),
         (
             "tool",
+            [{"type": "openrouter:web_search", "parameters": {"engine": "auto"}}],
             "",
-            False,
         ),
-        (
-            "tool",
-            "",
-            True,
-        ),
-        ("off", "", False),
+        ("off", None, ""),
     ],
-    ids=[
-        "web_search_plugin_enabled",
-        "web_search_enabled",
-        "web_search_enabled_with_assist",
-        "web_search_disabled",
-    ],
+    ids=["web_search_plugin_enabled", "web_search_enabled", "web_search_disabled"],
 )
 async def test_web_search(
     hass: HomeAssistant,
@@ -108,10 +98,10 @@ async def test_web_search(
     mock_openai_client: AsyncMock,
     mock_chat_log: MockChatLog,  # noqa: F811
     web_search: str,
-    enable_assist: bool,
+    expected_server_tools: dict[str, str] | None,
     expected_model_suffix: str,
 ) -> None:
-    """Test that web search adds :online suffix to model."""
+    """Test that web search works correctly."""
     await setup_integration(hass, mock_config_entry)
     await conversation.async_converse(
         hass,
@@ -123,16 +113,43 @@ async def test_web_search(
     call = mock_openai_client.chat.completions.create.call_args_list[0][1]
     expected_model = "openai/gpt-3.5-turbo" + expected_model_suffix
     assert call["model"] == expected_model
-    if web_search == "tool":
-        assert {
-            "type": "openrouter:web_search",
-            "parameters": {"engine": "auto"},
-        } in call["extra_body"]["tools"]
-    if enable_assist:
-        assert any(
-            tool.get("function", {}).get("name") == "GetDateTime"
-            for tool in call["extra_body"]["tools"]
-        )
+    assert call["extra_body"].get("tools") == expected_server_tools
+
+
+@pytest.mark.parametrize(
+    ("web_search", "enable_assist"),
+    [("tool", True)],
+)
+async def test_web_search_with_assist(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_openai_client: AsyncMock,
+    mock_chat_log: MockChatLog,  # noqa: F811
+    web_search: bool,
+    enable_assist: bool,
+) -> None:
+    """Test that the web search and assist tools don't overwrite each other."""
+    await setup_integration(hass, mock_config_entry)
+    await conversation.async_converse(
+        hass,
+        "hello",
+        mock_chat_log.conversation_id,
+        Context(),
+        agent_id="conversation.gpt_3_5_turbo",
+    )
+    call = mock_openai_client.chat.completions.create.call_args_list[0][1]
+    expected_model = "openai/gpt-3.5-turbo"
+    assert call["model"] == expected_model
+    assert call["extra_body"].get("tools")
+    # Ensure the web search tool is in the tools list
+    assert {"type": "openrouter:web_search", "parameters": {"engine": "auto"}} in call[
+        "extra_body"
+    ]["tools"]
+    # Ensure GetDateTime is in the tools list
+    assert any(
+        tool.get("function", {}).get("name") == "GetDateTime"
+        for tool in call["extra_body"]["tools"]
+    )
 
 
 async def test_empty_api_response(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
This fixes the assist tools being overwritten by the web search tools when web search is on any tool mode by sending the tools directly through the extra body instead of through function parameters.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
