### PR TITLE
Fix via_device race in duco

### DIFF
--- a/homeassistant/components/duco/__init__.py
+++ b/homeassistant/components/duco/__init__.py
@@ -1,15 +1,16 @@
 """The Duco integration."""
 
 import re
+from typing import TYPE_CHECKING
 
 from duco_connectivity import DucoClient
 
 from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import PLATFORMS
+from .const import BOX_NODE_ID, DOMAIN, PLATFORMS
 from .coordinator import DucoConfigEntry, DucoCoordinator
 
 _REMOVED_SENSOR_RE = re.compile(r"_\d+_(box_)?temperature$")
@@ -36,6 +37,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: DucoConfigEntry) -> bool
     await coordinator.async_config_entry_first_refresh()
 
     entry.runtime_data = coordinator
+
+    # Pre-register the box before forwarding platforms so sub-node entities can
+    # resolve it as their via_device parent regardless of entity setup order.
+    mac = entry.unique_id
+    if TYPE_CHECKING:
+        assert mac is not None
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, f"{mac}_{BOX_NODE_ID}")},
+        connections={(dr.CONNECTION_NETWORK_MAC, mac)},
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/duco/entity.py
+++ b/homeassistant/components/duco/entity.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, override
 
 from duco_connectivity.models import Node, NodeType
 
-from homeassistant.const import ATTR_VIA_DEVICE
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -38,7 +38,15 @@ class DucoEntity(CoordinatorEntity[DucoCoordinator]):
                 "serial_number": coordinator.board_info.serial_board_box,
             }
             if node.general.node_type == NodeType.BOX
-            else {ATTR_VIA_DEVICE: (DOMAIN, f"{mac}_1")}
+            # The box is pre-registered in async_setup_entry, so it is always
+            # resolvable here even if a sub-node entity is added first.
+            else {
+                "via_device_id": dr.async_get_device_id_by_identifier(
+                    coordinator.hass,
+                    (DOMAIN, f"{mac}_1"),
+                    config_entry_id=coordinator.config_entry.entry_id,
+                )
+            }
         )
         self._attr_device_info = device_info
 

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -20,7 +20,7 @@ from duco_connectivity import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.duco.const import SCAN_INTERVAL
+from homeassistant.components.duco.const import DOMAIN, SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
@@ -135,6 +135,23 @@ async def test_setup_entry_success(
 ) -> None:
     """Test successful setup of the Duco integration."""
     assert init_integration.state is ConfigEntryState.LOADED
+
+
+async def test_device_via_device_links(
+    init_integration: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that sub-node devices link to the box parent via via_device_id."""
+    box_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_MAC}_1"), init_integration.entry_id
+    )
+    assert box_device is not None
+
+    node_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_MAC}_2"), init_integration.entry_id
+    )
+    assert node_device is not None
+    assert node_device.via_device_id == box_device.id
 
 
 @pytest.mark.parametrize(

--- a/tests/components/duco/test_init.py
+++ b/tests/components/duco/test_init.py
@@ -20,12 +20,13 @@ from duco_connectivity import (
 from freezegun.api import FrozenDateTimeFactory
 import pytest
 
-from homeassistant.components.duco.const import DOMAIN, SCAN_INTERVAL
+from homeassistant.components.duco.const import BOX_NODE_ID, DOMAIN, SCAN_INTERVAL
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
+from . import setup_platform_integration
 from .conftest import (
     TEST_HOST,
     TEST_MAC,
@@ -138,20 +139,33 @@ async def test_setup_entry_success(
 
 
 async def test_device_via_device_links(
-    init_integration: MockConfigEntry,
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_duco_client: AsyncMock,
+    mock_nodes: list[Node],
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test that sub-node devices link to the box parent via via_device_id."""
+    """Test a sub-node added before the box still links to it via via_device_id."""
+    # Force the child-before-parent race: return a sub-node ahead of the box node
+    # and set up only the sensor platform (the fan platform would otherwise create
+    # the box first). This only resolves because the box is pre-registered in
+    # async_setup_entry before the platforms build their entities.
+    box_node = next(node for node in mock_nodes if node.node_id == BOX_NODE_ID)
+    child_node = next(node for node in mock_nodes if node.node_id != BOX_NODE_ID)
+    mock_duco_client.async_get_nodes.return_value = [child_node, box_node]
+
+    await setup_platform_integration(hass, mock_config_entry, [Platform.SENSOR])
+
     box_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, f"{TEST_MAC}_1"), init_integration.entry_id
+        (DOMAIN, f"{TEST_MAC}_{BOX_NODE_ID}"), mock_config_entry.entry_id
     )
     assert box_device is not None
 
-    node_device = device_registry.async_get_device_by_identifier(
-        (DOMAIN, f"{TEST_MAC}_2"), init_integration.entry_id
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_MAC}_{child_node.node_id}"), mock_config_entry.entry_id
     )
-    assert node_device is not None
-    assert node_device.via_device_id == box_device.id
+    assert child_device is not None
+    assert child_device.via_device_id == box_device.id
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `duco`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
