### PR TITLE
Add release notes messages for update entities

### DIFF
--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -280,7 +280,7 @@ class UpdateEntity(
     _attr_supported_features: UpdateEntityFeature = UpdateEntityFeature(0)
     _attr_title: str | None = None
     _attr_update_percentage: int | float | None = None
-    _attr_release_notes_messages: tuple[UpdateReleaseNotesMessage, ...] = ()
+    _attr_release_notes_messages: tuple[UpdateReleaseNotesMessage, ...]
     __skipped_version: str | None = None
     __in_progress: bool = False
 
@@ -634,6 +634,9 @@ async def _async_render_release_notes_messages(
     hass: HomeAssistant, messages: tuple[UpdateReleaseNotesMessage, ...]
 ) -> str | None:
     """Render release notes messages as alert elements."""
+    if not messages:
+        return None
+
     entity_component_translations = await async_get_translations(
         hass, hass.config.language, "entity_component", {DOMAIN}
     )

--- a/homeassistant/components/update/__init__.py
+++ b/homeassistant/components/update/__init__.py
@@ -1,5 +1,8 @@
 """Component to allow for providing device or service updates."""
 
+from collections.abc import Mapping
+from contextlib import suppress
+from dataclasses import dataclass
 from datetime import timedelta
 from enum import StrEnum
 from functools import lru_cache
@@ -24,6 +27,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.entity import ABCCachedProperties, EntityDescription
 from homeassistant.helpers.entity_component import EntityComponent
 from homeassistant.helpers.restore_state import RestoreEntity
+from homeassistant.helpers.translation import async_get_translations
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.hass_dict import HassKey
 
@@ -62,7 +66,39 @@ class UpdateDeviceClass(StrEnum):
     FIRMWARE = "firmware"
 
 
+class UpdateReleaseNotesMessageSeverity(StrEnum):
+    """Severity for an update release notes message."""
+
+    INFO = "info"
+    WARNING = "warning"
+    ERROR = "error"
+
+
+@dataclass(frozen=True, kw_only=True)
+class UpdateReleaseNotesMessage:
+    """Message shown before update release notes.
+
+    This is intended for static guidance that accompanies release notes, not for
+    translating the release notes themselves.
+    """
+
+    translation_domain: str
+    translation_key: str
+    severity: UpdateReleaseNotesMessageSeverity = UpdateReleaseNotesMessageSeverity.INFO
+    translation_placeholders: Mapping[str, str] | None = None
+
+
 DEVICE_CLASSES_SCHEMA = vol.All(vol.Lower, vol.Coerce(UpdateDeviceClass))
+
+RELEASE_NOTES_MESSAGE_BATTERY_POWERED = UpdateReleaseNotesMessage(
+    translation_domain=DOMAIN,
+    translation_key="battery_powered_update",
+)
+RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT = UpdateReleaseNotesMessage(
+    translation_domain=DOMAIN,
+    translation_key="do_not_interrupt",
+    severity=UpdateReleaseNotesMessageSeverity.WARNING,
+)
 
 
 __all__ = [
@@ -74,6 +110,8 @@ __all__ = [
     "DOMAIN",
     "PLATFORM_SCHEMA",
     "PLATFORM_SCHEMA_BASE",
+    "RELEASE_NOTES_MESSAGE_BATTERY_POWERED",
+    "RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT",
     "SERVICE_INSTALL",
     "SERVICE_SKIP",
     "UpdateDeviceClass",
@@ -81,6 +119,8 @@ __all__ = [
     "UpdateEntityDescription",
     "UpdateEntityFeature",
     "UpdateEntityStateAttribute",
+    "UpdateReleaseNotesMessage",
+    "UpdateReleaseNotesMessageSeverity",
 ]
 
 # mypy: disallow-any-generics
@@ -186,6 +226,7 @@ class UpdateEntityDescription(EntityDescription, frozen_or_thawed=True):
     device_class: UpdateDeviceClass | None = None
     display_precision: int = 0
     entity_category: EntityCategory | None = EntityCategory.CONFIG
+    release_notes_messages: tuple[UpdateReleaseNotesMessage, ...] = ()
 
 
 @lru_cache(maxsize=256)
@@ -239,6 +280,7 @@ class UpdateEntity(
     _attr_supported_features: UpdateEntityFeature = UpdateEntityFeature(0)
     _attr_title: str | None = None
     _attr_update_percentage: int | float | None = None
+    _attr_release_notes_messages: tuple[UpdateReleaseNotesMessage, ...] = ()
     __skipped_version: str | None = None
     __in_progress: bool = False
 
@@ -329,6 +371,15 @@ class UpdateEntity(
     def release_url(self) -> str | None:
         """URL to the full release notes of the latest version available."""
         return self._attr_release_url
+
+    @property
+    def release_notes_messages(self) -> tuple[UpdateReleaseNotesMessage, ...]:
+        """Messages shown before the release notes."""
+        if hasattr(self, "_attr_release_notes_messages"):
+            return self._attr_release_notes_messages
+        if hasattr(self, "entity_description"):
+            return self.entity_description.release_notes_messages
+        return ()
 
     @cached_property
     @override
@@ -559,5 +610,63 @@ async def websocket_release_notes(
         return
     connection.send_result(
         msg["id"],
-        await entity.async_release_notes(),
+        await _async_render_release_notes(hass, entity),
     )
+
+
+async def _async_render_release_notes(
+    hass: HomeAssistant, entity: UpdateEntity
+) -> str | None:
+    """Render release notes messages followed by the entity release notes."""
+    release_notes_messages = await _async_render_release_notes_messages(
+        hass, entity.release_notes_messages
+    )
+    release_notes = await entity.async_release_notes()
+
+    if release_notes_messages is None:
+        return release_notes
+    if not release_notes:
+        return release_notes_messages
+    return f"{release_notes_messages}\n\n{release_notes}"
+
+
+async def _async_render_release_notes_messages(
+    hass: HomeAssistant, messages: tuple[UpdateReleaseNotesMessage, ...]
+) -> str | None:
+    """Render release notes messages as alert elements."""
+    entity_component_translations = await async_get_translations(
+        hass, hass.config.language, "entity_component", {DOMAIN}
+    )
+    entity_translations = await async_get_translations(
+        hass,
+        hass.config.language,
+        "entity",
+        {
+            message.translation_domain
+            for message in messages
+            if message.translation_domain != DOMAIN
+        },
+    )
+
+    rendered_messages: list[str] = []
+    for message in messages:
+        if message.translation_domain == DOMAIN:
+            translation = entity_component_translations.get(
+                "component.update.entity_component.release_notes_messages."
+                f"{message.translation_key}",
+                message.translation_key,
+            )
+        else:
+            translation = entity_translations.get(
+                f"component.{message.translation_domain}.entity.update."
+                f"release_notes_messages.{message.translation_key}",
+                message.translation_key,
+            )
+        if message.translation_placeholders is not None:
+            with suppress(KeyError):
+                translation = translation.format(**message.translation_placeholders)
+        rendered_messages.append(
+            f'<ha-alert alert-type="{message.severity}">{translation}</ha-alert>'
+        )
+
+    return "\n\n".join(rendered_messages)

--- a/homeassistant/components/update/strings.json
+++ b/homeassistant/components/update/strings.json
@@ -85,6 +85,10 @@
     },
     "firmware": {
       "name": "Firmware"
+    },
+    "release_notes_messages": {
+      "battery_powered_update": "Battery powered devices can sometimes take multiple hours to update and you may need to wake the device for the update to begin.",
+      "do_not_interrupt": "Do not restart, remove power from, or otherwise interrupt the device while the update is in progress."
     }
   },
   "services": {

--- a/script/hassfest/translations.py
+++ b/script/hassfest/translations.py
@@ -339,6 +339,73 @@ _EXCEPTIONS_SCHEMA = {
 }
 
 
+RELEASE_NOTES_MESSAGES_SCHEMA = cv.schema_with_slug_keys(
+    translation_value_validator,
+    slug_validator=translation_key_validator,
+)
+
+ENTITY_COMPONENT_TRANSLATION_SCHEMA = {
+    vol.Optional("name"): str,
+    vol.Optional("state"): cv.schema_with_slug_keys(
+        custom_translation_value_validator(allow_placeholders=False),
+        slug_validator=translation_key_validator,
+    ),
+    vol.Optional("state_attributes"): cv.schema_with_slug_keys(
+        {
+            vol.Optional("name"): str,
+            vol.Optional("state"): cv.schema_with_slug_keys(
+                custom_translation_value_validator(allow_placeholders=False),
+                slug_validator=translation_key_validator,
+            ),
+        },
+        slug_validator=translation_key_validator,
+    ),
+}
+
+ENTITY_TRANSLATION_SCHEMA = {
+    vol.Optional("name"): translation_value_validator,
+    vol.Optional("state"): cv.schema_with_slug_keys(
+        custom_translation_value_validator(allow_placeholders=False),
+        slug_validator=translation_key_validator,
+    ),
+    vol.Optional("state_attributes"): cv.schema_with_slug_keys(
+        {
+            vol.Optional("name"): custom_translation_value_validator(
+                allow_placeholders=False
+            ),
+            vol.Optional("state"): cv.schema_with_slug_keys(
+                custom_translation_value_validator(allow_placeholders=False),
+                slug_validator=translation_key_validator,
+            ),
+        },
+        slug_validator=translation_key_validator,
+    ),
+    vol.Optional("unit_of_measurement"): custom_translation_value_validator(
+        allow_placeholders=False
+    ),
+}
+
+ENTITY_COMPONENT_SCHEMA = vol.Schema(
+    {
+        vol.Optional("release_notes_messages"): RELEASE_NOTES_MESSAGES_SCHEMA,
+        vol.Any("_", cv.slug): ENTITY_COMPONENT_TRANSLATION_SCHEMA,
+    }
+)
+
+ENTITY_SCHEMA = vol.Schema(
+    {
+        vol.Optional("update"): {
+            vol.Optional("release_notes_messages"): RELEASE_NOTES_MESSAGES_SCHEMA,
+            translation_key_validator: ENTITY_TRANSLATION_SCHEMA,
+        },
+        cv.slug: cv.schema_with_slug_keys(
+            ENTITY_TRANSLATION_SCHEMA,
+            slug_validator=translation_key_validator,
+        ),
+    }
+)
+
+
 def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
     """Generate a strings schema."""
     return vol.Schema(
@@ -445,68 +512,14 @@ def gen_strings_schema(config: Config, integration: Integration) -> vol.Schema:
                 vol.Optional("description"): translation_value_validator,
             },
             vol.Optional("issues"): gen_issues_schema(config, integration),
-            vol.Optional("entity_component"): cv.schema_with_slug_keys(
-                {
-                    vol.Optional("name"): str,
-                    vol.Optional("state"): cv.schema_with_slug_keys(
-                        custom_translation_value_validator(allow_placeholders=False),
-                        slug_validator=translation_key_validator,
-                    ),
-                    vol.Optional("state_attributes"): cv.schema_with_slug_keys(
-                        {
-                            vol.Optional("name"): str,
-                            vol.Optional("state"): cv.schema_with_slug_keys(
-                                custom_translation_value_validator(
-                                    allow_placeholders=False
-                                ),
-                                slug_validator=translation_key_validator,
-                            ),
-                        },
-                        slug_validator=translation_key_validator,
-                    ),
-                },
-                slug_validator=vol.Any("_", cv.slug),
-            ),
+            vol.Optional("entity_component"): ENTITY_COMPONENT_SCHEMA,
             vol.Optional("device"): cv.schema_with_slug_keys(
                 {
                     vol.Optional("name"): translation_value_validator,
                 },
                 slug_validator=translation_key_validator,
             ),
-            vol.Optional("entity"): cv.schema_with_slug_keys(
-                cv.schema_with_slug_keys(
-                    {
-                        vol.Optional("name"): translation_value_validator,
-                        vol.Optional("state"): cv.schema_with_slug_keys(
-                            custom_translation_value_validator(
-                                allow_placeholders=False
-                            ),
-                            slug_validator=translation_key_validator,
-                        ),
-                        vol.Optional("state_attributes"): cv.schema_with_slug_keys(
-                            {
-                                vol.Optional(
-                                    "name"
-                                ): custom_translation_value_validator(
-                                    allow_placeholders=False
-                                ),
-                                vol.Optional("state"): cv.schema_with_slug_keys(
-                                    custom_translation_value_validator(
-                                        allow_placeholders=False
-                                    ),
-                                    slug_validator=translation_key_validator,
-                                ),
-                            },
-                            slug_validator=translation_key_validator,
-                        ),
-                        vol.Optional(
-                            "unit_of_measurement"
-                        ): custom_translation_value_validator(allow_placeholders=False),
-                    },
-                    slug_validator=translation_key_validator,
-                ),
-                slug_validator=cv.slug,
-            ),
+            vol.Optional("entity"): ENTITY_SCHEMA,
             **_EXCEPTIONS_SCHEMA,
             vol.Optional("services"): cv.schema_with_slug_keys(
                 {

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -16,6 +16,7 @@ from homeassistant.components.update import (
     UpdateDeviceClass,
     UpdateEntity,
     UpdateEntityDescription,
+    UpdateReleaseNotesMessage,
 )
 from homeassistant.components.update.const import (
     ATTR_AUTO_UPDATE,
@@ -781,6 +782,64 @@ async def test_release_notes_with_messages(
         '<ha-alert alert-type="warning">'
         "Do not restart, remove power from, or otherwise interrupt the device "
         "while the update is in progress."
+        "</ha-alert>\n\n"
+        "Release notes"
+    )
+
+
+async def test_release_notes_with_integration_message_placeholders(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test rendering integration release notes messages with placeholders."""
+    entity = MockUpdateEntity(
+        name="Update with integration release notes message",
+        unique_id="with_integration_release_notes_message",
+        installed_version="1.0.0",
+        latest_version="1.0.1",
+        supported_features=UpdateEntityFeature.RELEASE_NOTES,
+    )
+    entity.entity_description = UpdateEntityDescription(
+        key="with_integration_release_notes_message",
+        release_notes_messages=(
+            UpdateReleaseNotesMessage(
+                translation_domain=TEST_DOMAIN,
+                translation_key="review_docs",
+                translation_placeholders={"docs_url": "https://example.com/update"},
+            ),
+        ),
+    )
+    setup_test_component_platform(hass, DOMAIN, [entity])
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.update.async_get_translations",
+        side_effect=[
+            {},
+            {
+                "component.test.entity.update.release_notes_messages.review_docs": (
+                    "Review {docs_url} before starting the update."
+                ),
+            },
+        ],
+    ):
+        await client.send_json(
+            {
+                "id": 1,
+                "type": "update/release_notes",
+                "entity_id": "update.update_with_integration_release_notes_message",
+            }
+        )
+        result = await client.receive_json()
+
+    assert result["result"] == (
+        '<ha-alert alert-type="info">'
+        "Review https://example.com/update before starting the update."
         "</ha-alert>\n\n"
         "Release notes"
     )

--- a/tests/components/update/test_init.py
+++ b/tests/components/update/test_init.py
@@ -10,6 +10,7 @@ from homeassistant.components.update import (
     ATTR_BACKUP,
     ATTR_VERSION,
     DOMAIN,
+    RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,
     SERVICE_INSTALL,
     SERVICE_SKIP,
     UpdateDeviceClass,
@@ -742,6 +743,47 @@ async def test_release_notes(
     )
     result = await client.receive_json()
     assert result["result"] == "Release notes"
+
+
+async def test_release_notes_with_messages(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test rendering release notes messages before release notes."""
+    entity = MockUpdateEntity(
+        name="Update with release notes message",
+        unique_id="with_release_notes_message",
+        installed_version="1.0.0",
+        latest_version="1.0.1",
+        supported_features=UpdateEntityFeature.RELEASE_NOTES,
+    )
+    entity.entity_description = UpdateEntityDescription(
+        key="with_release_notes_message",
+        release_notes_messages=(RELEASE_NOTES_MESSAGE_DO_NOT_INTERRUPT,),
+    )
+    setup_test_component_platform(hass, DOMAIN, [entity])
+
+    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {CONF_PLATFORM: "test"}})
+    await hass.async_block_till_done()
+
+    client = await hass_ws_client(hass)
+    await hass.async_block_till_done()
+
+    await client.send_json(
+        {
+            "id": 1,
+            "type": "update/release_notes",
+            "entity_id": "update.update_with_release_notes_message",
+        }
+    )
+    result = await client.receive_json()
+    assert result["result"] == (
+        '<ha-alert alert-type="warning">'
+        "Do not restart, remove power from, or otherwise interrupt the device "
+        "while the update is in progress."
+        "</ha-alert>\n\n"
+        "Release notes"
+    )
 
 
 async def test_release_notes_entity_not_found(

--- a/tests/hassfest/test_translations.py
+++ b/tests/hassfest/test_translations.py
@@ -252,6 +252,9 @@ SAMPLE_STRINGS = {
         },
     },
     "entity_component": {
+        "release_notes_messages": {
+            "battery_powered_update": "Battery powered devices may take longer to update.",
+        },
         "_": {
             "name": "Test Integration",
             "state": {
@@ -328,6 +331,13 @@ SAMPLE_STRINGS = {
         "switch": {
             "power": {
                 "name": "Power",
+            },
+        },
+        "update": {
+            "release_notes_messages": {
+                "network_reliability": (
+                    "Review {docs_url} before starting the update."
+                ),
             },
         },
     },


### PR DESCRIPTION
## Proposed change
Add the base implementation for generic update entity release notes messages, as approved in architecture discussion https://github.com/home-assistant/architecture/discussions/1423.

This lets update entities define static, translatable messages that are rendered before `async_release_notes()` output, without each integration building `<ha-alert>` markup manually.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: https://github.com/home-assistant/developers.home-assistant/pull/3288
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
