### PR TITLE
Use dt_util.naive_now() in upnp tests

### DIFF
--- a/tests/components/upnp/conftest.py
+++ b/tests/components/upnp/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable, Coroutine, Generator
 import copy
-from datetime import datetime
 import socket
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, create_autospec, patch
@@ -32,6 +31,7 @@ from homeassistant.helpers.service_info.ssdp import (
     ATTR_UPNP_UDN,
     SsdpServiceInfo,
 )
+from homeassistant.util import dt as dt_util
 
 from tests.common import MockConfigEntry
 
@@ -93,7 +93,7 @@ def mock_igd_device(mock_async_create_device) -> IgdDevice:
     mock_igd_device.device = mock_upnp_device
 
     mock_igd_device.async_get_traffic_and_status_data.return_value = IgdState(
-        timestamp=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+        timestamp=dt_util.naive_now(),
         bytes_received=0,
         bytes_sent=0,
         packets_received=0,

--- a/tests/components/upnp/test_binary_sensor.py
+++ b/tests/components/upnp/test_binary_sensor.py
@@ -1,6 +1,6 @@
 """Tests for UPnP/IGD binary_sensor."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from async_upnp_client.profiles.igd import IgdDevice, IgdState
 
@@ -22,7 +22,7 @@ async def test_upnp_binary_sensors(
     # Second poll.
     mock_igd_device: IgdDevice = mock_config_entry.igd_device
     mock_igd_device.async_get_traffic_and_status_data.return_value = IgdState(
-        timestamp=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+        timestamp=dt_util.naive_now(),
         bytes_received=0,
         bytes_sent=0,
         packets_received=0,

--- a/tests/components/upnp/test_sensor.py
+++ b/tests/components/upnp/test_sensor.py
@@ -1,6 +1,6 @@
 """Tests for UPnP/IGD sensor."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from async_upnp_client.profiles.igd import IgdDevice, IgdState
 import pytest
@@ -53,7 +53,7 @@ async def test_upnp_sensors(
     # Second poll.
     mock_igd_device: IgdDevice = mock_config_entry.igd_device
     mock_igd_device.async_get_traffic_and_status_data.return_value = IgdState(
-        timestamp=datetime.now(),  # pylint: disable=home-assistant-enforce-naive-now
+        timestamp=dt_util.naive_now(),
         bytes_received=10240,
         bytes_sent=20480,
         packets_received=30,


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Avoid a naive datetime.now() in upnp. Fixes #177839


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177839
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
