### PR TITLE
Bump tuya-device-sharing-sdk to 0.2.14

### DIFF
--- a/homeassistant/components/tuya/manifest.json
+++ b/homeassistant/components/tuya/manifest.json
@@ -45,6 +45,6 @@
   "loggers": ["tuya_sharing"],
   "requirements": [
     "tuya-device-handlers==0.0.26",
-    "tuya-device-sharing-sdk==0.2.10"
+    "tuya-device-sharing-sdk==0.2.14"
   ]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3241,7 +3241,7 @@ ttn_client==1.3.0
 tuya-device-handlers==0.0.26
 
 # homeassistant.components.tuya
-tuya-device-sharing-sdk==0.2.10
+tuya-device-sharing-sdk==0.2.14
 
 # homeassistant.components.twentemilieu
 twentemilieu==3.0.0


### PR DESCRIPTION
## Proposed change

Bump `tuya-device-sharing-sdk` from 0.2.10 to 0.2.14.

The main motivation is a fix for an unrecoverable MQTT failure: on credential
renewal / auth failure (`rc=5`), the previous SDK re-ran the connect flow
directly inside the paho `on_connect` callback. Any error there — e.g.
`network error:(-9999999) sign invalid` from `/v1.0/m/life/ha/access/config` —
propagated as an uncaught exception that killed the MQTT network thread with no
recovery, leaving all Tuya entities stale until the integration was manually
reloaded. 0.2.14 moves reconnection out of the callback into the SDK's own run
loop (with backoff) and fully tears down the stale client, so a transient auth
error no longer permanently breaks push updates.

Version diff / release notes: https://github.com/tuya/tuya-device-sharing-sdk/compare/0.2.10...0.2.14

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
