### PR TITLE
Don't fire a feedreader event, when there are no new entries

### DIFF
--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -145,15 +145,14 @@ class FeedReaderCoordinator(
             assert isinstance(self._feed.entries, list)
 
         self._filter_entries()
-        if self._publish_new_entries() == 0:
-            return None
+        new_entries = self._publish_new_entries()
 
         _LOGGER.debug("Fetch from feed %s completed", self.url)
 
         if self._last_entry_timestamp:
             self._storage.async_put_timestamp(self._feed_id, self._last_entry_timestamp)
 
-        return self._feed.entries
+        return new_entries
 
     @callback
     def _filter_entries(self) -> None:
@@ -186,10 +185,10 @@ class FeedReaderCoordinator(
         _LOGGER.debug("New event fired for entry %s", entry.get("link"))
 
     @callback
-    def _publish_new_entries(self) -> int:
-        """Publish new entries to the event bus and return new entry count."""
+    def _publish_new_entries(self) -> list[feedparser.FeedParserDict]:
+        """Publish new entries to the event bus and return new entries."""
         assert self._feed is not None
-        new_entry_count = 0
+        new_entries: list[feedparser.FeedParserDict] = []
         firstrun = False
         self._last_entry_timestamp = self._storage.get_timestamp(self._feed_id)
         if not self._last_entry_timestamp:
@@ -208,14 +207,14 @@ class FeedReaderCoordinator(
                 and time_stamp > last_entry_timestamp
             ):
                 self._update_and_fire_entry(entry)
-                new_entry_count += 1
+                new_entries.append(entry)
             else:
                 _LOGGER.debug("Already processed entry %s", entry.get("link"))
-        if new_entry_count == 0:
+        if not new_entries:
             self._log_no_entries()
         else:
-            _LOGGER.debug("%d entries published in feed %s", new_entry_count, self.url)
-        return new_entry_count
+            _LOGGER.debug("%d entries published in feed %s", len(new_entries), self.url)
+        return new_entries
 
 
 class StoredData:

--- a/homeassistant/components/feedreader/coordinator.py
+++ b/homeassistant/components/feedreader/coordinator.py
@@ -145,7 +145,8 @@ class FeedReaderCoordinator(
             assert isinstance(self._feed.entries, list)
 
         self._filter_entries()
-        self._publish_new_entries()
+        if self._publish_new_entries() == 0:
+            return None
 
         _LOGGER.debug("Fetch from feed %s completed", self.url)
 
@@ -185,8 +186,8 @@ class FeedReaderCoordinator(
         _LOGGER.debug("New event fired for entry %s", entry.get("link"))
 
     @callback
-    def _publish_new_entries(self) -> None:
-        """Publish new entries to the event bus."""
+    def _publish_new_entries(self) -> int:
+        """Publish new entries to the event bus and return new entry count."""
         assert self._feed is not None
         new_entry_count = 0
         firstrun = False
@@ -214,6 +215,7 @@ class FeedReaderCoordinator(
             self._log_no_entries()
         else:
             _LOGGER.debug("%d entries published in feed %s", new_entry_count, self.url)
+        return new_entry_count
 
 
 class StoredData:

--- a/tests/components/feedreader/test_event.py
+++ b/tests/components/feedreader/test_event.py
@@ -75,7 +75,7 @@ async def test_event_entity(
             assert state.attributes[attribute] == value
 
 
-async def test_event_new_entry(
+async def test_event_new_entry_sorted(
     hass: HomeAssistant, feed_one_event, feed_two_event
 ) -> None:
     """Test feed event entity fires on new event."""
@@ -106,6 +106,33 @@ async def test_event_new_entry(
         assert state.attributes[ATTR_DESCRIPTION] == "Description 2"
 
 
+async def test_event_new_entry_unsorted(
+    hass: HomeAssistant, feed_unsorted, feed_unsorted_update
+) -> None:
+    """Test feed event entity fires on new event."""
+    entry = create_mock_entry(VALID_CONFIG_DEFAULT)
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.feedreader.coordinator.feedparser.http.get",
+        side_effect=[feed_unsorted, feed_unsorted_update],
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("event.mock_title")
+        assert state
+        assert state.attributes[ATTR_TITLE] == "Title 3"
+        assert state.attributes[ATTR_CONTENT] == "Content 3"
+
+        future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get("event.mock_title")
+        assert state
+        assert state.attributes[ATTR_TITLE] == "Title 4"
+        assert state.attributes[ATTR_CONTENT] == "Content 4"
+
+
 @pytest.mark.parametrize(
     ("fixture_name"),
     [
@@ -134,9 +161,7 @@ async def test_event_htmlentities(
         assert state.attributes == snapshot
 
 
-async def test_no_state_change_when_no_new_entry(
-    hass: HomeAssistant, feed_two_event
-) -> None:
+async def test_event_no_new_entry(hass: HomeAssistant, feed_two_event) -> None:
     """Test feed event entity is not firing when there are no new entries."""
     entry = create_mock_entry(VALID_CONFIG_DEFAULT)
     entry.add_to_hass(hass)

--- a/tests/components/feedreader/test_event.py
+++ b/tests/components/feedreader/test_event.py
@@ -57,7 +57,7 @@ async def test_event_entity(
     hass: HomeAssistant,
     request: pytest.FixtureRequest,
     fixture_name: str,
-    expected_attributes: dict,
+    expected_attributes: dict[str, str],
 ) -> None:
     """Test feed event entity."""
     entry = create_mock_entry(VALID_CONFIG_DEFAULT)
@@ -76,7 +76,7 @@ async def test_event_entity(
 
 
 async def test_event_new_entry_sorted(
-    hass: HomeAssistant, feed_one_event, feed_two_event
+    hass: HomeAssistant, feed_one_event: bytes, feed_two_event: bytes
 ) -> None:
     """Test feed event entity fires on new event."""
     entry = create_mock_entry(VALID_CONFIG_DEFAULT)
@@ -107,7 +107,7 @@ async def test_event_new_entry_sorted(
 
 
 async def test_event_new_entry_unsorted(
-    hass: HomeAssistant, feed_unsorted, feed_unsorted_update
+    hass: HomeAssistant, feed_unsorted: bytes, feed_unsorted_update: bytes
 ) -> None:
     """Test feed event entity fires on new event."""
     entry = create_mock_entry(VALID_CONFIG_DEFAULT)
@@ -143,7 +143,7 @@ async def test_event_new_entry_unsorted(
 async def test_event_htmlentities(
     hass: HomeAssistant,
     snapshot: SnapshotAssertion,
-    fixture_name,
+    fixture_name: str,
     request: pytest.FixtureRequest,
 ) -> None:
     """Test feed event entity with HTML Entities."""
@@ -161,7 +161,7 @@ async def test_event_htmlentities(
         assert state.attributes == snapshot
 
 
-async def test_event_no_new_entry(hass: HomeAssistant, feed_two_event) -> None:
+async def test_event_no_new_entry(hass: HomeAssistant, feed_two_event: bytes) -> None:
     """Test feed event entity is not firing when there are no new entries."""
     entry = create_mock_entry(VALID_CONFIG_DEFAULT)
     entry.add_to_hass(hass)

--- a/tests/components/feedreader/test_event.py
+++ b/tests/components/feedreader/test_event.py
@@ -21,47 +21,58 @@ from .const import VALID_CONFIG_DEFAULT
 from tests.common import async_fire_time_changed
 
 
+@pytest.mark.parametrize(
+    ("fixture_name", "expected_attributes"),
+    [
+        (
+            "feed_one_event",
+            {
+                ATTR_TITLE: "Title 1",
+                ATTR_LINK: "http://www.example.com/link/1",
+                ATTR_CONTENT: "Content 1",
+                ATTR_DESCRIPTION: "Description 1",
+            },
+        ),
+        (
+            "feed_two_event",
+            {
+                ATTR_TITLE: "Title 2",
+                ATTR_LINK: "http://www.example.com/link/2",
+                ATTR_CONTENT: "Content 2",
+                ATTR_DESCRIPTION: "Description 2",
+            },
+        ),
+        (
+            "feed_only_summary",
+            {
+                ATTR_TITLE: "Title 1",
+                ATTR_LINK: "http://www.example.com/link/1",
+                ATTR_CONTENT: "This is a summary",
+                ATTR_DESCRIPTION: "Description 1",
+            },
+        ),
+    ],
+)
 async def test_event_entity(
-    hass: HomeAssistant, feed_one_event, feed_two_event, feed_only_summary
+    hass: HomeAssistant,
+    request: pytest.FixtureRequest,
+    fixture_name,
+    expected_attributes: dict,
 ) -> None:
     """Test feed event entity."""
     entry = create_mock_entry(VALID_CONFIG_DEFAULT)
     entry.add_to_hass(hass)
     with patch(
         "homeassistant.components.feedreader.coordinator.feedparser.http.get",
-        side_effect=[feed_one_event, feed_two_event, feed_only_summary],
+        side_effect=[request.getfixturevalue(fixture_name)],
     ):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
         state = hass.states.get("event.mock_title")
         assert state
-        assert state.attributes[ATTR_TITLE] == "Title 1"
-        assert state.attributes[ATTR_LINK] == "http://www.example.com/link/1"
-        assert state.attributes[ATTR_CONTENT] == "Content 1"
-        assert state.attributes[ATTR_DESCRIPTION] == "Description 1"
-
-        future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-        state = hass.states.get("event.mock_title")
-        assert state
-        assert state.attributes[ATTR_TITLE] == "Title 2"
-        assert state.attributes[ATTR_LINK] == "http://www.example.com/link/2"
-        assert state.attributes[ATTR_CONTENT] == "Content 2"
-        assert state.attributes[ATTR_DESCRIPTION] == "Description 2"
-
-        future = dt_util.utcnow() + timedelta(hours=2, seconds=2)
-        async_fire_time_changed(hass, future)
-        await hass.async_block_till_done(wait_background_tasks=True)
-
-        state = hass.states.get("event.mock_title")
-        assert state
-        assert state.attributes[ATTR_TITLE] == "Title 1"
-        assert state.attributes[ATTR_LINK] == "http://www.example.com/link/1"
-        assert state.attributes[ATTR_CONTENT] == "This is a summary"
-        assert state.attributes[ATTR_DESCRIPTION] == "Description 1"
+        for attribute, value in expected_attributes.items():
+            assert state.attributes[attribute] == value
 
 
 @pytest.mark.parametrize(
@@ -90,3 +101,27 @@ async def test_event_htmlentities(
         state = hass.states.get("event.mock_title")
         assert state
         assert state.attributes == snapshot
+
+
+async def test_no_state_change_when_no_new_entry(
+    hass: HomeAssistant, feed_two_event
+) -> None:
+    """Test feed event entity is not firing when there are no new entries."""
+    entry = create_mock_entry(VALID_CONFIG_DEFAULT)
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.feedreader.coordinator.feedparser.http.get",
+        side_effect=[feed_two_event, feed_two_event],
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("event.mock_title")
+        assert state
+        old_state = state
+
+        future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get("event.mock_title")
+        assert state == old_state

--- a/tests/components/feedreader/test_event.py
+++ b/tests/components/feedreader/test_event.py
@@ -56,7 +56,7 @@ from tests.common import async_fire_time_changed
 async def test_event_entity(
     hass: HomeAssistant,
     request: pytest.FixtureRequest,
-    fixture_name,
+    fixture_name: str,
     expected_attributes: dict,
 ) -> None:
     """Test feed event entity."""

--- a/tests/components/feedreader/test_event.py
+++ b/tests/components/feedreader/test_event.py
@@ -75,6 +75,37 @@ async def test_event_entity(
             assert state.attributes[attribute] == value
 
 
+async def test_event_new_entry(
+    hass: HomeAssistant, feed_one_event, feed_two_event
+) -> None:
+    """Test feed event entity fires on new event."""
+    entry = create_mock_entry(VALID_CONFIG_DEFAULT)
+    entry.add_to_hass(hass)
+    with patch(
+        "homeassistant.components.feedreader.coordinator.feedparser.http.get",
+        side_effect=[feed_one_event, feed_two_event],
+    ):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        state = hass.states.get("event.mock_title")
+        assert state
+        assert state.attributes[ATTR_TITLE] == "Title 1"
+        assert state.attributes[ATTR_LINK] == "http://www.example.com/link/1"
+        assert state.attributes[ATTR_CONTENT] == "Content 1"
+        assert state.attributes[ATTR_DESCRIPTION] == "Description 1"
+
+        future = dt_util.utcnow() + timedelta(hours=1, seconds=1)
+        async_fire_time_changed(hass, future)
+        await hass.async_block_till_done(wait_background_tasks=True)
+        state = hass.states.get("event.mock_title")
+        assert state
+        assert state.attributes[ATTR_TITLE] == "Title 2"
+        assert state.attributes[ATTR_LINK] == "http://www.example.com/link/2"
+        assert state.attributes[ATTR_CONTENT] == "Content 2"
+        assert state.attributes[ATTR_DESCRIPTION] == "Description 2"
+
+
 @pytest.mark.parametrize(
     ("fixture_name"),
     [


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
With the previous #177954 we fixed that even unordered entries are recognize correct, but we still fire the event entity, even there are no new entries in the feed. With this fix now, we only return new feed entries to the event entity, so we don't fire at all when there is no new entry and if, than we have the proper new entry data to fire, not all entries.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
