### PR TITLE
Match only lights and covers in the light and cover intents

### DIFF
--- a/homeassistant/components/cover/intent.py
+++ b/homeassistant/components/cover/intent.py
@@ -17,6 +17,7 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             SERVICE_OPEN_COVER,
             description="Opens a cover",
             platforms={DOMAIN},
+            required_domains={DOMAIN},
             device_classes={CoverDeviceClass},
         ),
     )
@@ -28,6 +29,7 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             SERVICE_CLOSE_COVER,
             description="Closes a cover",
             platforms={DOMAIN},
+            required_domains={DOMAIN},
             device_classes={CoverDeviceClass},
         ),
     )

--- a/homeassistant/components/light/intent.py
+++ b/homeassistant/components/light/intent.py
@@ -46,5 +46,6 @@ async def async_setup_intents(hass: HomeAssistant) -> None:
             },
             description="Sets the brightness percentage or color of a light",
             platforms={DOMAIN},
+            required_domains={DOMAIN},
         ),
     )

--- a/tests/components/cover/test_intent.py
+++ b/tests/components/cover/test_intent.py
@@ -116,3 +116,19 @@ async def test_set_cover_position(hass: HomeAssistant, slots: dict[str, Any]) ->
     assert call.domain == DOMAIN
     assert call.service == SERVICE_SET_COVER_POSITION
     assert call.data == {"entity_id": entity_id, "position": 50}
+
+
+async def test_open_cover_intent_does_not_match_other_domains(
+    hass: HomeAssistant,
+) -> None:
+    """Test HassOpenCover does not match an entity of another domain."""
+    await cover_intent.async_setup_intents(hass)
+
+    hass.states.async_set("light.living_square", "off")
+
+    with pytest.raises(intent.MatchFailedError) as err:
+        await intent.async_handle(
+            hass, "test", "HassOpenCover", {"name": {"value": "living_square"}}
+        )
+
+    assert err.value.result.no_match_reason == intent.MatchFailedReason.DOMAIN

--- a/tests/components/light/test_intent.py
+++ b/tests/components/light/test_intent.py
@@ -1,9 +1,12 @@
 """Tests for the light intents."""
 
+import pytest
+
 from homeassistant.components import light
 from homeassistant.components.light import ATTR_SUPPORTED_COLOR_MODES, ColorMode, intent
 from homeassistant.const import ATTR_ENTITY_ID, SERVICE_TURN_ON
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import intent as intent_helper
 from homeassistant.helpers.intent import async_handle
 
 from tests.common import async_mock_service
@@ -89,3 +92,19 @@ async def test_intent_set_temperature(hass: HomeAssistant) -> None:
     assert call.service == SERVICE_TURN_ON
     assert call.data.get(ATTR_ENTITY_ID) == "light.test"
     assert call.data.get(light.ATTR_COLOR_TEMP_KELVIN) == 2000
+
+
+async def test_intent_set_does_not_match_other_domains(hass: HomeAssistant) -> None:
+    """Test the set intent does not match an entity of another domain."""
+    hass.states.async_set("cover.curtain_left", "open")
+    await intent.async_setup_intents(hass)
+
+    with pytest.raises(intent_helper.MatchFailedError) as err:
+        await async_handle(
+            hass,
+            "test",
+            intent.INTENT_SET,
+            {"name": {"value": "curtain_left"}, "brightness": {"value": 50}},
+        )
+
+    assert err.value.result.no_match_reason == intent_helper.MatchFailedReason.DOMAIN


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project.
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change

The light and cover intent handlers pass `platforms={DOMAIN}`. That looks like a domain filter but it is not one. It filters on `intent_obj.platform`, the assistant that sent the intent. Nothing constrains the domain of the matched entity, so a name belonging to another domain still matches, the service call is made with that entity id, the service does nothing, raises nothing, and `async_handle` files the entity under `success_results`.

The caller gets `response_type: action_done` with the entity listed as a success, and nothing happened.

Reproduced against 2026.7.4 with plain REST calls:

```
HassLightSet {"name": "Curtain Left", "brightness": 50}
  before: cover.curtain_left  state=open  current_position=40
  reply : response_type=action_done  success=['cover.curtain_left']  failed=[]
  after : cover.curtain_left  state=open  current_position=40

HassOpenCover {"name": "Living square"}
  before: light.living_square  state=off
  reply : response_type=action_done  success=['light.living_square']  failed=[]
  after : light.living_square  state=off
```

`fan`, `lawn_mower`, `media_player` and `vacuum` already pass `required_domains`. This does the same for `light` and `cover`.

There is a second, client-visible effect. `required_domains` also constrains the published `domain` slot, so an assistant reading the schema can tell what the tool acts on:

```json
HassSetVolume  "domain": {"items": {"enum": ["media_player"], ...}}
HassLightSet   "domain": {"items": {"type": "string"}}
```

A model reading the second writes `"domain": ["light"]` for a device that is not a light. A model reading the first cannot.

One thing left for the maintainers to decide, out of scope here: a client-supplied `domain` slot replaces `required_domains` rather than intersecting with it, so `HassLightSet {"domain": ["cover"]}` still reaches a cover after this change.

## Type of change

<!--
  Pick one or more items and add an `x`.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #178033

## Checklist

- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
