### PR TITLE
Fix via_device race in hydrawise

### DIFF
--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -1,6 +1,8 @@
 """Support for Hydrawise cloud."""
 
-from pydrawise import auth, hybrid
+from collections.abc import Iterable
+
+from pydrawise import Controller, auth, hybrid
 
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant, callback
@@ -51,25 +53,33 @@ async def async_setup_entry(
     device_registry = dr.async_get(hass)
 
     @callback
-    def _async_register_controller_devices() -> None:
+    def _async_register_controller_devices(controllers: Iterable[Controller]) -> None:
         """Register controller devices so children can resolve via_device_id.
 
-        Controllers can appear on later coordinator updates, so this runs on
-        every update before the zone-tracking listener, keeping the via_device
-        parents registered before their child entities are constructed.
+        Runs as the first new-controller callback so via_device parents are
+        registered before the new-zone callbacks construct zone entities that
+        resolve their via_device_id. Registration must not run before
+        _add_remove_zones computes the previous controllers, or newly discovered
+        controllers would be treated as already-known and their controller-level
+        entities would never be added.
         """
-        for controller in main_coordinator.data.controllers.values():
+        for controller in controllers:
             device_registry.async_get_or_create(
                 config_entry_id=config_entry.entry_id,
                 identifiers={(DOMAIN, str(controller.id))},
                 manufacturer=MANUFACTURER,
                 model=controller.hardware.model.description,
                 name=controller.name,
+                # Explicitly clear any via_device_id: older versions linked the
+                # controller device to itself via its rain sensor entity.
+                via_device_id=None,
             )
 
-    _async_register_controller_devices()
-    config_entry.async_on_unload(
-        main_coordinator.async_add_listener(_async_register_controller_devices)
+    # Register the controllers known at setup before the platforms construct
+    # their entities.
+    _async_register_controller_devices(main_coordinator.data.controllers.values())
+    main_coordinator.new_controllers_callbacks.append(
+        _async_register_controller_devices
     )
 
     # async_track_zones is registered first on water_use_coordinator,

--- a/homeassistant/components/hydrawise/__init__.py
+++ b/homeassistant/components/hydrawise/__init__.py
@@ -3,10 +3,11 @@
 from pydrawise import auth, hybrid
 
 from homeassistant.const import CONF_API_KEY, CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
 
-from .const import APP_ID
+from .const import APP_ID, DOMAIN, MANUFACTURER
 from .coordinator import (
     HydrawiseConfigEntry,
     HydrawiseMainDataUpdateCoordinator,
@@ -46,6 +47,31 @@ async def async_setup_entry(
     water_use_coordinator = HydrawiseWaterUseDataUpdateCoordinator(
         hass, config_entry, hydrawise, main_coordinator
     )
+
+    device_registry = dr.async_get(hass)
+
+    @callback
+    def _async_register_controller_devices() -> None:
+        """Register controller devices so children can resolve via_device_id.
+
+        Controllers can appear on later coordinator updates, so this runs on
+        every update before the zone-tracking listener, keeping the via_device
+        parents registered before their child entities are constructed.
+        """
+        for controller in main_coordinator.data.controllers.values():
+            device_registry.async_get_or_create(
+                config_entry_id=config_entry.entry_id,
+                identifiers={(DOMAIN, str(controller.id))},
+                manufacturer=MANUFACTURER,
+                model=controller.hardware.model.description,
+                name=controller.name,
+            )
+
+    _async_register_controller_devices()
+    config_entry.async_on_unload(
+        main_coordinator.async_add_listener(_async_register_controller_devices)
+    )
+
     # async_track_zones is registered first on water_use_coordinator,
     # so the water-use coordinator's data is in sync before
     # callbacks below construct entities for newly added zones.

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -5,6 +5,7 @@ from typing import override
 from pydrawise.schema import Controller, Sensor, Zone
 
 from homeassistant.core import callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import EntityDescription
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -47,7 +48,13 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
             manufacturer=MANUFACTURER,
         )
         if zone_id is not None or sensor_id is not None:
-            self._attr_device_info["via_device"] = (DOMAIN, str(controller.id))
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, str(controller.id)),
+                    config_entry_id=self.coordinator.config_entry.entry_id,
+                )
+            )
         self._update_attrs()
 
     @property

--- a/homeassistant/components/hydrawise/entity.py
+++ b/homeassistant/components/hydrawise/entity.py
@@ -47,7 +47,10 @@ class HydrawiseEntity(CoordinatorEntity[HydrawiseDataUpdateCoordinator]):
             ),
             manufacturer=MANUFACTURER,
         )
-        if zone_id is not None or sensor_id is not None:
+        if zone_id is not None:
+            # Only zones get their own device; sensor entities share the
+            # controller device, so linking them to the controller would create
+            # a self-referential via_device.
             self._attr_device_info["via_device_id"] = (
                 dr.async_get_device_id_by_identifier(
                     self.coordinator.hass,

--- a/tests/components/hydrawise/test_device.py
+++ b/tests/components/hydrawise/test_device.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import Mock
 
+import pytest
+
 from homeassistant.components.hydrawise.const import DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -38,3 +40,21 @@ def test_controller_in_device_registry(
     assert device is not None
     assert device.name == "Home Controller"
     assert device.manufacturer == "Hydrawise"
+
+
+@pytest.mark.usefixtures("mock_pydrawise")
+def test_zone_via_device_links_to_controller(
+    device_registry: dr.DeviceRegistry,
+    mock_added_config_entry: ConfigEntry,
+) -> None:
+    """Test that a zone device links to its controller via via_device_id."""
+    controller = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "52496"), mock_added_config_entry.entry_id
+    )
+    assert controller is not None
+
+    zone = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "5965394"), mock_added_config_entry.entry_id
+    )
+    assert zone is not None
+    assert zone.via_device_id == controller.id

--- a/tests/components/hydrawise/test_device.py
+++ b/tests/components/hydrawise/test_device.py
@@ -58,3 +58,20 @@ def test_zone_via_device_links_to_controller(
     )
     assert zone is not None
     assert zone.via_device_id == controller.id
+
+
+@pytest.mark.usefixtures("mock_pydrawise")
+def test_controller_has_no_self_via_device(
+    device_registry: dr.DeviceRegistry,
+    mock_added_config_entry: ConfigEntry,
+) -> None:
+    """Test the controller device does not link to itself via via_device_id.
+
+    Sensor entities share the controller device, so they must not set
+    via_device_id, which would point the controller device at itself.
+    """
+    controller = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "52496"), mock_added_config_entry.entry_id
+    )
+    assert controller is not None
+    assert controller.via_device_id is None

--- a/tests/components/hydrawise/test_init.py
+++ b/tests/components/hydrawise/test_init.py
@@ -94,6 +94,12 @@ async def test_auto_add_devices(
         identifiers={(DOMAIN, str(controller2.id))}
     )
     assert new_controller_device is not None
+
+    # The new controller's own entities must also be added, not just its device.
+    # Registering the controller device must not make _add_remove_zones treat the
+    # controller as already-known and skip the new-controller callbacks.
+    assert hass.states.get("binary_sensor.home_controller_2_connectivity") is not None
+
     for zone in zones2:
         new_zone_device = device_registry.async_get_device(
             identifiers={(DOMAIN, str(zone.id))}
@@ -110,6 +116,38 @@ async def test_auto_add_devices(
     # newly added zones, even though the water-use coordinator hasn't refreshed.
     assert hass.states.get("sensor.zone_one_2_daily_active_watering_time") is not None
     assert hass.states.get("sensor.zone_two_2_daily_active_watering_time") is not None
+
+
+async def test_setup_clears_self_referential_via_device(
+    hass: HomeAssistant,
+    device_registry: DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
+    mock_pydrawise: AsyncMock,
+) -> None:
+    """Test setup clears a self-referential via_device left by older versions.
+
+    Older versions linked the controller device to itself via its rain sensor
+    entity, which persists in the device registry across upgrades.
+    """
+    mock_config_entry.add_to_hass(hass)
+    controller = device_registry.async_get_or_create(
+        config_entry_id=mock_config_entry.entry_id,
+        identifiers={(DOMAIN, "52496")},
+        name="Home Controller",
+    )
+    controller = device_registry.async_update_device(
+        controller.id, via_device_id=controller.id
+    )
+    assert controller.via_device_id == controller.id
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    controller = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "52496"), mock_config_entry.entry_id
+    )
+    assert controller is not None
+    assert controller.via_device_id is None
 
 
 async def test_auto_remove_devices(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `hydrawise`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
