### PR TITLE
Add test for _abort_if_unique_id_configured in Google Health

### DIFF
--- a/tests/components/google_health/conftest.py
+++ b/tests/components/google_health/conftest.py
@@ -44,6 +44,7 @@ CLIENT_ID = "1234"
 CLIENT_SECRET = "5678"
 FAKE_ACCESS_TOKEN = "some-access-token"
 FAKE_REFRESH_TOKEN = "some-refresh-token"
+HEALTH_USER_ID = "mock-health-user-id"
 
 
 def _rollup_fixture(
@@ -101,7 +102,7 @@ def mock_config_entry(token_entry: dict[str, Any]) -> MockConfigEntry:
     return MockConfigEntry(
         domain=DOMAIN,
         title="Google Health",
-        unique_id="mock-health-user-id",
+        unique_id=HEALTH_USER_ID,
         entry_id="01J0BC4QM2YBRP6H5G933CETT7",
         data={
             "auth_implementation": DOMAIN,

--- a/tests/components/google_health/test_config_flow.py
+++ b/tests/components/google_health/test_config_flow.py
@@ -22,6 +22,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_entry_oauth2_flow
 
+from .conftest import HEALTH_USER_ID
+
 from tests.common import MockConfigEntry
 from tests.test_util.aiohttp import AiohttpClientMocker
 from tests.typing import ClientSessionGenerator
@@ -92,8 +94,57 @@ async def test_full_flow(
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test"
-    assert result["result"].unique_id == "mock-health-user-id"
+    assert result["result"].unique_id == HEALTH_USER_ID
     assert len(hass.config_entries.async_entries(DOMAIN)) == 1
+
+
+@pytest.mark.usefixtures(
+    "current_request_with_host",
+    "mock_setup_entry",
+    "setup_credentials",
+    "mock_google_health_client",
+)
+async def test_already_configured(
+    hass: HomeAssistant,
+    hass_client_no_auth: ClientSessionGenerator,
+    aioclient_mock: AiohttpClientMocker,
+) -> None:
+    """Test config flow aborts when account is already configured."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=HEALTH_USER_ID,
+    )
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    state = config_entry_oauth2_flow._encode_jwt(
+        hass,
+        {
+            "flow_id": result["flow_id"],
+            "redirect_uri": "https://example.com/auth/external/callback",
+        },
+    )
+
+    client = await hass_client_no_auth()
+    await client.get(f"/auth/external/callback?code=abcd&state={state}")
+
+    aioclient_mock.post(
+        OAUTH2_TOKEN,
+        json={
+            "refresh_token": "mock-refresh-token",
+            "access_token": "mock-access-token",
+            "type": "Bearer",
+            "expires_in": 60,
+            "scope": " ".join(OAUTH_SCOPES),
+        },
+    )
+
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 @pytest.mark.usefixtures(
@@ -332,7 +383,7 @@ async def test_reauth_flow(
                 "scope": " ".join(OAUTH_SCOPES),
             },
         },
-        unique_id="mock-health-user-id",
+        unique_id=HEALTH_USER_ID,
     )
     config_entry.add_to_hass(hass)
 
@@ -380,7 +431,7 @@ async def test_reauth_flow(
         IDENTITY_URL,
         json={
             "name": "users/me/identity",
-            "healthUserId": "mock-health-user-id",
+            "healthUserId": HEALTH_USER_ID,
         },
     )
 
@@ -423,7 +474,7 @@ async def test_reconfigure_flow(
                 "scope": HealthApiScope.PROFILE_READ,
             },
         },
-        unique_id="mock-health-user-id",
+        unique_id=HEALTH_USER_ID,
     )
     config_entry.add_to_hass(hass)
 
@@ -463,7 +514,7 @@ async def test_reconfigure_flow(
         IDENTITY_URL,
         json={
             "name": "users/me/identity",
-            "healthUserId": "mock-health-user-id",
+            "healthUserId": HEALTH_USER_ID,
         },
     )
 
@@ -507,7 +558,7 @@ async def test_reconfigure_flow_wrong_account(
                 "scope": " ".join(OAUTH_SCOPES),
             },
         },
-        unique_id="mock-health-user-id",
+        unique_id=HEALTH_USER_ID,
     )
     config_entry.add_to_hass(hass)
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adds a unit test (`test_already_configured`) in `google_health` to verify that the config flow aborts with reason `already_configured` when an entry with the same unique ID is already configured (`_abort_if_unique_id_configured`). Also refactors `mock-health-user-id` into a shared `HEALTH_USER_ID` constant across `google_health` tests.

This gap was found during audit of the quality scale in #177989

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
