### PR TITLE
Adapt velbus to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/velbus/entity.py
+++ b/homeassistant/components/velbus/entity.py
@@ -8,6 +8,7 @@ from velbusaio.channels import Channel as VelbusChannel
 from velbusaio.properties import Property as VelbusProperty
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity import Entity
 
@@ -31,22 +32,6 @@ class VelbusEntity(Entity):
         self._channel = channel
         self._module_address = str(channel.get_module_address())
         self._attr_name = channel.get_name()
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (DOMAIN, self._get_identifier()),
-            },
-            manufacturer="Velleman",
-            model=channel.get_module_type_name(),
-            model_id=str(channel.get_module_type()),
-            name=channel.get_full_name(),
-            sw_version=channel.get_module_sw_version(),
-            serial_number=channel.get_module_serial(),
-        )
-        if self._channel.is_sub_device():
-            self._attr_device_info["via_device"] = (
-                DOMAIN,
-                self._module_address,
-            )
         serial = channel.get_module_serial() or self._module_address
         self._attr_unique_id = f"{serial}-{channel.get_channel_number()}"
 
@@ -55,6 +40,30 @@ class VelbusEntity(Entity):
         if not self._channel.is_sub_device():
             return self._module_address
         return f"{self._module_address}-{self._channel.get_channel_number()}"
+
+    @property
+    @override
+    def device_info(self) -> DeviceInfo:
+        """Return device info, linking a sub-device to its module device."""
+        channel = self._channel
+        device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._get_identifier())},
+            manufacturer="Velleman",
+            model=channel.get_module_type_name(),
+            model_id=str(channel.get_module_type()),
+            name=channel.get_full_name(),
+            sw_version=channel.get_module_sw_version(),
+            serial_number=channel.get_module_serial(),
+        )
+        if channel.is_sub_device():
+            config_entry = self.platform.config_entry
+            assert config_entry
+            device_info["via_device_id"] = dr.async_get_device_id_by_identifier(
+                self.hass,
+                (DOMAIN, self._module_address),
+                config_entry_id=config_entry.entry_id,
+            )
+        return device_info
 
     @override
     async def async_added_to_hass(self) -> None:

--- a/homeassistant/components/velbus/entity.py
+++ b/homeassistant/components/velbus/entity.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Awaitable, Callable, Coroutine
 from functools import wraps
-from typing import Any, Concatenate, override
+from typing import TYPE_CHECKING, Any, Concatenate, override
 
 from velbusaio.channels import Channel as VelbusChannel
 from velbusaio.properties import Property as VelbusProperty
@@ -57,7 +57,8 @@ class VelbusEntity(Entity):
         )
         if channel.is_sub_device():
             config_entry = self.platform.config_entry
-            assert config_entry
+            if TYPE_CHECKING:
+                assert config_entry
             device_info["via_device_id"] = dr.async_get_device_id_by_identifier(
                 self.hass,
                 (DOMAIN, self._module_address),

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -226,6 +226,26 @@ async def test_device_registry(
     assert device_no_sub.via_device_id is None
 
 
+async def test_device_via_device_links(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that a sub-device channel links to its module via via_device_id."""
+    await init_integration(hass, config_entry)
+
+    module_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "88"), config_entry.entry_id
+    )
+    assert module_device is not None
+
+    sub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "88-9"), config_entry.entry_id
+    )
+    assert sub_device is not None
+    assert sub_device.via_device_id == module_device.id
+
+
 async def test_remove_config_entry_device(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,

--- a/tests/components/velbus/test_init.py
+++ b/tests/components/velbus/test_init.py
@@ -226,26 +226,6 @@ async def test_device_registry(
     assert device_no_sub.via_device_id is None
 
 
-async def test_device_via_device_links(
-    hass: HomeAssistant,
-    config_entry: MockConfigEntry,
-    device_registry: dr.DeviceRegistry,
-) -> None:
-    """Test that a sub-device channel links to its module via via_device_id."""
-    await init_integration(hass, config_entry)
-
-    module_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "88"), config_entry.entry_id
-    )
-    assert module_device is not None
-
-    sub_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, "88-9"), config_entry.entry_id
-    )
-    assert sub_device is not None
-    assert sub_device.via_device_id == module_device.id
-
-
 async def test_remove_config_entry_device(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `velbus` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
