### PR TITLE
Adapt incomfort to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/incomfort/climate.py
+++ b/homeassistant/components/incomfort/climate.py
@@ -12,6 +12,7 @@ from homeassistant.components.climate import (
 )
 from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -70,9 +71,12 @@ class InComfortClimate(IncomfortEntity, ClimateEntity):
             name=f"Thermostat {room.room_no}",
         )
         if coordinator.unique_id:
-            self._attr_device_info["via_device"] = (
-                DOMAIN,
-                coordinator.config_entry.entry_id,
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, coordinator.config_entry.entry_id),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                )
             )
 
     @property

--- a/homeassistant/components/incomfort/entity.py
+++ b/homeassistant/components/incomfort/entity.py
@@ -2,6 +2,7 @@
 
 from incomfortclient import Heater
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -29,7 +30,10 @@ class IncomfortBoilerEntity(IncomfortEntity):
             serial_number=heater.serial_no,
         )
         if coordinator.unique_id:
-            self._attr_device_info["via_device"] = (
-                DOMAIN,
-                coordinator.config_entry.entry_id,
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, coordinator.config_entry.entry_id),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                )
             )

--- a/tests/components/incomfort/conftest.py
+++ b/tests/components/incomfort/conftest.py
@@ -81,14 +81,24 @@ def mock_entry_options() -> dict[str, Any] | None:
 
 
 @pytest.fixture
+def mock_entry_unique_id() -> str | None:
+    """Mock config entry unique_id for fixture."""
+    return None
+
+
+@pytest.fixture
 def mock_config_entry(
     hass: HomeAssistant,
     mock_entry_data: dict[str, Any],
     mock_entry_options: dict[str, Any],
+    mock_entry_unique_id: str | None,
 ) -> MockConfigEntry:
     """Mock a config entry setup for incomfort integration."""
     entry = MockConfigEntry(
-        domain=DOMAIN, data=mock_entry_data, options=mock_entry_options
+        domain=DOMAIN,
+        data=mock_entry_data,
+        options=mock_entry_options,
+        unique_id=mock_entry_unique_id,
     )
     entry.add_to_hass(hass)
     return entry

--- a/tests/components/incomfort/test_init.py
+++ b/tests/components/incomfort/test_init.py
@@ -35,6 +35,36 @@ async def test_setup_platforms(
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("mock_entry_unique_id", ["00:04:a3:de:ad:ff"])
+async def test_device_via_device_links(
+    hass: HomeAssistant,
+    device_registry: DeviceRegistry,
+    mock_incomfort: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test that child devices link to the gateway via via_device_id."""
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    gateway_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    )
+    assert gateway_device is not None
+
+    boiler_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee"), mock_config_entry.entry_id
+    )
+    assert boiler_device is not None
+    assert boiler_device.via_device_id == gateway_device.id
+
+    thermostat_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "c0ffeec0ffee_1"), mock_config_entry.entry_id
+    )
+    assert thermostat_device is not None
+    assert thermostat_device.via_device_id == gateway_device.id
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize(
     "mock_heater_status", [MOCK_HEATER_STATUS | {"serial_no": "c01d00c0ffee"}]
 )


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `incomfort` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
