### PR TITLE
Shield config entry removal from client disconnect

### DIFF
--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -1,5 +1,6 @@
 """Http views to control the config manager."""
 
+from asyncio import shield
 from collections.abc import Callable
 from http import HTTPStatus
 import logging
@@ -111,7 +112,9 @@ class ConfigManagerEntryResourceView(HomeAssistantView):
         hass = request.app[KEY_HASS]
 
         try:
-            result = await hass.config_entries.async_remove(entry_id)
+            # shield the removal from cancellation on connection drop, otherwise
+            # the entry is dropped from memory but never saved or cleaned up
+            result = await shield(hass.config_entries.async_remove(entry_id))
         except config_entries.UnknownEntry:
             return self.json_message("Invalid entry specified", HTTPStatus.NOT_FOUND)
 

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -111,10 +111,19 @@ class ConfigManagerEntryResourceView(HomeAssistantView):
 
         hass = request.app[KEY_HASS]
 
+        # Shield the removal from cancellation on connection drop, otherwise the
+        # entry is dropped from memory but never saved or cleaned up. The task is
+        # created through hass so a strong reference is held for its lifetime,
+        # which keeps it from being garbage collected once the request handler
+        # has gone away.
+        remove_task = hass.async_create_task(
+            hass.config_entries.async_remove(entry_id),
+            f"config entry remove {entry_id}",
+            eager_start=False,
+        )
+
         try:
-            # shield the removal from cancellation on connection drop, otherwise
-            # the entry is dropped from memory but never saved or cleaned up
-            result = await shield(hass.config_entries.async_remove(entry_id))
+            result = await shield(remove_task)
         except config_entries.UnknownEntry:
             return self.json_message("Invalid entry specified", HTTPStatus.NOT_FOUND)
 

--- a/homeassistant/components/config/config_entries.py
+++ b/homeassistant/components/config/config_entries.py
@@ -119,7 +119,6 @@ class ConfigManagerEntryResourceView(HomeAssistantView):
         remove_task = hass.async_create_task(
             hass.config_entries.async_remove(entry_id),
             f"config entry remove {entry_id}",
-            eager_start=False,
         )
 
         try:

--- a/tests/components/config/test_config_entries.py
+++ b/tests/components/config/test_config_entries.py
@@ -1,5 +1,6 @@
 """Test config entries API."""
 
+import asyncio
 from collections.abc import Generator
 from http import HTTPStatus
 from typing import Any
@@ -13,6 +14,7 @@ import voluptuous as vol
 
 from homeassistant import config_entries as core_ce, data_entry_flow, loader
 from homeassistant.components.config import DOMAIN, config_entries
+from homeassistant.components.http import KEY_HASS
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE, CONF_RADIUS
 from homeassistant.core import HomeAssistant, callback
@@ -267,6 +269,55 @@ async def test_remove_entry(hass: HomeAssistant, client: TestClient) -> None:
     data = await resp.json()
     assert data == {"require_restart": True}
     assert len(hass.config_entries.async_entries()) == 0
+
+
+async def test_remove_entry_survives_client_disconnect(
+    hass: HomeAssistant, hass_admin_user: MockUser
+) -> None:
+    """Test a client disconnect does not truncate the removal.
+
+    The HTTP runner is created with handler_cancellation=True, so a disconnect
+    cancels the request handler. Removal deletes the entry from memory before
+    awaiting the integration, so an unshielded cancel leaves the entry on disk
+    and its registry rows behind.
+    """
+    entry = MockConfigEntry(domain="test", state=core_ce.ConfigEntryState.LOADED)
+    entry.add_to_hass(hass)
+
+    removing = asyncio.Event()
+    disconnected = asyncio.Event()
+    original_async_remove = core_ce.ConfigEntry.async_remove
+
+    async def blocking_async_remove(self: core_ce.ConfigEntry, *args: Any) -> None:
+        """Stall inside the removal, so the cancel lands on this await."""
+        removing.set()
+        await disconnected.wait()
+        await original_async_remove(self, *args)
+
+    view = config_entries.ConfigManagerEntryResourceView()
+    request = Mock()
+    request.__getitem__ = Mock(side_effect={"hass_user": hass_admin_user}.__getitem__)
+    request.app = {KEY_HASS: hass}
+
+    with (
+        patch.object(core_ce.ConfigEntry, "async_remove", blocking_async_remove),
+        patch.object(hass.config_entries, "_async_schedule_save") as mock_schedule_save,
+    ):
+        task = hass.async_create_task(view.delete(request, entry.entry_id))
+        await removing.wait()
+
+        # The client goes away mid-removal.
+        task.cancel()
+        disconnected.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        await hass.async_block_till_done()
+
+    # The rest of the removal must still have run.
+    assert mock_schedule_save.called
+    assert hass.config_entries.async_entries() == []
 
 
 async def test_reload_entry(hass: HomeAssistant, client: TestClient) -> None:


### PR DESCRIPTION
The HTTP runner is created with handler_cancellation=True, so aiohttp cancels the request handler as soon as the client goes away. Nothing on the DELETE path was shielded, and the entry is removed from memory before the integration is awaited:

    del self._entries[entry.entry_id]
    await entry.async_remove(self.hass)
    self.async_update_issues()
    self._async_schedule_save()

A disconnect during that await skips the save and _async_clean_up(), so the entry is gone from the running instance but still in .storage/core.config_entries, with device and entity registry rows still pointing at it.

Shield the call, matching the existing treatment of service calls in components/api.

Fixes #178092

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
The HTTP runner is created with `handler_cancellation=True`, so aiohttp cancels the
request handler as soon as the client goes away. Nothing on the DELETE path was
shielded, and the entry is removed from memory before the integration is awaited:

```python
del self._entries[entry.entry_id]
await entry.async_remove(self.hass)
self.async_update_issues()
self._async_schedule_save()
```

A disconnect during that await skips the save and `_async_clean_up()`, so the entry
is gone from the running instance but still in `.storage/core.config_entries`, with
device and entity registry rows still pointing at it. Which state wins after a
restart then depends on whether some other entry happens to be saved first.

The removal is now created as a task through `hass.async_create_task()` and that task
is shielded. Going through hass keeps a strong reference in `hass._tasks` until the
task completes, so it cannot be garbage collected once the request handler is gone —
`shield()` alone does not hold one.

Matches the existing treatment of service calls in `components/api`.



## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178092
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


