### PR TITLE
HomeConnect - Add active program sensor

### DIFF
--- a/homeassistant/components/home_connect/const.py
+++ b/homeassistant/components/home_connect/const.py
@@ -69,6 +69,7 @@ SERVICE_START_SELECTED_PROGRAM = "start_selected_program"
 ATTR_AFFECTS_TO = "affects_to"
 ATTR_KEY = "key"
 ATTR_PROGRAM = "program"
+ATTR_RAW_VALUE = "raw_value"
 ATTR_VALUE = "value"
 
 AFFECTS_TO_ACTIVE_PROGRAM = "active_program"

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -75,10 +75,15 @@ BSH_PROGRAM_SENSORS = (
     ),
 )
 
-ACTIVE_PROGRAM_SENSORS = (
+PROGRAM_KEY_SENSORS = (
     HomeConnectSensorEntityDescription(
         key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
         translation_key="active_program",
+        appliance_types=APPLIANCES_WITH_PROGRAMS,
+    ),
+    HomeConnectSensorEntityDescription(
+        key=EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+        translation_key="selected_program",
         appliance_types=APPLIANCES_WITH_PROGRAMS,
     ),
 )
@@ -539,8 +544,8 @@ def _get_entities_for_appliance(
             and appliance_coordinator.data.info.type in desc.appliance_types
         ],
         *[
-            HomeConnectActiveProgramSensor(appliance_coordinator, desc)
-            for desc in ACTIVE_PROGRAM_SENSORS
+            HomeConnectProgramKeySensor(appliance_coordinator, desc)
+            for desc in PROGRAM_KEY_SENSORS
             if desc.appliance_types
             and appliance_coordinator.data.info.type in desc.appliance_types
         ],
@@ -668,10 +673,10 @@ class HomeConnectProgramSensor(HomeConnectSensor):
             self._update_native_value(event.value)
 
 
-class HomeConnectActiveProgramSensor(HomeConnectEntity, SensorEntity):
-    """Sensor class for the Home Connect active program, including non-selectable ones.
+class HomeConnectProgramKeySensor(HomeConnectEntity, SensorEntity):
+    """Sensor class for a Home Connect program key, including non-selectable programs.
 
-    Unlike the active program select entity, this reports every program the
+    Unlike the program select entities, this reports every program the
     appliance sends back, even those that cannot be selected by the user,
     such as an auto-started rinse or cleaning cycle.
     """
@@ -682,8 +687,8 @@ class HomeConnectActiveProgramSensor(HomeConnectEntity, SensorEntity):
 
     @override
     def update_native_value(self) -> None:
-        """Update the sensor's value from the active program event."""
-        event = self.appliance.events.get(EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM)
+        """Update the sensor's value from the program event."""
+        event = self.appliance.events.get(EventKey(self.bsh_key))
         value = event.value if event else None
         if not isinstance(value, str):
             self._raw_value = None

--- a/homeassistant/components/home_connect/sensor.py
+++ b/homeassistant/components/home_connect/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.util import dt as dt_util, slugify
 from .common import setup_home_connect_entry
 from .const import (
     APPLIANCES_WITH_PROGRAMS,
+    ATTR_RAW_VALUE,
     BSH_OPERATION_STATE_DELAYED_START,
     BSH_OPERATION_STATE_FINISHED,
     BSH_OPERATION_STATE_PAUSE,
@@ -29,6 +30,7 @@ from .const import (
 )
 from .coordinator import HomeConnectApplianceCoordinator, HomeConnectConfigEntry
 from .entity import HomeConnectEntity, constraint_fetcher
+from .utils import program_key_to_readable_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -69,6 +71,14 @@ BSH_PROGRAM_SENSORS = (
         key=EventKey.BSH_COMMON_OPTION_PROGRAM_PROGRESS,
         native_unit_of_measurement=UnitOfRatio.PERCENTAGE,
         translation_key="program_progress",
+        appliance_types=APPLIANCES_WITH_PROGRAMS,
+    ),
+)
+
+ACTIVE_PROGRAM_SENSORS = (
+    HomeConnectSensorEntityDescription(
+        key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+        translation_key="active_program",
         appliance_types=APPLIANCES_WITH_PROGRAMS,
     ),
 )
@@ -529,6 +539,12 @@ def _get_entities_for_appliance(
             and appliance_coordinator.data.info.type in desc.appliance_types
         ],
         *[
+            HomeConnectActiveProgramSensor(appliance_coordinator, desc)
+            for desc in ACTIVE_PROGRAM_SENSORS
+            if desc.appliance_types
+            and appliance_coordinator.data.info.type in desc.appliance_types
+        ],
+        *[
             HomeConnectSensor(appliance_coordinator, description)
             for description in SENSORS
             if description.key in appliance_coordinator.data.status
@@ -650,6 +666,39 @@ class HomeConnectProgramSensor(HomeConnectSensor):
         event = self.appliance.events.get(cast(EventKey, self.bsh_key))
         if event:
             self._update_native_value(event.value)
+
+
+class HomeConnectActiveProgramSensor(HomeConnectEntity, SensorEntity):
+    """Sensor class for the Home Connect active program, including non-selectable ones.
+
+    Unlike the active program select entity, this reports every program the
+    appliance sends back, even those that cannot be selected by the user,
+    such as an auto-started rinse or cleaning cycle.
+    """
+
+    entity_description: HomeConnectSensorEntityDescription
+    _attr_entity_registry_enabled_default = False
+    _raw_value: str | None = None
+
+    @override
+    def update_native_value(self) -> None:
+        """Update the sensor's value from the active program event."""
+        event = self.appliance.events.get(EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM)
+        value = event.value if event else None
+        if not isinstance(value, str):
+            self._raw_value = None
+            self._attr_native_value = None
+            return
+        self._raw_value = value
+        self._attr_native_value = program_key_to_readable_name(value)
+
+    @property
+    @override
+    def extra_state_attributes(self) -> dict[str, str] | None:
+        """Return the raw program key as reported by the API."""
+        if self._raw_value is None:
+            return None
+        return {ATTR_RAW_VALUE: self._raw_value}
 
 
 class HomeConnectEventSensor(HomeConnectSensor):

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -832,6 +832,9 @@
       }
     },
     "sensor": {
+      "active_program": {
+        "name": "Active program"
+      },
       "alarm_clock_elapsed": {
         "name": "Alarm clock elapsed",
         "state": {

--- a/homeassistant/components/home_connect/strings.json
+++ b/homeassistant/components/home_connect/strings.json
@@ -1218,6 +1218,9 @@
           "present": "[%key:component::home_connect::common::present%]"
         }
       },
+      "selected_program": {
+        "name": "Selected program"
+      },
       "water_tank_empty": {
         "name": "Water tank empty",
         "state": {

--- a/homeassistant/components/home_connect/utils.py
+++ b/homeassistant/components/home_connect/utils.py
@@ -4,11 +4,13 @@ import re
 
 from aiohomeconnect.model.error import HomeConnectError
 
+# Splits before every uppercase letter and every digit group. Its output makes
+# up the translation keys stored in strings.json, e.g. `x_l_coffee`, so it has
+# to stay as it is for those translations to keep resolving.
 RE_CAMEL_CASE = re.compile(r"(?<!^)(?=[A-Z])|(?=\d)(?<=\D)")
 
-# Unlike RE_CAMEL_CASE, this keeps acronyms and dimensions together, so that
-# `XLCoffee` and `3DHotAir` become `XL Coffee` and `3D Hot Air` instead of
-# `X L Coffee` and `3 D Hot Air`.
+# Splits into display words, keeping acronyms and dimensions in one word, e.g.
+# `XLCoffee` and `3DHotAir` become `XL Coffee` and `3D Hot Air`.
 RE_ACRONYM_AWARE_CAMEL_CASE = re.compile(
     r"(?<=[a-z])(?=[A-Z])|(?<=[A-Za-z\d])(?=[A-Z][a-z])|(?<=[A-Za-z])(?=\d)"
 )
@@ -40,15 +42,17 @@ def program_key_to_readable_name(program_key: str) -> str:
     `ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto`, and converts its
     last segment into a human-readable string, such as `Ristretto`.
 
-    Favorites, such as `BSH.Common.Program.Favorite.001`, keep the `Favorite`
-    segment too, e.g. `Favorite 001`, since the trailing number alone would
-    not be descriptive.
+    Keys ending in a purely numeric segment, such as
+    `BSH.Common.Program.Favorite.001` or
+    `LaundryCare.WasherDryer.Program.WashAndDry.60`, keep the segment before it
+    too, e.g. `Favorite 001` and `Wash And Dry 60`, since the number alone
+    would not be descriptive.
 
     Acronyms and dimensions are kept as one word, so `XLCoffee` becomes
     `XL Coffee` and `3DHotAir` becomes `3D Hot Air`.
     """
     segments = program_key.split(".")
-    name_segments = segments[-2:] if segments[-2:-1] == ["Favorite"] else segments[-1:]
+    name_segments = segments[-2:] if segments[-1].isdigit() else segments[-1:]
     return " ".join(
         RE_ACRONYM_AWARE_CAMEL_CASE.sub(" ", segment) for segment in name_segments
     )

--- a/homeassistant/components/home_connect/utils.py
+++ b/homeassistant/components/home_connect/utils.py
@@ -24,3 +24,19 @@ def bsh_key_to_translation_key(bsh_key: str) -> str:
     return "_".join(
         RE_CAMEL_CASE.sub("_", split) for split in bsh_key.split(".")
     ).lower()
+
+
+def program_key_to_readable_name(program_key: str) -> str:
+    """Return a human-readable name derived from a raw program key.
+
+    This function takes a program key, such as
+    `ConsumerProducts.CoffeeMaker.Program.Beverage.Ristretto`, and converts its
+    last segment into a human-readable string, such as `Ristretto`.
+
+    Favorites, such as `BSH.Common.Program.Favorite.001`, keep the `Favorite`
+    segment too, e.g. `Favorite 001`, since the trailing number alone would
+    not be descriptive.
+    """
+    segments = program_key.split(".")
+    name_segments = segments[-2:] if segments[-2:-1] == ["Favorite"] else segments[-1:]
+    return " ".join(RE_CAMEL_CASE.sub(" ", segment) for segment in name_segments)

--- a/homeassistant/components/home_connect/utils.py
+++ b/homeassistant/components/home_connect/utils.py
@@ -6,6 +6,13 @@ from aiohomeconnect.model.error import HomeConnectError
 
 RE_CAMEL_CASE = re.compile(r"(?<!^)(?=[A-Z])|(?=\d)(?<=\D)")
 
+# Unlike RE_CAMEL_CASE, this keeps acronyms and dimensions together, so that
+# `XLCoffee` and `3DHotAir` become `XL Coffee` and `3D Hot Air` instead of
+# `X L Coffee` and `3 D Hot Air`.
+RE_ACRONYM_AWARE_CAMEL_CASE = re.compile(
+    r"(?<=[a-z])(?=[A-Z])|(?<=[A-Za-z\d])(?=[A-Z][a-z])|(?<=[A-Za-z])(?=\d)"
+)
+
 
 def get_dict_from_home_connect_error(
     err: HomeConnectError,
@@ -36,7 +43,12 @@ def program_key_to_readable_name(program_key: str) -> str:
     Favorites, such as `BSH.Common.Program.Favorite.001`, keep the `Favorite`
     segment too, e.g. `Favorite 001`, since the trailing number alone would
     not be descriptive.
+
+    Acronyms and dimensions are kept as one word, so `XLCoffee` becomes
+    `XL Coffee` and `3DHotAir` becomes `3D Hot Air`.
     """
     segments = program_key.split(".")
     name_segments = segments[-2:] if segments[-2:-1] == ["Favorite"] else segments[-1:]
-    return " ".join(RE_CAMEL_CASE.sub(" ", segment) for segment in name_segments)
+    return " ".join(
+        RE_ACRONYM_AWARE_CAMEL_CASE.sub(" ", segment) for segment in name_segments
+    )

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -936,6 +936,14 @@ async def _send_active_program_event(
             "BSH.Common.Program.Favorite.001",
             "Favorite 001",
         ),
+        (
+            "ConsumerProducts.CoffeeMaker.Program.Beverage.XLCoffee",
+            "XL Coffee",
+        ),
+        (
+            "Cooking.Oven.Program.HeatingMode.3DHotAir",
+            "3D Hot Air",
+        ),
     ],
 )
 async def test_active_program_sensor_states(
@@ -952,8 +960,9 @@ async def test_active_program_sensor_states(
     Regardless of whether the program is known to aiohomeconnect or not, only
     the last segment of the key is used, except for favorites - reported as
     an opaque "Favorite.NNN" key - where the "Favorite" segment is kept too,
-    since the trailing number alone would not be descriptive. The raw value
-    is always exposed as-is via the raw_value attribute.
+    since the trailing number alone would not be descriptive. Acronyms and
+    dimensions are kept as one word. The raw value is always exposed as-is
+    via the raw_value attribute.
     """
     entity_id = "sensor.dishwasher_active_program"
     assert await integration_setup(client)

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -19,6 +19,7 @@ from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.home_connect.const import (
+    ATTR_RAW_VALUE,
     BSH_DOOR_STATE_CLOSED,
     BSH_DOOR_STATE_LOCKED,
     BSH_DOOR_STATE_OPEN,
@@ -890,3 +891,153 @@ async def test_sensor_unit_fetching_after_rate_limit_error(
     entity_state = hass.states.get(entity_id)
     assert entity_state
     assert entity_state.attributes["unit_of_measurement"] == unit
+
+
+async def _send_active_program_event(
+    client: MagicMock, appliance: HomeAppliance, value: str | None
+) -> None:
+    """Send an active program event with the given raw value."""
+    await client.add_events(
+        [
+            EventMessage(
+                appliance.ha_id,
+                EventType.NOTIFY,
+                ArrayOfEvents(
+                    [
+                        Event(
+                            key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+                            raw_key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM.value,
+                            timestamp=0,
+                            level="",
+                            handling="",
+                            value=value,
+                        )
+                    ]
+                ),
+            )
+        ]
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize(
+    ("raw_value", "expected_state"),
+    [
+        (
+            "Dishcare.Dishwasher.Program.Eco50",
+            "Eco 50",
+        ),
+        (
+            "Dishcare.Dishwasher.Program.RinseOnStartup",
+            "Rinse On Startup",
+        ),
+        (
+            "BSH.Common.Program.Favorite.001",
+            "Favorite 001",
+        ),
+    ],
+)
+async def test_active_program_sensor_states(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+    raw_value: str,
+    expected_state: str,
+) -> None:
+    """Test the active program sensor formats the raw program key into a readable name.
+
+    Regardless of whether the program is known to aiohomeconnect or not, only
+    the last segment of the key is used, except for favorites - reported as
+    an opaque "Favorite.NNN" key - where the "Favorite" segment is kept too,
+    since the trailing number alone would not be descriptive. The raw value
+    is always exposed as-is via the raw_value attribute.
+    """
+    entity_id = "sensor.dishwasher_active_program"
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    await _send_active_program_event(client, appliance, raw_value)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == expected_state
+    assert state.attributes[ATTR_RAW_VALUE] == raw_value
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+async def test_active_program_sensor_cleared_when_program_becomes_none(
+    hass: HomeAssistant,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+) -> None:
+    """Test the active program sensor resets when the active program is cleared."""
+    entity_id = "sensor.dishwasher_active_program"
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    # The mocked client reports the first known program as active on setup.
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Auto 1"
+    assert state.attributes[ATTR_RAW_VALUE] == "Dishcare.Dishwasher.Program.Auto1"
+
+    await _send_active_program_event(
+        client, appliance, "Dishcare.Dishwasher.Program.Eco50"
+    )
+    await hass.async_block_till_done()
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == "Eco 50"
+
+    await _send_active_program_event(client, appliance, None)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.state == STATE_UNKNOWN
+    assert ATTR_RAW_VALUE not in state.attributes
+
+
+@pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+async def test_active_program_sensor_disabled_by_default(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+) -> None:
+    """Test that the active program sensor is disabled by default."""
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    entry = entity_registry.async_get("sensor.dishwasher_active_program")
+    assert entry
+    assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
+
+
+@pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
+async def test_active_program_sensor_not_created_without_programs(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    client: MagicMock,
+    config_entry: MockConfigEntry,
+    integration_setup: Callable[[MagicMock], Awaitable[bool]],
+    appliance: HomeAppliance,
+) -> None:
+    """Test that the active program sensor is not created for appliances without programs."""
+    assert await integration_setup(client)
+    assert config_entry.state is ConfigEntryState.LOADED
+
+    assert not entity_registry.async_get_entity_id(
+        Platform.SENSOR,
+        DOMAIN,
+        f"{appliance.ha_id}-{EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM}",
+    )

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -955,6 +955,10 @@ async def _send_program_event(
             "Favorite 001",
         ),
         (
+            "LaundryCare.WasherDryer.Program.WashAndDry.60",
+            "Wash And Dry 60",
+        ),
+        (
             "ConsumerProducts.CoffeeMaker.Program.Beverage.XLCoffee",
             "XL Coffee",
         ),
@@ -978,11 +982,11 @@ async def test_program_key_sensor_states(
     """Test the program sensors format the raw program key into a readable name.
 
     Regardless of whether the program is known to aiohomeconnect or not, only
-    the last segment of the key is used, except for favorites - reported as
-    an opaque "Favorite.NNN" key - where the "Favorite" segment is kept too,
-    since the trailing number alone would not be descriptive. Acronyms and
-    dimensions are kept as one word. The raw value is always exposed as-is
-    via the raw_value attribute.
+    the last segment of the key is used, except for keys ending in a number -
+    such as favorites, reported as an opaque "Favorite.NNN" key - where the
+    segment before it is kept too, since the number alone would not be
+    descriptive. Acronyms and dimensions are kept as one word. The raw value
+    is always exposed as-is via the raw_value attribute.
     """
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -893,10 +893,27 @@ async def test_sensor_unit_fetching_after_rate_limit_error(
     assert entity_state.attributes["unit_of_measurement"] == unit
 
 
-async def _send_active_program_event(
-    client: MagicMock, appliance: HomeAppliance, value: str | None
+DISHWASHER_PROGRAM_SENSORS = [
+    pytest.param(
+        EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+        "sensor.dishwasher_active_program",
+        id="active_program",
+    ),
+    pytest.param(
+        EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+        "sensor.dishwasher_selected_program",
+        id="selected_program",
+    ),
+]
+
+
+async def _send_program_event(
+    client: MagicMock,
+    appliance: HomeAppliance,
+    event_key: EventKey,
+    value: str | None,
 ) -> None:
-    """Send an active program event with the given raw value."""
+    """Send a program event with the given raw value."""
     await client.add_events(
         [
             EventMessage(
@@ -905,8 +922,8 @@ async def _send_active_program_event(
                 ArrayOfEvents(
                     [
                         Event(
-                            key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
-                            raw_key=EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM.value,
+                            key=event_key,
+                            raw_key=event_key.value,
                             timestamp=0,
                             level="",
                             handling="",
@@ -921,6 +938,7 @@ async def _send_active_program_event(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
+@pytest.mark.parametrize(("event_key", "entity_id"), DISHWASHER_PROGRAM_SENSORS)
 @pytest.mark.parametrize(
     ("raw_value", "expected_state"),
     [
@@ -946,16 +964,18 @@ async def _send_active_program_event(
         ),
     ],
 )
-async def test_active_program_sensor_states(
+async def test_program_key_sensor_states(
     hass: HomeAssistant,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
+    event_key: EventKey,
+    entity_id: str,
     raw_value: str,
     expected_state: str,
 ) -> None:
-    """Test the active program sensor formats the raw program key into a readable name.
+    """Test the program sensors format the raw program key into a readable name.
 
     Regardless of whether the program is known to aiohomeconnect or not, only
     the last segment of the key is used, except for favorites - reported as
@@ -964,11 +984,10 @@ async def test_active_program_sensor_states(
     dimensions are kept as one word. The raw value is always exposed as-is
     via the raw_value attribute.
     """
-    entity_id = "sensor.dishwasher_active_program"
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    await _send_active_program_event(client, appliance, raw_value)
+    await _send_program_event(client, appliance, event_key, raw_value)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -979,33 +998,35 @@ async def test_active_program_sensor_states(
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default")
 @pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
-async def test_active_program_sensor_cleared_when_program_becomes_none(
+@pytest.mark.parametrize(("event_key", "entity_id"), DISHWASHER_PROGRAM_SENSORS)
+async def test_program_key_sensor_cleared_when_program_becomes_none(
     hass: HomeAssistant,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
+    event_key: EventKey,
+    entity_id: str,
 ) -> None:
-    """Test the active program sensor resets when the active program is cleared."""
-    entity_id = "sensor.dishwasher_active_program"
+    """Test the program sensors reset when the program is cleared."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    # The mocked client reports the first known program as active on setup.
+    # The mocked client reports the first known program on setup.
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "Auto 1"
     assert state.attributes[ATTR_RAW_VALUE] == "Dishcare.Dishwasher.Program.Auto1"
 
-    await _send_active_program_event(
-        client, appliance, "Dishcare.Dishwasher.Program.Eco50"
+    await _send_program_event(
+        client, appliance, event_key, "Dishcare.Dishwasher.Program.Eco50"
     )
     await hass.async_block_till_done()
     state = hass.states.get(entity_id)
     assert state
     assert state.state == "Eco 50"
 
-    await _send_active_program_event(client, appliance, None)
+    await _send_program_event(client, appliance, event_key, None)
     await hass.async_block_till_done()
 
     state = hass.states.get(entity_id)
@@ -1015,38 +1036,48 @@ async def test_active_program_sensor_cleared_when_program_becomes_none(
 
 
 @pytest.mark.parametrize("appliance", ["Dishwasher"], indirect=True)
-async def test_active_program_sensor_disabled_by_default(
-    hass: HomeAssistant,
+@pytest.mark.parametrize(("event_key", "entity_id"), DISHWASHER_PROGRAM_SENSORS)
+async def test_program_key_sensor_disabled_by_default(
     entity_registry: er.EntityRegistry,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
+    event_key: EventKey,
+    entity_id: str,
 ) -> None:
-    """Test that the active program sensor is disabled by default."""
+    """Test that the program sensors are disabled by default."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    entry = entity_registry.async_get("sensor.dishwasher_active_program")
+    entry = entity_registry.async_get(entity_id)
     assert entry
+    assert entry.unique_id == f"{appliance.ha_id}-{event_key}"
     assert entry.disabled_by is er.RegistryEntryDisabler.INTEGRATION
 
 
 @pytest.mark.parametrize("appliance", ["FridgeFreezer"], indirect=True)
-async def test_active_program_sensor_not_created_without_programs(
-    hass: HomeAssistant,
+@pytest.mark.parametrize(
+    "event_key",
+    [
+        EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM,
+        EventKey.BSH_COMMON_ROOT_SELECTED_PROGRAM,
+    ],
+)
+async def test_program_key_sensor_not_created_without_programs(
     entity_registry: er.EntityRegistry,
     client: MagicMock,
     config_entry: MockConfigEntry,
     integration_setup: Callable[[MagicMock], Awaitable[bool]],
     appliance: HomeAppliance,
+    event_key: EventKey,
 ) -> None:
-    """Test that the active program sensor is not created for appliances without programs."""
+    """Test that the program sensors are not created for appliances without programs."""
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert not entity_registry.async_get_entity_id(
         Platform.SENSOR,
         DOMAIN,
-        f"{appliance.ha_id}-{EventKey.BSH_COMMON_ROOT_ACTIVE_PROGRAM}",
+        f"{appliance.ha_id}-{event_key}",
     )


### PR DESCRIPTION
Following up #157332 and infollowing [this](https://github.com/home-assistant/core/pull/157332#issuecomment-3595237974) recommendation this adds an additional sensor reporting the current active program on Home Connect devices.

This is required because there are a bunch of programs that are not user selectable and thus not appear in the existing dropdown menus (and should not, as they cannot be activated by the user). To run automations on those programs as well, this adds an additional sensor which report **all** programs, when they are running. It is disabled by default. 

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
