### PR TITLE
Use library model names in tesla_fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/__init__.py
+++ b/homeassistant/components/tesla_fleet/__init__.py
@@ -33,7 +33,7 @@ from homeassistant.helpers.config_entry_oauth2_flow import (
 )
 from homeassistant.helpers.device_registry import DeviceInfo
 
-from .const import DOMAIN, LOGGER, MODELS
+from .const import DOMAIN, LOGGER
 from .coordinator import (
     TeslaFleetEnergySiteHistoryCoordinator,
     TeslaFleetEnergySiteInfoCoordinator,
@@ -183,7 +183,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslaFleetConfigEntry) -
                 identifiers={(DOMAIN, vin)},
                 manufacturer="Tesla",
                 name=product["display_name"],
-                model=MODELS.get(vin[3]),
+                model=api_vehicle.model,
                 serial_number=vin,
             )
 

--- a/homeassistant/components/tesla_fleet/const.py
+++ b/homeassistant/components/tesla_fleet/const.py
@@ -25,15 +25,6 @@ SCOPES = [
     Scope.ENERGY_CMDS,
 ]
 
-MODELS = {
-    "S": "Model S",
-    "3": "Model 3",
-    "X": "Model X",
-    "Y": "Model Y",
-    "C": "Cybertruck",
-    "T": "Tesla Semi",
-}
-
 ENERGY_HISTORY_FIELDS = [
     "solar_energy_exported",
     "generator_energy_exported",

--- a/tests/components/tesla_fleet/test_init.py
+++ b/tests/components/tesla_fleet/test_init.py
@@ -2,7 +2,7 @@
 
 from copy import deepcopy
 from datetime import timedelta
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, PropertyMock, patch
 
 from freezegun.api import FrozenDateTimeFactory
 import pytest
@@ -231,6 +231,26 @@ async def test_devices(
 
     for device in devices:
         assert device == snapshot(name=f"{device.identifiers}")
+
+
+async def test_vehicle_device_model_from_library(
+    hass: HomeAssistant,
+    normal_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the vehicle device model is provided by the library."""
+    with patch(
+        "tesla_fleet_api.tesla.VehicleFleet.model",
+        new_callable=PropertyMock,
+        return_value="Cybercab",
+    ):
+        await setup_platform(hass, normal_config_entry)
+
+    device = device_registry.async_get_device(
+        identifiers={(DOMAIN, "LRWXF7EK4KC700000")}
+    )
+    assert device is not None
+    assert device.model == "Cybercab"
 
 
 # Vehicle Coordinator


### PR DESCRIPTION
## Breaking change

## Proposed change

Get the vehicle model name from `tesla-fleet-api` (`api_vehicle.model`) instead of the integration's own hardcoded `MODELS` map, matching the pattern already used by teslemetry. This makes the library the single source of truth for model names, so new models (e.g. Cybercab) arrive by bumping the library pin rather than editing the integration.

The `MODELS` dict in `const.py` is removed along with its now-unused import.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
