### PR TITLE
Make switch non-optimistic for Mikrotik

### DIFF
--- a/homeassistant/components/mikrotik/switch.py
+++ b/homeassistant/components/mikrotik/switch.py
@@ -69,8 +69,7 @@ class MikrotikSwitchEntity(MikrotikDeviceEntity, SwitchEntity):
                 f"/interface/{action}",
                 {".id": self._interface[".id"]},
             )
-        self._interface["disabled"] = action == "disable"
-        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
 
     @override
     async def async_turn_on(self, **kwargs: Any) -> None:

--- a/tests/components/mikrotik/conftest.py
+++ b/tests/components/mikrotik/conftest.py
@@ -1,6 +1,7 @@
 """Mikrotik test configuration."""
 
 from collections.abc import Callable, Generator
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,6 +11,10 @@ from . import create_mock_config_entry
 from tests.common import MockConfigEntry
 
 type MockConfigEntryFactory = Callable[..., MockConfigEntry]
+type MockCommandSideEffectFactory = Callable[
+    [dict[str, Any], dict[str, dict[str, Any]], str],
+    Callable[..., list[dict[str, Any]]],
+]
 
 
 @pytest.fixture
@@ -25,6 +30,33 @@ def mock_api() -> Generator[MagicMock]:
 
     with patch("librouteros.connect", return_value=api_instance):
         yield api_instance
+
+
+@pytest.fixture
+def mock_command_side_effect() -> MockCommandSideEffectFactory:
+    """Create a stateful librouteros command side_effect for the mocked API.
+
+    Given mutable state, a mapping of command to the field updates it applies,
+    and the command that reports current state, returns a callable to assign
+    to `mock_api.side_effect` so tests can verify entity state that is driven
+    by a coordinator refresh rather than an optimistic local update.
+    """
+
+    def _create(
+        state: dict[str, Any],
+        actions: dict[str, dict[str, Any]],
+        print_cmd: str,
+    ) -> Callable[..., list[dict[str, Any]]]:
+        def _handler(cmd: str, **params: Any) -> list[dict[str, Any]]:
+            if update := actions.get(cmd):
+                state.update(update)
+            elif cmd == print_cmd:
+                return [dict(state)]
+            return []
+
+        return _handler
+
+    return _create
 
 
 @pytest.fixture

--- a/tests/components/mikrotik/conftest.py
+++ b/tests/components/mikrotik/conftest.py
@@ -1,7 +1,6 @@
 """Mikrotik test configuration."""
 
 from collections.abc import Callable, Generator
-from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,10 +10,6 @@ from . import create_mock_config_entry
 from tests.common import MockConfigEntry
 
 type MockConfigEntryFactory = Callable[..., MockConfigEntry]
-type MockCommandSideEffectFactory = Callable[
-    [dict[str, Any], dict[str, dict[str, Any]], str],
-    Callable[..., list[dict[str, Any]]],
-]
 
 
 @pytest.fixture
@@ -30,33 +25,6 @@ def mock_api() -> Generator[MagicMock]:
 
     with patch("librouteros.connect", return_value=api_instance):
         yield api_instance
-
-
-@pytest.fixture
-def mock_command_side_effect() -> MockCommandSideEffectFactory:
-    """Create a stateful librouteros command side_effect for the mocked API.
-
-    Given mutable state, a mapping of command to the field updates it applies,
-    and the command that reports current state, returns a callable to assign
-    to `mock_api.side_effect` so tests can verify entity state that is driven
-    by a coordinator refresh rather than an optimistic local update.
-    """
-
-    def _create(
-        state: dict[str, Any],
-        actions: dict[str, dict[str, Any]],
-        print_cmd: str,
-    ) -> Callable[..., list[dict[str, Any]]]:
-        def _handler(cmd: str, **params: Any) -> list[dict[str, Any]]:
-            if update := actions.get(cmd):
-                state.update(update)
-            elif cmd == print_cmd:
-                return [dict(state)]
-            return []
-
-        return _handler
-
-    return _create
 
 
 @pytest.fixture

--- a/tests/components/mikrotik/test_switch.py
+++ b/tests/components/mikrotik/test_switch.py
@@ -16,7 +16,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_mikrotik_entry
-from .conftest import MockCommandSideEffectFactory
 from .const import BRIDGE1_INTERFACE, ETHER1_INTERFACE, INTERFACE_DATA, WLAN1_INTERFACE
 
 from tests.common import snapshot_platform
@@ -75,7 +74,6 @@ async def test_switch_no_matching_interfaces(hass: HomeAssistant) -> None:
 async def test_switch_turn_on_off(
     hass: HomeAssistant,
     mock_api: MagicMock,
-    mock_command_side_effect: MockCommandSideEffectFactory,
     interface: dict[str, Any],
     entity_id: str,
     initial_state: str,
@@ -91,11 +89,7 @@ async def test_switch_turn_on_off(
     assert (state := hass.states.get(entity_id))
     assert state.state == initial_state
 
-    mock_api.side_effect = mock_command_side_effect(
-        interface,
-        {command: {"disabled": final_state == STATE_OFF}},
-        "/interface/print",
-    )
+    mock_api.return_value = [{**interface, "disabled": final_state == STATE_OFF}]
 
     await hass.services.async_call(
         SWITCH_DOMAIN,

--- a/tests/components/mikrotik/test_switch.py
+++ b/tests/components/mikrotik/test_switch.py
@@ -1,7 +1,9 @@
 """Tests for the Mikrotik switch platform."""
 
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.switch import (
@@ -14,6 +16,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_mikrotik_entry
+from .conftest import MockCommandSideEffectFactory
 from .const import BRIDGE1_INTERFACE, ETHER1_INTERFACE, INTERFACE_DATA, WLAN1_INTERFACE
 
 from tests.common import snapshot_platform
@@ -39,45 +42,69 @@ async def test_switch_no_matching_interfaces(hass: HomeAssistant) -> None:
     assert hass.states.async_entity_ids(SWITCH_DOMAIN) == []
 
 
-async def test_switch_turn_on(hass: HomeAssistant, mock_api: MagicMock) -> None:
-    """Test turning on a Mikrotik switch enables the interface."""
-    with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
-        await setup_mikrotik_entry(hass, interface_data=[dict(WLAN1_INTERFACE)])
+@pytest.mark.parametrize(
+    (
+        "interface",
+        "entity_id",
+        "initial_state",
+        "service",
+        "command",
+        "final_state",
+    ),
+    [
+        pytest.param(
+            ETHER1_INTERFACE,
+            "switch.ether1_ethernet",
+            STATE_ON,
+            SERVICE_TURN_OFF,
+            "/interface/disable",
+            STATE_OFF,
+            id="turn_off",
+        ),
+        pytest.param(
+            WLAN1_INTERFACE,
+            "switch.wlan1_wlan",
+            STATE_OFF,
+            SERVICE_TURN_ON,
+            "/interface/enable",
+            STATE_ON,
+            id="turn_on",
+        ),
+    ],
+)
+async def test_switch_turn_on_off(
+    hass: HomeAssistant,
+    mock_api: MagicMock,
+    mock_command_side_effect: MockCommandSideEffectFactory,
+    interface: dict[str, Any],
+    entity_id: str,
+    initial_state: str,
+    service: str,
+    command: str,
+    final_state: str,
+) -> None:
+    """Test turning a Mikrotik switch on/off updates state via the coordinator."""
 
-    entity_id = "switch.wlan1_wlan"
+    with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
+        await setup_mikrotik_entry(hass, interface_data=[interface])
+
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OFF
+    assert state.state == initial_state
+
+    mock_api.side_effect = mock_command_side_effect(
+        interface,
+        {command: {"disabled": final_state == STATE_OFF}},
+        "/interface/print",
+    )
 
     await hass.services.async_call(
         SWITCH_DOMAIN,
-        SERVICE_TURN_ON,
+        service,
         {ATTR_ENTITY_ID: entity_id},
         blocking=True,
     )
 
-    mock_api.assert_called_with("/interface/enable", **{".id": "*2"})
+    mock_api.assert_any_call(command, **{".id": interface[".id"]})
 
     assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_ON
-
-
-async def test_switch_turn_off(hass: HomeAssistant, mock_api: MagicMock) -> None:
-    """Test turning off a Mikrotik switch disables the interface."""
-    with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
-        await setup_mikrotik_entry(hass, interface_data=[dict(ETHER1_INTERFACE)])
-
-    entity_id = "switch.ether1_ethernet"
-    assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_ON
-
-    await hass.services.async_call(
-        SWITCH_DOMAIN,
-        SERVICE_TURN_OFF,
-        {ATTR_ENTITY_ID: entity_id},
-        blocking=True,
-    )
-
-    mock_api.assert_called_with("/interface/disable", **{".id": "*1"})
-
-    assert (state := hass.states.get(entity_id))
-    assert state.state == STATE_OFF
+    assert state.state == final_state


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Make switch non-optimistic for Mikrotik

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
