### PR TITLE
persistent device tracking for Jellyfin clients

### DIFF
--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -1,11 +1,16 @@
 """The Jellyfin integration."""
 
+from collections.abc import Callable
 from typing import Any
 
 from homeassistant.const import CONF_URL
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers.device_registry import (
+    EVENT_DEVICE_REGISTRY_UPDATED,
+    EventDeviceRegistryUpdatedData,
+)
 from homeassistant.helpers.typing import ConfigType
 
 from .client_wrapper import CannotConnect, InvalidAuth, create_client, validate_input
@@ -48,6 +53,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> 
     )
     await coordinator.async_config_entry_first_refresh()
 
+    # Migrate config entry unique_id from bare user_id to {server_id}-{user_id}.
+    expected_unique_id = f"{coordinator.server_id}-{coordinator.user_id}"
+    if entry.unique_id != expected_unique_id:
+        hass.config_entries.async_update_entry(entry, unique_id=expected_unique_id)
+
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -58,8 +68,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> 
         sw_version=coordinator.server_version,
     )
 
+    _migrate_device_identifiers(hass, entry, coordinator.server_id, coordinator.user_id)
+
     entry.runtime_data = coordinator
     entry.async_on_unload(client.stop)
+    entry.async_on_unload(
+        hass.bus.async_listen(
+            EVENT_DEVICE_REGISTRY_UPDATED,
+            _handle_device_removed(coordinator),
+            event_filter=_device_removed_filter,
+        )
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
@@ -80,6 +99,78 @@ async def async_unload_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) ->
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+def _migrate_device_identifiers(
+    hass: HomeAssistant, entry: JellyfinConfigEntry, server_id: str, user_id: str
+) -> None:
+    """Migrate bare client device identifiers to the fully-scoped format.
+
+    Before this integration tracked devices persistently, client devices were
+    registered as (DOMAIN, device_id) with no server or user scoping. These
+    are updated in place to (DOMAIN, {server_id}-{user_id}-{device_id}),
+    preserving area assignments and name overrides.
+    """
+    device_registry = dr.async_get(hass)
+    full_prefix = f"{server_id}-{user_id}-"
+    for device_entry in dr.async_entries_for_config_entry(
+        device_registry, entry.entry_id
+    ):
+        for domain, identifier in device_entry.identifiers:
+            if domain != DOMAIN:
+                continue
+            if identifier == server_id or identifier.startswith(full_prefix):
+                # Server device or already fully scoped — nothing to do.
+                break
+            # Bare device_id with no prefix.
+            new_identifiers = (device_entry.identifiers - {(DOMAIN, identifier)}) | {
+                (DOMAIN, f"{server_id}-{user_id}-{identifier}")
+            }
+            device_registry.async_update_device(
+                device_entry.id,
+                new_identifiers=new_identifiers,
+            )
+            break
+
+
+@callback
+def _device_removed_filter(event_data: EventDeviceRegistryUpdatedData) -> bool:
+    """Filter device registry events to only removals."""
+    return event_data["action"] == "remove"
+
+
+def _handle_device_removed(
+    coordinator: JellyfinDataUpdateCoordinator,
+) -> Callable[[Event[EventDeviceRegistryUpdatedData]], None]:
+    """Return a handler that purges a removed Jellyfin client device from storage."""
+
+    @callback
+    def handle(event: Event[EventDeviceRegistryUpdatedData]) -> None:
+        # The event filter guarantees action == "remove". The remove payload
+        # includes a "device" snapshot with the identifiers of the deleted device.
+        # We narrow the type explicitly so mypy accepts the "device" key access.
+        if event.data["action"] != "remove":
+            return
+        device: dict[str, Any] = event.data["device"]
+        prefix = f"{coordinator.server_id}-{coordinator.user_id}-"
+        for domain, identifier in device.get("identifiers", []):
+            if domain != DOMAIN or not identifier.startswith(prefix):
+                continue
+            jellyfin_device_id = identifier[len(prefix) :]
+            if jellyfin_device_id not in coordinator.known_devices:
+                continue
+            coordinator.known_devices.pop(jellyfin_device_id)
+            coordinator.session_device_map = {
+                sid: did
+                for sid, did in coordinator.session_device_map.items()
+                if did != jellyfin_device_id
+            }
+            coordinator.device_player_ids.discard(jellyfin_device_id)
+            coordinator.device_remote_ids.discard(jellyfin_device_id)
+            coordinator.hass.async_create_task(coordinator.async_persist())
+            break
+
+    return handle
+
+
 async def async_remove_config_entry_device(
     hass: HomeAssistant, config_entry: JellyfinConfigEntry, device_entry: dr.DeviceEntry
 ) -> bool:
@@ -87,8 +178,11 @@ async def async_remove_config_entry_device(
     coordinator = config_entry.runtime_data
 
     return not device_entry.identifiers.intersection(
-        (
+        {
             (DOMAIN, coordinator.server_id),
-            *((DOMAIN, device_id) for device_id in coordinator.device_ids),
-        )
+            *(
+                (DOMAIN, f"{coordinator.server_id}-{coordinator.user_id}-{device_id}")
+                for device_id in coordinator.data
+            ),
+        }
     )

--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -7,14 +7,16 @@ from homeassistant.const import CONF_URL
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv, device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.device_registry import (
     EVENT_DEVICE_REGISTRY_UPDATED,
     EventDeviceRegistryUpdatedData,
 )
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.typing import ConfigType
 
 from .client_wrapper import CannotConnect, InvalidAuth, create_client, validate_input
-from .const import CONF_CLIENT_DEVICE_ID, DEFAULT_NAME, DOMAIN, PLATFORMS
+from .const import CONF_CLIENT_DEVICE_ID, DEFAULT_NAME, DOMAIN, LOGGER, PLATFORMS
 from .coordinator import JellyfinConfigEntry, JellyfinDataUpdateCoordinator
 from .services import async_setup_services
 
@@ -68,7 +70,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> 
         sw_version=coordinator.server_version,
     )
 
-    _migrate_device_identifiers(hass, entry, coordinator.server_id, coordinator.user_id)
+    _migrate_device_identifiers(
+        hass,
+        entry,
+        coordinator.server_id,
+        coordinator.user_id,
+        set(coordinator.known_devices) | set(coordinator.data),
+    )
+    # Migrate entity unique IDs before forwarding platform setups to prevent
+    # the remote platform from registering a new device-based unique ID before
+    # media_player can migrate the old session-based one, causing a collision.
+    _migrate_unique_ids(hass, coordinator)
 
     entry.runtime_data = coordinator
     entry.async_on_unload(client.stop)
@@ -99,8 +111,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) ->
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
 
+async def async_remove_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> None:
+    """Remove a config entry and clean up stored data."""
+    store: Store[dict[str, Any]] = Store(
+        hass, 1, f"jellyfin_{entry.entry_id}_devices"
+    )
+    await store.async_remove()
+
+
 def _migrate_device_identifiers(
-    hass: HomeAssistant, entry: JellyfinConfigEntry, server_id: str, user_id: str
+    hass: HomeAssistant,
+    entry: JellyfinConfigEntry,
+    server_id: str,
+    user_id: str,
+    known_device_ids: set[str],
 ) -> None:
     """Migrate bare client device identifiers to the fully-scoped format.
 
@@ -108,6 +132,10 @@ def _migrate_device_identifiers(
     registered as (DOMAIN, device_id) with no server or user scoping. These
     are updated in place to (DOMAIN, {server_id}-{user_id}-{device_id}),
     preserving area assignments and name overrides.
+
+    Only identifiers matching a known Jellyfin device ID for this entry are
+    migrated, preventing double-prefixing when multiple config entries share a
+    device registry entry.
     """
     device_registry = dr.async_get(hass)
     full_prefix = f"{server_id}-{user_id}-"
@@ -120,7 +148,9 @@ def _migrate_device_identifiers(
             if identifier == server_id or identifier.startswith(full_prefix):
                 # Server device or already fully scoped — nothing to do.
                 break
-            # Bare device_id with no prefix.
+            if identifier not in known_device_ids:
+                # Not a bare device ID belonging to this entry — skip.
+                break
             new_identifiers = (device_entry.identifiers - {(DOMAIN, identifier)}) | {
                 (DOMAIN, f"{server_id}-{user_id}-{identifier}")
             }
@@ -169,6 +199,55 @@ def _handle_device_removed(
             break
 
     return handle
+
+
+def _migrate_unique_ids(
+    hass: HomeAssistant, coordinator: JellyfinDataUpdateCoordinator
+) -> None:
+    """Migrate entity unique IDs from the session-based to device-based format.
+
+    The original integration used {server_id}-{session_id} as the unique ID.
+    Session IDs are transient, so these are migrated to the stable format
+    {server_id}-{user_id}-{device_id} using session_device_map to resolve
+    the device_id for any offline devices.
+    """
+    registry = er.async_get(hass)
+    device_registry = dr.async_get(hass)
+    session_to_device = {
+        **coordinator.session_device_map,
+        **{session["Id"]: device_id for device_id, session in coordinator.data.items()},
+    }
+    prefix = f"{coordinator.server_id}-"
+    full_prefix = f"{coordinator.server_id}-{coordinator.user_id}-"
+    for entity_entry in er.async_entries_for_config_entry(
+        registry, coordinator.config_entry.entry_id
+    ):
+        uid = entity_entry.unique_id
+        if not uid.startswith(prefix) or uid.startswith(full_prefix):
+            continue
+        suffix = uid[len(prefix) :]
+        device_id = session_to_device.get(suffix)
+        if device_id is None and entity_entry.device_id:
+            # No session map entry — fall back to device registry for devices
+            # that were offline on first upgrade (store not yet populated).
+            dev = device_registry.async_get(entity_entry.device_id)
+            if dev:
+                for dom, ident in dev.identifiers:
+                    if dom == DOMAIN and ident.startswith(full_prefix):
+                        device_id = ident[len(full_prefix) :]
+                        break
+        if device_id is None:
+            continue
+        new_unique_id = f"{coordinator.server_id}-{coordinator.user_id}-{device_id}"
+        LOGGER.debug(
+            "Migrating entity %s unique_id from %s to %s",
+            entity_entry.entity_id,
+            uid,
+            new_unique_id,
+        )
+        registry.async_update_entity(
+            entity_entry.entity_id, new_unique_id=new_unique_id
+        )
 
 
 async def async_remove_config_entry_device(

--- a/homeassistant/components/jellyfin/__init__.py
+++ b/homeassistant/components/jellyfin/__init__.py
@@ -6,8 +6,11 @@ from typing import Any
 from homeassistant.const import CONF_URL
 from homeassistant.core import Event, HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers import config_validation as cv, device_registry as dr
-from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import (
+    config_validation as cv,
+    device_registry as dr,
+    entity_registry as er,
+)
 from homeassistant.helpers.device_registry import (
     EVENT_DEVICE_REGISTRY_UPDATED,
     EventDeviceRegistryUpdatedData,
@@ -113,9 +116,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) ->
 
 async def async_remove_entry(hass: HomeAssistant, entry: JellyfinConfigEntry) -> None:
     """Remove a config entry and clean up stored data."""
-    store: Store[dict[str, Any]] = Store(
-        hass, 1, f"jellyfin_{entry.entry_id}_devices"
-    )
+    store: Store[dict[str, Any]] = Store(hass, 1, f"jellyfin_{entry.entry_id}_devices")
     await store.async_remove()
 
 

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -85,6 +85,12 @@ class JellyfinConfigFlow(ConfigFlow, domain=DOMAIN):
                 if server_name := server_info.get("Name"):
                     entry_title = server_name
 
+                # Migrate a legacy config entry whose unique_id is the bare
+                # user_id (pre-scoped format) before checking the new format.
+                await self.async_set_unique_id(user_id)
+                self._abort_if_unique_id_configured(
+                    updates={"unique_id": f"{server_info['Id']}-{user_id}"}
+                )
                 await self.async_set_unique_id(f"{server_info['Id']}-{user_id}")
                 self._abort_if_unique_id_configured()
 

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -87,11 +87,15 @@ class JellyfinConfigFlow(ConfigFlow, domain=DOMAIN):
 
                 # Migrate a legacy config entry whose unique_id is the bare
                 # user_id (pre-scoped format) before checking the new format.
+                new_unique_id = f"{server_info['Id']}-{user_id}"
                 await self.async_set_unique_id(user_id)
-                self._abort_if_unique_id_configured(
-                    updates={"unique_id": f"{server_info['Id']}-{user_id}"}
-                )
-                await self.async_set_unique_id(f"{server_info['Id']}-{user_id}")
+                if legacy_entry := self.hass.config_entries.async_entry_for_domain_unique_id(
+                    DOMAIN, user_id
+                ):
+                    self.hass.config_entries.async_update_entry(
+                        legacy_entry, unique_id=new_unique_id
+                    )
+                await self.async_set_unique_id(new_unique_id)
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -85,7 +85,7 @@ class JellyfinConfigFlow(ConfigFlow, domain=DOMAIN):
                 if server_name := server_info.get("Name"):
                     entry_title = server_name
 
-                await self.async_set_unique_id(user_id)
+                await self.async_set_unique_id(f"{server_info['Id']}-{user_id}")
                 self._abort_if_unique_id_configured()
 
                 return self.async_create_entry(

--- a/homeassistant/components/jellyfin/config_flow.py
+++ b/homeassistant/components/jellyfin/config_flow.py
@@ -89,8 +89,11 @@ class JellyfinConfigFlow(ConfigFlow, domain=DOMAIN):
                 # user_id (pre-scoped format) before checking the new format.
                 new_unique_id = f"{server_info['Id']}-{user_id}"
                 await self.async_set_unique_id(user_id)
-                if legacy_entry := self.hass.config_entries.async_entry_for_domain_unique_id(
-                    DOMAIN, user_id
+                if (
+                    legacy_entry
+                    := self.hass.config_entries.async_entry_for_domain_unique_id(
+                        DOMAIN, user_id
+                    )
                 ):
                     self.hass.config_entries.async_update_entry(
                         legacy_entry, unique_id=new_unique_id

--- a/homeassistant/components/jellyfin/coordinator.py
+++ b/homeassistant/components/jellyfin/coordinator.py
@@ -7,11 +7,26 @@ from jellyfin_apiclient_python import JellyfinClient
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from .const import CONF_CLIENT_DEVICE_ID, DOMAIN, LOGGER, USER_APP_NAME
 
 type JellyfinConfigEntry = ConfigEntry[JellyfinDataUpdateCoordinator]
+
+_STORAGE_VERSION = 1
+
+
+def _device_info_from_session(session: dict[str, Any]) -> dict[str, Any]:
+    """Extract stable device info from a session for persistent storage."""
+    return {
+        "DeviceId": session["DeviceId"],
+        "DeviceName": session["DeviceName"],
+        "Client": session["Client"],
+        "ApplicationVersion": session["ApplicationVersion"],
+        "Capabilities": session.get("Capabilities", {}),
+        "SupportsRemoteControl": session.get("SupportsRemoteControl", False),
+    }
 
 
 class JellyfinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, Any]]]):
@@ -42,13 +57,58 @@ class JellyfinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         self.client_device_id: str = config_entry.data[CONF_CLIENT_DEVICE_ID]
         self.user_id: str = user_id
 
+        # Persistent devices: seen at least once with SupportsPersistentIdentifier=True.
+        # Persisted to storage and used to recreate entities after HA restarts.
+        self.known_devices: dict[str, dict[str, Any]] = {}
+
+        # Ephemeral devices: active session with SupportsPersistentIdentifier=False
+        # (e.g. web browsers). In-memory only; reset each poll. Entities are created
+        # while the session is active and removed when it ends.
+        self.ephemeral_devices: dict[str, dict[str, Any]] = {}
+
+        # Persisted map of session_id -> device_id for unique_id migration.
+        # Allows migrating offline devices that had session-based unique_ids.
+        self.session_device_map: dict[str, str] = {}
+
+        # Tracks which device_ids already have HA entities created.
+        self.device_player_ids: set[str] = set()
+        self.device_remote_ids: set[str] = set()
+
+        # Legacy sets kept for compatibility — no longer used internally.
         self.session_ids: set[str] = set()
         self.remote_session_ids: set[str] = set()
         self.device_ids: set[str] = set()
 
+        self._store: Store[dict[str, Any]] = Store(
+            hass,
+            _STORAGE_VERSION,
+            f"jellyfin_{config_entry.entry_id}_devices",
+        )
+        self._store_loaded = False
+        self._store_needs_migration = False
+
     @override
     async def _async_update_data(self) -> dict[str, dict[str, Any]]:
-        """Get the latest data from Jellyfin."""
+        """Get the latest data from Jellyfin.
+
+        Returns active sessions keyed by device_id (not session_id).
+        Known but offline devices are tracked in self.known_devices but
+        not included in the returned dict.
+        """
+        if not self._store_loaded:
+            stored = await self._store.async_load()
+            if stored:
+                if "known_devices" in stored:
+                    # Current format
+                    self.known_devices = stored["known_devices"]
+                    self.session_device_map = stored.get("session_device_map", {})
+                else:
+                    # Legacy format: bare dict of known_devices (no session map).
+                    # Mark dirty so it gets rewritten in the new format.
+                    self.known_devices = stored
+                    self._store_needs_migration = True
+            self._store_loaded = True
+
         sessions = await self.hass.async_add_executor_job(
             self.api_client.jellyfin.sessions
         )
@@ -56,13 +116,49 @@ class JellyfinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
         if sessions is None:
             return {}
 
-        sessions_by_id: dict[str, dict[str, Any]] = {
-            session["Id"]: session
-            for session in sessions
-            if session["DeviceId"] != self.client_device_id
-            and session["Client"] != USER_APP_NAME
-        }
+        active: dict[str, dict[str, Any]] = {}
+        self.ephemeral_devices = {}
+        _store_dirty = self._store_needs_migration
+        self._store_needs_migration = False
+        for session in sessions:
+            if (
+                session["DeviceId"] == self.client_device_id
+                or session["Client"] == USER_APP_NAME
+            ):
+                continue
+            device_id = session["DeviceId"]
+            active[device_id] = session
+            if session.get("Capabilities", {}).get(
+                "SupportsPersistentIdentifier", False
+            ):
+                new_device_info = _device_info_from_session(session)
+                if self.known_devices.get(device_id) != new_device_info:
+                    self.known_devices[device_id] = new_device_info
+                    _store_dirty = True
+                new_session_map = session["Id"]
+                if self.session_device_map.get(new_session_map) != device_id:
+                    self.session_device_map[new_session_map] = device_id
+                    _store_dirty = True
+            else:
+                self.ephemeral_devices[device_id] = _device_info_from_session(session)
 
-        self.device_ids = {session["DeviceId"] for session in sessions_by_id.values()}
+        self.device_ids = set(active.keys())
 
-        return sessions_by_id
+        if _store_dirty:
+            await self._store.async_save(
+                {
+                    "known_devices": self.known_devices,
+                    "session_device_map": self.session_device_map,
+                }
+            )
+
+        return active
+
+    async def async_persist(self) -> None:
+        """Persist known_devices and session_device_map to storage."""
+        await self._store.async_save(
+            {
+                "known_devices": self.known_devices,
+                "session_device_map": self.session_device_map,
+            }
+        )

--- a/homeassistant/components/jellyfin/coordinator.py
+++ b/homeassistant/components/jellyfin/coordinator.py
@@ -135,9 +135,15 @@ class JellyfinDataUpdateCoordinator(DataUpdateCoordinator[dict[str, dict[str, An
                 if self.known_devices.get(device_id) != new_device_info:
                     self.known_devices[device_id] = new_device_info
                     _store_dirty = True
-                new_session_map = session["Id"]
-                if self.session_device_map.get(new_session_map) != device_id:
-                    self.session_device_map[new_session_map] = device_id
+                new_session_id = session["Id"]
+                if self.session_device_map.get(new_session_id) != device_id:
+                    # Prune stale entries for this device before adding the new one.
+                    self.session_device_map = {
+                        sid: did
+                        for sid, did in self.session_device_map.items()
+                        if did != device_id
+                    }
+                    self.session_device_map[new_session_id] = device_id
                     _store_dirty = True
             else:
                 self.ephemeral_devices[device_id] = _device_info_from_session(session)

--- a/homeassistant/components/jellyfin/diagnostics.py
+++ b/homeassistant/components/jellyfin/diagnostics.py
@@ -29,9 +29,9 @@ async def async_get_config_entry_diagnostics(
         },
         "sessions": [
             {
-                "id": session_id,
+                "id": session_data.get("Id"),
                 "user_id": session_data.get("UserId"),
-                "device_id": session_data.get("DeviceId"),
+                "device_id": device_id,
                 "device_name": session_data.get("DeviceName"),
                 "client_name": session_data.get("Client"),
                 "client_version": session_data.get("ApplicationVersion"),
@@ -39,6 +39,16 @@ async def async_get_config_entry_diagnostics(
                 "now_playing": session_data.get("NowPlayingItem"),
                 "play_state": session_data.get("PlayState"),
             }
-            for session_id, session_data in coordinator.data.items()
+            for device_id, session_data in coordinator.data.items()
+        ],
+        "known_devices": [
+            {
+                "device_id": device_id,
+                "device_name": device_info.get("DeviceName"),
+                "client_name": device_info.get("Client"),
+                "client_version": device_info.get("ApplicationVersion"),
+                "online": device_id in coordinator.data,
+            }
+            for device_id, device_info in coordinator.known_devices.items()
         ],
     }

--- a/homeassistant/components/jellyfin/entity.py
+++ b/homeassistant/components/jellyfin/entity.py
@@ -66,7 +66,11 @@ class JellyfinClientEntity(JellyfinEntity):
                 identifiers={
                     (
                         DOMAIN,
-                        f"{coordinator.server_id}-{coordinator.user_id}-{self.device_id}",
+                        (
+                            f"{coordinator.server_id}"
+                            f"-{coordinator.user_id}"
+                            f"-{self.device_id}"
+                        ),
                     )
                 },
                 manufacturer="Jellyfin",

--- a/homeassistant/components/jellyfin/entity.py
+++ b/homeassistant/components/jellyfin/entity.py
@@ -28,48 +28,71 @@ class JellyfinServerEntity(JellyfinEntity):
 
 
 class JellyfinClientEntity(JellyfinEntity):
-    """Defines a base Jellyfin client entity."""
+    """Defines a base Jellyfin client entity.
+
+    Persistent devices (SupportsPersistentIdentifier=True) are stored in
+    coordinator.known_devices, recreated after HA restarts, and show OFF when
+    the device is offline.
+
+    Ephemeral devices (SupportsPersistentIdentifier=False, e.g. web browsers)
+    are in coordinator.ephemeral_devices. They show unavailable when offline
+    and are not persisted across restarts.
+    """
 
     def __init__(
         self,
         coordinator: JellyfinDataUpdateCoordinator,
-        session_id: str,
+        device_id: str,
     ) -> None:
         """Initialize the Jellyfin entity."""
         super().__init__(coordinator)
-        self.session_id = session_id
-        self.device_id: str = self.session_data["DeviceId"]
-        self.device_name: str = self.session_data["DeviceName"]
-        self.client_name: str = self.session_data["Client"]
-        self.app_version: str = self.session_data["ApplicationVersion"]
-        self.capabilities: dict[str, Any] = self.session_data["Capabilities"]
+        self.device_id: str = device_id
 
-        if self.capabilities.get("SupportsPersistentIdentifier", False):
-            self._attr_device_info = DeviceInfo(
-                identifiers={(DOMAIN, self.device_id)},
-                manufacturer="Jellyfin",
-                model=self.client_name,
-                name=self.device_name,
-                sw_version=self.app_version,
-                via_device_id=dr.async_get_device_id_by_identifier(
-                    coordinator.hass,
-                    (DOMAIN, coordinator.server_id),
-                    config_entry_id=coordinator.config_entry.entry_id,
-                ),
-            )
-            self._attr_name = None
-        else:
-            self._attr_device_info = None
-            self._attr_has_entity_name = False
-            self._attr_name = self.device_name
+        device_info = (
+            coordinator.known_devices.get(device_id)
+            or coordinator.ephemeral_devices[device_id]
+        )
+        self._is_ephemeral: bool = device_id not in coordinator.known_devices
+        self.device_name: str = device_info["DeviceName"]
+        self.client_name: str = device_info["Client"]
+        self.app_version: str = device_info["ApplicationVersion"]
+        self.capabilities: dict[str, Any] = device_info.get("Capabilities", {})
+
+        self._attr_device_info = DeviceInfo(
+            identifiers={
+                (
+                    DOMAIN,
+                    f"{coordinator.server_id}-{coordinator.user_id}-{self.device_id}",
+                )
+            },
+            manufacturer="Jellyfin",
+            model=self.client_name,
+            name=self.device_name,
+            sw_version=self.app_version,
+            via_device=(DOMAIN, coordinator.server_id),
+        )
+        self._attr_name = None
 
     @property
-    def session_data(self) -> dict[str, Any]:
-        """Return the session data."""
-        return self.coordinator.data[self.session_id]
+    def session_data(self) -> dict[str, Any] | None:
+        """Return active session data, or None if the device is offline."""
+        return self.coordinator.data.get(self.device_id)
+
+    @property
+    def session_id(self) -> str | None:
+        """Return the active session ID, or None if the device is offline."""
+        session = self.session_data
+        return session["Id"] if session else None
 
     @property
     @override
     def available(self) -> bool:
-        """Return if entity is available."""
-        return super().available and self.session_id in self.coordinator.data
+        """Return True when the device is reachable.
+
+        Persistent devices show state OFF when offline (server is reachable,
+        device is just turned off). Ephemeral devices become unavailable when
+        their session ends, since they have no stable persistent presence.
+        """
+        if self._is_ephemeral:
+            return super().available and self.device_id in self.coordinator.data
+        return super().available

--- a/homeassistant/components/jellyfin/entity.py
+++ b/homeassistant/components/jellyfin/entity.py
@@ -2,7 +2,6 @@
 
 from typing import Any, override
 
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -58,20 +57,25 @@ class JellyfinClientEntity(JellyfinEntity):
         self.app_version: str = device_info["ApplicationVersion"]
         self.capabilities: dict[str, Any] = device_info.get("Capabilities", {})
 
-        self._attr_device_info = DeviceInfo(
-            identifiers={
-                (
-                    DOMAIN,
-                    f"{coordinator.server_id}-{coordinator.user_id}-{self.device_id}",
-                )
-            },
-            manufacturer="Jellyfin",
-            model=self.client_name,
-            name=self.device_name,
-            sw_version=self.app_version,
-            via_device=(DOMAIN, coordinator.server_id),
-        )
-        self._attr_name = None
+        if self._is_ephemeral:
+            self._attr_device_info = None
+            self._attr_has_entity_name = False
+            self._attr_name = self.device_name
+        else:
+            self._attr_device_info = DeviceInfo(
+                identifiers={
+                    (
+                        DOMAIN,
+                        f"{coordinator.server_id}-{coordinator.user_id}-{self.device_id}",
+                    )
+                },
+                manufacturer="Jellyfin",
+                model=self.client_name,
+                name=self.device_name,
+                sw_version=self.app_version,
+                via_device=(DOMAIN, coordinator.server_id),
+            )
+            self._attr_name = None
 
     @property
     def session_data(self) -> dict[str, Any] | None:

--- a/homeassistant/components/jellyfin/media_player.py
+++ b/homeassistant/components/jellyfin/media_player.py
@@ -15,6 +15,8 @@ from homeassistant.components.media_player import (
     SearchMediaQuery,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.dt import parse_datetime
 
@@ -35,15 +37,33 @@ async def async_setup_entry(
     """Set up Jellyfin media_player from a config entry."""
     coordinator = entry.runtime_data
 
+    # Run migration once at setup for online devices, and once more after the
+    # first coordinator update (when the store is loaded) for offline devices
+    # whose session_device_map entries were only just restored from disk.
+    _migrate_unique_ids(hass, coordinator)
+    _migration_done = False
+
     @callback
     def handle_coordinator_update() -> None:
-        """Add media player per session."""
+        """Add a media player for each known and ephemeral device."""
+        nonlocal _migration_done
+        if not _migration_done:
+            _migrate_unique_ids(hass, coordinator)
+            _migration_done = True
         entities: list[MediaPlayerEntity] = []
-        for session_id in coordinator.data:
-            if session_id not in coordinator.session_ids:
-                entity: MediaPlayerEntity = JellyfinMediaPlayer(coordinator, session_id)
-                LOGGER.debug("Creating media player for session: %s", session_id)
-                coordinator.session_ids.add(session_id)
+        for device_id in coordinator.known_devices:
+            if device_id not in coordinator.device_player_ids:
+                entity: MediaPlayerEntity = JellyfinMediaPlayer(coordinator, device_id)
+                LOGGER.debug("Creating media player for device: %s", device_id)
+                coordinator.device_player_ids.add(device_id)
+                entities.append(entity)
+        for device_id in coordinator.ephemeral_devices:
+            if device_id not in coordinator.device_player_ids:
+                entity = JellyfinMediaPlayer(coordinator, device_id)
+                LOGGER.debug(
+                    "Creating ephemeral media player for device: %s", device_id
+                )
+                coordinator.device_player_ids.add(device_id)
                 entities.append(entity)
         async_add_entities(entities)
 
@@ -52,31 +72,77 @@ async def async_setup_entry(
     entry.async_on_unload(coordinator.async_add_listener(handle_coordinator_update))
 
 
+def _migrate_unique_ids(
+    hass: HomeAssistant, coordinator: JellyfinDataUpdateCoordinator
+) -> None:
+    """Migrate entity unique IDs from the session-based to device-based format.
+
+    The original integration used {server_id}-{session_id} as the unique ID.
+    Session IDs are transient, so these are migrated to the stable format
+    {server_id}-{user_id}-{device_id} using session_device_map to resolve
+    the device_id for any offline devices.
+    """
+    registry = er.async_get(hass)
+    session_to_device = {
+        **coordinator.session_device_map,
+        **{session["Id"]: device_id for device_id, session in coordinator.data.items()},
+    }
+    prefix = f"{coordinator.server_id}-"
+    full_prefix = f"{coordinator.server_id}-{coordinator.user_id}-"
+    for entity_entry in er.async_entries_for_config_entry(
+        registry, coordinator.config_entry.entry_id
+    ):
+        uid = entity_entry.unique_id
+        if not uid.startswith(prefix) or uid.startswith(full_prefix):
+            continue
+        suffix = uid[len(prefix) :]
+        # suffix is a session_id from the original format
+        if suffix not in session_to_device:
+            continue
+        device_id = session_to_device[suffix]
+        new_unique_id = f"{coordinator.server_id}-{coordinator.user_id}-{device_id}"
+        LOGGER.debug(
+            "Migrating entity %s unique_id from %s to %s",
+            entity_entry.entity_id,
+            uid,
+            new_unique_id,
+        )
+        registry.async_update_entity(
+            entity_entry.entity_id, new_unique_id=new_unique_id
+        )
+
+
 class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):
     """Represents a Jellyfin Player device."""
 
     def __init__(
         self,
         coordinator: JellyfinDataUpdateCoordinator,
-        session_id: str,
+        device_id: str,
     ) -> None:
         """Initialize the Jellyfin Media Player entity."""
-        super().__init__(coordinator, session_id)
-        self._attr_unique_id = f"{coordinator.server_id}-{session_id}"
-
-        self.now_playing: dict[str, Any] | None = self.session_data.get(
-            "NowPlayingItem"
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = (
+            f"{coordinator.server_id}-{coordinator.user_id}-{device_id}"
         )
-        self.play_state: dict[str, Any] | None = self.session_data.get("PlayState")
+
+        session = self.session_data
+        self.now_playing: dict[str, Any] | None = (
+            session.get("NowPlayingItem") if session else None
+        )
+        self.play_state: dict[str, Any] | None = (
+            session.get("PlayState") if session else None
+        )
 
         self._update_from_session_data()
 
     @callback
     @override
     def _handle_coordinator_update(self) -> None:
-        if self.available:
-            self.now_playing = self.session_data.get("NowPlayingItem")
-            self.play_state = self.session_data.get("PlayState")
+        session = self.session_data
+        if session is not None:
+            self.now_playing = session.get("NowPlayingItem")
+            self.play_state = session.get("PlayState")
         else:
             self.now_playing = None
             self.play_state = None
@@ -104,13 +170,17 @@ class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):
         volume_muted = False
         volume_level = None
 
-        if self.available:
+        session = self.session_data
+        if session is not None:
             state = MediaPlayerState.IDLE
             media_position_updated = (
-                parse_datetime(self.session_data["LastPlaybackCheckIn"])
+                parse_datetime(session["LastPlaybackCheckIn"])
                 if self.now_playing
                 else None
             )
+        elif self.available:
+            # Server is reachable but device is offline.
+            state = MediaPlayerState.OFF
 
         if self.now_playing is not None:
             state = MediaPlayerState.PLAYING
@@ -217,35 +287,41 @@ class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):
 
         return features
 
+    def _require_session(self) -> str:
+        """Return the active session ID or raise if the device is offline."""
+        if (sid := self.session_id) is None:
+            raise HomeAssistantError("Device is offline")
+        return sid
+
     @override
     def media_seek(self, position: float) -> None:
         """Send seek command."""
         self.coordinator.api_client.jellyfin.remote_seek(
-            self.session_id, int(position * 10000000)
+            self._require_session(), int(position * 10000000)
         )
 
     @override
     def media_pause(self) -> None:
         """Send pause command."""
-        self.coordinator.api_client.jellyfin.remote_pause(self.session_id)
+        self.coordinator.api_client.jellyfin.remote_pause(self._require_session())
         self._attr_state = MediaPlayerState.PAUSED
         self.schedule_update_ha_state()
 
     @override
     def media_play(self) -> None:
         """Send play command."""
-        self.coordinator.api_client.jellyfin.remote_unpause(self.session_id)
+        self.coordinator.api_client.jellyfin.remote_unpause(self._require_session())
         self._attr_state = MediaPlayerState.PLAYING
         self.schedule_update_ha_state()
 
     def media_play_pause(self) -> None:
         """Send the PlayPause command to the session."""
-        self.coordinator.api_client.jellyfin.remote_playpause(self.session_id)
+        self.coordinator.api_client.jellyfin.remote_playpause(self._require_session())
 
     @override
     def media_stop(self) -> None:
         """Send stop command."""
-        self.coordinator.api_client.jellyfin.remote_stop(self.session_id)
+        self.coordinator.api_client.jellyfin.remote_stop(self._require_session())
         self._attr_state = MediaPlayerState.IDLE
         self.schedule_update_ha_state()
 
@@ -261,20 +337,20 @@ class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):
         elif enqueue == MediaPlayerEnqueue.ADD:
             command = "PlayLast"
         self.coordinator.api_client.jellyfin.remote_play_media(
-            self.session_id, [media_id], command
+            self._require_session(), [media_id], command
         )
 
     def play_media_shuffle(self, media_content_id: str) -> None:
         """Play a piece of media on shuffle."""
         self.coordinator.api_client.jellyfin.remote_play_media(
-            self.session_id, [media_content_id], "PlayShuffle"
+            self._require_session(), [media_content_id], "PlayShuffle"
         )
 
     @override
     def set_volume_level(self, volume: float) -> None:
         """Set volume level, range 0..1."""
         self.coordinator.api_client.jellyfin.remote_set_volume(
-            self.session_id, int(volume * 100)
+            self._require_session(), int(volume * 100)
         )
         self._attr_volume_level = volume
         self.schedule_update_ha_state()
@@ -282,10 +358,11 @@ class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):
     @override
     def mute_volume(self, mute: bool) -> None:
         """Mute the volume."""
+        sid = self._require_session()
         if mute:
-            self.coordinator.api_client.jellyfin.remote_mute(self.session_id)
+            self.coordinator.api_client.jellyfin.remote_mute(sid)
         else:
-            self.coordinator.api_client.jellyfin.remote_unmute(self.session_id)
+            self.coordinator.api_client.jellyfin.remote_unmute(sid)
         self._attr_is_volume_muted = mute
         self.schedule_update_ha_state()
 

--- a/homeassistant/components/jellyfin/media_player.py
+++ b/homeassistant/components/jellyfin/media_player.py
@@ -16,7 +16,6 @@ from homeassistant.components.media_player import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.util.dt import parse_datetime
 
@@ -37,19 +36,17 @@ async def async_setup_entry(
     """Set up Jellyfin media_player from a config entry."""
     coordinator = entry.runtime_data
 
-    # Run migration once at setup for online devices, and once more after the
-    # first coordinator update (when the store is loaded) for offline devices
-    # whose session_device_map entries were only just restored from disk.
-    _migrate_unique_ids(hass, coordinator)
-    _migration_done = False
-
     @callback
     def handle_coordinator_update() -> None:
         """Add a media player for each known and ephemeral device."""
-        nonlocal _migration_done
-        if not _migration_done:
-            _migrate_unique_ids(hass, coordinator)
-            _migration_done = True
+        # Prune ephemeral device IDs whose session has ended so new entities
+        # can be created if the device reconnects with a fresh device ID.
+        coordinator.device_player_ids -= {
+            did
+            for did in coordinator.device_player_ids
+            if did not in coordinator.known_devices
+            and did not in coordinator.ephemeral_devices
+        }
         entities: list[MediaPlayerEntity] = []
         for device_id in coordinator.known_devices:
             if device_id not in coordinator.device_player_ids:
@@ -70,46 +67,6 @@ async def async_setup_entry(
     handle_coordinator_update()
 
     entry.async_on_unload(coordinator.async_add_listener(handle_coordinator_update))
-
-
-def _migrate_unique_ids(
-    hass: HomeAssistant, coordinator: JellyfinDataUpdateCoordinator
-) -> None:
-    """Migrate entity unique IDs from the session-based to device-based format.
-
-    The original integration used {server_id}-{session_id} as the unique ID.
-    Session IDs are transient, so these are migrated to the stable format
-    {server_id}-{user_id}-{device_id} using session_device_map to resolve
-    the device_id for any offline devices.
-    """
-    registry = er.async_get(hass)
-    session_to_device = {
-        **coordinator.session_device_map,
-        **{session["Id"]: device_id for device_id, session in coordinator.data.items()},
-    }
-    prefix = f"{coordinator.server_id}-"
-    full_prefix = f"{coordinator.server_id}-{coordinator.user_id}-"
-    for entity_entry in er.async_entries_for_config_entry(
-        registry, coordinator.config_entry.entry_id
-    ):
-        uid = entity_entry.unique_id
-        if not uid.startswith(prefix) or uid.startswith(full_prefix):
-            continue
-        suffix = uid[len(prefix) :]
-        # suffix is a session_id from the original format
-        if suffix not in session_to_device:
-            continue
-        device_id = session_to_device[suffix]
-        new_unique_id = f"{coordinator.server_id}-{coordinator.user_id}-{device_id}"
-        LOGGER.debug(
-            "Migrating entity %s unique_id from %s to %s",
-            entity_entry.entity_id,
-            uid,
-            new_unique_id,
-        )
-        registry.async_update_entity(
-            entity_entry.entity_id, new_unique_id=new_unique_id
-        )
 
 
 class JellyfinMediaPlayer(JellyfinClientEntity, MediaPlayerEntity):

--- a/homeassistant/components/jellyfin/remote.py
+++ b/homeassistant/components/jellyfin/remote.py
@@ -12,6 +12,7 @@ from homeassistant.components.remote import (
     RemoteEntity,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import LOGGER
@@ -29,16 +30,23 @@ async def async_setup_entry(
 
     @callback
     def handle_coordinator_update() -> None:
-        """Add remote per session."""
+        """Add remote per device that supports remote control."""
         entities: list[RemoteEntity] = []
-        for session_id, session_data in coordinator.data.items():
-            if (
-                session_id not in coordinator.remote_session_ids
-                and session_data["SupportsRemoteControl"]
+        for device_id, device_info in coordinator.known_devices.items():
+            if device_id not in coordinator.device_remote_ids and device_info.get(
+                "SupportsRemoteControl", False
             ):
-                entity = JellyfinRemote(coordinator, session_id)
-                LOGGER.debug("Creating remote for session: %s", session_id)
-                coordinator.remote_session_ids.add(session_id)
+                entity = JellyfinRemote(coordinator, device_id)
+                LOGGER.debug("Creating remote for device: %s", device_id)
+                coordinator.device_remote_ids.add(device_id)
+                entities.append(entity)
+        for device_id, device_info in coordinator.ephemeral_devices.items():
+            if device_id not in coordinator.device_remote_ids and device_info.get(
+                "SupportsRemoteControl", False
+            ):
+                entity = JellyfinRemote(coordinator, device_id)
+                LOGGER.debug("Creating ephemeral remote for device: %s", device_id)
+                coordinator.device_remote_ids.add(device_id)
                 entities.append(entity)
         async_add_entities(entities)
 
@@ -53,27 +61,30 @@ class JellyfinRemote(JellyfinClientEntity, RemoteEntity):
     def __init__(
         self,
         coordinator: JellyfinDataUpdateCoordinator,
-        session_id: str,
+        device_id: str,
     ) -> None:
         """Initialize the Jellyfin Remote entity."""
-        super().__init__(coordinator, session_id)
-        self._attr_unique_id = f"{coordinator.server_id}-{session_id}"
+        super().__init__(coordinator, device_id)
+        self._attr_unique_id = (
+            f"{coordinator.server_id}-{coordinator.user_id}-{device_id}"
+        )
 
     @property
     @override
     def is_on(self) -> bool:
-        """Return if the client is on."""
-        return self.session_data["IsActive"] if self.session_data else False
+        """Return True if the device has an active session."""
+        session = self.session_data
+        return bool(session and session.get("IsActive", False))
 
     @override
     def send_command(self, command: Iterable[str], **kwargs: Any) -> None:
         """Send a command to the client."""
+        if (sid := self.session_id) is None:
+            raise HomeAssistantError("Device is offline")
         num_repeats = kwargs.get(ATTR_NUM_REPEATS, DEFAULT_NUM_REPEATS)
         delay = kwargs.get(ATTR_DELAY_SECS, DEFAULT_DELAY_SECS)
 
         for _ in range(num_repeats):
             for single_command in command:
-                self.coordinator.api_client.jellyfin.command(
-                    self.session_id, single_command
-                )
+                self.coordinator.api_client.jellyfin.command(sid, single_command)
                 time.sleep(delay)

--- a/homeassistant/components/jellyfin/remote.py
+++ b/homeassistant/components/jellyfin/remote.py
@@ -31,6 +31,14 @@ async def async_setup_entry(
     @callback
     def handle_coordinator_update() -> None:
         """Add remote per device that supports remote control."""
+        # Prune ephemeral device IDs whose session has ended so new entities
+        # can be created if the device reconnects with a fresh device ID.
+        coordinator.device_remote_ids -= {
+            did
+            for did in coordinator.device_remote_ids
+            if did not in coordinator.known_devices
+            and did not in coordinator.ephemeral_devices
+        }
         entities: list[RemoteEntity] = []
         for device_id, device_info in coordinator.known_devices.items():
             if device_id not in coordinator.device_remote_ids and device_info.get(

--- a/tests/components/jellyfin/conftest.py
+++ b/tests/components/jellyfin/conftest.py
@@ -30,7 +30,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_USERNAME: TEST_USERNAME,
             CONF_PASSWORD: TEST_PASSWORD,
         },
-        unique_id="USER-UUID",
+        unique_id="SERVER-UUID-USER-UUID",
     )
 
 

--- a/tests/components/jellyfin/snapshots/test_diagnostics.ambr
+++ b/tests/components/jellyfin/snapshots/test_diagnostics.ambr
@@ -10,6 +10,22 @@
       }),
       'title': 'Jellyfin',
     }),
+    'known_devices': list([
+      dict({
+        'client_name': 'Jellyfin for Developers',
+        'client_version': '1.0.0',
+        'device_id': 'DEVICE-UUID',
+        'device_name': 'JELLYFIN-DEVICE',
+        'online': True,
+      }),
+      dict({
+        'client_name': 'Jellyfin for Developers',
+        'client_version': '1.0.0',
+        'device_id': 'DEVICE-UUID-TWO',
+        'device_name': 'JELLYFIN-DEVICE-TWO',
+        'online': True,
+      }),
+    ]),
     'server': dict({
       'id': 'SERVER-UUID',
       'name': 'JELLYFIN-SERVER',

--- a/tests/components/jellyfin/test_init.py
+++ b/tests/components/jellyfin/test_init.py
@@ -1,5 +1,6 @@
 """Tests for the Jellyfin integration."""
 
+from datetime import timedelta
 from unittest.mock import MagicMock
 
 from homeassistant.components.jellyfin.const import DOMAIN
@@ -8,11 +9,12 @@ from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.setup import async_setup_component
+from homeassistant.util.dt import utcnow
 
 from . import async_load_json_fixture
 from .const import TEST_PASSWORD, TEST_URL, TEST_USERNAME
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 from tests.typing import WebSocketGenerator
 
 
@@ -119,11 +121,12 @@ async def test_device_remove_devices(
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
+    # Active device (in current sessions) — cannot be removed.
     device_entry = device_registry.async_get_device(
         identifiers={
             (
                 DOMAIN,
-                "DEVICE-UUID",
+                "SERVER-UUID-USER-UUID-DEVICE-UUID",
             )
         },
     )
@@ -139,3 +142,49 @@ async def test_device_remove_devices(
         old_device_entry.id, mock_config_entry.entry_id
     )
     assert response["success"]
+
+
+async def test_device_remove_offline_device(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    mock_config_entry: MockConfigEntry,
+    mock_jellyfin: MagicMock,
+    mock_api: MagicMock,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test that offline devices can be removed and are purged from storage."""
+    assert await async_setup_component(hass, "config", {})
+
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    coordinator = mock_config_entry.runtime_data
+
+    # Confirm DEVICE-UUID is known.
+    assert "DEVICE-UUID" in coordinator.known_devices
+
+    # Take the device offline — return empty sessions.
+    mock_api.sessions.return_value = []
+
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+
+    # Device is offline (not in coordinator.data) — removal should be allowed.
+    device_entry = device_registry.async_get_device(
+        identifiers={(DOMAIN, "SERVER-UUID-USER-UUID-DEVICE-UUID")}
+    )
+    assert device_entry is not None
+
+    ws_client = await hass_ws_client(hass)
+    response = await ws_client.remove_device(
+        device_entry.id, mock_config_entry.entry_id
+    )
+    assert response["success"]
+    await hass.async_block_till_done()
+
+    # Device must be purged from known_devices and entity tracking sets.
+    assert "DEVICE-UUID" not in coordinator.known_devices
+    assert "DEVICE-UUID" not in coordinator.device_player_ids
+    assert "DEVICE-UUID" not in coordinator.device_remote_ids

--- a/tests/components/jellyfin/test_media_player.py
+++ b/tests/components/jellyfin/test_media_player.py
@@ -31,6 +31,7 @@ from homeassistant.const import (
     ATTR_ENTITY_PICTURE,
     ATTR_FRIENDLY_NAME,
     ATTR_ICON,
+    STATE_UNAVAILABLE,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -73,7 +74,7 @@ async def test_media_player(
     assert entry
     assert entry.device_id
     assert entry.entity_category is None
-    assert entry.unique_id == "SERVER-UUID-SESSION-UUID"
+    assert entry.unique_id == "SERVER-UUID-USER-UUID-DEVICE-UUID"
 
     assert len(mock_api.sessions.mock_calls) == 1
     async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
@@ -91,7 +92,7 @@ async def test_media_player(
     assert device.connections == set()
     assert device.entry_type is None
     assert device.hw_version is None
-    assert device.identifiers == {(DOMAIN, "DEVICE-UUID")}
+    assert device.identifiers == {(DOMAIN, "SERVER-UUID-USER-UUID-DEVICE-UUID")}
     assert device.manufacturer == "Jellyfin"
     assert device.name == "JELLYFIN-DEVICE"
     assert device.sw_version == "1.0.0"
@@ -135,9 +136,9 @@ async def test_media_player_music(
 
     entry = entity_registry.async_get(state.entity_id)
     assert entry
-    assert entry.device_id is None
+    assert entry.device_id is not None
     assert entry.entity_category is None
-    assert entry.unique_id == "SERVER-UUID-SESSION-UUID-FOUR"
+    assert entry.unique_id == "SERVER-UUID-USER-UUID-DEVICE-UUID-FOUR"
 
 
 async def test_services(
@@ -646,3 +647,58 @@ async def test_mute_requires_both_commands(
     # But should still have other features
     assert features_six & MediaPlayerEntityFeature.PLAY
     assert features_six & MediaPlayerEntityFeature.VOLUME_SET
+
+
+async def test_ephemeral_device_unavailable_when_session_ends(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    init_integration: MockConfigEntry,
+    mock_jellyfin: MagicMock,
+    mock_api: MagicMock,
+) -> None:
+    """Test that ephemeral device entities become unavailable when their session ends.
+
+    Ephemeral devices (SupportsPersistentIdentifier=False) are not persisted,
+    but their entities remain in the registry and show unavailable when offline
+    rather than being removed.
+    """
+    # DEVICE-UUID-SIX is ephemeral — verify it has an entity initially
+    assert hass.states.get("media_player.jellyfin_device_six") is not None
+
+    # DEVICE-UUID is persistent — verify it exists too
+    assert hass.states.get("media_player.jellyfin_device") is not None
+
+    # Switch to sessions-new-client.json which drops DEVICE-UUID-SIX
+    mock_api.sessions.return_value = await async_load_json_fixture(
+        hass, "sessions-new-client.json"
+    )
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+
+    # Ephemeral device SIX should be unavailable but still in the registry
+    state = hass.states.get("media_player.jellyfin_device_six")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    # Persistent device should still exist and remain active (still in sessions-new-client)
+    state = hass.states.get("media_player.jellyfin_device")
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+
+
+async def test_persistent_device_remains_offline(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+    mock_jellyfin: MagicMock,
+    mock_api: MagicMock,
+) -> None:
+    """Test that persistent devices stay in HA showing OFF when their session ends."""
+    assert hass.states.get("media_player.jellyfin_device") is not None
+
+    mock_api.sessions.return_value = []
+    async_fire_time_changed(hass, utcnow() + timedelta(seconds=10))
+    await hass.async_block_till_done()
+
+    state = hass.states.get("media_player.jellyfin_device")
+    assert state is not None
+    assert state.state == MediaPlayerState.OFF

--- a/tests/components/jellyfin/test_media_player.py
+++ b/tests/components/jellyfin/test_media_player.py
@@ -136,7 +136,7 @@ async def test_media_player_music(
 
     entry = entity_registry.async_get(state.entity_id)
     assert entry
-    assert entry.device_id is not None
+    assert entry.device_id is None  # ephemeral device has no device registry entry
     assert entry.entity_category is None
     assert entry.unique_id == "SERVER-UUID-USER-UUID-DEVICE-UUID-FOUR"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
There are many open issues for Jellyfin that relate to the current ephemeral state of entities in the integration.  This PR aims to rectify that by creating persistent devices while rethinking the fundamental ID strategy to allow the future implementation of multiple instances of the integration.

This PR contains a migration to remain backwards compatible.  It also continues to use the ephemeral Sessions endpoint, instead of the more reliable Devices endpoint, to allow compatibility with non-admin accounts.

There are few other opinionated changes/concepts I introduce here:
- The concept of devices that support persistent identifiers, provided by the Jellyfin API, is now used to determine whether or not a device should persist after session ends.  i.e. A browser connection to a Jellyfin server will create new device on every connection, so they should be considered ephemeral and not persist in HA on restart.  This also paves the way for a future PR that allows the integration to not automatically create entities for ephemeral devices.  When an ephemeral device goes offline, the entity/device is removed from the integration and becomes unavailable.
- The Sessions API is still used instead of the Devices endpoint even though this requires more complicated logic and the use of home assistant storage because it allows users to be non-admin.  The Devices endpoint is admin only.
- The underlying unique ID is migrated from (DOMAIN, device_id) to (DOMAIN, {server_id}-{user_id}-{device_id}) to prevent duplicates, and allow future expansion to multiple instances of the integration.
- There is a handler that listens for the removal of devices to perform cleanup of the local known_devices list.  This is list is necessary to allow the Sessions API to be used while keeping devices persistent.  The alternative is to use the Devices API endpoint, but that is a breaking change that requires admin-only integration to Jellyfin.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #165063 #163187 #146995 #108276
- This PR is related to issue: #159280 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
