### PR TITLE
Add SHT40 sensors to opendisplay

### DIFF
--- a/homeassistant/components/opendisplay/sensor.py
+++ b/homeassistant/components/opendisplay/sensor.py
@@ -5,8 +5,9 @@ from dataclasses import dataclass
 from typing import override
 
 from opendisplay import voltage_to_percent
-from opendisplay.models.advertisement import AdvertisementData
-from opendisplay.models.enums import CapacityEstimator, PowerMode
+from opendisplay.models.advertisement import AdvertisementData, Sht40Reading
+from opendisplay.models.config import SensorData
+from opendisplay.models.enums import CapacityEstimator, PowerMode, SensorType
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -36,8 +37,10 @@ class OpenDisplaySensorEntityDescription(SensorEntityDescription):
     value_fn: Callable[[AdvertisementData], float | int | None]
 
 
-_TEMPERATURE_DESCRIPTION = OpenDisplaySensorEntityDescription(
+# The key stays "temperature": it is part of the unique_id of existing entities.
+_CHIP_TEMPERATURE_DESCRIPTION = OpenDisplaySensorEntityDescription(
     key="temperature",
+    translation_key="chip_temperature",
     device_class=SensorDeviceClass.TEMPERATURE,
     native_unit_of_measurement=UnitOfTemperature.CELSIUS,
     state_class=SensorStateClass.MEASUREMENT,
@@ -60,6 +63,48 @@ _BATTERY_VOLTAGE_DESCRIPTION = OpenDisplaySensorEntityDescription(
 )
 
 
+def _sht40_descriptions(
+    sensor: SensorData,
+) -> list[OpenDisplaySensorEntityDescription]:
+    """Build ambient temperature and humidity entities for one SHT40.
+
+    The offset of the reading within the dynamic block is per-board -- the
+    reTerminal E1001/E1002/E1004 use 1 while the firmware default is 7 -- so it
+    comes from the device's own config.
+    """
+    start_byte = sensor.sht40_msd_start_byte
+
+    def _reading(adv: AdvertisementData) -> Sht40Reading | None:
+        return adv.sht40_reading(start_byte)
+
+    def _temperature(adv: AdvertisementData) -> float | None:
+        reading = _reading(adv)
+        return None if reading is None else reading.temperature_c
+
+    def _humidity(adv: AdvertisementData) -> float | None:
+        reading = _reading(adv)
+        return None if reading is None else reading.humidity_percent
+
+    return [
+        OpenDisplaySensorEntityDescription(
+            key=f"sht40_{sensor.instance_number}_temperature",
+            device_class=SensorDeviceClass.TEMPERATURE,
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=1,
+            value_fn=_temperature,
+        ),
+        OpenDisplaySensorEntityDescription(
+            key=f"sht40_{sensor.instance_number}_humidity",
+            device_class=SensorDeviceClass.HUMIDITY,
+            native_unit_of_measurement=PERCENTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            suggested_display_precision=1,
+            value_fn=_humidity,
+        ),
+    ]
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: OpenDisplayConfigEntry,
@@ -67,8 +112,15 @@ async def async_setup_entry(
 ) -> None:
     """Set up OpenDisplay sensor entities."""
     coordinator = entry.runtime_data.coordinator
-    power_config = entry.runtime_data.device_config.power
-    descriptions: list[OpenDisplaySensorEntityDescription] = [_TEMPERATURE_DESCRIPTION]
+    device_config = entry.runtime_data.device_config
+    power_config = device_config.power
+    descriptions: list[OpenDisplaySensorEntityDescription] = [
+        _CHIP_TEMPERATURE_DESCRIPTION
+    ]
+
+    for sensor in device_config.sensors:
+        if sensor.sensor_type_enum is SensorType.SHT40:
+            descriptions += _sht40_descriptions(sensor)
 
     if power_config.power_mode_enum in _BATTERY_POWER_MODES:
         capacity_estimator = power_config.capacity_estimator or CapacityEstimator.LI_ION

--- a/homeassistant/components/opendisplay/strings.json
+++ b/homeassistant/components/opendisplay/strings.json
@@ -67,6 +67,9 @@
     "sensor": {
       "battery_voltage": {
         "name": "Battery voltage"
+      },
+      "chip_temperature": {
+        "name": "Chip temperature"
       }
     }
   },

--- a/tests/components/opendisplay/__init__.py
+++ b/tests/components/opendisplay/__init__.py
@@ -13,8 +13,11 @@ from opendisplay import (
     ManufacturerData,
     PowerOption,
     SecurityConfig,
+    SensorType,
     SystemConfig,
 )
+from opendisplay.models.advertisement import SHT40_DEFAULT_MSD_START
+from opendisplay.models.config import SensorData
 
 from homeassistant.components.bluetooth import BluetoothServiceInfoBleak
 
@@ -212,6 +215,46 @@ def make_button_device_config(binary_inputs: list[BinaryInputs]) -> GlobalConfig
         displays=DEVICE_CONFIG.displays,
         binary_inputs=binary_inputs,
     )
+
+
+def make_sht40_sensor(
+    instance_number: int = 0,
+    msd_data_start_byte: int = 0,
+) -> SensorData:
+    """Create a SensorData config entry for an SHT40."""
+    return SensorData(
+        instance_number=instance_number,
+        sensor_type=SensorType.SHT40,
+        bus_id=0,
+        msd_data_start_byte=msd_data_start_byte,
+        reserved=b"\x00" * 24,
+    )
+
+
+def make_sensor_device_config(sensors: list[SensorData]) -> GlobalConfig:
+    """Return a GlobalConfig with the given sensors list."""
+    return GlobalConfig(
+        system=DEVICE_CONFIG.system,
+        manufacturer=DEVICE_CONFIG.manufacturer,
+        power=DEVICE_CONFIG.power,
+        displays=DEVICE_CONFIG.displays,
+        sensors=sensors,
+    )
+
+
+def make_sht40_dynamic_data(
+    temperature_c: float,
+    humidity_percent: float,
+    start_byte: int = SHT40_DEFAULT_MSD_START,
+) -> bytes:
+    """Build an 11-byte dynamic block holding one SHT40 reading.
+
+    The firmware packs the reading as a little-endian 24-bit word:
+    ((temperature * 10 + 400) << 10) | (humidity * 10).
+    """
+    packed = (round(temperature_c * 10) + 400) << 10 | round(humidity_percent * 10)
+    block = packed.to_bytes(3, "little")
+    return (b"\x00" * start_byte + block).ljust(11, b"\x00")
 
 
 VALID_SERVICE_INFO = make_service_info()

--- a/tests/components/opendisplay/snapshots/test_sensor.ambr
+++ b/tests/components/opendisplay/snapshots/test_sensor.ambr
@@ -112,7 +112,7 @@
     'state': '3700',
   })
 # ---
-# name: test_sensor_entities_battery_device[sensor.opendisplay_1234_temperature-entry]
+# name: test_sensor_entities_battery_device[sensor.opendisplay_1234_chip_temperature-entry]
   EntityRegistryEntrySnapshot({
     'aliases': list([
       None,
@@ -128,6 +128,238 @@
     'disabled_by': None,
     'domain': 'sensor',
     'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.opendisplay_1234_chip_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Chip temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Chip temperature',
+    'platform': 'opendisplay',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'chip_temperature',
+    'unique_id': 'AA:BB:CC:DD:EE:FF-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_battery_device[sensor.opendisplay_1234_chip_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OpenDisplay 1234 Chip temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.opendisplay_1234_chip_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.0',
+  })
+# ---
+# name: test_sensor_entities_usb_device[sensor.opendisplay_1234_chip_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.opendisplay_1234_chip_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Chip temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Chip temperature',
+    'platform': 'opendisplay',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'chip_temperature',
+    'unique_id': 'AA:BB:CC:DD:EE:FF-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sensor_entities_usb_device[sensor.opendisplay_1234_chip_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OpenDisplay 1234 Chip temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.opendisplay_1234_chip_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.0',
+  })
+# ---
+# name: test_sht40_sensor_entities[sensor.opendisplay_1234_chip_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.opendisplay_1234_chip_temperature',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Chip temperature',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
+    'original_icon': None,
+    'original_name': 'Chip temperature',
+    'platform': 'opendisplay',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'chip_temperature',
+    'unique_id': 'AA:BB:CC:DD:EE:FF-temperature',
+    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
+  })
+# ---
+# name: test_sht40_sensor_entities[sensor.opendisplay_1234_chip_temperature-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OpenDisplay 1234 Chip temperature',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.opendisplay_1234_chip_temperature',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '25.0',
+  })
+# ---
+# name: test_sht40_sensor_entities[sensor.opendisplay_1234_humidity-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
+    'entity_id': 'sensor.opendisplay_1234_humidity',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Humidity',
+    'options': dict({
+      'sensor': dict({
+        'suggested_display_precision': 1,
+      }),
+    }),
+    'original_device_class': <SensorDeviceClass.HUMIDITY: 'humidity'>,
+    'original_icon': None,
+    'original_name': 'Humidity',
+    'platform': 'opendisplay',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': None,
+    'unique_id': 'AA:BB:CC:DD:EE:FF-sht40_0_humidity',
+    'unit_of_measurement': '%',
+  })
+# ---
+# name: test_sht40_sensor_entities[sensor.opendisplay_1234_humidity-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'humidity',
+      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OpenDisplay 1234 Humidity',
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: '%',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.opendisplay_1234_humidity',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '48.2',
+  })
+# ---
+# name: test_sht40_sensor_entities[sensor.opendisplay_1234_temperature-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': dict({
+      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
+    }),
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': None,
     'entity_id': 'sensor.opendisplay_1234_temperature',
     'has_entity_name': True,
     'hidden_by': None,
@@ -150,11 +382,11 @@
     'suggested_object_id': None,
     'supported_features': 0,
     'translation_key': None,
-    'unique_id': 'AA:BB:CC:DD:EE:FF-temperature',
+    'unique_id': 'AA:BB:CC:DD:EE:FF-sht40_0_temperature',
     'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
   })
 # ---
-# name: test_sensor_entities_battery_device[sensor.opendisplay_1234_temperature-state]
+# name: test_sht40_sensor_entities[sensor.opendisplay_1234_temperature-state]
   StateSnapshot({
     'attributes': ReadOnlyDict({
       <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
@@ -167,64 +399,6 @@
     'last_changed': <ANY>,
     'last_reported': <ANY>,
     'last_updated': <ANY>,
-    'state': '25.0',
-  })
-# ---
-# name: test_sensor_entities_usb_device[sensor.opendisplay_1234_temperature-entry]
-  EntityRegistryEntrySnapshot({
-    'aliases': list([
-      None,
-    ]),
-    'area_id': None,
-    'capabilities': dict({
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-    }),
-    'config_entry_id': <ANY>,
-    'config_subentry_id': <ANY>,
-    'device_class': None,
-    'device_id': <ANY>,
-    'disabled_by': None,
-    'domain': 'sensor',
-    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
-    'entity_id': 'sensor.opendisplay_1234_temperature',
-    'has_entity_name': True,
-    'hidden_by': None,
-    'icon': None,
-    'id': <ANY>,
-    'labels': set({
-    }),
-    'name': None,
-    'object_id_base': 'Temperature',
-    'options': dict({
-      'sensor': dict({
-        'suggested_display_precision': 1,
-      }),
-    }),
-    'original_device_class': <SensorDeviceClass.TEMPERATURE: 'temperature'>,
-    'original_icon': None,
-    'original_name': 'Temperature',
-    'platform': 'opendisplay',
-    'previous_unique_id': None,
-    'suggested_object_id': None,
-    'supported_features': 0,
-    'translation_key': None,
-    'unique_id': 'AA:BB:CC:DD:EE:FF-temperature',
-    'unit_of_measurement': <UnitOfTemperature.CELSIUS: '°C'>,
-  })
-# ---
-# name: test_sensor_entities_usb_device[sensor.opendisplay_1234_temperature-state]
-  StateSnapshot({
-    'attributes': ReadOnlyDict({
-      <EntityStateAttribute.DEVICE_CLASS: 'device_class'>: 'temperature',
-      <EntityStateAttribute.FRIENDLY_NAME: 'friendly_name'>: 'OpenDisplay 1234 Temperature',
-      <SensorEntityCapabilityAttribute.STATE_CLASS: 'state_class'>: <SensorStateClass.MEASUREMENT: 'measurement'>,
-      <EntityStateAttribute.UNIT_OF_MEASUREMENT: 'unit_of_measurement'>: <UnitOfTemperature.CELSIUS: '°C'>,
-    }),
-    'context': <ANY>,
-    'entity_id': 'sensor.opendisplay_1234_temperature',
-    'last_changed': <ANY>,
-    'last_reported': <ANY>,
-    'last_updated': <ANY>,
-    'state': '25.0',
+    'state': '21.5',
   })
 # ---

--- a/tests/components/opendisplay/test_sensor.py
+++ b/tests/components/opendisplay/test_sensor.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 
 from habluetooth import CONNECTABLE_FALLBACK_MAXIMUM_STALE_ADVERTISEMENT_SECONDS
 from opendisplay import voltage_to_percent
+from opendisplay.models.advertisement import SHT40_DEFAULT_MSD_START
 from opendisplay.models.enums import CapacityEstimator, PowerMode
 import pytest
 from syrupy.assertion import SnapshotAssertion
@@ -19,7 +20,16 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
-from . import DEVICE_CONFIG, TEST_ADDRESS, VALID_SERVICE_INFO, make_service_info
+from . import (
+    DEVICE_CONFIG,
+    TEST_ADDRESS,
+    VALID_SERVICE_INFO,
+    make_sensor_device_config,
+    make_service_info,
+    make_sht40_dynamic_data,
+    make_sht40_sensor,
+    make_v1_service_info,
+)
 
 from tests.common import MockConfigEntry, async_fire_time_changed, snapshot_platform
 from tests.components.bluetooth import (
@@ -30,11 +40,21 @@ from tests.components.bluetooth import (
 
 pytestmark = pytest.mark.usefixtures("entity_registry_enabled_by_default")
 
+CHIP_TEMPERATURE_ENTITY_ID = "sensor.opendisplay_1234_chip_temperature"
+SHT40_TEMPERATURE_ENTITY_ID = "sensor.opendisplay_1234_temperature"
+SHT40_HUMIDITY_ENTITY_ID = "sensor.opendisplay_1234_humidity"
+
 
 @pytest.fixture
 def platforms() -> list[Platform]:
     """Only set up the sensor platform."""
     return [Platform.SENSOR]
+
+
+@pytest.fixture
+def mock_sht40_device(mock_opendisplay_device: MagicMock) -> None:
+    """Configure the mock device with one SHT40 in the default slot."""
+    mock_opendisplay_device.config = make_sensor_device_config([make_sht40_sensor()])
 
 
 async def test_sensors_before_data(
@@ -45,11 +65,8 @@ async def test_sensors_before_data(
     await setup_entry()
 
     # All sensors exist but coordinator has no data yet
-    assert hass.states.get("sensor.opendisplay_1234_temperature") is not None
-    assert (
-        hass.states.get("sensor.opendisplay_1234_temperature").state
-        == STATE_UNAVAILABLE
-    )
+    assert hass.states.get(CHIP_TEMPERATURE_ENTITY_ID) is not None
+    assert hass.states.get(CHIP_TEMPERATURE_ENTITY_ID).state == STATE_UNAVAILABLE
 
 
 async def test_sensor_entities_usb_device(
@@ -93,6 +110,91 @@ async def test_sensor_entities_battery_device(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
 
+@pytest.mark.usefixtures("mock_sht40_device")
+async def test_sht40_sensor_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+    setup_entry: Callable[[], Awaitable[None]],
+) -> None:
+    """Test the ambient sensor entities of an attached SHT40."""
+    await setup_entry()
+
+    inject_bluetooth_service_info(
+        hass, make_v1_service_info(make_sht40_dynamic_data(21.5, 48.2))
+    )
+    await hass.async_block_till_done()
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+@pytest.mark.parametrize(
+    ("msd_data_start_byte", "start_byte"),
+    [
+        pytest.param(0, SHT40_DEFAULT_MSD_START, id="zero_means_default_slot"),
+        pytest.param(0xFF, SHT40_DEFAULT_MSD_START, id="unset_means_default_slot"),
+        pytest.param(1, 1, id="explicit_slot"),
+    ],
+)
+async def test_sht40_reading_offset_from_device_config(
+    hass: HomeAssistant,
+    mock_opendisplay_device: MagicMock,
+    setup_entry: Callable[[], Awaitable[None]],
+    msd_data_start_byte: int,
+    start_byte: int,
+) -> None:
+    """The reading is decoded at the offset the device config declares."""
+    mock_opendisplay_device.config = make_sensor_device_config(
+        [make_sht40_sensor(msd_data_start_byte=msd_data_start_byte)]
+    )
+
+    await setup_entry()
+
+    inject_bluetooth_service_info(
+        hass, make_v1_service_info(make_sht40_dynamic_data(21.5, 48.2, start_byte))
+    )
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SHT40_TEMPERATURE_ENTITY_ID).state == "21.5"
+    assert hass.states.get(SHT40_HUMIDITY_ENTITY_ID).state == "48.2"
+
+
+@pytest.mark.parametrize(
+    "dynamic_data",
+    [
+        pytest.param(b"\x00" * 11, id="never_written"),
+        pytest.param(b"\x00" * 7 + b"\xff\xff\xff" + b"\x00", id="read_failed"),
+    ],
+)
+@pytest.mark.usefixtures("mock_sht40_device")
+async def test_sht40_without_valid_reading(
+    hass: HomeAssistant,
+    setup_entry: Callable[[], Awaitable[None]],
+    dynamic_data: bytes,
+) -> None:
+    """A slot holding no measurement leaves the sensors unknown."""
+    await setup_entry()
+
+    inject_bluetooth_service_info(hass, make_v1_service_info(dynamic_data))
+    await hass.async_block_till_done()
+
+    assert hass.states.get(SHT40_TEMPERATURE_ENTITY_ID).state == STATE_UNKNOWN
+    assert hass.states.get(SHT40_HUMIDITY_ENTITY_ID).state == STATE_UNKNOWN
+
+
+async def test_no_sht40_sensors_without_configured_sensor(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    setup_entry: Callable[[], Awaitable[None]],
+) -> None:
+    """No ambient sensors are created when the device has no SHT40."""
+    await setup_entry()
+
+    assert entity_registry.async_get(SHT40_TEMPERATURE_ENTITY_ID) is None
+    assert entity_registry.async_get(SHT40_HUMIDITY_ENTITY_ID) is None
+
+
 async def test_battery_sensors_not_created_for_usb_devices(
     hass: HomeAssistant,
     entity_registry: er.EntityRegistry,
@@ -118,7 +220,7 @@ async def test_no_sensors_for_non_flex_devices(
     mock_opendisplay_device.is_flex = False
     await setup_entry()
 
-    assert entity_registry.async_get("sensor.opendisplay_1234_temperature") is None
+    assert entity_registry.async_get(CHIP_TEMPERATURE_ENTITY_ID) is None
     assert entity_registry.async_get("sensor.opendisplay_1234_battery") is None
     assert entity_registry.async_get("sensor.opendisplay_1234_battery_voltage") is None
 
@@ -138,7 +240,7 @@ async def test_coordinator_ignores_unknown_manufacturer(
     await hass.async_block_till_done()
 
     # Coordinator has no data; device is visible but no OpenDisplay data parsed
-    assert hass.states.get("sensor.opendisplay_1234_temperature").state == STATE_UNKNOWN
+    assert hass.states.get(CHIP_TEMPERATURE_ENTITY_ID).state == STATE_UNKNOWN
 
 
 async def test_sensor_goes_unavailable_when_device_disappears(
@@ -152,10 +254,7 @@ async def test_sensor_goes_unavailable_when_device_disappears(
     inject_bluetooth_service_info(hass, VALID_SERVICE_INFO)
     await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("sensor.opendisplay_1234_temperature").state
-        != STATE_UNAVAILABLE
-    )
+    assert hass.states.get(CHIP_TEMPERATURE_ENTITY_ID).state != STATE_UNAVAILABLE
 
     # Must exceed both the connectable stale threshold (195s) and the
     # unavailability polling interval (300s) to trigger the callback.
@@ -175,10 +274,7 @@ async def test_sensor_goes_unavailable_when_device_disappears(
         )
         await hass.async_block_till_done()
 
-    assert (
-        hass.states.get("sensor.opendisplay_1234_temperature").state
-        == STATE_UNAVAILABLE
-    )
+    assert hass.states.get(CHIP_TEMPERATURE_ENTITY_ID).state == STATE_UNAVAILABLE
 
 
 async def test_battery_sensor_defaults_to_liion_when_capacity_estimator_unset(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Some OpenDisplay compatible devices (like the [Seeed reTerminals](https://wiki.seeedstudio.com/reterminal_e10xx_main_page/#specification-comparison)) expose a SHT40 temperature and humidity sensor.
This PR adds support for that

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
