### PR TITLE
Adapt homekit_controller to set via_device_id in DeviceInfo

### DIFF
--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -28,7 +28,7 @@ from aiohomekit.model.services import Service, ServicesTypes
 
 from homeassistant.components.thread import async_get_preferred_dataset
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_VIA_DEVICE, EVENT_HOMEASSISTANT_STARTED
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import CALLBACK_TYPE, CoreState, Event, HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -429,7 +429,7 @@ class HKDevice:
                 (dr.CONNECTION_BLUETOOTH, cast(BleDiscovery, discovery).device.address),
             }
 
-        device_info = DeviceInfo(
+        return DeviceInfo(
             identifiers={
                 (
                     IDENTIFIER_ACCESSORY_ID,
@@ -444,17 +444,6 @@ class HKDevice:
             hw_version=accessory.hardware_revision,
             serial_number=accessory.serial_number,
         )
-
-        if accessory.aid != 1:
-            # Every pairing has an accessory 1
-            # It *doesn't* have a via_device, as it is the device we are connecting to
-            # Every other accessory should use it as its via device.
-            device_info[ATTR_VIA_DEVICE] = (
-                IDENTIFIER_ACCESSORY_ID,
-                f"{self.unique_id}:aid:1",
-            )
-
-        return device_info
 
     @callback
     def async_migrate_devices(self) -> None:
@@ -679,16 +668,25 @@ class HKDevice:
         device_registry = dr.async_get(self.hass)
 
         devices = {}
+        bridge_device_id: str | None = None
 
-        # Accessories need to be created in the correct order or setting up
-        # relationships with ATTR_VIA_DEVICE may fail.
+        # Accessories are registered in aid order so the bridge (accessory 1) is
+        # registered before the accessories that link to it via via_device_id.
         for accessory in sorted(self.entity_map.accessories, key=attrgetter("aid")):
             device_info = self.device_info_for_accessory(accessory)
+
+            # Accessory 1 is the device we connect to and has no via_device; every
+            # other accessory links to it as its via device.
+            if accessory.aid != 1 and bridge_device_id is not None:
+                device_info["via_device_id"] = bridge_device_id
 
             device = device_registry.async_get_or_create(
                 config_entry_id=self.config_entry.entry_id,
                 **device_info,
             )
+
+            if accessory.aid == 1:
+                bridge_device_id = device.id
 
             devices[accessory.aid] = device.id
 

--- a/homeassistant/components/homekit_controller/connection.py
+++ b/homeassistant/components/homekit_controller/connection.py
@@ -670,13 +670,12 @@ class HKDevice:
         devices = {}
         bridge_device_id: str | None = None
 
-        # Accessories are registered in aid order so the bridge (accessory 1) is
-        # registered before the accessories that link to it via via_device_id.
+        # Accessories are sorted by their HomeKit accessory id (aid). The bridge is
+        # always aid 1, so it is registered before the accessories that link back to
+        # it via via_device_id.
         for accessory in sorted(self.entity_map.accessories, key=attrgetter("aid")):
             device_info = self.device_info_for_accessory(accessory)
 
-            # Accessory 1 is the device we connect to and has no via_device; every
-            # other accessory links to it as its via device.
             if accessory.aid != 1 and bridge_device_id is not None:
                 device_info["via_device_id"] = bridge_device_id
 

--- a/tests/components/homekit_controller/test_connection.py
+++ b/tests/components/homekit_controller/test_connection.py
@@ -748,3 +748,28 @@ async def test_async_setup_handles_unparsable_response(
     # though initial polling failed
     state = hass.states.get("light.testdevice")
     assert state is not None
+
+
+async def test_device_via_device_links(
+    hass: HomeAssistant,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test bridged accessories link to the bridge via via_device_id."""
+    accessories = await setup_accessories_from_file(
+        hass, "ryse_smart_bridge_four_shades.json"
+    )
+    config_entry, _ = await setup_test_accessories(hass, accessories)
+
+    bridge_device = device_registry.async_get_device_by_identifier(
+        (IDENTIFIER_ACCESSORY_ID, "00:00:00:00:00:00:aid:1"), config_entry.entry_id
+    )
+    assert bridge_device is not None
+    assert bridge_device.via_device_id is None
+
+    for aid in (2, 3, 4, 5):
+        shade_device = device_registry.async_get_device_by_identifier(
+            (IDENTIFIER_ACCESSORY_ID, f"00:00:00:00:00:00:aid:{aid}"),
+            config_entry.entry_id,
+        )
+        assert shade_device is not None
+        assert shade_device.via_device_id == bridge_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Adapt `homekit_controller` to set `via_device_id` in `DeviceInfo`

Context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
