### PR TITLE
Adapt notion to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/notion/entity.py
+++ b/homeassistant/components/notion/entity.py
@@ -50,7 +50,13 @@ class NotionEntity(CoordinatorEntity[NotionDataUpdateCoordinator]):
         )
 
         if bridge := self._async_get_bridge(bridge_id):
-            self._attr_device_info["via_device"] = (DOMAIN, bridge.hardware_id)
+            self._attr_device_info["via_device_id"] = (
+                dr.async_get_device_id_by_identifier(
+                    self.coordinator.hass,
+                    (DOMAIN, bridge.hardware_id),
+                    config_entry_id=self.coordinator.config_entry.entry_id,
+                )
+            )
 
         self._attr_extra_state_attributes = {}
         self._attr_unique_id = listener_id

--- a/tests/components/notion/test_init.py
+++ b/tests/components/notion/test_init.py
@@ -1,0 +1,63 @@
+"""Test Notion setup."""
+
+from copy import deepcopy
+from typing import Any
+
+from aionotion.listener.models import ListenerKind
+import pytest
+
+from homeassistant.components.notion.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+# The id of the bridge in the bridge fixture; the sensor must reference it to link.
+BRIDGE_ID = 12345
+BRIDGE_HARDWARE_ID = "0x0000000000000012"
+SENSOR_HARDWARE_ID = "0x0000000000000034"
+
+
+@pytest.fixture(name="data_bridge")
+def data_bridge_fixture(data_bridge: dict[str, Any]) -> dict[str, Any]:
+    """Give the bridge a hardware id distinct from the sensor."""
+    data = deepcopy(data_bridge)
+    data["base_stations"][0]["hardware_id"] = BRIDGE_HARDWARE_ID
+    return data
+
+
+@pytest.fixture(name="data_sensor")
+def data_sensor_fixture(data_sensor: dict[str, Any]) -> dict[str, Any]:
+    """Link the sensor to the bridge and give it a distinct hardware id."""
+    data = deepcopy(data_sensor)
+    data["sensors"][0]["hardware_id"] = SENSOR_HARDWARE_ID
+    data["sensors"][0]["bridge"]["id"] = BRIDGE_ID
+    data["sensors"][0]["bridge"]["hardware_id"] = BRIDGE_HARDWARE_ID
+    return data
+
+
+@pytest.fixture(name="data_listener")
+def data_listener_fixture(data_listener: dict[str, Any]) -> dict[str, Any]:
+    """Use a listener kind that maps to an entity so a sensor device is created."""
+    data = deepcopy(data_listener)
+    data["listeners"][0]["definition_id"] = ListenerKind.HINGED_WINDOW.value
+    return data
+
+
+@pytest.mark.usefixtures("setup_config_entry")
+async def test_device_via_device_links(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a sensor device links to its bridge via via_device_id."""
+    bridge_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, BRIDGE_HARDWARE_ID), config_entry.entry_id
+    )
+    assert bridge_device is not None
+
+    sensor_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SENSOR_HARDWARE_ID), config_entry.entry_id
+    )
+    assert sensor_device is not None
+    assert sensor_device.via_device_id == bridge_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `notion` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
