### PR TITLE
Add sensors for day, night and twilight duration to the sun integration

### DIFF
--- a/homeassistant/components/sun/const.py
+++ b/homeassistant/components/sun/const.py
@@ -19,6 +19,7 @@ ELEVATION_ASTRONOMICAL: Final[float] = -astral.Depression.ASTRONOMICAL.value
 
 SIGNAL_POSITION_CHANGED = f"{DOMAIN}_position_changed"
 SIGNAL_EVENTS_CHANGED = f"{DOMAIN}_events_changed"
+SIGNAL_DURATIONS_CHANGED = f"{DOMAIN}_durations_changed"
 
 
 STATE_ABOVE_HORIZON = "above_horizon"

--- a/homeassistant/components/sun/entity.py
+++ b/homeassistant/components/sun/entity.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import logging
 from typing import Any, override
 
-from astral import Observer
+from astral import Observer, SunDirection
 import astral.sun
 
 from homeassistant.config_entries import ConfigEntry
@@ -30,6 +30,7 @@ from .const import (
     ELEVATION_NAUTICAL,
     SIGNAL_EVENTS_CHANGED,
     SIGNAL_POSITION_CHANGED,
+    SIGNAL_DURATIONS_CHANGED,
     STATE_ABOVE_HORIZON,
     STATE_BELOW_HORIZON,
 )
@@ -49,6 +50,10 @@ STATE_ATTR_NEXT_MIDNIGHT = "next_midnight"
 STATE_ATTR_NEXT_NOON = "next_noon"
 STATE_ATTR_NEXT_RISING = "next_rising"
 STATE_ATTR_NEXT_SETTING = "next_setting"
+STATE_ATTR_DAYLIGHT_DURATION = "daylight_duration"
+STATE_ATTR_NIGHT_DURATION = "night_duration"
+STATE_ATTR_TWILIGHT_SUNRISE_DURATION = "twilight_sunrise_duration"
+STATE_ATTR_TWILIGHT_SUNSET_DURATION = "twilight_sunset_duration"
 
 # The algorithm used here is somewhat complicated. It aims to cut down
 # the number of sensor updates over the day. It's documented best in
@@ -101,6 +106,10 @@ class Sun(Entity):
             STATE_ATTR_NEXT_NOON,
             STATE_ATTR_NEXT_RISING,
             STATE_ATTR_NEXT_SETTING,
+            STATE_ATTR_DAYLIGHT_DURATION,
+            STATE_ATTR_NIGHT_DURATION,
+            STATE_ATTR_TWILIGHT_SUNRISE_DURATION,
+            STATE_ATTR_TWILIGHT_SUNSET_DURATION,
         }
     )
 
@@ -117,6 +126,10 @@ class Sun(Entity):
     solar_elevation: float
     solar_azimuth: float
     rising: bool
+    daylight_duration: timedelta
+    night_duration: timedelta
+    twilight_sunrise_duration: timedelta
+    twilight_sunset_duration: timedelta
     _next_change: datetime
 
     def __init__(self, hass: HomeAssistant) -> None:
@@ -127,6 +140,7 @@ class Sun(Entity):
         self._config_listener: CALLBACK_TYPE | None = None
         self._update_events_listener: CALLBACK_TYPE | None = None
         self._update_sun_position_listener: CALLBACK_TYPE | None = None
+        self._update_durations_listener: CALLBACK_TYPE | None = None
         self._config_listener = self.hass.bus.async_listen(
             EVENT_CORE_CONFIG_UPDATE, self.update_location
         )
@@ -144,9 +158,17 @@ class Sun(Entity):
         if not initial and observer == self.observer:
             return
         self.observer = observer
+        # The attributes need to be initialized before the first call to update_events() to avoid an AttributeError.
+        self.daylight_duration = timedelta()
+        self.night_duration = timedelta()
+        self.twilight_sunrise_duration = timedelta()
+        self.twilight_sunset_duration = timedelta()
         if self._update_events_listener:
             self._update_events_listener()
         self.update_events()
+        if self._update_durations_listener:
+            self._update_durations_listener()
+        self.update_durations()
 
     @callback
     def remove_listeners(self) -> None:
@@ -157,6 +179,8 @@ class Sun(Entity):
             self._update_events_listener()
         if self._update_sun_position_listener:
             self._update_sun_position_listener()
+        if self._update_durations_listener:
+            self._update_durations_listener()
 
     @property
     @override
@@ -181,6 +205,10 @@ class Sun(Entity):
             STATE_ATTR_ELEVATION: self.solar_elevation,
             STATE_ATTR_AZIMUTH: self.solar_azimuth,
             STATE_ATTR_RISING: self.rising,
+            STATE_ATTR_DAYLIGHT_DURATION: self.daylight_duration.total_seconds(),
+            STATE_ATTR_NIGHT_DURATION: self.night_duration.total_seconds(),
+            STATE_ATTR_TWILIGHT_SUNRISE_DURATION: self.twilight_sunrise_duration.total_seconds(),
+            STATE_ATTR_TWILIGHT_SUNSET_DURATION: self.twilight_sunset_duration.total_seconds(),
         }
 
     def _check_event(
@@ -311,4 +339,74 @@ class Sun(Entity):
             return
         self._update_sun_position_listener = event.async_track_point_in_utc_time(
             self.hass, self.update_sun_position, utc_point_in_time + delta
+        )
+
+    @callback
+    def update_durations(self, now: datetime | None = None) -> None:
+        """Calculate the daylight, night, sunrise and sunset durations."""
+        # First update sun position to assure the values are up-to-date.
+        if self._update_sun_position_listener:
+            self._update_sun_position_listener()
+        self.update_sun_position()
+
+        # Grab current time in case system clock changed since last time we ran.
+        utc_point_in_time = dt_util.utcnow()
+        try:
+            start, end = astral.sun.daylight(self.observer, dt_util.as_local(utc_point_in_time))
+            self.daylight_duration = end - start
+        except ValueError:  # Catch Polar day / night / twilight.
+            self.daylight_duration = (
+                timedelta(days=1) if self.solar_elevation > ELEVATION_HORIZON else timedelta()
+            )
+        try:
+            start, end = astral.sun.night(self.observer, dt_util.as_local(utc_point_in_time))
+            self.night_duration = end - start
+        except ValueError:  # Catch Polar day / night / twilight.
+            self.night_duration = (
+                timedelta(days=1) if self.solar_elevation <= ELEVATION_CIVIL else timedelta()
+            )
+        try:
+            start, end = astral.sun.twilight(self.observer, dt_util.as_local(utc_point_in_time), SunDirection.RISING)
+            self.twilight_sunrise_duration = end - start
+        except ValueError:  # Catch Polar day / night / twilight.
+            self.twilight_sunrise_duration = (
+                timedelta(hours=12)
+                if self.solar_elevation > ELEVATION_CIVIL and self.solar_elevation <= ELEVATION_HORIZON
+                else timedelta()
+            )
+        try:
+            start, end = astral.sun.twilight(self.observer, dt_util.as_local(utc_point_in_time), SunDirection.SETTING)
+            self.twilight_sunset_duration = end - start
+        except ValueError:  # Catch Polar day / night / twilight.
+            self.twilight_sunset_duration = (
+                timedelta(hours=12)
+                if self.solar_elevation > ELEVATION_CIVIL and self.solar_elevation <= ELEVATION_HORIZON
+                else timedelta()
+            )
+
+        _LOGGER.debug(
+            "sun duarations_update@%s: daylight_duration=%s night_duration=%s twilight_sunrise_duration=%s twilight_sunset_duration=%s",
+            utc_point_in_time.isoformat(),
+            self.daylight_duration.total_seconds(),
+            self.night_duration.total_seconds(),
+            self.twilight_sunrise_duration.total_seconds(),
+            self.twilight_sunset_duration.total_seconds(),
+        )
+        self.async_write_ha_state()
+
+        async_dispatcher_send(self.hass, SIGNAL_DURATIONS_CHANGED)
+
+        # Next update will occur on the beginning of the next day.
+        delta = timedelta(
+            seconds=(
+                (
+                    (24 - dt_util.as_local(utc_point_in_time).hour) * 60
+                    - dt_util.as_local(utc_point_in_time).minute
+                )
+                * 60
+                - dt_util.as_local(utc_point_in_time).second
+            )
+        )
+        self._update_durations_listener = event.async_track_point_in_utc_time(
+            self.hass, self.update_durations, utc_point_in_time + delta
         )

--- a/homeassistant/components/sun/icons.json
+++ b/homeassistant/components/sun/icons.json
@@ -59,6 +59,18 @@
       },
       "solar_elevation": {
         "default": "mdi:theme-light-dark"
+      },
+      "daylight_duration": {
+        "default": "mdi:weather-sunny"
+      },
+      "night_duration": {
+        "default": "mdi:weather-night"
+      },
+      "twilight_sunrise_duration": {
+        "default": "mdi:weather-sunset-up"
+      },
+      "twilight_sunset_duration": {
+        "default": "mdi:weather-sunset-down"
       }
     }
   },

--- a/homeassistant/components/sun/sensor.py
+++ b/homeassistant/components/sun/sensor.py
@@ -12,14 +12,14 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.const import DEGREE, EntityCategory
+from homeassistant.const import DEGREE, EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.typing import StateType
 
-from .const import DOMAIN, SIGNAL_EVENTS_CHANGED, SIGNAL_POSITION_CHANGED
+from .const import DOMAIN, SIGNAL_EVENTS_CHANGED, SIGNAL_POSITION_CHANGED, SIGNAL_DURATIONS_CHANGED
 from .entity import Sun, SunConfigEntry
 
 ENTITY_ID_SENSOR_FORMAT = SENSOR_DOMAIN + ".sun_{}"
@@ -93,6 +93,46 @@ SENSOR_TYPES: tuple[SunSensorEntityDescription, ...] = (
         entity_registry_enabled_default=False,
         native_unit_of_measurement=DEGREE,
         signal=SIGNAL_POSITION_CHANGED,
+    ),
+    SunSensorEntityDescription(
+        key="daylight_duration",
+        device_class=SensorDeviceClass.DURATION,
+        translation_key="daylight_duration",
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data.daylight_duration.total_seconds(),
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        signal=SIGNAL_DURATIONS_CHANGED,
+    ),
+    SunSensorEntityDescription(
+        key="night_duration",
+        device_class=SensorDeviceClass.DURATION,
+        translation_key="night_duration",
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data.night_duration.total_seconds(),
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        signal=SIGNAL_DURATIONS_CHANGED,
+    ),
+    SunSensorEntityDescription(
+        key="twilight_sunrise_duration",
+        device_class=SensorDeviceClass.DURATION,
+        translation_key="twilight_sunrise_duration",
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data.twilight_sunrise_duration.total_seconds(),
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        signal=SIGNAL_DURATIONS_CHANGED,
+    ),
+    SunSensorEntityDescription(
+        key="twilight_sunset_duration",
+        device_class=SensorDeviceClass.DURATION,
+        translation_key="twilight_sunset_duration",
+        state_class=SensorStateClass.TOTAL,
+        value_fn=lambda data: data.twilight_sunset_duration.total_seconds(),
+        entity_registry_enabled_default=False,
+        native_unit_of_measurement=UnitOfTime.SECONDS,
+        signal=SIGNAL_DURATIONS_CHANGED,
     ),
 )
 

--- a/homeassistant/components/sun/strings.json
+++ b/homeassistant/components/sun/strings.json
@@ -86,7 +86,11 @@
       "next_rising": { "name": "Next rising" },
       "next_setting": { "name": "Next setting" },
       "solar_azimuth": { "name": "Solar azimuth" },
-      "solar_elevation": { "name": "Solar elevation" }
+      "solar_elevation": { "name": "Solar elevation" },
+      "daylight_duration": { "name": "Daylight duration" },
+      "night_duration": { "name": "Night duration" },
+      "twilight_sunrise_duration": { "name": "Twilight sunrise duration" },
+      "twilight_sunset_duration": { "name": "Twilight sunset duration" }
     }
   },
   "entity_component": {


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
I noticed that although the sun integration provides the times of sunrise and sunset there is no easy way to calculate the length of the current day as the timestamps may correspond to the current or already the next day. There are some workarounds with complicated templates like discussed here: https://community.home-assistant.io/t/hours-of-daylight/59422 but that seems unsatisfactory to me.
In particular as the astral package used in the backend of the sun integration already provides functions to calculate the lengths of day, night and twilight. Furthermore, these calculations are rather inexpensive as they have to be perforemed only once per day. Therefore, I added 4 new sensors to the sun integration which are disabled by default that hold the lengths of the day, the night and the twilight at sunrise and sunset as defined by the astral package.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: 
- This PR is related to issue: 
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47249
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
