### PR TITLE
Improve via_device handling in smartthings

### DIFF
--- a/homeassistant/components/smartthings/__init__.py
+++ b/homeassistant/components/smartthings/__init__.py
@@ -498,12 +498,8 @@ def create_devices(
     rooms: dict[str, str],
 ) -> None:
     """Create devices in the device registry."""
-    # Devices are sorted so a parent is always created before its children,
-    # allowing children to reference the parent's registered device id.
     created_devices: dict[str, dr.DeviceEntry] = {}
-    for device in sorted(
-        devices.values(), key=lambda d: d.device.parent_device_id or ""
-    ):
+    for device in devices.values():
         kwargs: dict[str, Any] = {}
         if device.device.hub is not None:
             kwargs = {
@@ -522,8 +518,6 @@ def create_devices(
                         format_zigbee_address(device.device.hub.hub_eui),
                     )
                 )
-        if device.device.parent_device_id and device.device.parent_device_id in devices:
-            kwargs["via_device_id"] = created_devices[device.device.parent_device_id].id
         if (ocf := device.device.ocf) is not None:
             kwargs.update(
                 {
@@ -608,6 +602,17 @@ def create_devices(
             name=device.device.label,
             **kwargs,
         )
+
+    # Link child devices to their parent in a second pass, so registration is
+    # robust to any ordering of parents and children in the device list,
+    # including nested hierarchies where a parent is itself a child device.
+    for device in devices.values():
+        parent_device_id = device.device.parent_device_id
+        if parent_device_id and parent_device_id in devices:
+            device_registry.async_update_device(
+                created_devices[device.device.device_id].id,
+                via_device_id=created_devices[parent_device_id].id,
+            )
 
 
 KEEP_CAPABILITY_QUIRK: dict[

--- a/tests/components/smartthings/test_init.py
+++ b/tests/components/smartthings/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the SmartThings component init module."""
 
+from dataclasses import replace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from pysmartthings import (
@@ -412,6 +413,50 @@ async def test_hub_via_device(
     )
     assert child_device is not None
     assert child_device.via_device_id == hub_device.id
+
+
+async def test_via_device_nested_hierarchy(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
+    mock_smartthings: AsyncMock,
+) -> None:
+    """Test a nested device hierarchy is linked regardless of device order."""
+    grandparent_id = "11111111-1111-1111-1111-111111111111"
+    parent_id = "00000000-0000-0000-0000-000000000000"
+    child_id = "22222222-2222-2222-2222-222222222222"
+
+    base_device = DeviceResponse.from_json(
+        await async_load_fixture(hass, "devices/virtual_valve.json", DOMAIN)
+    ).items[0]
+    # Children precede their parents to exercise ordering-independent linking.
+    mock_smartthings.get_devices.return_value = [
+        replace(base_device, device_id=child_id, parent_device_id=parent_id),
+        replace(base_device, device_id=parent_id, parent_device_id=grandparent_id),
+        replace(base_device, device_id=grandparent_id, parent_device_id=None),
+    ]
+    mock_smartthings.get_device_status.return_value = DeviceStatus.from_json(
+        await async_load_fixture(hass, "device_status/virtual_valve.json", DOMAIN)
+    ).components
+
+    await setup_integration(hass, mock_config_entry)
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    grandparent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, grandparent_id), mock_config_entry.entry_id
+    )
+    parent_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, parent_id), mock_config_entry.entry_id
+    )
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, child_id), mock_config_entry.entry_id
+    )
+    assert grandparent_device is not None
+    assert parent_device is not None
+    assert child_device is not None
+    assert grandparent_device.via_device_id is None
+    assert parent_device.via_device_id == grandparent_device.id
+    assert child_device.via_device_id == parent_device.id
 
 
 @pytest.mark.parametrize("device_fixture", ["da_ac_rac_000001"])


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve via_device handling in `smartthings`

This fixes the edge case found by the bot here https://github.com/home-assistant/core/pull/178167#discussion_r3713526967

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
