### PR TITLE
Remove stale paired devices in Google Health integration

### DIFF
--- a/homeassistant/components/google_health/quality_scale.yaml
+++ b/homeassistant/components/google_health/quality_scale.yaml
@@ -76,9 +76,7 @@ rules:
   repair-issues:
     status: exempt
     comment: This integration does not raise repair issues.
-  stale-devices:
-    status: exempt
-    comment: This integration has a static device.
+  stale-devices: done
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/google_health/sensor.py
+++ b/homeassistant/components/google_health/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
     UnitOfVolume,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import (
     CONNECTION_NETWORK_MAC,
     DeviceInfo,
@@ -313,7 +314,12 @@ async def async_setup_entry(
 
         @callback
         def async_add_device_entities() -> None:
-            """Add entities for new devices."""
+            """Add entities for new devices and remove stale devices."""
+            current_device_ids = set(device_coordinator.data)
+            # Drop any devices no longer present in the API. They will be removed below
+            added_device_ids.intersection_update(current_device_ids)
+
+            # Add any newly discovered devices
             new_entities: list[SensorEntity] = []
             for device in device_coordinator.data.values():
                 if device.device_id in added_device_ids:
@@ -330,6 +336,21 @@ async def async_setup_entry(
                 )
             if new_entities:
                 async_add_entities(new_entities)
+
+            # Remove any stale devices
+            device_registry = dr.async_get(hass)
+            for device_entry in dr.async_entries_for_config_entry(
+                device_registry, entry.entry_id
+            ):
+                for identifier in device_entry.identifiers:
+                    if identifier[0] == DOMAIN:
+                        device_id = identifier[1]
+                        if (
+                            device_id != entry.entry_id
+                            and device_id not in current_device_ids
+                        ):
+                            device_registry.async_remove_device(device_entry.id)
+                        break
 
         async_add_device_entities()
         entry.async_on_unload(

--- a/homeassistant/components/google_health/sensor.py
+++ b/homeassistant/components/google_health/sensor.py
@@ -339,18 +339,14 @@ async def async_setup_entry(
 
             # Remove any stale devices
             device_registry = dr.async_get(hass)
+            active_identifiers = {(DOMAIN, entry.entry_id)} | {
+                (DOMAIN, device_id) for device_id in current_device_ids
+            }
             for device_entry in dr.async_entries_for_config_entry(
                 device_registry, entry.entry_id
             ):
-                for identifier in device_entry.identifiers:
-                    if identifier[0] == DOMAIN:
-                        device_id = identifier[1]
-                        if (
-                            device_id != entry.entry_id
-                            and device_id not in current_device_ids
-                        ):
-                            device_registry.async_remove_device(device_entry.id)
-                        break
+                if not set(device_entry.identifiers) & active_identifiers:
+                    device_registry.async_remove_device(device_entry.id)
 
         async_add_device_entities()
         entry.async_on_unload(

--- a/tests/components/google_health/conftest.py
+++ b/tests/components/google_health/conftest.py
@@ -65,7 +65,7 @@ def _list_fixture(filename: str, data_type: DataType) -> ListDataPointResult:
     return ListDataPointResult(_ListDataPointsModel(data_points=data_points))
 
 
-def _paired_devices_fixture(filename: str) -> ListPairedDevicesResult:
+def paired_devices_fixture(filename: str) -> ListPairedDevicesResult:
     """Build a list of paired devices result from a fixture."""
     raw_json = load_json_object_fixture(filename, DOMAIN)
     return ListPairedDevicesResult(_ListPairedDevicesModel.from_dict(raw_json))
@@ -181,7 +181,7 @@ def mock_google_health_client() -> Generator[AsyncMock]:
         client.body_fat = AsyncMock()
         client.body_fat.list.return_value = _list_fixture("body_fat.json", BODY_FAT)
         client.paired_devices = AsyncMock()
-        client.paired_devices.list.return_value = _paired_devices_fixture(
+        client.paired_devices.list.return_value = paired_devices_fixture(
             "paired_devices.json"
         )
         client.paired_devices.required_read_scopes = [

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -21,6 +21,8 @@ from homeassistant.util.unit_system import (
     UnitSystem,
 )
 
+from .conftest import _paired_devices_fixture
+
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
@@ -235,3 +237,45 @@ async def test_stale_device_removed_on_setup(
     assert await integration_setup()
 
     assert device_registry.async_get(stale_device.id) is None
+
+
+async def test_auto_add_new_device(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_google_health_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test new paired devices returned on coordinator update are automatically added."""
+    mock_google_health_client.paired_devices.list.return_value = (
+        ListPairedDevicesResult(_ListPairedDevicesModel([]))
+    )
+
+    assert await integration_setup()
+
+    assert hass.states.get("sensor.fitbit_charge_6_battery") is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "watch_123"), config_entry.entry_id
+        )
+        is None
+    )
+
+    mock_google_health_client.paired_devices.list.return_value = (
+        _paired_devices_fixture("paired_devices.json")
+    )
+
+    freezer.tick(DEVICE_POLLING_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    battery_state = hass.states.get("sensor.fitbit_charge_6_battery")
+    assert battery_state is not None
+    assert battery_state.state == "85"
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "watch_123"), config_entry.entry_id
+    )
+    assert device is not None
+

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -21,7 +21,7 @@ from homeassistant.util.unit_system import (
     UnitSystem,
 )
 
-from .conftest import _paired_devices_fixture
+from .conftest import paired_devices_fixture
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
@@ -263,7 +263,7 @@ async def test_auto_add_new_device(
     )
 
     mock_google_health_client.paired_devices.list.return_value = (
-        _paired_devices_fixture("paired_devices.json")
+        paired_devices_fixture("paired_devices.json")
     )
 
     freezer.tick(DEVICE_POLLING_INTERVAL)

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -262,8 +262,8 @@ async def test_auto_add_new_device(
         is None
     )
 
-    mock_google_health_client.paired_devices.list.return_value = (
-        paired_devices_fixture("paired_devices.json")
+    mock_google_health_client.paired_devices.list.return_value = paired_devices_fixture(
+        "paired_devices.json"
     )
 
     freezer.tick(DEVICE_POLLING_INTERVAL)
@@ -278,4 +278,3 @@ async def test_auto_add_new_device(
         (DOMAIN, "watch_123"), config_entry.entry_id
     )
     assert device is not None
-

--- a/tests/components/google_health/test_sensor.py
+++ b/tests/components/google_health/test_sensor.py
@@ -4,11 +4,14 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from freezegun.api import FrozenDateTimeFactory
 from google_health_api.const import HealthApiScope
+from google_health_api.model import ListPairedDevicesResult, _ListPairedDevicesModel
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
 from homeassistant.components.google_health.const import DOMAIN
+from homeassistant.components.google_health.coordinator import DEVICE_POLLING_INTERVAL
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -18,7 +21,7 @@ from homeassistant.util.unit_system import (
     UnitSystem,
 )
 
-from tests.common import MockConfigEntry, snapshot_platform
+from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 
 
 @pytest.mark.usefixtures("mock_google_health_client")
@@ -175,3 +178,60 @@ async def test_device_sensor_via_device_id(
     )
     assert paired_device is not None
     assert paired_device.via_device_id == account_device.id
+
+
+async def test_stale_device_removed(
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+    mock_google_health_client: AsyncMock,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test stale devices are removed when no longer returned by API."""
+    assert await integration_setup()
+
+    battery_state = hass.states.get("sensor.fitbit_charge_6_battery")
+    assert battery_state is not None
+    assert battery_state.state == "85"
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "watch_123"), config_entry.entry_id
+    )
+    assert device is not None
+
+    mock_google_health_client.paired_devices.list.return_value = (
+        ListPairedDevicesResult(_ListPairedDevicesModel([]))
+    )
+
+    freezer.tick(DEVICE_POLLING_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    assert hass.states.get("sensor.fitbit_charge_6_battery") is None
+
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "watch_123"), config_entry.entry_id
+    )
+    assert device is None
+
+
+@pytest.mark.usefixtures("mock_google_health_client")
+async def test_stale_device_removed_on_setup(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[], Awaitable[bool]],
+) -> None:
+    """Test stale device present in registry before setup is removed during setup."""
+    config_entry.add_to_hass(hass)
+    stale_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, "old_stale_watch")},
+        name="Old Stale Watch",
+    )
+    assert device_registry.async_get(stale_device.id) is not None
+
+    assert await integration_setup()
+
+    assert device_registry.async_get(stale_device.id) is None


### PR DESCRIPTION
## Proposed change

This PR adds stale device removal to the Google Health integration. When paired devices are no longer returned by the Google Health API (or if stale device entries exist in the device registry), the stale devices and their associated entities are automatically removed from the Home Assistant device registry.

This was raised as a gap in #177989 since the quality scale was incorrect once we added support for device battery sensors.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
