### PR TITLE
Do not probe Pi-hole v6 API version with a wrong password

### DIFF
--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -146,7 +146,13 @@ async def determine_api_version(
     debugging.
     """
 
-    hole_v6 = api_by_version(hass, entry, 6, password="wrong_password")
+    # Do not probe with a deliberately wrong password. Pi-hole v6
+    # rate-limits login attempts, so the real login that follows a few
+    # hundred milliseconds later in async_setup_entry is rejected as
+    # well and setup fails permanently. Using the configured password
+    # still identifies v6: if the v6 auth endpoint answers at all -
+    # with success or with 401 - it is a v6 instance.
+    hole_v6 = api_by_version(hass, entry, 6)
     try:
         await hole_v6.authenticate()
     except HoleConnectionError as err:
@@ -160,7 +166,8 @@ async def determine_api_version(
     except HoleError as ex_v6:
         if str(ex_v6) == "Authentication failed: Invalid password":
             _LOGGER.debug(
-                "Success connecting to Pi-hole at %s without auth, API version is : %s",
+                "Pi-hole at %s answered the v6 auth endpoint (password"
+                " rejected), API version is : %s",
                 hole_v6.base_url,
                 6,
             )
@@ -169,13 +176,10 @@ async def determine_api_version(
             "Connection to %s failed: %s, trying API version 5", hole_v6.base_url, ex_v6
         )
     else:
-        # It seems that occasionally the auth can succeed
-        # unexpectedly when there is a valid session
-        _LOGGER.warning(
-            "Authenticated with %s through v6 API, but"
-            " succeeded with an incorrect password."
-            " This is a known bug",
+        _LOGGER.debug(
+            "Authenticated with %s through v6 API, API version is : %s",
             hole_v6.base_url,
+            6,
         )
         return 6
     hole_v5 = api_by_version(hass, entry, 5, password="wrong_token")

--- a/homeassistant/components/pi_hole/__init__.py
+++ b/homeassistant/components/pi_hole/__init__.py
@@ -146,12 +146,10 @@ async def determine_api_version(
     debugging.
     """
 
-    # Do not probe with a deliberately wrong password. Pi-hole v6
-    # rate-limits login attempts, so the real login that follows a few
-    # hundred milliseconds later in async_setup_entry is rejected as
-    # well and setup fails permanently. Using the configured password
-    # still identifies v6: if the v6 auth endpoint answers at all -
-    # with success or with 401 - it is a v6 instance.
+    # Pi-hole v6 rate-limits login attempts, so probing with a deliberately
+    # wrong password makes the real login that follows shortly after fail as
+    # well. Probe with the configured password instead: a 401 identifies v6
+    # just as well as a success does.
     hole_v6 = api_by_version(hass, entry, 6)
     try:
         await hole_v6.authenticate()
@@ -176,6 +174,15 @@ async def determine_api_version(
             "Connection to %s failed: %s, trying API version 5", hole_v6.base_url, ex_v6
         )
     else:
+        # Release the probe session again: the operational client
+        # authenticates separately and Pi-hole allows only a limited
+        # number of concurrent sessions.
+        try:
+            await hole_v6.logout()
+        except HoleError as err:
+            _LOGGER.debug(
+                "Could not release the probe session at %s: %s", hole_v6.base_url, err
+            )
         _LOGGER.debug(
             "Authenticated with %s through v6 API, API version is : %s",
             hole_v6.base_url,

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -202,6 +202,7 @@ def _create_mocked_hole(
     incorrect_app_password: bool = False,
     wrong_host: bool = False,
     ftl_error: bool = False,
+    logout_error: bool = False,
 ) -> MagicMock:
     """Return a mocked Hole API object with side effects based on constructor args."""
 
@@ -250,7 +251,9 @@ def _create_mocked_hole(
             mocked_hole.data = FTL_ERROR
 
         mocked_hole.authenticate = AsyncMock(side_effect=authenticate_side_effect)
-        mocked_hole.logout = AsyncMock()
+        mocked_hole.logout = AsyncMock(
+            side_effect=HoleError("Logout failed") if logout_error else None
+        )
         mocked_hole.get_data = AsyncMock(side_effect=get_data_side_effect)
 
         if ftl_error:

--- a/tests/components/pi_hole/__init__.py
+++ b/tests/components/pi_hole/__init__.py
@@ -250,6 +250,7 @@ def _create_mocked_hole(
             mocked_hole.data = FTL_ERROR
 
         mocked_hole.authenticate = AsyncMock(side_effect=authenticate_side_effect)
+        mocked_hole.logout = AsyncMock()
         mocked_hole.get_data = AsyncMock(side_effect=get_data_side_effect)
 
         if ftl_error:

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -62,6 +62,26 @@ async def test_setup_api_v6(
         )
 
 
+async def test_version_probe_uses_configured_password(hass: HomeAssistant) -> None:
+    """Test the v6 version probe never authenticates with a sentinel password.
+
+    Pi-hole v6 rate-limits login attempts, so a deliberately failed probe makes
+    the real login that follows shortly after fail as well, and the config entry
+    then never recovers on its own.
+    """
+    mocked_hole = _create_mocked_hole(api_version=6)
+    entry = MockConfigEntry(domain=pi_hole.DOMAIN, data={**CONFIG_DATA_DEFAULTS})
+    entry.add_to_hass(hass)
+    with _patch_init_hole(mocked_hole):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    assert mocked_hole.instances
+    assert all(instance.password == API_KEY for instance in mocked_hole.instances)
+    # The probe releases its session again so it does not use up one of the
+    # limited number of Pi-hole sessions.
+    mocked_hole.instances[0].logout.assert_awaited_once()
+
+
 @pytest.mark.parametrize(
     ("config_entry_data", "expected_api_token"),
     [({**CONFIG_DATA_DEFAULTS}, API_KEY)],

--- a/tests/components/pi_hole/test_init.py
+++ b/tests/components/pi_hole/test_init.py
@@ -82,6 +82,21 @@ async def test_version_probe_uses_configured_password(hass: HomeAssistant) -> No
     mocked_hole.instances[0].logout.assert_awaited_once()
 
 
+async def test_version_probe_survives_failing_logout(hass: HomeAssistant) -> None:
+    """Test setup still succeeds when releasing the probe session fails.
+
+    Releasing the session is a courtesy, not a requirement, so a failure there
+    must not turn a working configuration into a failed setup.
+    """
+    mocked_hole = _create_mocked_hole(api_version=6, logout_error=True)
+    entry = MockConfigEntry(domain=pi_hole.DOMAIN, data={**CONFIG_DATA_DEFAULTS})
+    entry.add_to_hass(hass)
+    with _patch_init_hole(mocked_hole):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+
+    assert entry.state is ConfigEntryState.LOADED
+
+
 @pytest.mark.parametrize(
     ("config_entry_data", "expected_api_token"),
     [({**CONFIG_DATA_DEFAULTS}, API_KEY)],


### PR DESCRIPTION
## Proposed change

`determine_api_version()` detects the Pi-hole API version by authenticating
with the literal password `"wrong_password"`. Pi-hole v6 rate-limits login
attempts, so the real login issued a few hundred milliseconds later in
`async_setup_entry` is rejected as well. Setup then fails with
`reported an invalid password` even though the password is correct, and
because every retry starts with another deliberate failure, the config entry
never recovers on its own.

Measured against Pi-hole FTL v6.4.3:

| Sequence against `POST /api/auth` | Result |
|---|---|
| wrong password, **no pause**, then correct password | `401` → **`401`** |
| wrong password, **4 s pause**, then correct password | `401` → `200` |
| correct password only | `200` |

Tested over both a reused and a fresh TCP connection — no difference, so it is
not connection or cookie related. The stored credential was verified to be
byte-identical to the working app password by comparing SHA-256 hashes.

Timing from the failing setup, `homeassistant.components.pi_hole` at debug
level:

```
22:33:11.211 Determining Pi-hole API version for 192.168.1.10:80
22:33:11.289 Success connecting to Pi-hole at http://192.168.1.10:80 without auth, API version is : 6
22:33:11.617 Finished fetching Pi-Hole data in 0.328 seconds (success: False)
22:33:11.618 Config entry 'Pi-Hole' ... reported an invalid password
```

This change uses the configured password for the probe instead of a
deliberately wrong one. **Version detection is unchanged:** if the v6 auth
endpoint answers at all — with success or with `401` — it is a v6 instance,
and a v5 instance still falls through to the existing v5 probe. Two log
messages are adjusted because they would otherwise state something untrue
(`without auth`, `succeeded with an incorrect password. This is a known bug`).

When the probe authenticates successfully it now calls `logout()` before
returning, so it does not occupy one of Pi-hole's limited session slots while
the operational client authenticates separately. The logout is best-effort and
never fails version detection.

A regression test asserts that no client is constructed with a sentinel
password and that the probe session is released again.

### Note on the failure code

Pi-hole documents `429 rate_limiting` for exceeded login rates, and `429` was
observed with four logins in rapid succession. The two-login case reported here
returns `401 password incorrect` instead. That difference could not be
explained from the outside; either way the correct password is rejected because
a failed attempt immediately preceded it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #178142
- This PR is related to issue: #150151, #150851 — same symptom, both closed as
  stale without a root cause. Pi-hole side: pi-hole/FTL#2304, where the
  maintainers confirm login rate limiting (>3 attempts per second).
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

---

**On "Local tests pass":** left unchecked on purpose. The contributor's machine
runs Python 3.11 and this branch needs 3.13+, so the suite could not be run
locally; CI runs it. Verified by hand instead — the change has been running as a
custom component copy of 2026.7.4 against Pi-hole v6.4.3 since 2026-08-04, the
config entry sets up on the first attempt and all 14 entities are created and
populated.

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
