### PR TITLE
Recalculate time SMA filter when a sample leaves the window

### DIFF
--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -271,17 +271,19 @@ class SensorFilter(SensorEntity):
                 "While updating filter %s, the new_state is None", self.name
             )
             self._state = None
+            self._async_forget_source_state()
             self.async_write_ha_state()
             return
 
         if new_state.state == STATE_UNKNOWN:
             self._state = None
+            self._async_forget_source_state()
             self.async_write_ha_state()
             return
 
         if new_state.state == STATE_UNAVAILABLE:
             self._attr_available = False
-            self._async_cancel_expiry_listener()
+            self._async_forget_source_state()
             self.async_write_ha_state()
             return
 
@@ -301,7 +303,6 @@ class SensorFilter(SensorEntity):
                     "skip" if filt.skip_processing else filtered_state.state,
                 )
                 if filt.skip_processing:
-                    self._async_schedule_next_expiry()
                     return
                 temp_state = filtered_state
         except ValueError:
@@ -344,12 +345,24 @@ class SensorFilter(SensorEntity):
             self._expiry_listener = None
 
     @callback
+    def _async_forget_source_state(self) -> None:
+        """Drop the source value so no stale value is fed back in."""
+        self._last_source_state = None
+        self._async_cancel_expiry_listener()
+
+    @callback
     def _async_schedule_next_expiry(self) -> None:
         """Schedule a re-evaluation for when a sample leaves a time window."""
         self._async_cancel_expiry_listener()
 
+        # An expiry in the past belongs to a filter the chain did not reach,
+        # so re-evaluating would not move it forward. Ignoring it keeps the
+        # callback from rearming itself on the same timestamp.
+        now = dt_util.utcnow()
         expiries = [
-            expiry for filt in self._filters if (expiry := filt.next_expiry) is not None
+            expiry
+            for filt in self._filters
+            if (expiry := filt.next_expiry) is not None and expiry > now
         ]
         if not expiries:
             return
@@ -771,6 +784,16 @@ class TimeSMAFilter(Filter, SensorEntity):
         """Return when the oldest sample leaves the window."""
         if not self.queue:
             return None
+
+        # With a single value held across the whole window the average no
+        # longer moves, so there is nothing to wake up for until the source
+        # reports something different.
+        values = {state.state for state in self.queue}
+        if self.last_leak is not None:
+            values.add(self.last_leak.state)
+        if len(values) == 1:
+            return None
+
         return self.queue[0].timestamp + self._time_window
 
     def _leak(self, left_boundary: datetime) -> None:

--- a/homeassistant/components/filter/sensor.py
+++ b/homeassistant/components/filter/sensor.py
@@ -33,6 +33,7 @@ from homeassistant.const import (
     EntityStateAttribute,
 )
 from homeassistant.core import (
+    CALLBACK_TYPE,
     Event,
     EventStateChangedData,
     HomeAssistant,
@@ -44,7 +45,10 @@ from homeassistant.helpers.entity_platform import (
     AddConfigEntryEntitiesCallback,
     AddEntitiesCallback,
 )
-from homeassistant.helpers.event import async_track_state_change_event
+from homeassistant.helpers.event import (
+    async_track_point_in_utc_time,
+    async_track_state_change_event,
+)
 from homeassistant.helpers.reload import async_setup_reload_service
 from homeassistant.helpers.start import async_at_started
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType, StateType
@@ -246,6 +250,8 @@ class SensorFilter(SensorEntity):
         self._attr_device_class = None
         self._attr_state_class = None
         self._attr_extra_state_attributes = {ATTR_ENTITY_ID: entity_id}
+        self._last_source_state: State | None = None
+        self._expiry_listener: CALLBACK_TYPE | None = None
 
     @callback
     def _update_filter_sensor_state_event(
@@ -275,10 +281,12 @@ class SensorFilter(SensorEntity):
 
         if new_state.state == STATE_UNAVAILABLE:
             self._attr_available = False
+            self._async_cancel_expiry_listener()
             self.async_write_ha_state()
             return
 
         self._attr_available = True
+        self._last_source_state = new_state
 
         temp_state = _State(new_state.last_updated, new_state.state)
 
@@ -293,6 +301,7 @@ class SensorFilter(SensorEntity):
                     "skip" if filt.skip_processing else filtered_state.state,
                 )
                 if filt.skip_processing:
+                    self._async_schedule_next_expiry()
                     return
                 temp_state = filtered_state
         except ValueError:
@@ -324,6 +333,54 @@ class SensorFilter(SensorEntity):
 
         if update_ha:
             self.async_write_ha_state()
+
+        self._async_schedule_next_expiry()
+
+    @callback
+    def _async_cancel_expiry_listener(self) -> None:
+        """Cancel a pending re-evaluation."""
+        if self._expiry_listener is not None:
+            self._expiry_listener()
+            self._expiry_listener = None
+
+    @callback
+    def _async_schedule_next_expiry(self) -> None:
+        """Schedule a re-evaluation for when a sample leaves a time window."""
+        self._async_cancel_expiry_listener()
+
+        expiries = [
+            expiry for filt in self._filters if (expiry := filt.next_expiry) is not None
+        ]
+        if not expiries:
+            return
+
+        expiry = min(expiries)
+        _LOGGER.debug("%s: scheduling re-evaluation at %s", self._entity, expiry)
+        self._expiry_listener = async_track_point_in_utc_time(
+            self.hass, self._async_expiry_reached, expiry
+        )
+
+    @callback
+    def _async_expiry_reached(self, now: datetime) -> None:
+        """Re-evaluate the chain when a sample leaves a time window.
+
+        The source entity only reports changes, so its last known value is
+        still the current one. Feeding that value back in with the current
+        timestamp is what the time based filters already assume between two
+        samples, and it keeps the rest of the chain in sync.
+        """
+        self._expiry_listener = None
+        if (last_state := self._last_source_state) is None:
+            return
+
+        self._update_filter_sensor_state(
+            State(
+                last_state.entity_id,
+                last_state.state,
+                last_state.attributes,
+                last_updated=now,
+            )
+        )
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -400,6 +457,7 @@ class SensorFilter(SensorEntity):
             )
 
         self.async_on_remove(async_at_started(self.hass, _async_hass_started))
+        self.async_on_remove(self._async_cancel_expiry_listener)
 
     @property
     @override
@@ -497,6 +555,18 @@ class Filter:
     def skip_processing(self) -> bool:
         """Return whether the current filter_state should be skipped."""
         return self._skip_processing
+
+    @property
+    def next_expiry(self) -> datetime | None:
+        """Return when the output changes without a new source sample.
+
+        Filters with a time based window keep producing a different result as
+        old samples fall out of the window, even when the source entity stays
+        silent. They report the next such moment here so the sensor can
+        re-evaluate the chain. Filters whose output only depends on the samples
+        themselves return None.
+        """
+        return None
 
     def reset(self) -> None:
         """Reset filter."""
@@ -694,6 +764,14 @@ class TimeSMAFilter(Filter, SensorEntity):
         self._time_window = window_size
         self.last_leak: FilterState | None = None
         self.queue = deque[FilterState]()
+
+    @property
+    @override
+    def next_expiry(self) -> datetime | None:
+        """Return when the oldest sample leaves the window."""
+        if not self.queue:
+            return None
+        return self.queue[0].timestamp + self._time_window
 
     def _leak(self, left_boundary: datetime) -> None:
         """Remove timeouted elements."""

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -554,6 +554,14 @@ def test_time_sma(values: list[State]) -> None:
     assert filtered.state == 21.5
 
 
+def test_time_sma_without_samples_has_no_expiry() -> None:
+    """Test a filter that has not seen a sample yet does not ask for a wake up."""
+    filt = TimeSMAFilter(
+        window_size=timedelta(minutes=2), precision=2, entity=None, type="last"
+    )
+    assert filt.next_expiry is None
+
+
 async def test_time_sma_expiring_sample(
     recorder_mock: Recorder,
     hass: HomeAssistant,

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -3,6 +3,7 @@
 from datetime import timedelta
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant import config as hass_config
@@ -46,7 +47,12 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from tests.common import MockConfigEntry, assert_setup_component, get_fixture_path
+from tests.common import (
+    MockConfigEntry,
+    assert_setup_component,
+    async_fire_time_changed,
+    get_fixture_path,
+)
 
 
 @pytest.fixture(name="values")
@@ -545,6 +551,67 @@ def test_time_sma(values: list[State]) -> None:
     for state in values:
         filtered = filt.filter_state(state)
     assert filtered.state == 21.5
+
+
+async def test_time_sma_expiring_sample(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test that a sample leaving the time window updates the filtered value.
+
+    The source only reports changes, so a short spike followed by silence must
+    still fall out of the window on its own.
+    """
+    config = {
+        "sensor": {
+            "platform": "filter",
+            "name": "test",
+            "entity_id": "sensor.test_monitored",
+            "filters": [
+                {
+                    "filter": "time_simple_moving_average",
+                    "window_size": "01:00:00",
+                    "precision": 2,
+                }
+            ],
+        }
+    }
+
+    async def advance(delta: timedelta) -> None:
+        """Advance time in steps so scheduled updates can chain."""
+        remaining = delta
+        while remaining > timedelta(0):
+            tick = min(timedelta(minutes=5), remaining)
+            freezer.tick(tick)
+            async_fire_time_changed(hass, dt_util.utcnow())
+            await hass.async_block_till_done()
+            remaining -= tick
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test_monitored", "0")
+    await hass.async_block_till_done()
+
+    await advance(timedelta(minutes=30))
+    hass.states.async_set("sensor.test_monitored", "100")
+    await hass.async_block_till_done()
+
+    await advance(timedelta(minutes=1))
+    hass.states.async_set("sensor.test_monitored", "0")
+    await hass.async_block_till_done()
+
+    # One minute at 100 within a 60 minute window
+    assert hass.states.get("sensor.test").state == "1.67"
+
+    # While the spike is still inside the window the value does not change
+    await advance(timedelta(minutes=49))
+    assert hass.states.get("sensor.test").state == "1.67"
+
+    # Once the spike has left the window the average returns to the source value
+    await advance(timedelta(hours=1))
+    assert hass.states.get("sensor.test").state == "0.0"
 
 
 async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:

--- a/tests/components/filter/test_sensor.py
+++ b/tests/components/filter/test_sensor.py
@@ -1,6 +1,6 @@
 """The test for the data filter sensor platform."""
 
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 from freezegun.api import FrozenDateTimeFactory
@@ -44,6 +44,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.event import async_track_point_in_utc_time
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
@@ -578,15 +579,12 @@ async def test_time_sma_expiring_sample(
         }
     }
 
-    async def advance(delta: timedelta) -> None:
-        """Advance time in steps so scheduled updates can chain."""
-        remaining = delta
-        while remaining > timedelta(0):
-            tick = min(timedelta(minutes=5), remaining)
-            freezer.tick(tick)
+    async def advance(minutes: int) -> None:
+        """Advance time minute by minute so scheduled updates can chain."""
+        for _ in range(minutes):
+            freezer.tick(timedelta(minutes=1))
             async_fire_time_changed(hass, dt_util.utcnow())
             await hass.async_block_till_done()
-            remaining -= tick
 
     assert await async_setup_component(hass, "sensor", config)
     await hass.async_block_till_done()
@@ -594,24 +592,129 @@ async def test_time_sma_expiring_sample(
     hass.states.async_set("sensor.test_monitored", "0")
     await hass.async_block_till_done()
 
-    await advance(timedelta(minutes=30))
+    await advance(30)
     hass.states.async_set("sensor.test_monitored", "100")
     await hass.async_block_till_done()
 
-    await advance(timedelta(minutes=1))
+    await advance(1)
     hass.states.async_set("sensor.test_monitored", "0")
     await hass.async_block_till_done()
 
     # One minute at 100 within a 60 minute window
     assert hass.states.get("sensor.test").state == "1.67"
 
-    # While the spike is still inside the window the value does not change
-    await advance(timedelta(minutes=49))
+    # The spike ran from minute 30 to minute 31, so it only leaves the trailing
+    # window at minute 91. One minute before that the value must be unchanged.
+    await advance(59)
     assert hass.states.get("sensor.test").state == "1.67"
 
-    # Once the spike has left the window the average returns to the source value
-    await advance(timedelta(hours=1))
+    # And one minute after it, the average is back to the source value.
+    await advance(2)
     assert hass.states.get("sensor.test").state == "0.0"
+
+
+async def test_time_sma_expiry_with_throttle(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a time filter behind a throttle is never scheduled in the past.
+
+    The throttle short circuits the chain, so the moving average never advances
+    and its expiry stays behind. Scheduling on such an expiry would fire the
+    callback again on the same timestamp, over and over.
+    """
+    config = {
+        "sensor": {
+            "platform": "filter",
+            "name": "test",
+            "entity_id": "sensor.test_monitored",
+            "filters": [
+                {"filter": "time_throttle", "window_size": "02:00:00"},
+                {
+                    "filter": "time_simple_moving_average",
+                    "window_size": "01:00:00",
+                    "precision": 2,
+                },
+            ],
+        }
+    }
+
+    scheduled: list[tuple[datetime, datetime]] = []
+
+    def _track(hass_, action, point_in_time):
+        scheduled.append((dt_util.utcnow(), point_in_time))
+        return async_track_point_in_utc_time(hass_, action, point_in_time)
+
+    async def advance(minutes: int) -> None:
+        for _ in range(minutes):
+            freezer.tick(timedelta(minutes=1))
+            async_fire_time_changed(hass, dt_util.utcnow())
+            await hass.async_block_till_done()
+
+    with patch(
+        "homeassistant.components.filter.sensor.async_track_point_in_utc_time",
+        _track,
+    ):
+        assert await async_setup_component(hass, "sensor", config)
+        await hass.async_block_till_done()
+
+        hass.states.async_set("sensor.test_monitored", "20")
+        await hass.async_block_till_done()
+
+        # Far enough apart that the throttle lets both values through, so the
+        # moving average holds two different samples and arms a timer.
+        await advance(121)
+        hass.states.async_set("sensor.test_monitored", "100")
+        await hass.async_block_till_done()
+
+        # The timer now fires while the throttle is still blocking.
+        await advance(65)
+
+    assert scheduled, "expected the moving average to schedule a re-evaluation"
+    assert all(point > when for when, point in scheduled), (
+        "a re-evaluation was scheduled at a point in time that had already passed"
+    )
+
+
+async def test_time_sma_expiry_dropped_when_source_unknown(
+    recorder_mock: Recorder,
+    hass: HomeAssistant,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test a source going unknown is not overwritten by a scheduled update."""
+    config = {
+        "sensor": {
+            "platform": "filter",
+            "name": "test",
+            "entity_id": "sensor.test_monitored",
+            "filters": [
+                {
+                    "filter": "time_simple_moving_average",
+                    "window_size": "01:00:00",
+                    "precision": 2,
+                }
+            ],
+        }
+    }
+
+    assert await async_setup_component(hass, "sensor", config)
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test_monitored", "20")
+    await hass.async_block_till_done()
+
+    hass.states.async_set("sensor.test_monitored", STATE_UNKNOWN)
+    await hass.async_block_till_done()
+    assert hass.states.get("sensor.test").state == STATE_UNKNOWN
+
+    for _ in range(90):
+        freezer.tick(timedelta(minutes=1))
+        async_fire_time_changed(hass, dt_util.utcnow())
+        await hass.async_block_till_done()
+
+    # The pending re-evaluation must not resurrect the last numeric value
+    assert hass.states.get("sensor.test").state == STATE_UNKNOWN
 
 
 async def test_reload(recorder_mock: Recorder, hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Proposed change

The `time_simple_moving_average` filter is only evaluated when the source entity
reports a new state. Because a source entity only reports changes, a value that
falls out of the time window never triggers a recalculation, so the sensor stays
frozen on the last computed average until the source happens to update again.

This is what #170877 describes: with a source that updates every few hours, the
average drops the instant a spike arrives (the idle time before it is only
accounted for retroactively) and then never comes back down when the spike
leaves the window.

Filters now report when their output changes without new input, through a
`next_expiry` property on the `Filter` base class. It returns `None` by default,
so sample count based filters are unaffected. `TimeSMAFilter` returns the moment
the oldest queued sample leaves the window, and `None` once a single value spans
the whole window, since the average cannot change until the source reports
something different.

`SensorFilter` schedules a re-evaluation at the earliest expiry across its
filters using `async_track_point_in_utc_time`, the same mechanism the
`statistics` integration already uses for `max_age`. When it fires, the last
known source value is fed back through the chain with the current timestamp.
This matches the assumption the filter already makes between two samples
(`TIME_SMA_LAST` holds the last value), so the injected sample does not change
the step-hold integral, it only triggers the recomputation, and it keeps chained
filters consistent.

Two edge cases are handled explicitly:

- An expiry that already passed is never scheduled. A time based filter sitting
  behind a throttle is skipped by the chain and therefore never advances, so
  scheduling on its stale expiry would rearm the callback on the same timestamp
  repeatedly.
- The remembered source value is dropped when the source goes unknown, becomes
  unavailable or disappears, so a pending re-evaluation cannot feed a stale
  value back in.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #170877
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

