### PR TITLE
Add support for E2 tank full fault on Tuya dehumidifiers

### DIFF
--- a/homeassistant/components/tuya/binary_sensor.py
+++ b/homeassistant/components/tuya/binary_sensor.py
@@ -138,6 +138,14 @@ BINARY_SENSORS: dict[DeviceCategory, tuple[TuyaBinarySensorEntityDescription, ..
             translation_key="temp_error",
         ),
         TuyaBinarySensorEntityDescription(
+            key=f"{DPCode.FAULT}_E2",
+            dpcode=DPCode.FAULT,
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            bitmap_key="E2",
+            translation_key="tankfull",
+        ),
+        TuyaBinarySensorEntityDescription(
             key=f"{DPCode.FAULT}_CL",
             dpcode=DPCode.FAULT,
             device_class=BinarySensorDeviceClass.PROBLEM,


### PR DESCRIPTION
## Description

Some Tuya dehumidifiers expose the `fault` bitmap using labels `E1` and `E2`.

The current integration already maps:

- water_full
- tankfull
- FULL
- E1

However, several OEM devices (including the Cecotec BigDry 9000 Professional) use `E2` to indicate that the water tank is full.

This PR adds an additional binary sensor mapping:

- bitmap_key = "E2"
- translation_key = "tankfull"

No existing behaviour is modified.

## Tested

Tested with:

- Cecotec BigDry 9000 Professional
- Home Assistant Core 2026.7.1

When `fault = 2`, the new binary sensor is correctly reported as ON.