### PR TITLE
Adapt drop_connect to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/drop_connect/entity.py
+++ b/homeassistant/components/drop_connect/entity.py
@@ -43,8 +43,10 @@ class DROPEntity(CoordinatorEntity[DROPDeviceDataUpdateCoordinator]):
             identifiers={(DOMAIN, unique_id)},
         )
         if entry_data[CONF_DEVICE_TYPE] != DEV_HUB:
-            # The owner hub lives in a separate config entry created independently by
-            # MQTT discovery, so it may not exist yet. Link best-effort when present.
+            # The owner hub lives in a separate config entry created independently
+            # by MQTT discovery, so it may not exist yet. Link best-effort when
+            # present; an identifier can match devices from several config entries
+            # and we can't tell which is the owner hub, so link to the first.
             via_devices = dr.async_get(coordinator.hass).async_get_devices(
                 identifiers={(DOMAIN, entry_data[CONF_DEVICE_OWNER_ID])}
             )

--- a/homeassistant/components/drop_connect/entity.py
+++ b/homeassistant/components/drop_connect/entity.py
@@ -2,6 +2,7 @@
 
 from typing import TYPE_CHECKING
 
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -42,11 +43,10 @@ class DROPEntity(CoordinatorEntity[DROPDeviceDataUpdateCoordinator]):
             identifiers={(DOMAIN, unique_id)},
         )
         if entry_data[CONF_DEVICE_TYPE] != DEV_HUB:
-            self._attr_device_info.update(
-                {
-                    "via_device": (
-                        DOMAIN,
-                        entry_data[CONF_DEVICE_OWNER_ID],
-                    )
-                }
+            # The owner hub lives in a separate config entry created independently by
+            # MQTT discovery, so it may not exist yet. Link best-effort when present.
+            via_device = dr.async_get(coordinator.hass).async_get_device(
+                identifiers={(DOMAIN, entry_data[CONF_DEVICE_OWNER_ID])}
             )
+            if via_device is not None:
+                self._attr_device_info["via_device_id"] = via_device.id

--- a/homeassistant/components/drop_connect/entity.py
+++ b/homeassistant/components/drop_connect/entity.py
@@ -45,8 +45,8 @@ class DROPEntity(CoordinatorEntity[DROPDeviceDataUpdateCoordinator]):
         if entry_data[CONF_DEVICE_TYPE] != DEV_HUB:
             # The owner hub lives in a separate config entry created independently by
             # MQTT discovery, so it may not exist yet. Link best-effort when present.
-            via_device = dr.async_get(coordinator.hass).async_get_device(
+            via_devices = dr.async_get(coordinator.hass).async_get_devices(
                 identifiers={(DOMAIN, entry_data[CONF_DEVICE_OWNER_ID])}
             )
-            if via_device is not None:
-                self._attr_device_info["via_device_id"] = via_device.id
+            if via_devices:
+                self._attr_device_info["via_device_id"] = via_devices[0].id

--- a/tests/components/drop_connect/test_device.py
+++ b/tests/components/drop_connect/test_device.py
@@ -1,0 +1,58 @@
+"""Test DROP device registry linkage."""
+
+import pytest
+
+from homeassistant.components.drop_connect.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from .common import config_entry_hub, config_entry_softener
+
+HUB_IDENTIFIER = (DOMAIN, "DROP-1_C0FFEE_255")
+SOFTENER_IDENTIFIER = (DOMAIN, "DROP-1_C0FFEE_0")
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_sub_device_links_to_hub(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a sub-device links to its hub via via_device_id when the hub exists."""
+    hub_entry = config_entry_hub()
+    hub_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(hub_entry.entry_id)
+    await hass.async_block_till_done()
+
+    softener_entry = config_entry_softener()
+    softener_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(softener_entry.entry_id)
+    await hass.async_block_till_done()
+
+    hub_device = device_registry.async_get_device_by_identifier(
+        HUB_IDENTIFIER, hub_entry.entry_id
+    )
+    assert hub_device is not None
+
+    softener_device = device_registry.async_get_device_by_identifier(
+        SOFTENER_IDENTIFIER, softener_entry.entry_id
+    )
+    assert softener_device is not None
+    assert softener_device.via_device_id == hub_device.id
+
+
+@pytest.mark.usefixtures("mqtt_mock")
+async def test_sub_device_without_hub(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test a sub-device set up without its hub is not linked and does not crash."""
+    softener_entry = config_entry_softener()
+    softener_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(softener_entry.entry_id)
+    await hass.async_block_till_done()
+
+    softener_device = device_registry.async_get_device_by_identifier(
+        SOFTENER_IDENTIFIER, softener_entry.entry_id
+    )
+    assert softener_device is not None
+    assert softener_device.via_device_id is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `drop_connect` to set `via_device_id` in `DeviceInfo`

The `via_device_id` is best effort because the linked device may be created by another config entry.
In a follow-up PR, the solution can be improved to for example update the device if the expected via device is created.

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
