### PR TITLE
Adapt telegram_bot to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/telegram_bot/notify.py
+++ b/homeassistant/components/telegram_bot/notify.py
@@ -9,6 +9,7 @@ from homeassistant.components.notify import (
 )
 from homeassistant.config_entries import ConfigSubentry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from . import TelegramBotConfigEntry
@@ -51,7 +52,11 @@ class TelegramBotNotifyEntity(TelegramBotEntity, NotifyEntity):
         assert device_info is not None
         device_info["identifiers"] = {(DOMAIN, f"{self.bot_id}_{self.chat_id}")}
         device_info["name"] = subentry.title
-        device_info["via_device"] = (DOMAIN, f"{self.bot_id}")
+        device_info["via_device_id"] = dr.async_get_device_id_by_identifier(
+            config_entry.runtime_data.hass,
+            (DOMAIN, f"{self.bot_id}"),
+            config_entry_id=config_entry.entry_id,
+        )
 
     @override
     async def async_send_message(self, message: str, title: str | None = None) -> None:

--- a/tests/components/telegram_bot/test_init.py
+++ b/tests/components/telegram_bot/test_init.py
@@ -208,6 +208,30 @@ async def test_per_chat_devices(
         assert entity_registry.async_get(notify_entity_id).device_id == chat_device.id
 
 
+async def test_device_via_device_links(
+    hass: HomeAssistant,
+    mock_broadcast_config_entry: MockConfigEntry,
+    mock_external_calls: None,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that per-chat devices link to the bot device via via_device_id."""
+    mock_broadcast_config_entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    bot_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456"), mock_broadcast_config_entry.entry_id
+    )
+    assert bot_device is not None
+
+    for chat_id in (123456, 654321):
+        chat_device = device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"123456_{chat_id}"), mock_broadcast_config_entry.entry_id
+        )
+        assert chat_device is not None
+        assert chat_device.via_device_id == bot_device.id
+
+
 async def test_remove_chat_subentry_removes_per_chat_device(
     hass: HomeAssistant,
     mock_broadcast_config_entry: MockConfigEntry,

--- a/tests/components/telegram_bot/test_init.py
+++ b/tests/components/telegram_bot/test_init.py
@@ -208,30 +208,6 @@ async def test_per_chat_devices(
         assert entity_registry.async_get(notify_entity_id).device_id == chat_device.id
 
 
-async def test_device_via_device_links(
-    hass: HomeAssistant,
-    mock_broadcast_config_entry: MockConfigEntry,
-    mock_external_calls: None,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test that per-chat devices link to the bot device via via_device_id."""
-    mock_broadcast_config_entry.add_to_hass(hass)
-    await hass.config_entries.async_setup(mock_broadcast_config_entry.entry_id)
-    await hass.async_block_till_done()
-
-    bot_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "123456"), mock_broadcast_config_entry.entry_id
-    )
-    assert bot_device is not None
-
-    for chat_id in (123456, 654321):
-        chat_device = device_registry.async_get_device_by_identifier(
-            (DOMAIN, f"123456_{chat_id}"), mock_broadcast_config_entry.entry_id
-        )
-        assert chat_device is not None
-        assert chat_device.via_device_id == bot_device.id
-
-
 async def test_remove_chat_subentry_removes_per_chat_device(
     hass: HomeAssistant,
     mock_broadcast_config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `telegram_bot` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
