### PR TITLE
Handle inconsistence api response in Husqvarna Automower

### DIFF
--- a/homeassistant/components/husqvarna_automower/calendar.py
+++ b/homeassistant/components/husqvarna_automower/calendar.py
@@ -74,10 +74,10 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
         if not program_event:
             return None
         work_area_name = None
-        if self.mower_attributes.work_area_dict and program_event.work_area_id:
-            work_area_name = self.mower_attributes.work_area_dict[
-                program_event.work_area_id
-            ]
+        if (work_area_dict := self.mower_attributes.work_area_dict) and (
+            work_area_id := program_event.work_area_id
+        ) is not None:
+            work_area_name = work_area_dict.get(work_area_id)
         name_str = make_name_string(work_area_name, program_event.schedule_no)
         return CalendarEvent(
             summary=f"{self.device_name} {name_str}",
@@ -104,10 +104,10 @@ class AutomowerCalendarEntity(AutomowerBaseEntity, CalendarEntity):
         calendar_events = []
         for program_event in cursor:
             work_area_name = None
-            if self.mower_attributes.work_area_dict and program_event.work_area_id:
-                work_area_name = self.mower_attributes.work_area_dict[
-                    program_event.work_area_id
-                ]
+            if (work_area_dict := self.mower_attributes.work_area_dict) and (
+                work_area_id := program_event.work_area_id
+            ) is not None:
+                work_area_name = work_area_dict.get(work_area_id)
             name_str = make_name_string(work_area_name, program_event.schedule_no)
             calendar_events.append(
                 CalendarEvent(

--- a/homeassistant/components/husqvarna_automower/coordinator.py
+++ b/homeassistant/components/husqvarna_automower/coordinator.py
@@ -249,6 +249,7 @@ class AutomowerDataUpdateCoordinator(DataUpdateCoordinator[MowerDictionary]):
             for mower_id, mower_data in self.data.items()
             if mower_data.capabilities.stay_out_zones
             and mower_data.stay_out_zones is not None
+            and mower_data.stay_out_zones.zones is not None
         }
 
         entity_registry = er.async_get(self.hass)

--- a/homeassistant/components/husqvarna_automower/entity.py
+++ b/homeassistant/components/husqvarna_automower/entity.py
@@ -4,7 +4,7 @@ import asyncio
 from collections.abc import Callable, Coroutine
 import functools
 import logging
-from typing import TYPE_CHECKING, Any, Concatenate, overload, override
+from typing import Any, Concatenate, overload, override
 
 from aioautomower.exceptions import ApiError
 from aioautomower.model import MowerActivities, MowerAttributes, MowerStates, WorkArea
@@ -170,22 +170,26 @@ class WorkAreaAvailableEntity(AutomowerControlEntity):
         self.work_area_id = work_area_id
 
     @property
-    def work_areas(self) -> dict[int, WorkArea]:
+    def work_areas(self) -> dict[int, WorkArea] | None:
         """Get the work areas from the mower attributes."""
-        if TYPE_CHECKING:
-            assert self.mower_attributes.work_areas is not None
         return self.mower_attributes.work_areas
 
     @property
-    def work_area_attributes(self) -> WorkArea:
+    def work_area_attributes(self) -> WorkArea | None:
         """Get the work area attributes of the current work area."""
-        return self.work_areas[self.work_area_id]
+        if (work_areas := self.work_areas) is None:
+            return None
+        return work_areas.get(self.work_area_id)
 
     @property
     @override
     def available(self) -> bool:
         """Return True if the work area is available and the mower has no errors."""
-        return super().available and self.work_area_id in self.work_areas
+        return (
+            super().available
+            and self.work_areas is not None
+            and self.work_area_id in self.work_areas
+        )
 
 
 class WorkAreaControlEntity(WorkAreaAvailableEntity, AutomowerControlEntity):

--- a/homeassistant/components/husqvarna_automower/lawn_mower.py
+++ b/homeassistant/components/husqvarna_automower/lawn_mower.py
@@ -1,7 +1,7 @@
 """Husqvarna Automower lawn mower entity."""
 
 from datetime import timedelta
-from typing import TYPE_CHECKING, override
+from typing import override
 
 from aioautomower.model import MowerActivities, MowerStates, WorkArea
 
@@ -141,9 +141,7 @@ class AutomowerLawnMowerEntity(AutomowerBaseEntity, LawnMowerEntity):
             raise ServiceValidationError(
                 translation_domain=DOMAIN, translation_key="work_areas_not_supported"
             )
-        if TYPE_CHECKING:
-            assert self.work_areas is not None
-        if work_area_id not in self.work_areas:
+        if (work_areas := self.work_areas) is None or work_area_id not in work_areas:
             raise ServiceValidationError(
                 translation_domain=DOMAIN, translation_key="work_area_not_existing"
             )

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -201,9 +201,8 @@ class WorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
         super().__init__(mower_id, coordinator, work_area_id)
         self.entity_description = description
         self._attr_unique_id = f"{mower_id}_{work_area_id}_{description.key}"
-        self._attr_translation_placeholders = {
-            "work_area": self.work_area_attributes.name
-        }
+        if (work_area := self.work_area_attributes) is not None:
+            self._attr_translation_placeholders = {"work_area": work_area.name}
 
     @property
     @override
@@ -215,9 +214,11 @@ class WorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
 
     @property
     @override
-    def native_value(self) -> float:
+    def native_value(self) -> float | None:
         """Return the state of the number."""
-        return self.entity_description.value_fn(self.work_area_attributes)
+        if (work_area := self.work_area_attributes) is None:
+            return None
+        return self.entity_description.value_fn(work_area)
 
     @handle_sending_exception(poll_after_sending=True)
     @override

--- a/homeassistant/components/husqvarna_automower/number.py
+++ b/homeassistant/components/husqvarna_automower/number.py
@@ -201,8 +201,12 @@ class WorkAreaNumberEntity(WorkAreaControlEntity, NumberEntity):
         super().__init__(mower_id, coordinator, work_area_id)
         self.entity_description = description
         self._attr_unique_id = f"{mower_id}_{work_area_id}_{description.key}"
-        if (work_area := self.work_area_attributes) is not None:
-            self._attr_translation_placeholders = {"work_area": work_area.name}
+        if TYPE_CHECKING:
+            # Work area does not get created if it is None
+            assert self.work_area_attributes is not None
+        self._attr_translation_placeholders = {
+            "work_area": self.work_area_attributes.name
+        }
 
     @property
     @override

--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 from operator import attrgetter
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from aioautomower.model import (
     ExternalReasons,
@@ -478,8 +478,11 @@ class WorkAreaSensorEntity(WorkAreaAvailableEntity, SensorEntity):
         super().__init__(mower_id, coordinator, work_area_id)
         self.entity_description = description
         self._attr_unique_id = f"{mower_id}_{work_area_id}_{description.key}"
-        if (work_area := self.work_area_attributes) is not None:
-            self._attr_translation_placeholders = {"work_area": work_area.name}
+        if TYPE_CHECKING:
+            assert self.work_area_attributes is not None
+        self._attr_translation_placeholders = {
+            "work_area": self.work_area_attributes.name
+        }
 
     @property
     @override

--- a/homeassistant/components/husqvarna_automower/sensor.py
+++ b/homeassistant/components/husqvarna_automower/sensor.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 import logging
 from operator import attrgetter
-from typing import TYPE_CHECKING, Any, override
+from typing import Any, override
 
 from aioautomower.model import (
     ExternalReasons,
@@ -98,12 +98,7 @@ def _get_restricted_reason(data: MowerAttributes) -> str:
 @callback
 def _get_work_area_names(data: MowerAttributes) -> list[str]:
     """Return a list with all work area names."""
-    if TYPE_CHECKING:
-        # Sensor does not get created if it is None
-        assert data.work_areas is not None
-    work_area_list = [
-        data.work_areas[work_area_id].name for work_area_id in data.work_areas
-    ]
+    work_area_list = [work_area.name for work_area in (data.work_areas or {}).values()]
     work_area_list.append(STATE_NO_WORK_AREA_ACTIVE)
     return work_area_list
 
@@ -111,14 +106,12 @@ def _get_work_area_names(data: MowerAttributes) -> list[str]:
 @callback
 def _get_current_work_area_name(data: MowerAttributes) -> str:
     """Return the name of the current work area."""
-    if TYPE_CHECKING:
-        # Sensor does not get created if values are None
-        assert data.work_areas is not None
+    work_areas = data.work_areas or {}
     if (
         data.mower.work_area_id is not None
-        and data.mower.work_area_id in data.work_areas
+        and (work_area := work_areas.get(data.mower.work_area_id)) is not None
     ):
-        return data.work_areas[data.mower.work_area_id].name
+        return work_area.name
 
     return STATE_NO_WORK_AREA_ACTIVE
 
@@ -133,10 +126,9 @@ def _get_remaining_charging_time(data: MowerAttributes) -> int | None:
 @callback
 def _get_current_work_area_dict(data: MowerAttributes) -> Mapping[str, Any]:
     """Return the name of the current work area."""
-    if TYPE_CHECKING:
-        # Sensor does not get created if it is None
-        assert data.work_areas is not None
-    return {ATTR_WORK_AREA_ID_ASSIGNMENT: data.work_area_dict}
+    return {
+        ATTR_WORK_AREA_ID_ASSIGNMENT: data.work_area_dict if data.work_areas else {}
+    }
 
 
 @callback
@@ -383,8 +375,8 @@ async def async_setup_entry(
                         mower_id, coordinator, description, work_area_id
                     )
                     for description in WORK_AREA_SENSOR_TYPES
-                    for work_area_id in _work_areas
-                    if description.exists_fn(_work_areas[work_area_id])
+                    for work_area_id, work_area in _work_areas.items()
+                    if description.exists_fn(work_area)
                 )
         entities.extend(
             AutomowerSensorEntity(mower_id, coordinator, description)
@@ -394,16 +386,15 @@ async def async_setup_entry(
     async_add_entities(entities)
 
     def _async_add_new_work_areas(mower_id: str, work_area_ids: set[int]) -> None:
-        mower_data = coordinator.data[mower_id]
-        if mower_data.work_areas is None:
+        if (work_areas := coordinator.data[mower_id].work_areas) is None:
             return
 
         async_add_entities(
             WorkAreaSensorEntity(mower_id, coordinator, description, work_area_id)
             for description in WORK_AREA_SENSOR_TYPES
             for work_area_id in work_area_ids
-            if work_area_id in mower_data.work_areas
-            and description.exists_fn(mower_data.work_areas[work_area_id])
+            if (work_area := work_areas.get(work_area_id)) is not None
+            and description.exists_fn(work_area)
         )
 
     def _async_add_new_devices(mower_ids: set[str]) -> None:
@@ -464,7 +455,11 @@ class AutomowerSensorEntity(AutomowerBaseEntity, SensorEntity):
     @override
     def available(self) -> bool:
         """Return the available attribute of the entity."""
-        return super().available and self.native_value is not None
+        return (
+            super().available
+            and self.entity_description.exists_fn(self.mower_attributes)
+            and self.native_value is not None
+        )
 
 
 class WorkAreaSensorEntity(WorkAreaAvailableEntity, SensorEntity):
@@ -483,15 +478,16 @@ class WorkAreaSensorEntity(WorkAreaAvailableEntity, SensorEntity):
         super().__init__(mower_id, coordinator, work_area_id)
         self.entity_description = description
         self._attr_unique_id = f"{mower_id}_{work_area_id}_{description.key}"
-        self._attr_translation_placeholders = {
-            "work_area": self.work_area_attributes.name
-        }
+        if (work_area := self.work_area_attributes) is not None:
+            self._attr_translation_placeholders = {"work_area": work_area.name}
 
     @property
     @override
-    def native_value(self) -> StateType | datetime:
+    def native_value(self) -> StateType | datetime | None:
         """Return the state of the sensor."""
-        return self.entity_description.value_fn(self.work_area_attributes)
+        if (work_area := self.work_area_attributes) is None:
+            return None
+        return self.entity_description.value_fn(work_area)
 
     @property
     @override

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -1,7 +1,7 @@
 """Creates a switch entity for the mower."""
 
 import logging
-from typing import TYPE_CHECKING, Any, override
+from typing import Any, override
 
 from aioautomower.model import MowerModes, StayOutZones, Zone
 
@@ -140,31 +140,42 @@ class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
         self._attr_unique_id = (
             f"{self.mower_id}_{stay_out_zone_uid}_{self._attr_translation_key}"
         )
-        self._attr_translation_placeholders = {"stay_out_zone": self.stay_out_zone.name}
+        if (stay_out_zone := self.stay_out_zone) is not None:
+            self._attr_translation_placeholders = {"stay_out_zone": stay_out_zone.name}
 
     @property
-    def stay_out_zones(self) -> StayOutZones:
+    def stay_out_zones(self) -> StayOutZones | None:
         """Return all stay out zones."""
-        if TYPE_CHECKING:
-            assert self.mower_attributes.stay_out_zones is not None
         return self.mower_attributes.stay_out_zones
 
     @property
-    def stay_out_zone(self) -> Zone:
+    def stay_out_zone(self) -> Zone | None:
         """Return the specific stay out zone."""
-        return self.stay_out_zones.zones[self.stay_out_zone_uid]
+        if (
+            stay_out_zones := self.stay_out_zones
+        ) is None or stay_out_zones.zones is None:
+            return None
+        return stay_out_zones.zones.get(self.stay_out_zone_uid)
 
     @property
     @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
-        return self.stay_out_zone.enabled
+        if (stay_out_zone := self.stay_out_zone) is None:
+            return False
+        return stay_out_zone.enabled
 
     @property
     @override
     def available(self) -> bool:
-        """Return True if the device is available and the zones are not `dirty`."""
-        return super().available and not self.stay_out_zones.dirty
+        if not super().available:
+            return False
+        stay_out_zones = self.stay_out_zones
+        if stay_out_zones is None or stay_out_zones.zones is None:
+            return False
+        if self.stay_out_zone_uid not in stay_out_zones.zones:
+            return False
+        return not stay_out_zones.dirty
 
     @handle_sending_exception(poll_after_sending=True)
     @override
@@ -197,18 +208,20 @@ class WorkAreaSwitchEntity(WorkAreaControlEntity, SwitchEntity):
         key = "work_area"
         self._attr_translation_key = _work_area_translation_key(work_area_id, key)
         self._attr_unique_id = f"{mower_id}_{work_area_id}_{key}"
-        if self.work_area_attributes.name == "my_lawn":
-            self._attr_translation_placeholders = {
-                "work_area": self.work_area_attributes.name
-            }
+        if (work_area := self.work_area_attributes) is None:
+            return
+        if work_area.name == "my_lawn":
+            self._attr_translation_placeholders = {"work_area": work_area.name}
         else:
-            self._attr_name = self.work_area_attributes.name
+            self._attr_name = work_area.name
 
     @property
     @override
     def is_on(self) -> bool:
         """Return the state of the switch."""
-        return self.work_area_attributes.enabled
+        if (work_area := self.work_area_attributes) is None:
+            return False
+        return work_area.enabled
 
     @handle_sending_exception(poll_after_sending=True)
     @override

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -38,7 +38,7 @@ async def async_setup_entry(
     for mower_id in coordinator.data:
         if coordinator.data[mower_id].capabilities.stay_out_zones:
             _stay_out_zones = coordinator.data[mower_id].stay_out_zones
-            if _stay_out_zones is not None:
+            if _stay_out_zones is not None and _stay_out_zones.zones is not None:
                 entities.extend(
                     StayOutZoneSwitchEntity(coordinator, mower_id, stay_out_zone_uid)
                     for stay_out_zone_uid in _stay_out_zones.zones

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -1,7 +1,7 @@
 """Creates a switch entity for the mower."""
 
 import logging
-from typing import Any, override
+from typing import TYPE_CHECKING, Any, override
 
 from aioautomower.model import MowerModes, StayOutZones, Zone
 
@@ -140,8 +140,9 @@ class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
         self._attr_unique_id = (
             f"{self.mower_id}_{stay_out_zone_uid}_{self._attr_translation_key}"
         )
-        if (stay_out_zone := self.stay_out_zone) is not None:
-            self._attr_translation_placeholders = {"stay_out_zone": stay_out_zone.name}
+        if TYPE_CHECKING:
+            assert self.stay_out_zone is not None
+        self._attr_translation_placeholders = {"stay_out_zone": self.stay_out_zone.name}
 
     @property
     def stay_out_zones(self) -> StayOutZones | None:
@@ -159,10 +160,10 @@ class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
 
     @property
     @override
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return the state of the switch."""
         if (stay_out_zone := self.stay_out_zone) is None:
-            return False
+            return None
         return stay_out_zone.enabled
 
     @property
@@ -208,19 +209,21 @@ class WorkAreaSwitchEntity(WorkAreaControlEntity, SwitchEntity):
         key = "work_area"
         self._attr_translation_key = _work_area_translation_key(work_area_id, key)
         self._attr_unique_id = f"{mower_id}_{work_area_id}_{key}"
-        if (work_area := self.work_area_attributes) is None:
-            return
-        if work_area.name == "my_lawn":
-            self._attr_translation_placeholders = {"work_area": work_area.name}
+        if TYPE_CHECKING:
+            assert self.work_area_attributes is not None
+        if self.work_area_attributes.name == "my_lawn":
+            self._attr_translation_placeholders = {
+                "work_area": self.work_area_attributes.name
+            }
         else:
-            self._attr_name = work_area.name
+            self._attr_name = self.work_area_attributes.name
 
     @property
     @override
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return the state of the switch."""
         if (work_area := self.work_area_attributes) is None:
-            return False
+            return None
         return work_area.enabled
 
     @handle_sending_exception(poll_after_sending=True)

--- a/homeassistant/components/husqvarna_automower/switch.py
+++ b/homeassistant/components/husqvarna_automower/switch.py
@@ -152,9 +152,7 @@ class StayOutZoneSwitchEntity(AutomowerControlEntity, SwitchEntity):
     @property
     def stay_out_zone(self) -> Zone | None:
         """Return the specific stay out zone."""
-        if (
-            stay_out_zones := self.stay_out_zones
-        ) is None or stay_out_zones.zones is None:
+        if (stay_out_zones := self.stay_out_zones) is None:
             return None
         return stay_out_zones.zones.get(self.stay_out_zone_uid)
 

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -128,6 +128,25 @@ async def test_work_area_sensor(
     state = hass.states.get("sensor.garden_test_mower_1_work_area")
     assert state.state == "no_work_area_active"
 
+    work_areas = values[TEST_MOWER_ID].work_areas
+    values[TEST_MOWER_ID].capabilities.work_areas = False
+    values[TEST_MOWER_ID].work_areas = None
+    mock_automower_client.get_status.return_value = values
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    for entity_id in (
+        "sensor.garden_test_mower_1_work_area",
+        "sensor.garden_test_mower_1_front_lawn_progress",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_UNAVAILABLE
+
+    values[TEST_MOWER_ID].capabilities.work_areas = True
+    values[TEST_MOWER_ID].work_areas = work_areas
+
 
 async def test_restricted_reason_sensor(
     hass: HomeAssistant,

--- a/tests/components/husqvarna_automower/test_sensor.py
+++ b/tests/components/husqvarna_automower/test_sensor.py
@@ -128,7 +128,6 @@ async def test_work_area_sensor(
     state = hass.states.get("sensor.garden_test_mower_1_work_area")
     assert state.state == "no_work_area_active"
 
-    work_areas = values[TEST_MOWER_ID].work_areas
     values[TEST_MOWER_ID].capabilities.work_areas = False
     values[TEST_MOWER_ID].work_areas = None
     mock_automower_client.get_status.return_value = values
@@ -143,9 +142,6 @@ async def test_work_area_sensor(
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
-
-    values[TEST_MOWER_ID].capabilities.work_areas = True
-    values[TEST_MOWER_ID].work_areas = work_areas
 
 
 async def test_restricted_reason_sensor(

--- a/tests/components/husqvarna_automower/test_switch.py
+++ b/tests/components/husqvarna_automower/test_switch.py
@@ -77,9 +77,7 @@ async def test_work_area_and_stay_out_zone_entities_unavailable_without_data(
     """Test entities become unavailable when capability data disappears."""
     await setup_integration(hass, mock_config_entry)
 
-    values[TEST_MOWER_ID].capabilities.work_areas = False
     values[TEST_MOWER_ID].work_areas = None
-    values[TEST_MOWER_ID].capabilities.stay_out_zones = False
     values[TEST_MOWER_ID].stay_out_zones = None
     mock_automower_client.get_status.return_value = values
     freezer.tick(SCAN_INTERVAL)

--- a/tests/components/husqvarna_automower/test_switch.py
+++ b/tests/components/husqvarna_automower/test_switch.py
@@ -22,6 +22,7 @@ from homeassistant.const import (
     SERVICE_TOGGLE,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
+    STATE_UNAVAILABLE,
     Platform,
 )
 from homeassistant.core import HomeAssistant
@@ -64,6 +65,34 @@ async def test_switch_states(
         await hass.async_block_till_done()
         state = hass.states.get("switch.garden_test_mower_1_enable_schedule")
         assert state.state == expected_state
+
+
+async def test_work_area_and_stay_out_zone_entities_unavailable_without_data(
+    hass: HomeAssistant,
+    mock_automower_client: AsyncMock,
+    mock_config_entry: MockConfigEntry,
+    freezer: FrozenDateTimeFactory,
+    values: dict[str, MowerAttributes],
+) -> None:
+    """Test entities become unavailable when capability data disappears."""
+    await setup_integration(hass, mock_config_entry)
+
+    values[TEST_MOWER_ID].capabilities.work_areas = False
+    values[TEST_MOWER_ID].work_areas = None
+    values[TEST_MOWER_ID].capabilities.stay_out_zones = False
+    values[TEST_MOWER_ID].stay_out_zones = None
+    mock_automower_client.get_status.return_value = values
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+
+    for entity_id in (
+        "switch.garden_test_mower_1_my_lawn",
+        "switch.garden_test_mower_1_avoid_danger_zone",
+    ):
+        state = hass.states.get(entity_id)
+        assert state is not None
+        assert state.state == STATE_UNAVAILABLE
 
 
 @pytest.mark.parametrize(

--- a/tests/components/husqvarna_automower/test_switch.py
+++ b/tests/components/husqvarna_automower/test_switch.py
@@ -1,5 +1,6 @@
 """Tests for switch platform."""
 
+from copy import deepcopy
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 import zoneinfo
@@ -76,7 +77,7 @@ async def test_work_area_and_stay_out_zone_entities_unavailable_without_data(
 ) -> None:
     """Test entities become unavailable when capability data disappears."""
     await setup_integration(hass, mock_config_entry)
-
+    original_values = deepcopy(values)
     values[TEST_MOWER_ID].work_areas = None
     values[TEST_MOWER_ID].stay_out_zones = None
     mock_automower_client.get_status.return_value = values
@@ -91,6 +92,15 @@ async def test_work_area_and_stay_out_zone_entities_unavailable_without_data(
         state = hass.states.get(entity_id)
         assert state is not None
         assert state.state == STATE_UNAVAILABLE
+
+    original_values[TEST_MOWER_ID].stay_out_zones.zones = None
+    mock_automower_client.get_status.return_value = original_values
+    freezer.tick(SCAN_INTERVAL)
+    async_fire_time_changed(hass)
+    await hass.async_block_till_done()
+    state = hass.states.get("switch.garden_test_mower_1_avoid_danger_zone")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Improve the robustness of entities that depend on work areas and stay-out zones by handling missing runtime data gracefully.
Background: Currently the API sometimes doesn't report stay-out-zones and work-areas. Although they exist. Also the capability attributes change from `True` to `Flase`
Please include in next patch release.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178136
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
