### PR TITLE
Use combined setpoint properties for Netatmo climate

### DIFF
--- a/homeassistant/components/netatmo/climate.py
+++ b/homeassistant/components/netatmo/climate.py
@@ -431,14 +431,14 @@ class NetatmoThermostat(NetatmoRoomEntity, ClimateEntity):
         self._away_temperature = self.home.get_away_temp()
         self._hg_temperature = self.home.get_hg_temp()
         self._attr_current_temperature = self.device.therm_measured_temperature
-        self._attr_target_temperature = self.device.therm_setpoint_temperature
+        # A home in cooling mode reports cooling_setpoint_* instead of
+        # therm_setpoint_*. Room.setpoint_temperature / Room.setpoint_mode pick
+        # whichever of the two the backend actually sent.
+        self._attr_target_temperature = self.device.setpoint_temperature
 
-        therm_setpoint_mode = getattr(self.device, "therm_setpoint_mode", None)
-
-        if therm_setpoint_mode is None:
-            therm_setpoint_mode = STATE_NETATMO_SCHEDULE
-
-        self._attr_preset_mode = NETATMO_MAP_PRESET[therm_setpoint_mode]
+        self._attr_preset_mode = NETATMO_MAP_PRESET.get(
+            self.device.setpoint_mode, PRESET_SCHEDULE
+        )
         self._attr_hvac_mode = HVAC_MAP_NETATMO[self._attr_preset_mode]
         self._away = self._attr_hvac_mode == HVAC_MAP_NETATMO[STATE_NETATMO_AWAY]
 

--- a/tests/components/netatmo/test_climate.py
+++ b/tests/components/netatmo/test_climate.py
@@ -1145,6 +1145,56 @@ async def test_thermostat_update_with_none_therm_setpoint_mode(
     assert state.attributes["preset_mode"] == PRESET_SCHEDULE
 
 
+async def test_thermostat_update_with_cooling_setpoint(
+    hass: HomeAssistant, config_entry: MockConfigEntry
+) -> None:
+    """Test thermostat setup for a home in cooling mode.
+
+    A home whose temperature control mode is cooling gets cooling_setpoint_mode
+    and cooling_setpoint_temperature from the backend, and no therm_setpoint_*
+    fields at all.
+    """
+
+    def set_cooling_setpoint(payload: dict[str, Any]) -> None:
+        """Replace the therm setpoint with a cooling one in the response."""
+        home = payload.get("body", {}).get("home")
+        if home is None:
+            return
+
+        for room in home.get("rooms", []):
+            if room["id"] == "2746182631":
+                room.pop("therm_setpoint_mode", None)
+                room.pop("therm_setpoint_temperature", None)
+                room["cooling_setpoint_mode"] = "hg"
+                room["cooling_setpoint_temperature"] = 7
+
+    async def fake_post(*args: Any, **kwargs: Any):
+        """Return backend data for a home in cooling mode."""
+        kwargs["msg_callback"] = set_cooling_setpoint
+        return await fake_post_request(hass, *args, **kwargs)
+
+    with (
+        selected_platforms([Platform.CLIMATE]),
+        patch(
+            "homeassistant.components.netatmo.api.AsyncConfigEntryNetatmoAuth"
+        ) as mock_auth,
+    ):
+        mock_auth.return_value.async_post_request.side_effect = fake_post
+        mock_auth.return_value.async_post_api_request.side_effect = fake_post
+        mock_auth.return_value.async_get_image.side_effect = fake_get_image
+        mock_auth.return_value.async_addwebhook.side_effect = AsyncMock()
+        mock_auth.return_value.async_dropwebhook.side_effect = AsyncMock()
+
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    state = hass.states.get("climate.livingroom_livingroom")
+    assert state is not None
+    assert state.state == HVACMode.AUTO
+    assert state.attributes["preset_mode"] == PRESET_FROST_GUARD
+    assert state.attributes[ATTR_TEMPERATURE] == 7
+
+
 async def test_webhook_set_point(
     hass: HomeAssistant, config_entry: MockConfigEntry, netatmo_auth: AsyncMock
 ) -> None:


### PR DESCRIPTION
## Proposed change

A Netatmo home whose `temperature_control_mode` is `cooling` receives `cooling_setpoint_mode` and `cooling_setpoint_temperature` from `/homestatus`, and no `therm_setpoint_*` fields at all. Raw response from such a home (BTicino/Legrand Smarther 2 + NRV valves, 9 rooms):

```
ROOM 2139487205  reachable: True  therm_measured_temperature: 27
                 cooling_setpoint_mode: 'home'  cooling_setpoint_temperature: 27
ROOM 3067026880  reachable: True  therm_measured_temperature: 29
                 cooling_setpoint_mode: 'hg'    cooling_setpoint_temperature: 7
```

#172204 stopped the `KeyError: None` these homes used to raise, but the entity still ends up describing the wrong thing: `therm_setpoint_temperature` is `None`, so `target_temperature` is unset, and the preset falls back to `schedule` instead of reflecting the cooling mode the backend actually reported (`home` / `hg` — both already valid keys in `NETATMO_MAP_PRESET`).

`pyatmo` already exposes properties that resolve this, so the integration does not have to branch on the home's temperature control mode itself:

```python
@property
def setpoint_mode(self) -> str:
    return self.therm_setpoint_mode or self.cooling_setpoint_mode or UNKNOWN

@property
def setpoint_temperature(self) -> float | None:
    return self.therm_setpoint_temperature or self.cooling_setpoint_temperature or None
```

This PR switches `async_update_callback` to those two properties and makes the preset lookup a `.get(..., PRESET_SCHEDULE)`. The fallback keeps the behaviour introduced by #172204 for the degenerate case where neither field family is present (`pyatmo` returns its `UNKNOWN` sentinel), and it also removes the last way an unmapped mode can raise out of `update_callback()` in `coordinator.async_fetch_data` — which matters because that exception aborts the whole callback loop, so one bad room stops every remaining entity of the home from updating.

Behaviour for homes in heating mode is unchanged.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #175581
- This PR is related to issue: #172204 (partial fix for the same report)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

Verified against a live account with two homes — one in `cooling` (9 climate entities affected) and one in `heating` (unaffected) — on 2026.7.4 with pyatmo 9.4.0.

On local tests: `tests/components/netatmo/test_climate.py` passes, 20 passed including the new case. My local checkout also shows 27 failures elsewhere under `tests/components/netatmo/` and a `services.register_webhook.name` translation error at teardown; those are identical with and without this patch (`diff` of the failure lists is empty), so they are environmental on my side, not introduced here.

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
