### PR TITLE
Bump tesla-fleet-api to 1.8.0

### DIFF
--- a/homeassistant/components/tesla_fleet/manifest.json
+++ b/homeassistant/components/tesla_fleet/manifest.json
@@ -8,5 +8,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "loggers": ["tesla-fleet-api"],
-  "requirements": ["tesla-fleet-api==1.7.6"]
+  "requirements": ["tesla-fleet-api==1.8.0"]
 }

--- a/homeassistant/components/teslemetry/manifest.json
+++ b/homeassistant/components/teslemetry/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tesla_fleet_api", "teslemetry_stream"],
   "quality_scale": "platinum",
-  "requirements": ["tesla-fleet-api==1.7.6", "teslemetry-stream==0.10.0"]
+  "requirements": ["tesla-fleet-api==1.8.0", "teslemetry-stream==0.10.0"]
 }

--- a/homeassistant/components/tessie/manifest.json
+++ b/homeassistant/components/tessie/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "loggers": ["tessie", "tesla-fleet-api"],
   "quality_scale": "silver",
-  "requirements": ["tessie-api==0.1.3", "tesla-fleet-api==1.7.6"]
+  "requirements": ["tessie-api==0.1.3", "tesla-fleet-api==1.8.0"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3169,7 +3169,7 @@ temperusb==1.6.1
 # homeassistant.components.tesla_fleet
 # homeassistant.components.teslemetry
 # homeassistant.components.tessie
-tesla-fleet-api==1.7.6
+tesla-fleet-api==1.8.0
 
 # homeassistant.components.powerwall
 tesla-powerwall==0.5.3

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -18,7 +18,6 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
-from tesla_fleet_api.teslemetry.vehicle import TeslemetryVehicle
 
 from homeassistant.components.teslemetry import _get_access_token
 from homeassistant.components.teslemetry.const import CLIENT_ID, DOMAIN
@@ -119,23 +118,6 @@ async def test_devices(
 
     for device in devices:
         assert device == snapshot(name=f"{device.identifiers}")
-
-
-@pytest.mark.parametrize(
-    ("vin", "model"),
-    [
-        ("LRW3F7EK4NC700000", "Model 3"),
-        ("LRWAF7EK4NC700000", "Cybercab"),
-    ],
-    ids=["model_3", "cybercab"],
-)
-def test_vehicle_model(vin: str, model: str) -> None:
-    """Test the device model is derived from the library, keyed on the VIN.
-
-    Teslemetry sets the device model to ``vehicle.model``, so the Cybercab VIN
-    prefix (4th character ``A``) added in tesla-fleet-api 1.8.0 must resolve.
-    """
-    assert TeslemetryVehicle(MagicMock(), vin).model == model
 
 
 @pytest.mark.parametrize(("side_effect", "state"), VEHICLE_ERRORS)

--- a/tests/components/teslemetry/test_init.py
+++ b/tests/components/teslemetry/test_init.py
@@ -18,6 +18,7 @@ from tesla_fleet_api.exceptions import (
     SubscriptionRequired,
     TeslaFleetError,
 )
+from tesla_fleet_api.teslemetry.vehicle import TeslemetryVehicle
 
 from homeassistant.components.teslemetry import _get_access_token
 from homeassistant.components.teslemetry.const import CLIENT_ID, DOMAIN
@@ -118,6 +119,23 @@ async def test_devices(
 
     for device in devices:
         assert device == snapshot(name=f"{device.identifiers}")
+
+
+@pytest.mark.parametrize(
+    ("vin", "model"),
+    [
+        ("LRW3F7EK4NC700000", "Model 3"),
+        ("LRWAF7EK4NC700000", "Cybercab"),
+    ],
+    ids=["model_3", "cybercab"],
+)
+def test_vehicle_model(vin: str, model: str) -> None:
+    """Test the device model is derived from the library, keyed on the VIN.
+
+    Teslemetry sets the device model to ``vehicle.model``, so the Cybercab VIN
+    prefix (4th character ``A``) added in tesla-fleet-api 1.8.0 must resolve.
+    """
+    assert TeslemetryVehicle(MagicMock(), vin).model == model
 
 
 @pytest.mark.parametrize(("side_effect", "state"), VEHICLE_ERRORS)


### PR DESCRIPTION
## Breaking change



## Proposed change

Bump `tesla-fleet-api` from 1.7.6 to 1.8.0 across the `teslemetry`, `tesla_fleet`, and `tessie` manifests, and regenerate `requirements_all.txt`.

1.8.0 adds the Cybercab model (VIN 4th-character `A` → "Cybercab") and `VehicleBluetooth.listen_connection_status`.

Diff: https://github.com/Teslemetry/python-tesla-fleet-api/compare/v1.7.6...v1.8.0
Release notes: https://github.com/Teslemetry/python-tesla-fleet-api/releases/tag/v1.8.0

## Type of change

- [x] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
