### PR TITLE
Add callback for Docker image update in Portainer

### DIFF
--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from pyportainer import Portainer, PortainerImageWatcher
 from pyportainer.exceptions import PortainerError
+from pyportainer.watcher import PortainerImageWatcherResult
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -115,6 +116,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: PortainerConfigEntry) ->
     def _stop_watcher(_event: Event) -> None:
         """Stop the image watcher in the event loop."""
         watcher.stop()
+
+    async def _handle_watcher_result(_result: PortainerImageWatcherResult) -> None:
+        """Request a coordinator refresh so watcher detected updates surface."""
+        await coordinator.async_request_refresh()
+
+    watcher.register_callback(_handle_watcher_result)
 
     entry.async_on_unload(async_at_started(hass, _start_watcher))
     entry.async_on_unload(watcher.stop)

--- a/homeassistant/components/portainer/__init__.py
+++ b/homeassistant/components/portainer/__init__.py
@@ -115,6 +115,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PortainerConfigEntry) ->
     @callback
     def _stop_watcher(_event: Event) -> None:
         """Stop the image watcher in the event loop."""
+        watcher.unregister_callback(_handle_watcher_result)
         watcher.stop()
 
     async def _handle_watcher_result(_result: PortainerImageWatcherResult) -> None:

--- a/tests/components/portainer/test_init.py
+++ b/tests/components/portainer/test_init.py
@@ -11,6 +11,7 @@ from pyportainer.exceptions import (
 from pyportainer.models.docker import DockerContainer, EndpointStatus
 from pyportainer.models.portainer import Endpoint
 from pyportainer.models.stacks import Stack
+from pyportainer.watcher import PortainerImageWatcherResult
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
@@ -221,6 +222,26 @@ async def test_watcher_start_stop(
     await hass.async_block_till_done()
 
     mock_portainer_watcher.stop.assert_called_once()
+
+
+async def test_watcher_callback_requests_refresh(
+    hass: HomeAssistant,
+    mock_portainer_client: AsyncMock,
+    mock_portainer_watcher: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a watcher result callback triggers a coordinator refresh."""
+    await setup_integration(hass, mock_config_entry)
+    mock_portainer_watcher.register_callback.assert_called_once()
+    result_callback = mock_portainer_watcher.register_callback.call_args[0][0]
+
+    calls_before = mock_portainer_client.get_endpoints.call_count
+    await result_callback(
+        PortainerImageWatcherResult(endpoint_id=1, container_id="abc", status=None)
+    )
+    await hass.async_block_till_done()
+
+    assert mock_portainer_client.get_endpoints.call_count == calls_before + 1
 
 
 async def test_migration_v4_to_v5(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Start utilizing the callbacks mechanism from pyportainer: https://github.com/erwindouna/pyportainer#callbacks
This now registers a callback and once a result of the Watcher comes in, a new coordinator refresh is requested, so image update feel more instant.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
