### PR TITLE
Pass the full converted schema from the MCP server

### DIFF
--- a/homeassistant/components/mcp_server/server.py
+++ b/homeassistant/components/mcp_server/server.py
@@ -42,14 +42,10 @@ def _format_tool(
     tool: llm.Tool, custom_serializer: Callable[[Any], Any] | None
 ) -> types.Tool:
     """Format tool specification."""
-    input_schema = convert(tool.parameters, custom_serializer=custom_serializer)
     return types.Tool(
         name=tool.name,
         description=tool.description or "",
-        inputSchema={
-            "type": "object",
-            "properties": input_schema["properties"],
-        },
+        inputSchema=convert(tool.parameters, custom_serializer=custom_serializer),
     )
 
 

--- a/tests/components/mcp_server/test_http.py
+++ b/tests/components/mcp_server/test_http.py
@@ -392,6 +392,9 @@ async def test_mcp_tools_list(
     assert tool.inputSchema.get("type") == "object"
     properties = tool.inputSchema.get("properties")
     assert properties.get("name") == {"type": "string"}
+    # Clients need to know which arguments are mandatory, so the converted
+    # schema is passed through whole rather than only its properties.
+    assert "required" in tool.inputSchema
 
 
 @pytest.mark.parametrize("llm_hass_api", [llm.LLM_API_ASSIST, STATELESS_LLM_API])


### PR DESCRIPTION
## Proposed change

The MCP server builds a fresh `inputSchema` dict and copies only `properties` out of the converted voluptuous schema, so `required` never reaches the client. A client has no way to know which tool arguments are mandatory. It writes a call without them, and Home Assistant answers with a 500:

```
HassClimateSetTemperature {"name": "Office thermostat"}  -> HTTP 500
HassSetPosition           {"name": "Curtain Left"}       -> HTTP 500
```

Every other LLM integration (`anthropic`, `ollama`, `openai_conversation`, `google_generative_ai_conversation`) passes the result of `convert()` straight through. This does the same. `convert()` always returns `type`, `properties` and `required`, so the published schema is a strict superset of what it was.

Fixes #178032

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #178032

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
