### PR TITLE
Add configurable PurpleAir polling interval

### DIFF
--- a/homeassistant/components/purpleair/config_flow.py
+++ b/homeassistant/components/purpleair/config_flow.py
@@ -32,13 +32,22 @@ from homeassistant.helpers import (
 )
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.helpers.selector import (
+    NumberSelector,
+    NumberSelectorConfig,
+    NumberSelectorMode,
     SelectOptionDict,
     SelectSelector,
     SelectSelectorConfig,
     SelectSelectorMode,
 )
 
-from .const import CONF_SENSOR_INDICES, DOMAIN, LOGGER
+from .const import (
+    CONF_SCAN_INTERVAL,
+    CONF_SENSOR_INDICES,
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    LOGGER,
+)
 
 CONF_DISTANCE = "distance"
 CONF_NEARBY_SENSOR_OPTIONS = "nearby_sensor_options"
@@ -331,7 +340,17 @@ class PurpleAirOptionsFlowHandler(OptionsFlowWithReload):
                             CONF_SHOW_ON_MAP
                         )
                     },
-                ): bool
+                ): bool,
+                vol.Optional(
+                    CONF_SCAN_INTERVAL, default=DEFAULT_SCAN_INTERVAL
+                ): NumberSelector(
+                    NumberSelectorConfig(
+                        min=1,
+                        max=60,
+                        step=1,
+                        mode=NumberSelectorMode.BOX,
+                    )
+                ),
             }
         )
 

--- a/homeassistant/components/purpleair/const.py
+++ b/homeassistant/components/purpleair/const.py
@@ -11,3 +11,5 @@ PLATFORMS: Final = [Platform.SENSOR]
 DOMAIN: Final[str] = "purpleair"
 
 CONF_SENSOR_INDICES: Final[str] = "sensor_indices"
+DEFAULT_SCAN_INTERVAL: Final[int] = 5
+CONF_SCAN_INTERVAL: Final[str] = "scan_interval"

--- a/homeassistant/components/purpleair/coordinator.py
+++ b/homeassistant/components/purpleair/coordinator.py
@@ -14,7 +14,12 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import aiohttp_client
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import CONF_SENSOR_INDICES, LOGGER
+from .const import (
+    CONF_SCAN_INTERVAL,
+    CONF_SENSOR_INDICES,
+    DEFAULT_SCAN_INTERVAL,
+    LOGGER,
+)
 
 SENSOR_FIELDS_TO_RETRIEVE = [
     "0.3_um_count",
@@ -42,9 +47,6 @@ SENSOR_FIELDS_TO_RETRIEVE = [
     "voc",
 ]
 
-UPDATE_INTERVAL = timedelta(minutes=5)
-
-
 type PurpleAirConfigEntry = ConfigEntry[PurpleAirDataUpdateCoordinator]
 
 
@@ -65,7 +67,9 @@ class PurpleAirDataUpdateCoordinator(DataUpdateCoordinator[GetSensorsResponse]):
             LOGGER,
             config_entry=entry,
             name=entry.title,
-            update_interval=UPDATE_INTERVAL,
+            update_interval=timedelta(
+                minutes=entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+            ),
         )
 
     @override

--- a/homeassistant/components/purpleair/strings.json
+++ b/homeassistant/components/purpleair/strings.json
@@ -133,7 +133,11 @@
       },
       "settings": {
         "data": {
+          "scan_interval": "Polling interval (minutes)",
           "show_on_map": "Show configured sensor locations on the map"
+        },
+        "data_description": {
+          "scan_interval": "How often to query PurpleAir for updated sensor data"
         },
         "title": "[%key:component::purpleair::options::step::init::menu_options::settings%]"
       }

--- a/tests/components/purpleair/test_config_flow.py
+++ b/tests/components/purpleair/test_config_flow.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, patch
 from aiopurpleair.errors import InvalidApiKeyError, PurpleAirError
 import pytest
 
-from homeassistant.components.purpleair.const import DOMAIN
+from homeassistant.components.purpleair.const import CONF_SCAN_INTERVAL, DOMAIN
 from homeassistant.config_entries import SOURCE_USER
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -319,12 +319,15 @@ async def test_options_settings(
     assert result["step_id"] == "settings"
 
     result = await hass.config_entries.options.async_configure(
-        result["flow_id"], user_input={"show_on_map": True}
+        result["flow_id"], user_input={"scan_interval": 15, "show_on_map": True}
     )
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {
         "sensor_indices": [TEST_SENSOR_INDEX1],
+        "scan_interval": 15,
         "show_on_map": True,
     }
 
     assert config_entry.options["show_on_map"] is True
+    assert config_entry.options[CONF_SCAN_INTERVAL] == 15
+    assert config_entry.runtime_data.update_interval.total_seconds() == 15 * 60


### PR DESCRIPTION
## Proposed change

Add a configurable PurpleAir polling interval to the integration options flow.

The current coordinator polls every five minutes, which can consume PurpleAir API quota quickly. This change:

- Adds a 1–60 minute polling interval selector to PurpleAir Settings.
- Preserves the existing five-minute default for existing and new entries.
- Applies the configured interval to the data update coordinator.
- Reloads the integration through the existing options-flow reload behavior.
- Adds the setting's strings and a config-flow test verifying a 15-minute interval.

## Testing

- `ruff check ...` — passed
- `ruff format --check ...` — passed
- `tests/components/purpleair/test_config_flow.py::test_options_settings` — passed
- Full PurpleAir config-flow test file: 20 passed, with unrelated existing translation-teardown errors in this checkout for common `unknown`/`already_configured` translation references.
