### PR TITLE
Fix via_device race in victron_gx

### DIFF
--- a/homeassistant/components/victron_gx/hub.py
+++ b/homeassistant/components/victron_gx/hub.py
@@ -28,7 +28,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.redact import async_redact_data
 
 from .const import CONF_INSTALLATION_ID, CONF_SERIAL, DOMAIN
@@ -40,7 +40,7 @@ TO_REDACT = {CONF_USERNAME, CONF_PASSWORD}
 type VictronGxConfigEntry = ConfigEntry[Hub]
 
 type NewMetricCallback = Callable[
-    [VictronVenusDevice, VictronVenusMetric, DeviceInfo, str], None
+    [VictronVenusDevice, VictronVenusMetric, dr.DeviceInfo, str], None
 ]
 
 
@@ -64,6 +64,8 @@ class Hub:
         config = {**entry.data, **entry.options}
         self.hass = hass
         self.host = config[CONF_HOST]
+        self._config_entry_id = entry.entry_id
+        self._device_registry = dr.async_get(hass)
 
         self._hub = VictronVenusHub(
             host=self.host,
@@ -120,15 +122,39 @@ class Hub:
         if TYPE_CHECKING:
             assert hub.installation_id is not None
         device_info = Hub._map_device_info(device, hub.installation_id)
+        if device.parent_device is not None:
+            device_info["via_device_id"] = self._ensure_device_registered(
+                device.parent_device, hub.installation_id
+            )
         callback = self.new_metric_callbacks.get(metric.metric_kind)
         if callback is not None:
             callback(device, metric, device_info, hub.installation_id)
 
+    def _ensure_device_registered(
+        self, device: VictronVenusDevice, installation_id: str
+    ) -> str:
+        """Register a device and its ancestors (parents first), returning its id.
+
+        Devices are discovered lazily as their metrics arrive, so a child's parent
+        may not be in the registry yet; registering the ancestor chain here lets
+        children link to it via via_device_id instead of the deprecated via_device.
+        """
+        device_info = Hub._map_device_info(device, installation_id)
+        if device.parent_device is not None:
+            device_info["via_device_id"] = self._ensure_device_registered(
+                device.parent_device, installation_id
+            )
+        device_entry = self._device_registry.async_get_or_create(
+            config_entry_id=self._config_entry_id,
+            **device_info,
+        )
+        return device_entry.id
+
     @staticmethod
     def _map_device_info(
         device: VictronVenusDevice, installation_id: str
-    ) -> DeviceInfo:
-        device_info = DeviceInfo(
+    ) -> dr.DeviceInfo:
+        return dr.DeviceInfo(
             identifiers={(DOMAIN, f"{installation_id}_{device.unique_id}")},
             manufacturer=(
                 device.manufacturer
@@ -139,13 +165,6 @@ class Hub:
             model=device.model,
             serial_number=device.serial_number,
         )
-        # Set via_device based on parent_device relationship
-        if device.parent_device is not None:
-            device_info["via_device"] = (
-                DOMAIN,
-                f"{installation_id}_{device.parent_device.unique_id}",
-            )
-        return device_info
 
     def is_device_connected(self, device_identifiers: set[tuple[str, str]]) -> bool:
         """Check if a device is currently known to the hub."""

--- a/tests/components/victron_gx/test_init.py
+++ b/tests/components/victron_gx/test_init.py
@@ -159,16 +159,12 @@ async def test_device_via_device_links(
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test a child device links to its registered parent via via_device_id."""
+    """Test a child device links to its missing parent via via_device_id."""
     victron_hub, mock_config_entry = init_integration
 
-    # Inject a system metric first so system_0 is registered as the gateway device.
-    await inject_message(
-        victron_hub,
-        f"N/{MOCK_INSTALLATION_ID}/system/0/SystemState/State",
-        '{"value": 9}',
-    )
-    # Inject a battery metric; its parent_device resolves to system_0.
+    # Inject only a battery metric. Its parent (system_0) has no metric of its
+    # own here, so it is not registered on its own; the child must trigger
+    # registration of the missing parent to be able to link to it.
     await inject_message(
         victron_hub,
         f"N/{MOCK_INSTALLATION_ID}/battery/0/Dc/0/Current",

--- a/tests/components/victron_gx/test_init.py
+++ b/tests/components/victron_gx/test_init.py
@@ -154,13 +154,13 @@ async def test_hub_start_success(
     assert victron_hub.installation_id == MOCK_INSTALLATION_ID
 
 
-async def test_child_device_via_device_links_to_parent_in_registry(
+async def test_device_via_device_links(
     hass: HomeAssistant,
     init_integration: tuple[VictronVenusHub, MockConfigEntry],
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test non-root device is linked to its parent device in the HA device registry."""
-    victron_hub, _mock_config_entry = init_integration
+    """Test a child device links to its registered parent via via_device_id."""
+    victron_hub, mock_config_entry = init_integration
 
     # Inject a system metric first so system_0 is registered as the gateway device.
     await inject_message(
@@ -177,15 +177,15 @@ async def test_child_device_via_device_links_to_parent_in_registry(
     await finalize_injection(victron_hub)
     await hass.async_block_till_done()
 
-    system_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0")}
+    system_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_system_0"), mock_config_entry.entry_id
     )
     assert system_device is not None
     # The GX gateway has no parent — it IS the root.
     assert system_device.via_device_id is None
 
-    battery_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{MOCK_INSTALLATION_ID}_battery_0")}
+    battery_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{MOCK_INSTALLATION_ID}_battery_0"), mock_config_entry.entry_id
     )
     assert battery_device is not None
     # Battery is a child of the GX gateway, not an orphan.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `victron_gx`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
