### PR TITLE
Remove redundancy and add typing to tests for Mikrotik

### DIFF
--- a/tests/components/mikrotik/conftest.py
+++ b/tests/components/mikrotik/conftest.py
@@ -1,15 +1,19 @@
 """Mikrotik test configuration."""
 
-from collections.abc import Generator
+from collections.abc import Callable, Generator
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from . import create_mock_config_entry
 
+from tests.common import MockConfigEntry
+
+type MockConfigEntryFactory = Callable[..., MockConfigEntry]
+
 
 @pytest.fixture
-def mock_config_entry():
+def mock_config_entry() -> MockConfigEntryFactory:
     """Create Mikrotik config entries with optional overrides."""
     return create_mock_config_entry
 
@@ -21,3 +25,10 @@ def mock_api() -> Generator[MagicMock]:
 
     with patch("librouteros.connect", return_value=api_instance):
         yield api_instance
+
+
+@pytest.fixture
+def mock_api_error(request: pytest.FixtureRequest) -> Generator[None]:
+    """Mock librouteros.connect raising the parametrized error."""
+    with patch("librouteros.connect", side_effect=request.param):
+        yield

--- a/tests/components/mikrotik/test_button.py
+++ b/tests/components/mikrotik/test_button.py
@@ -10,6 +10,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_mikrotik_entry
+from .conftest import MockConfigEntryFactory
 
 from tests.common import snapshot_platform
 
@@ -27,7 +28,9 @@ async def test_button_entities_created(
 
 
 async def test_button_press(
-    hass: HomeAssistant, mock_api: MagicMock, mock_config_entry
+    hass: HomeAssistant,
+    mock_api: MagicMock,
+    mock_config_entry: MockConfigEntryFactory,
 ) -> None:
     """Test Mikrotik button entities press."""
     await setup_mikrotik_entry(

--- a/tests/components/mikrotik/test_config_flow.py
+++ b/tests/components/mikrotik/test_config_flow.py
@@ -1,8 +1,6 @@
 """Test Mikrotik setup process."""
 
-from unittest.mock import patch
-
-import librouteros
+from librouteros.exceptions import ConnectionClosed, TrapError
 import pytest
 
 from homeassistant import config_entries
@@ -23,6 +21,8 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 
+from .conftest import MockConfigEntryFactory
+
 DEMO_USER_INPUT = {
     CONF_HOST: "0.0.0.0",
     CONF_USERNAME: "username",
@@ -42,34 +42,11 @@ DEMO_CONFIG_ENTRY = {
     CONF_DETECTION_TIME: 30,
 }
 
-
-@pytest.fixture(name="api")
-def mock_mikrotik_api():
-    """Mock an api."""
-    with patch("librouteros.connect"):
-        yield
+AUTH_ERROR = TrapError("invalid user name or password")
+CONN_ERROR = ConnectionClosed()
 
 
-@pytest.fixture(name="auth_error")
-def mock_api_authentication_error():
-    """Mock an api."""
-    with patch(
-        "librouteros.connect",
-        side_effect=librouteros.exceptions.TrapError("invalid user name or password"),
-    ):
-        yield
-
-
-@pytest.fixture(name="conn_error")
-def mock_api_connection_error():
-    """Mock an api."""
-    with patch(
-        "librouteros.connect", side_effect=librouteros.exceptions.ConnectionClosed
-    ):
-        yield
-
-
-async def test_flow_works(hass: HomeAssistant, api) -> None:
+async def test_flow_works(hass: HomeAssistant) -> None:
     """Test config flow."""
 
     result = await hass.config_entries.flow.async_init(
@@ -90,7 +67,10 @@ async def test_flow_works(hass: HomeAssistant, api) -> None:
     assert result["data"][CONF_PORT] == 8278
 
 
-async def test_options(hass: HomeAssistant, api, mock_config_entry) -> None:
+async def test_options(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntryFactory,
+) -> None:
     """Test updating options."""
     entry = mock_config_entry(data=DEMO_CONFIG_ENTRY)
     entry.add_to_hass(hass)
@@ -120,8 +100,11 @@ async def test_options(hass: HomeAssistant, api, mock_config_entry) -> None:
     }
 
 
+@pytest.mark.parametrize("mock_api_error", [AUTH_ERROR], indirect=True)
+@pytest.mark.usefixtures("mock_api_error")
 async def test_host_already_configured(
-    hass: HomeAssistant, auth_error, mock_config_entry
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntryFactory,
 ) -> None:
     """Test host already configured."""
 
@@ -138,7 +121,9 @@ async def test_host_already_configured(
     assert result["reason"] == "already_configured"
 
 
-async def test_connection_error(hass: HomeAssistant, conn_error) -> None:
+@pytest.mark.parametrize("mock_api_error", [CONN_ERROR], indirect=True)
+@pytest.mark.usefixtures("mock_api_error")
+async def test_connection_error(hass: HomeAssistant) -> None:
     """Test error when connection is unsuccessful."""
 
     result = await hass.config_entries.flow.async_init(
@@ -151,7 +136,9 @@ async def test_connection_error(hass: HomeAssistant, conn_error) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
-async def test_wrong_credentials(hass: HomeAssistant, auth_error) -> None:
+@pytest.mark.parametrize("mock_api_error", [AUTH_ERROR], indirect=True)
+@pytest.mark.usefixtures("mock_api_error")
+async def test_wrong_credentials(hass: HomeAssistant) -> None:
     """Test error when credentials are wrong."""
 
     result = await hass.config_entries.flow.async_init(
@@ -168,7 +155,10 @@ async def test_wrong_credentials(hass: HomeAssistant, auth_error) -> None:
     }
 
 
-async def test_reauth_success(hass: HomeAssistant, api, mock_config_entry) -> None:
+async def test_reauth_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntryFactory,
+) -> None:
     """Test we can reauth."""
     entry = mock_config_entry(data=DEMO_USER_INPUT)
     entry.add_to_hass(hass)
@@ -193,8 +183,11 @@ async def test_reauth_success(hass: HomeAssistant, api, mock_config_entry) -> No
     assert result2["reason"] == "reauth_successful"
 
 
+@pytest.mark.parametrize("mock_api_error", [AUTH_ERROR], indirect=True)
+@pytest.mark.usefixtures("mock_api_error")
 async def test_reauth_failed(
-    hass: HomeAssistant, auth_error, mock_config_entry
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntryFactory,
 ) -> None:
     """Test reauth fails due to wrong password."""
     entry = mock_config_entry(data=DEMO_USER_INPUT)
@@ -218,8 +211,11 @@ async def test_reauth_failed(
     }
 
 
+@pytest.mark.parametrize("mock_api_error", [CONN_ERROR], indirect=True)
+@pytest.mark.usefixtures("mock_api_error")
 async def test_reauth_failed_conn_error(
-    hass: HomeAssistant, conn_error, mock_config_entry
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntryFactory,
 ) -> None:
     """Test reauth failed due to connection error."""
     entry = mock_config_entry(data=DEMO_USER_INPUT)

--- a/tests/components/mikrotik/test_device_tracker.py
+++ b/tests/components/mikrotik/test_device_tracker.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.util.dt import utcnow
 
 from . import setup_mikrotik_entry
+from .conftest import MockConfigEntryFactory
 from .const import (
     DEVICE_2_WIRELESS,
     DEVICE_3_DHCP_NUMERIC_NAME,
@@ -33,7 +34,7 @@ from tests.common import async_fire_time_changed, patch
 def mock_device_registry_devices(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
-    mock_config_entry,
+    mock_config_entry: MockConfigEntryFactory,
 ) -> None:
     """Create device registry devices so the device tracker entities are enabled."""
     config_entry = mock_config_entry(domain="something_else", data={})
@@ -73,9 +74,8 @@ def mock_command(
     return {}
 
 
-async def test_device_trackers(
-    hass: HomeAssistant, mock_device_registry_devices
-) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_device_trackers(hass: HomeAssistant) -> None:
     """Test device_trackers created by mikrotik."""
 
     # test devices are added from wireless list only
@@ -124,7 +124,8 @@ async def test_device_trackers(
         assert device_2.state == "not_home"
 
 
-async def test_force_dhcp(hass: HomeAssistant, mock_device_registry_devices) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_force_dhcp(hass: HomeAssistant) -> None:
     """Test updating hub that supports wireless with forced dhcp method."""
 
     # hub supports wireless by default, force_dhcp is enabled to override
@@ -138,9 +139,8 @@ async def test_force_dhcp(hass: HomeAssistant, mock_device_registry_devices) -> 
     assert device_2.state == "home"
 
 
-async def test_hub_not_support_wireless(
-    hass: HomeAssistant, mock_device_registry_devices
-) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_hub_not_support_wireless(hass: HomeAssistant) -> None:
     """Test device_trackers created when hub doesn't support wireless."""
 
     await setup_mikrotik_entry(hass, support_wireless=False)
@@ -153,9 +153,8 @@ async def test_hub_not_support_wireless(
     assert device_2.state == "home"
 
 
-async def test_arp_ping_success(
-    hass: HomeAssistant, mock_device_registry_devices
-) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_arp_ping_success(hass: HomeAssistant) -> None:
     """Test arp ping devices to confirm they are connected."""
 
     with patch.object(
@@ -169,9 +168,8 @@ async def test_arp_ping_success(
         assert device_2.state == "home"
 
 
-async def test_arp_ping_timeout(
-    hass: HomeAssistant, mock_device_registry_devices
-) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_arp_ping_timeout(hass: HomeAssistant) -> None:
     """Test arp ping timeout so devices are shown away."""
     with patch.object(
         mikrotik.coordinator.MikrotikData, "do_arp_ping", return_value=False
@@ -184,9 +182,8 @@ async def test_arp_ping_timeout(
         assert device_2.state == "not_home"
 
 
-async def test_device_trackers_numerical_name(
-    hass: HomeAssistant, mock_device_registry_devices
-) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_device_trackers_numerical_name(hass: HomeAssistant) -> None:
     """Test device_trackers created by mikrotik with numerical device name."""
 
     await setup_mikrotik_entry(
@@ -202,7 +199,8 @@ async def test_device_trackers_numerical_name(
     assert device_3.attributes["host_name"] == "123"
 
 
-async def test_hub_wifiwave2(hass: HomeAssistant, mock_device_registry_devices) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_hub_wifiwave2(hass: HomeAssistant) -> None:
     """Test device_trackers created when hub supports wifiwave2."""
 
     await setup_mikrotik_entry(
@@ -225,7 +223,7 @@ async def test_hub_wifiwave2(hass: HomeAssistant, mock_device_registry_devices) 
 async def test_restoring_devices(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
-    mock_config_entry,
+    mock_config_entry: MockConfigEntryFactory,
 ) -> None:
     """Test restoring existing device_tracker entities if not detected on startup."""
     config_entry = mock_config_entry(
@@ -272,7 +270,8 @@ async def test_restoring_devices(
     assert device_3 is None
 
 
-async def test_update_failed(hass: HomeAssistant, mock_device_registry_devices) -> None:
+@pytest.mark.usefixtures("mock_device_registry_devices")
+async def test_update_failed(hass: HomeAssistant) -> None:
     """Test failing to connect during update."""
 
     await setup_mikrotik_entry(hass)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Remove redundancy and add typing to tests for Mikrotik

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
