### PR TITLE
Fix via_device race in yamaha_musiccast

### DIFF
--- a/homeassistant/components/yamaha_musiccast/__init__.py
+++ b/homeassistant/components/yamaha_musiccast/__init__.py
@@ -8,9 +8,10 @@ from aiomusiccast.musiccast_device import MusicCastDevice
 from homeassistant.components import ssdp
 from homeassistant.const import CONF_HOST, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
-from .const import CONF_SERIAL, CONF_UPNP_DESC
+from .const import BRAND, CONF_SERIAL, CONF_UPNP_DESC, DEFAULT_ZONE, DOMAIN
 from .coordinator import MusicCastConfigEntry, MusicCastDataUpdateCoordinator
 
 PLATFORMS = [Platform.MEDIA_PLAYER, Platform.NUMBER, Platform.SELECT, Platform.SWITCH]
@@ -60,6 +61,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: MusicCastConfigEntry) ->
     entry.runtime_data = coordinator
 
     await coordinator.musiccast.device.enable_polling()
+
+    # Register the main device before forwarding platforms so the zone sub-devices
+    # can resolve it as their via_device parent when they are added.
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, coordinator.data.device_id)},
+        connections={
+            (dr.CONNECTION_NETWORK_MAC, mac)
+            for mac in coordinator.data.mac_addresses.values()
+        },
+        name=coordinator.data.zones[DEFAULT_ZONE].name,
+        manufacturer=BRAND,
+        model=coordinator.data.model_name,
+        sw_version=str(coordinator.data.system_version),
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/homeassistant/components/yamaha_musiccast/entity.py
+++ b/homeassistant/components/yamaha_musiccast/entity.py
@@ -4,7 +4,8 @@ from typing import override
 
 from aiomusiccast.capabilities import Capability
 
-from homeassistant.const import ATTR_CONNECTIONS, ATTR_VIA_DEVICE
+from homeassistant.const import ATTR_CONNECTIONS
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -71,7 +72,11 @@ class MusicCastDeviceEntity(MusicCastEntity):
                 for mac in self.coordinator.data.mac_addresses.values()
             }
         else:
-            device_info[ATTR_VIA_DEVICE] = (DOMAIN, self.coordinator.data.device_id)
+            device_info["via_device_id"] = dr.async_get_device_id_by_identifier(
+                self.coordinator.hass,
+                (DOMAIN, self.coordinator.data.device_id),
+                config_entry_id=self.coordinator.config_entry.entry_id,
+            )
 
         return device_info
 

--- a/tests/components/yamaha_musiccast/test_init.py
+++ b/tests/components/yamaha_musiccast/test_init.py
@@ -1,0 +1,105 @@
+"""Test the MusicCast integration setup."""
+
+from collections.abc import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiomusiccast.capabilities import BinarySetter, EntityType
+from aiomusiccast.musiccast_data import MusicCastData, MusicCastZoneData
+import pytest
+
+from homeassistant.components.yamaha_musiccast.const import DEFAULT_ZONE, DOMAIN
+from homeassistant.const import CONF_HOST, Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+
+from tests.common import MockConfigEntry
+
+TEST_DEVICE_ID = "1234567890"
+TEST_ZONE = "zone2"
+
+
+@pytest.fixture(autouse=True)
+def silent_ssdp_scanner() -> Generator[None]:
+    """Start SSDP component and get Scanner, prevent actual SSDP traffic."""
+    with (
+        patch("homeassistant.components.ssdp.Scanner._async_start_ssdp_listeners"),
+        patch("homeassistant.components.ssdp.Scanner._async_stop_ssdp_listeners"),
+        patch("homeassistant.components.ssdp.Scanner.async_scan"),
+        patch("homeassistant.components.ssdp.Server._async_start_upnp_servers"),
+        patch("homeassistant.components.ssdp.Server._async_stop_upnp_servers"),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_musiccast_device() -> Generator[MagicMock]:
+    """Mock a MusicCast device with a main zone and a sub-zone."""
+    data = MusicCastData()
+    data.device_id = TEST_DEVICE_ID
+    data.model_name = "MC20"
+    data.system_version = "1.0"
+    data.mac_addresses = {"main": "001122334455"}
+    data.network_name = "MusicCast"
+
+    main_zone = MusicCastZoneData()
+    main_zone.name = "Main"
+    sub_zone = MusicCastZoneData()
+    sub_zone.name = "Zone 2"
+    # A capability on the sub-zone makes the switch platform register the
+    # sub-zone device, which links back to the main device via via_device_id.
+    sub_zone.capabilities = [
+        BinarySetter("power", "Power", EntityType.CONFIG, lambda: False, AsyncMock())
+    ]
+    data.zones = {DEFAULT_ZONE: main_zone, TEST_ZONE: sub_zone}
+
+    device = MagicMock()
+    device.data = data
+    device.ip = "127.0.0.1"
+    device.fetch = AsyncMock()
+    device.build_capabilities = MagicMock()
+    device.device = MagicMock()
+    device.device.enable_polling = AsyncMock()
+
+    with patch(
+        "homeassistant.components.yamaha_musiccast.MusicCastDevice",
+        return_value=device,
+    ):
+        yield device
+
+
+@pytest.mark.usefixtures("mock_musiccast_device")
+async def test_device_via_device_links(
+    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+) -> None:
+    """Test that a zone sub-device links to the main device via via_device_id.
+
+    Only the switch platform is loaded so the main device is registered solely
+    by the integration setup, exercising the via_device pre-registration.
+    """
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=TEST_DEVICE_ID,
+        data={
+            CONF_HOST: "127.0.0.1",
+            "serial": TEST_DEVICE_ID,
+            "upnp_description": "http://127.0.0.1:49154/MediaRenderer/desc.xml",
+        },
+    )
+    config_entry.add_to_hass(hass)
+
+    with patch(
+        "homeassistant.components.yamaha_musiccast.PLATFORMS", [Platform.SWITCH]
+    ):
+        assert await hass.config_entries.async_setup(config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    main_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_ID), config_entry.entry_id
+    )
+    assert main_device is not None
+
+    zone_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_DEVICE_ID}_{TEST_ZONE}"), config_entry.entry_id
+    )
+    assert zone_device is not None
+    assert zone_device.via_device_id == main_device.id


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Fix `via_device` race in `yamaha_musiccast`, and specify the via device by device ID

Background:
The device specified as via device must be created before the device linking to it.
In addition, via_device is deprecated, more context in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
