### PR TITLE
Avoid naive datetime.now() in ai_task

### DIFF
--- a/homeassistant/components/ai_task/task.py
+++ b/homeassistant/components/ai_task/task.py
@@ -1,7 +1,7 @@
 """AI tasks to be handled by agents."""
 
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import timedelta
 import io
 import mimetypes
 from pathlib import Path
@@ -16,7 +16,7 @@ from homeassistant.core import HomeAssistant, ServiceResponse, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import llm
 from homeassistant.helpers.chat_session import ChatSession, async_get_chat_session
-from homeassistant.util import RE_SANITIZE_FILENAME, slugify
+from homeassistant.util import RE_SANITIZE_FILENAME, dt as dt_util, slugify
 
 from .const import (
     DATA_COMPONENT,
@@ -210,7 +210,7 @@ async def async_generate_image(
 
     source = hass.data[DATA_MEDIA_SOURCE]
 
-    current_time = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+    current_time = dt_util.now()
     ext = mimetypes.guess_extension(task_result.mime_type, False) or ".png"
     sanitized_task_name = RE_SANITIZE_FILENAME.sub("", slugify(task_name))
 

--- a/tests/components/google_generative_ai_conversation/test_ai_task.py
+++ b/tests/components/google_generative_ai_conversation/test_ai_task.py
@@ -259,7 +259,7 @@ async def test_generate_image(
     with patch.object(
         media_source.local_source.LocalSource,
         "async_upload_media",
-        return_value="media-source://ai_task/image/2025-06-14_225900_test_task.png",
+        return_value="media-source://ai_task/image/2025-06-14_155900_test_task.png",
     ) as mock_upload_media:
         result = await ai_task.async_generate_image(
             hass,
@@ -278,7 +278,7 @@ async def test_generate_image(
     image_data = mock_upload_media.call_args[0][1]
     assert image_data.file.getvalue() == mock_image_data
     assert image_data.content_type == "image/png"
-    assert image_data.filename == "2025-06-14_225900_test_task.png"
+    assert image_data.filename == "2025-06-14_155900_test_task.png"
 
     # Verify that generate_content was called with correct parameters
     assert mock_generate_content.called

--- a/tests/components/openai_conversation/test_ai_task.py
+++ b/tests/components/openai_conversation/test_ai_task.py
@@ -285,7 +285,7 @@ async def test_generate_image(
     with patch.object(
         media_source.local_source.LocalSource,
         "async_upload_media",
-        return_value="media-source://ai_task/image/2025-06-14_225900_test_task.png",
+        return_value="media-source://ai_task/image/2025-06-14_155900_test_task.png",
     ) as mock_upload_media:
         result = await ai_task.async_generate_image(
             hass,
@@ -314,7 +314,7 @@ async def test_generate_image(
     image_data = mock_upload_media.call_args[0][1]
     assert image_data.file.getvalue() == b"A"
     assert image_data.content_type == "image/png"
-    assert image_data.filename == "2025-06-14_225900_test_task.png"
+    assert image_data.filename == "2025-06-14_155900_test_task.png"
 
     assert (
         issue_registry.async_get_issue(DOMAIN, "organization_verification_required")


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Small fix for a naive `datetime.now()` call in ai_task flagged in #177787.

The timestamp is only used to stamp the generated image filename, so it does not need to be naive. Swapped it to `dt_util.now()` and dropped the pylint suppression.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177787
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
