### PR TITLE
Explicitly set parallel-updates for OpenAI Conversation

### DIFF
--- a/homeassistant/components/openai_conversation/ai_task.py
+++ b/homeassistant/components/openai_conversation/ai_task.py
@@ -29,6 +29,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/openai_conversation/conversation.py
+++ b/homeassistant/components/openai_conversation/conversation.py
@@ -12,7 +12,7 @@ from . import OpenAIConfigEntry
 from .const import DOMAIN
 from .entity import OpenAIBaseLLMEntity
 
-# Max number of back and forth with the LLM to generate a response
+PARALLEL_UPDATES = 0
 
 
 async def async_setup_entry(

--- a/homeassistant/components/openai_conversation/quality_scale.yaml
+++ b/homeassistant/components/openai_conversation/quality_scale.yaml
@@ -36,7 +36,7 @@ rules:
   entity-unavailable: todo
   integration-owner: todo
   log-when-unavailable: todo
-  parallel-updates: todo
+  parallel-updates: done
   reauthentication-flow: done
   test-coverage: done
 

--- a/homeassistant/components/openai_conversation/stt.py
+++ b/homeassistant/components/openai_conversation/stt.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/homeassistant/components/openai_conversation/tts.py
+++ b/homeassistant/components/openai_conversation/tts.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
Explicitly set `PARALLEL_UPDATES = 0` for all OpenAI Conversation platforms (`conversation`, `ai_task`, `stt`, `tts`) and mark the quality-scale rule as done.

This matches the Anthropic change in #171387 and follows:
https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/parallel-updates/

Also removes an orphaned comment in `conversation.py` that no longer referred to any constant.

## Type of change
- [x] Code quality improvements to existing code or addition of tests

## Checklist
- [x] The code change is tested and works locally.
- [x] Local tests pass. Your PR cannot be merged unless tests pass
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] The [`hassfest` quality scale rules][hassfest-qs] that apply to this PR have been checked and addressed (where applicable).

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[perfect-pr]: https://developers.home-assistant.io/docs/submitting_pull_requests/#perfect-pr
[hassfest-qs]: https://developers.home-assistant.io/docs/core/integration-quality-scale/#rules

---

— Felipe Fernandes · Systems & Agentic AI Engineer
https://github.com/felipeofdev-ai · https://felipeofdev-ai.github.io/