### PR TITLE
Refresh the calendar entity when the current event ends

### DIFF
--- a/homeassistant/components/calendar/__init__.py
+++ b/homeassistant/components/calendar/__init__.py
@@ -637,6 +637,17 @@ class CalendarEntity(Entity):
             _LOGGER.debug("Running %s update", self.entity_id)
             self.async_write_ha_state()
 
+        @callback
+        def refresh(_: datetime.datetime) -> None:
+            """Refresh the upcoming event now that the current one ended.
+
+            Writing the state is not enough here: the entity still holds the
+            event that just ended, so the next one has to be fetched before
+            the state can be correct.
+            """
+            _LOGGER.debug("Running %s refresh", self.entity_id)
+            self.async_schedule_update_ha_state(force_refresh=True)
+
         if now < event.start_datetime_local:
             self._alarm_unsubs.append(
                 async_track_point_in_time(
@@ -646,7 +657,7 @@ class CalendarEntity(Entity):
                 )
             )
         self._alarm_unsubs.append(
-            async_track_point_in_time(self.hass, update, event.end_datetime_local)
+            async_track_point_in_time(self.hass, refresh, event.end_datetime_local)
         )
         _LOGGER.debug(
             "Scheduled %d updates for %s (%s, %s)",

--- a/tests/components/local_calendar/test_calendar.py
+++ b/tests/components/local_calendar/test_calendar.py
@@ -3,11 +3,14 @@
 import datetime
 import textwrap
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
+from homeassistant.components.local_calendar.const import DOMAIN
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.template import DATE_STR_FORMAT
+from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
 from .conftest import (
@@ -18,7 +21,7 @@ from .conftest import (
     event_fields,
 )
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 async def test_empty_calendar(
@@ -1158,3 +1161,64 @@ async def test_invalid_event_duration(
             "end": {"dateTime": "1997-07-14T11:30:00-06:00"},
         }
     ]
+
+
+BACK_TO_BACK_EVENTS = textwrap.dedent(
+    """\
+    BEGIN:VCALENDAR
+    VERSION:2.0
+    PRODID:-//test//test//EN
+    BEGIN:VEVENT
+    UID:first-event
+    DTSTAMP:20251231T000000Z
+    SUMMARY:First
+    DTSTART:20260101T014500Z
+    DTEND:20260101T020000Z
+    END:VEVENT
+    BEGIN:VEVENT
+    UID:second-event
+    DTSTAMP:20251231T000000Z
+    SUMMARY:Second
+    DTSTART:20260101T020000Z
+    DTEND:20260101T021500Z
+    END:VEVENT
+    END:VCALENDAR
+"""
+)
+
+
+@pytest.mark.parametrize("ics_content", [BACK_TO_BACK_EVENTS])
+async def test_back_to_back_events(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test the state stays on when one event ends as the next one starts.
+
+    The entity is set up on the half minute so that its poll interval does not
+    line up with the event boundary, which is what happens in practice.
+    """
+    freezer.move_to("2026-01-01T01:50:30+00:00")
+
+    config_entry.add_to_hass(hass)
+    assert await async_setup_component(hass, DOMAIN, {})
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state.state == STATE_ON
+    assert state.attributes["message"] == "First"
+
+    freezer.move_to("2026-01-01T01:59:59+00:00")
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    assert hass.states.get(TEST_ENTITY).state == STATE_ON
+
+    # On the boundary only the end alarm of the first event is due, the next
+    # poll does not happen until 02:00:30.
+    freezer.move_to("2026-01-01T02:00:00+00:00")
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(TEST_ENTITY)
+    assert state.state == STATE_ON
+    assert state.attributes["message"] == "Second"


### PR DESCRIPTION
## Proposed change

When the alarm for the end of the current event fires, `CalendarEntity` only
writes the state. The entity still holds the event that has just ended, so
`state` evaluates `start <= now < end` on the stale event and returns `off`.
On top of that, `_async_write_ha_state` sees `now >= event.end_datetime_local`
and returns early, so no new alarm is scheduled either.

The entity therefore stays `off` until the next poll happens to refresh it.
With two events that touch, such as 01:45-02:00 followed by 02:00-02:15, the
calendar reports `off` for the remainder of the poll interval instead of
staying `on`, which is what #177553 describes.

The alarm for the end of an event now refreshes the entity instead of only
writing the state, so the next event is picked up at the boundary. The alarm
for the start of an event is unchanged: the entity already holds the right
event there, only the state needs rewriting.

### A note on the blast radius

This touches the shared base entity, and around 14 of the calendar platforms
in core are coordinator based. For those, the forced refresh becomes a
`coordinator.async_request_refresh()`, so a remote calendar will now request a
refresh once per event end rather than waiting for its regular interval. That
seemed acceptable given it is bounded by the number of events and the
coordinator debounces, but it is a behaviour change for cloud backed
calendars, so I would rather raise it than hide it. If you prefer to keep the
base entity untouched and solve this inside `local_calendar` instead, for
example by computing `event` from the timeline instead of caching it between
polls, I am happy to redo it that way.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177553
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
