### PR TITLE
Fix target matching in Assist sentence parser debugger

### DIFF
--- a/homeassistant/components/conversation/default_agent.py
+++ b/homeassistant/components/conversation/default_agent.py
@@ -409,10 +409,13 @@ class DefaultAgent(ConversationEntity):
             }
 
             if successful_match:
+                satellite_area, _ = self._get_satellite_area_and_device(
+                    user_input.satellite_id, user_input.device_id
+                )
                 result_dict["targets"] = {
                     state.entity_id: {"matched": is_matched}
                     for state, is_matched in _get_debug_targets(
-                        self.hass, intent_result
+                        self.hass, intent_result, satellite_area
                     )
                 }
 
@@ -1676,12 +1679,14 @@ def _collect_list_references(expression: Expression, list_names: set[str]) -> No
 def _get_debug_targets(
     hass: HomeAssistant,
     result: RecognizeResult,
+    satellite_area: ar.AreaEntry | None = None,
 ) -> Iterable[tuple[State, bool]]:
     """Yield state/is_matched pairs for a hassil recognition."""
     entities = result.entities
 
     name: str | None = None
     area_name: str | None = None
+    floor_name: str | None = None
     domains: set[str] | None = None
     device_classes: set[str] | None = None
     state_names: set[str] | None = None
@@ -1691,6 +1696,9 @@ def _get_debug_targets(
 
     if "area" in entities:
         area_name = str(entities["area"].value)
+
+    if "floor" in entities:
+        floor_name = str(entities["floor"].value)
 
     if "domain" in entities:
         domains = set(cv.ensure_list(entities["domain"].value))
@@ -1702,23 +1710,26 @@ def _get_debug_targets(
         # HassGetState only
         state_names = set(cv.ensure_list(entities["state"].value))
 
-    if (
-        (name is None)
-        and (area_name is None)
-        and (not domains)
-        and (not device_classes)
-        and (not state_names)
-    ):
+    constraints = intent.MatchTargetsConstraints(
+        name=name,
+        area_name=area_name,
+        floor_name=floor_name,
+        domains=domains,
+        device_classes=device_classes,
+        assistant=DOMAIN,
+    )
+
+    if not (constraints.has_constraints or state_names):
         # Avoid "matching" all entities when there is no filter
         return
 
-    states = intent.async_match_states(
-        hass,
-        name=name,
-        area_name=area_name,
-        domains=domains,
-        device_classes=device_classes,
+    # Mirror the preferences used when the intent is actually handled so that
+    # duplicate names are deduplicated the same way.
+    preferences = intent.MatchTargetsPreferences(
+        area_id=satellite_area.id if satellite_area is not None else None
     )
+
+    states = intent.async_match_targets(hass, constraints, preferences).states
 
     for state in states:
         # For queries, a target is "matched" based on its state

--- a/tests/components/conversation/test_http.py
+++ b/tests/components/conversation/test_http.py
@@ -9,6 +9,7 @@ from freezegun import freeze_time
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.components import conversation
 from homeassistant.components.conversation import (
     AssistantContent,
     ConversationInput,
@@ -17,13 +18,16 @@ from homeassistant.components.conversation import (
 )
 from homeassistant.components.conversation.const import HOME_ASSISTANT_AGENT
 from homeassistant.components.conversation.models import ConversationResult
+from homeassistant.components.homeassistant.exposed_entities import async_expose_entity
 from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
 from homeassistant.const import ATTR_FRIENDLY_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import (
     area_registry as ar,
     chat_session,
+    device_registry as dr,
     entity_registry as er,
+    floor_registry as fr,
     intent,
 )
 from homeassistant.setup import async_setup_component
@@ -31,7 +35,12 @@ from homeassistant.util.dt import utcnow
 
 from . import MockAgent
 
-from tests.common import MockUser, async_fire_time_changed, async_mock_service
+from tests.common import (
+    MockConfigEntry,
+    MockUser,
+    async_fire_time_changed,
+    async_mock_service,
+)
 from tests.typing import ClientSessionGenerator, WebSocketGenerator
 
 AGENT_ID_OPTIONS = [
@@ -452,6 +461,148 @@ async def test_ws_hass_agent_debug_null_result(
     assert msg["success"]
     assert msg["result"] == snapshot
     assert msg["result"]["results"] == [None]
+
+
+async def test_ws_hass_agent_debug_floor(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    area_registry: ar.AreaRegistry,
+    floor_registry: fr.FloorRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that debug targets are restricted to the matched floor."""
+    first_floor = floor_registry.async_create("first floor")
+    floor_registry.async_create("ground floor")
+
+    bedroom_area = area_registry.async_create("bedroom", floor_id=first_floor.floor_id)
+    bedroom_light = entity_registry.async_get_or_create(
+        "light", "demo", "bedroom", original_name="bedroom light"
+    )
+    entity_registry.async_update_entity(
+        bedroom_light.entity_id, area_id=bedroom_area.id
+    )
+    hass.states.async_set(bedroom_light.entity_id, "on")
+
+    # Not assigned to a floor
+    garage_area = area_registry.async_create("garage")
+    garage_light = entity_registry.async_get_or_create(
+        "light", "demo", "garage", original_name="garage light"
+    )
+    entity_registry.async_update_entity(garage_light.entity_id, area_id=garage_area.id)
+    hass.states.async_set(garage_light.entity_id, "on")
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "conversation/agent/homeassistant/debug",
+            "sentences": [
+                "turn off the lights on the first floor",
+                "turn off the lights on the ground floor",
+            ],
+        }
+    )
+    msg = await client.receive_json()
+
+    assert msg["success"]
+    results = msg["result"]["results"]
+    assert results[0]["match"]
+    assert results[0]["targets"] == {bedroom_light.entity_id: {"matched": True}}
+
+    # No areas are assigned to the ground floor
+    assert results[1]["match"]
+    assert results[1]["targets"] == {}
+
+
+async def test_ws_hass_agent_debug_unexposed_entity(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    area_registry: ar.AreaRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that debug targets only include entities exposed to Assist."""
+    kitchen_area = area_registry.async_create("kitchen")
+
+    exposed_light = entity_registry.async_get_or_create(
+        "light", "demo", "exposed", original_name="exposed light"
+    )
+    hidden_light = entity_registry.async_get_or_create(
+        "light", "demo", "hidden", original_name="hidden light"
+    )
+    for entity_entry in (exposed_light, hidden_light):
+        entity_registry.async_update_entity(
+            entity_entry.entity_id, area_id=kitchen_area.id
+        )
+        hass.states.async_set(entity_entry.entity_id, "on")
+
+    async_expose_entity(hass, conversation.DOMAIN, hidden_light.entity_id, False)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "conversation/agent/homeassistant/debug",
+            "sentences": ["turn off the lights in the kitchen"],
+        }
+    )
+    msg = await client.receive_json()
+
+    assert msg["success"]
+    results = msg["result"]["results"]
+    assert results[0]["match"]
+    assert results[0]["targets"] == {exposed_light.entity_id: {"matched": True}}
+
+
+async def test_ws_hass_agent_debug_preferred_area(
+    hass: HomeAssistant,
+    init_components,
+    hass_ws_client: WebSocketGenerator,
+    area_registry: ar.AreaRegistry,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test that debug targets use the requesting device's area to disambiguate."""
+    config_entry = MockConfigEntry()
+    config_entry.add_to_hass(hass)
+
+    bedroom_area = area_registry.async_create("bedroom")
+    office_area = area_registry.async_create("office")
+
+    # Duplicate names in two areas
+    bedroom_light = entity_registry.async_get_or_create(
+        "light", "demo", "bedroom", original_name="overhead light"
+    )
+    entity_registry.async_update_entity(
+        bedroom_light.entity_id, area_id=bedroom_area.id
+    )
+    hass.states.async_set(bedroom_light.entity_id, "on")
+
+    office_light = entity_registry.async_get_or_create(
+        "light", "demo", "office", original_name="overhead light"
+    )
+    entity_registry.async_update_entity(office_light.entity_id, area_id=office_area.id)
+    hass.states.async_set(office_light.entity_id, "on")
+
+    voice_device = device_registry.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("demo", "voice-satellite")},
+    )
+    device_registry.async_update_device(voice_device.id, area_id=office_area.id)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "conversation/agent/homeassistant/debug",
+            "sentences": ["turn off the overhead light"],
+            "device_id": voice_device.id,
+        }
+    )
+    msg = await client.receive_json()
+
+    assert msg["success"]
+    results = msg["result"]["results"]
+    assert results[0]["match"]
+    assert results[0]["targets"] == {office_light.entity_id: {"matched": True}}
 
 
 async def test_ws_hass_agent_debug_out_of_range(


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change

The Assist sentence parser in developer tools reports the wrong targets when a
sentence matches a floor. `_get_debug_targets` builds its own target list
instead of reusing what the intent handlers do, and it had drifted:

- The `floor` slot was never read. For "turn off the lights on the first floor"
  the recognizer extracts `floor` correctly (it shows up in the slots output),
  but the target computation dropped it and filtered on `domain` alone, so
  *every* light in the house was reported as a target. The guard that avoids
  "matching all entities when there is no filter" did not count `floor` either,
  so it did not catch this.
- `assistant` was not passed, so entities not exposed to Assist were listed as
  targets.
- The requesting device's area was not passed, so duplicate names were
  disambiguated differently in the debugger than during real execution.

Only the developer-tools debugger was affected — actually speaking the command
goes through `async_match_targets` with the full constraints and behaves
correctly, which is why the reporter saw the mismatch between the two.

This switches `_get_debug_targets` from the simplified `async_match_states`
wrapper to `async_match_targets`, so the full constraint set can be expressed:
`floor_name` and `assistant=DOMAIN` on the constraints, and the requesting
device's area as `MatchTargetsPreferences(area_id=...)` — mirroring the
`preferred_area_id` slot that `_async_handle_message` already sets. The
empty-filter guard now uses `MatchTargetsConstraints.has_constraints` so it
stays in sync if new constraint fields are added. `state_names` stays separate
in that check because for `HassGetState` the `state` slot drives the per-target
`matched` flag rather than acting as a filter.

There is no `preferred_floor_id` to wire up — the default agent only ever sets
`preferred_area_id`, so passing `area_id` is full parity.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178005
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
