### PR TITLE
Translate WiiM browse media errors

### DIFF
--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -85,6 +85,8 @@ def media_player_exception_wrap[
     _R,
 ](
     func: Callable[Concatenate[_WiimMediaPlayerEntityT, _P], Awaitable[_R]],
+    *,
+    update_ha_state: bool = True,
 ) -> Callable[Concatenate[_WiimMediaPlayerEntityT, _P], Coroutine[Any, Any, _R]]:
     """Wrap media player commands to handle SDK exceptions consistently."""
 
@@ -114,11 +116,23 @@ def media_player_exception_wrap[
                 },
             ) from err
 
-        self._update_ha_state_from_sdk_cache()
+        if update_ha_state:
+            self._update_ha_state_from_sdk_cache()
 
         return result
 
     return _wrap
+
+
+def browse_media_exception_wrap[
+    _WiimMediaPlayerEntityT: WiimMediaPlayerEntity,
+    **_P,
+    _R,
+](
+    func: Callable[Concatenate[_WiimMediaPlayerEntityT, _P], Awaitable[_R]],
+) -> Callable[Concatenate[_WiimMediaPlayerEntityT, _P], Coroutine[Any, Any, _R]]:
+    """Wrap browse media calls without refreshing entity state after success."""
+    return media_player_exception_wrap(func, update_ha_state=False)
 
 
 async def async_setup_entry(
@@ -742,7 +756,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             source
         )
 
-    @media_player_exception_wrap
+    @browse_media_exception_wrap
     @override
     async def async_browse_media(
         self,

--- a/homeassistant/components/wiim/media_player.py
+++ b/homeassistant/components/wiim/media_player.py
@@ -742,6 +742,7 @@ class WiimMediaPlayerEntity(WiimBaseEntity, MediaPlayerEntity):
             source
         )
 
+    @media_player_exception_wrap
     @override
     async def async_browse_media(
         self,

--- a/homeassistant/components/wiim/quality_scale.yaml
+++ b/homeassistant/components/wiim/quality_scale.yaml
@@ -31,10 +31,7 @@ rules:
   test-before-setup: done
   unique-config-entry: done
   # Silver
-  action-exceptions:
-    status: todo
-    comment: |
-      - The calls to the api can be changed to return bool, and services can then raise HomeAssistantError
+  action-exceptions: done
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -994,6 +994,28 @@ async def test_browse_media_service_returns_wiim_library(
     assert [child.title for child in queue_browse.children] == ["Song A", "Song B"]
 
 
+@pytest.mark.usefixtures("mock_wiim_controller")
+async def test_browse_media_does_not_refresh_entity_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test browsing media does not refresh entity state after success."""
+    await setup_integration(hass, mock_config_entry)
+
+    with patch(
+        "homeassistant.components.wiim.media_player.WiimMediaPlayerEntity._update_ha_state_from_sdk_cache"
+    ) as mock_update:
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_BROWSE_MEDIA,
+            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+            blocking=True,
+            return_response=True,
+        )
+
+    mock_update.assert_not_called()
+
+
 async def test_browse_media_service_includes_media_sources_when_supported(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -1099,6 +1099,57 @@ async def test_browse_media_error_uses_translation(
     assert exc_info.value.translation_placeholders == translation_placeholders
 
 
+@pytest.mark.parametrize(
+    ("sdk_method", "media_content_id"),
+    [
+        pytest.param(
+            "async_get_presets",
+            "wiim_library/library_root/favorites",
+            id="presets",
+        ),
+        pytest.param(
+            "async_get_queue_snapshot",
+            "wiim_library/library_root/playlists",
+            id="queue",
+        ),
+    ],
+)
+@pytest.mark.usefixtures("mock_wiim_controller")
+async def test_browse_media_sdk_error_uses_translation(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
+    *,
+    sdk_method: str,
+    media_content_id: str,
+) -> None:
+    """Test browse media SDK errors raise a translated Home Assistant error."""
+    await setup_integration(hass, mock_config_entry)
+    getattr(mock_wiim_device, sdk_method).side_effect = WiimRequestException(
+        "request failed"
+    )
+
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await hass.services.async_call(
+            MEDIA_PLAYER_DOMAIN,
+            SERVICE_BROWSE_MEDIA,
+            {
+                ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID,
+                ATTR_MEDIA_CONTENT_TYPE: MediaType.PLAYLIST,
+                ATTR_MEDIA_CONTENT_ID: media_content_id,
+            },
+            blocking=True,
+            return_response=True,
+        )
+
+    assert exc_info.value.translation_domain == DOMAIN
+    assert exc_info.value.translation_key == "command_failed"
+    assert exc_info.value.translation_placeholders == {
+        "command": "async_browse_media",
+        "entity_id": MEDIA_PLAYER_ENTITY_ID,
+    }
+
+
 async def test_join_and_unjoin_services_use_resolved_member_udns(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/components/wiim/test_media_player.py
+++ b/tests/components/wiim/test_media_player.py
@@ -998,22 +998,27 @@ async def test_browse_media_service_returns_wiim_library(
 async def test_browse_media_does_not_refresh_entity_state(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    mock_wiim_device: MagicMock,
 ) -> None:
     """Test browsing media does not refresh entity state after success."""
     await setup_integration(hass, mock_config_entry)
 
-    with patch(
-        "homeassistant.components.wiim.media_player.WiimMediaPlayerEntity._update_ha_state_from_sdk_cache"
-    ) as mock_update:
-        await hass.services.async_call(
-            MEDIA_PLAYER_DOMAIN,
-            SERVICE_BROWSE_MEDIA,
-            {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
-            blocking=True,
-            return_response=True,
-        )
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state is not None
+    original_volume = state.attributes[ATTR_MEDIA_VOLUME_LEVEL]
+    mock_wiim_device.volume = 75
 
-    mock_update.assert_not_called()
+    await hass.services.async_call(
+        MEDIA_PLAYER_DOMAIN,
+        SERVICE_BROWSE_MEDIA,
+        {ATTR_ENTITY_ID: MEDIA_PLAYER_ENTITY_ID},
+        blocking=True,
+        return_response=True,
+    )
+
+    state = hass.states.get(MEDIA_PLAYER_ENTITY_ID)
+    assert state is not None
+    assert state.attributes[ATTR_MEDIA_VOLUME_LEVEL] == original_volume
 
 
 async def test_browse_media_service_includes_media_sources_when_supported(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
- Handle WiiM SDK errors raised while browsing presets and the playback queue. These failures are now converted into translated Home Assistant errors instead of leaking SDK exceptions.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
