### PR TITLE
Add position_state_send option to KNX cover

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -238,6 +238,7 @@ class CoverConf:
     INVERT_UPDOWN: Final = "invert_updown"
     INVERT_POSITION: Final = "invert_position"
     INVERT_ANGLE: Final = "invert_angle"
+    POSITION_STATE_SEND: Final = "position_state_send"
 
 
 class ClimateConf:

--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -246,6 +246,7 @@ class CoverConf:
     INVERT_UPDOWN: Final = "invert_updown"
     INVERT_POSITION: Final = "invert_position"
     INVERT_ANGLE: Final = "invert_angle"
+    POSITION_STATE_SEND: Final = "position_state_send"
 
 
 class ClimateConf:

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -3,7 +3,11 @@
 from typing import Any, override
 
 from xknx import XKNX
-from xknx.devices import Cover as XknxCover
+from xknx.devices import (
+    Cover as XknxCover,
+    Device as XknxDevice,
+    ExposeSensor as XknxExposeSensor,
+)
 
 from homeassistant import config_entries
 from homeassistant.components.cover import (
@@ -83,10 +87,48 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
+# Minimum time between two position telegrams while travelling. Without it every
+# travel calculator update would be sent - about one telegram per second and cover.
+POSITION_SEND_COOLDOWN = 2.0
+
+
+def _first_ga(group_addresses: str | list[str]) -> str:
+    """Return one group address - the YAML validator yields a list.
+
+    Only the first entry is used: a display value has exactly one sender, so
+    passive addresses make no sense here.
+    """
+    if isinstance(group_addresses, list):
+        return group_addresses[0]
+    return group_addresses
+
+
+def _create_position_publisher(
+    xknx: XKNX, name: str, group_address: Any, cooldown: float
+) -> XknxExposeSensor:
+    """Return an xknx device publishing the calculated position to the bus.
+
+    Used when no actuator reports the position: then the travel calculator is the
+    only source and displays have no other way to learn it. The caller must not
+    register the same address as position_state - Home Assistant would read its
+    own telegram back as actuator feedback and rewind the travel calculator.
+    """
+    return XknxExposeSensor(
+        xknx,
+        name=f"{name} Position",
+        group_address=group_address,
+        value_type="percent",
+        cooldown=cooldown,
+        respond_to_read=True,
+    )
+
+
 class _KnxCover(CoverEntity, RestoreEntity):
     """Representation of a KNX cover."""
 
     _device: XknxCover
+    _position_publisher: XknxExposeSensor | None = None
+    _published_position: int | None = None
 
     def init_base(self) -> None:
         """Initialize common attributes - may be based on xknx device instance."""
@@ -122,6 +164,8 @@ class _KnxCover(CoverEntity, RestoreEntity):
         response arrives; for non-readable ones it is the only source of state.
         """
         await super().async_added_to_hass()
+        if self._position_publisher is not None:
+            self._position_publisher.xknx.devices.async_add(self._position_publisher)
         if (last_state := await self.async_get_last_state()) is None or (
             last_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
         ):
@@ -133,6 +177,54 @@ class _KnxCover(CoverEntity, RestoreEntity):
             tilt_position := last_state.attributes.get(ATTR_CURRENT_TILT_POSITION)
         ) is not None:
             self._device.angle.value = 100 - tilt_position
+        if (
+            self._position_publisher is not None
+            and (position := self._payload_position()) is not None
+        ):
+            # seed the publisher so it can answer a read before the first travel
+            self._published_position = position
+            await self._position_publisher.set(position)
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the position publisher from xknx."""
+        if self._position_publisher is not None:
+            self._position_publisher.xknx.devices.async_remove(self._position_publisher)
+        await super().async_will_remove_from_hass()
+
+    def _payload_position(self) -> int | None:
+        """Return the position in the group address value domain.
+
+        The travel calculator counts 0 as open. For an actuator configured with
+        invert_position the group address counts the other way round - xknx does
+        that in the RemoteValueScaling ranges, which this device does not use.
+        """
+        if (position := self._device.current_position()) is None:
+            return None
+        if self._device.position_current.range_from == 100:
+            return 100 - position
+        return position
+
+    @override
+    def after_update_callback(self, device: XknxDevice) -> None:
+        """Publish the position when it changed.
+
+        current_position() is the KNX side value already - cover.py inverts it
+        with `100 - pos` when reading, so no conversion is needed here.
+
+        The last published value is cached to avoid creating a task on every
+        travel calculator update; only a real change is worth a telegram.
+        """
+        if (
+            self._position_publisher is not None
+            and (position := self._payload_position()) is not None
+            and position != self._published_position
+        ):
+            self._published_position = position
+            self.hass.async_create_task(
+                self._position_publisher.set(position, skip_unchanged=True)
+            )
+        super().after_update_callback(device)
 
     @property
     @override
@@ -250,8 +342,10 @@ class KnxYamlCover(_KnxCover, KnxYamlEntity):
             group_address_long=config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS),
             group_address_short=config.get(CoverSchema.CONF_MOVE_SHORT_ADDRESS),
             group_address_stop=config.get(CoverSchema.CONF_STOP_ADDRESS),
-            group_address_position_state=config.get(
-                CoverSchema.CONF_POSITION_STATE_ADDRESS
+            group_address_position_state=(
+                None
+                if config[CoverConf.POSITION_STATE_SEND]
+                else config.get(CoverSchema.CONF_POSITION_STATE_ADDRESS)
             ),
             group_address_angle=config.get(CoverSchema.CONF_ANGLE_ADDRESS),
             group_address_angle_state=config.get(CoverSchema.CONF_ANGLE_STATE_ADDRESS),
@@ -271,6 +365,15 @@ class KnxYamlCover(_KnxCover, KnxYamlEntity):
             entity_config=config,
         )
         self.init_base()
+        if config[CoverConf.POSITION_STATE_SEND] and (
+            state_ga := config.get(CoverSchema.CONF_POSITION_STATE_ADDRESS)
+        ):
+            self._position_publisher = _create_position_publisher(
+                knx_module.xknx,
+                name=config[CONF_NAME],
+                group_address=_first_ga(state_ga),
+                cooldown=POSITION_SEND_COOLDOWN,
+            )
         if custom_device_class := config.get(CONF_DEVICE_CLASS):
             self._attr_device_class = custom_device_class
 
@@ -287,7 +390,11 @@ def _create_ui_cover(xknx: XKNX, knx_config: ConfigType, name: str) -> XknxCover
         group_address_short=conf.get_write_and_passive(CONF_GA_STEP),
         group_address_stop=conf.get_write_and_passive(CONF_GA_STOP),
         group_address_position=conf.get_write_and_passive(CONF_GA_POSITION_SET),
-        group_address_position_state=conf.get_state_and_passive(CONF_GA_POSITION_STATE),
+        group_address_position_state=(
+            None
+            if conf.get(CoverConf.POSITION_STATE_SEND)
+            else conf.get_state_and_passive(CONF_GA_POSITION_STATE)
+        ),
         group_address_angle=conf.get_write(CONF_GA_ANGLE),
         group_address_angle_state=conf.get_state_and_passive(CONF_GA_ANGLE),
         travel_time_down=conf.get(CoverConf.TRAVELLING_TIME_DOWN),
@@ -316,4 +423,15 @@ class KnxUiCover(_KnxCover, KnxUiEntity):
         self._device = _create_ui_cover(
             knx_module.xknx, config[DOMAIN], config[CONF_ENTITY][CONF_NAME]
         )
+        knx_conf = ConfigExtractor(config[DOMAIN])
+        if (
+            knx_conf.get(CoverConf.POSITION_STATE_SEND)
+            and (state_ga := knx_conf.get_state(CONF_GA_POSITION_STATE)) is not None
+        ):
+            self._position_publisher = _create_position_publisher(
+                knx_module.xknx,
+                name=config[CONF_ENTITY][CONF_NAME],
+                group_address=state_ga,
+                cooldown=POSITION_SEND_COOLDOWN,
+            )
         self.init_base()

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -88,7 +88,7 @@ async def async_setup_entry(
 
 
 # Minimum time between two position telegrams while travelling. Without it every
-# travel calculator update would be sent - about one telegram per second and cover.
+# travel calculator update would be sent - about one telegram per second per cover.
 POSITION_SEND_COOLDOWN = 2.0
 
 
@@ -215,9 +215,10 @@ class _KnxCover(CoverEntity, RestoreEntity):
         after_update_callback: that method comes from the KNX entity mixin, which
         is only applied in the concrete YAML and UI classes.
 
-        The cached value skips a repeated publish while the cover stands still;
-        skip_unchanged is a redundant second guard against sending an
-        unchanged payload.
+        The cached value skips a repeated publish while the cover stands still.
+        It is deliberately read again when the task runs, so that closely
+        following updates collapse into one telegram carrying the newest
+        position - skip_unchanged then drops the trailing duplicates.
         """
         if (
             self._position_publisher is not None
@@ -232,7 +233,7 @@ class _KnxCover(CoverEntity, RestoreEntity):
 
         The task outlives async_will_remove_from_hass, and sending goes through
         the telegram queue rather than the device list - without this check a
-        reload during a travel would still put one stale value on the bus.
+        reload during a travel could still put a stale value on the bus.
         """
         if self._position_publisher is None or self._published_position is None:
             return

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -192,6 +192,7 @@ class _KnxCover(CoverEntity, RestoreEntity):
         if self._position_publisher is not None:
             self._device.unregister_device_updated_cb(self._publish_position)
             self._position_publisher.xknx.devices.async_remove(self._position_publisher)
+            self._position_publisher = None
         await super().async_will_remove_from_hass()
 
     def _payload_position(self) -> int | None:
@@ -224,9 +225,20 @@ class _KnxCover(CoverEntity, RestoreEntity):
             and position != self._published_position
         ):
             self._published_position = position
-            self.hass.async_create_task(
-                self._position_publisher.set(position, skip_unchanged=True)
-            )
+            self.hass.async_create_task(self._async_publish_position())
+
+    async def _async_publish_position(self) -> None:
+        """Send the cached position unless the entity was removed meanwhile.
+
+        The task outlives async_will_remove_from_hass, and sending goes through
+        the telegram queue rather than the device list - without this check a
+        reload during a travel would still put one stale value on the bus.
+        """
+        if self._position_publisher is None or self._published_position is None:
+            return
+        await self._position_publisher.set(
+            self._published_position, skip_unchanged=True
+        )
 
     @property
     @override

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -165,6 +165,7 @@ class _KnxCover(CoverEntity, RestoreEntity):
         """
         await super().async_added_to_hass()
         if self._position_publisher is not None:
+            self._device.register_device_updated_cb(self._publish_position)
             self._position_publisher.xknx.devices.async_add(self._position_publisher)
         if (last_state := await self.async_get_last_state()) is None or (
             last_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
@@ -189,6 +190,7 @@ class _KnxCover(CoverEntity, RestoreEntity):
     async def async_will_remove_from_hass(self) -> None:
         """Remove the position publisher from xknx."""
         if self._position_publisher is not None:
+            self._device.unregister_device_updated_cb(self._publish_position)
             self._position_publisher.xknx.devices.async_remove(self._position_publisher)
         await super().async_will_remove_from_hass()
 
@@ -205,15 +207,16 @@ class _KnxCover(CoverEntity, RestoreEntity):
             return 100 - position
         return position
 
-    @override
-    def after_update_callback(self, device: XknxDevice) -> None:
-        """Publish the position when it changed.
+    def _publish_position(self, device: XknxDevice) -> None:
+        """Publish the position after the travel calculator advanced.
 
-        current_position() is the KNX side value already - cover.py inverts it
-        with `100 - pos` when reading, so no conversion is needed here.
+        Registered as an additional device callback rather than overriding
+        after_update_callback: that method comes from the KNX entity mixin, which
+        is only applied in the concrete YAML and UI classes.
 
-        The last published value is cached to avoid creating a task on every
-        travel calculator update; only a real change is worth a telegram.
+        The cached value skips a repeated publish while the cover stands still;
+        skip_unchanged is a redundant second guard against sending an
+        unchanged payload.
         """
         if (
             self._position_publisher is not None
@@ -224,7 +227,6 @@ class _KnxCover(CoverEntity, RestoreEntity):
             self.hass.async_create_task(
                 self._position_publisher.set(position, skip_unchanged=True)
             )
-        super().after_update_callback(device)
 
     @property
     @override

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -3,7 +3,11 @@
 from typing import Any, override
 
 from xknx import XKNX
-from xknx.devices import Cover as XknxCover
+from xknx.devices import (
+    Cover as XknxCover,
+    Device as XknxDevice,
+    ExposeSensor as XknxExposeSensor,
+)
 
 from homeassistant import config_entries
 from homeassistant.components.cover import (
@@ -83,10 +87,48 @@ async def async_setup_entry(
         async_add_entities(entities)
 
 
+# Minimum time between two position telegrams while travelling. Without it every
+# travel calculator update would be sent - about one telegram per second and cover.
+POSITION_SEND_COOLDOWN = 2.0
+
+
+def _first_ga(group_addresses: str | list[str]) -> str:
+    """Return one group address - the YAML validator yields a list.
+
+    Only the first entry is used: a display value has exactly one sender, so
+    passive addresses make no sense here.
+    """
+    if isinstance(group_addresses, list):
+        return group_addresses[0]
+    return group_addresses
+
+
+def _create_position_publisher(
+    xknx: XKNX, name: str, group_address: Any, cooldown: float
+) -> XknxExposeSensor:
+    """Return an xknx device publishing the calculated position to the bus.
+
+    Used when no actuator reports the position: then the travel calculator is the
+    only source and displays have no other way to learn it. The caller must not
+    register the same address as position_state - Home Assistant would read its
+    own telegram back as actuator feedback and rewind the travel calculator.
+    """
+    return XknxExposeSensor(
+        xknx,
+        name=f"{name} Position",
+        group_address=group_address,
+        value_type="percent",
+        cooldown=cooldown,
+        respond_to_read=True,
+    )
+
+
 class _KnxCover(CoverEntity, RestoreEntity):
     """Representation of a KNX cover."""
 
     _device: XknxCover
+    _position_publisher: XknxExposeSensor | None = None
+    _published_position: int | None = None
 
     def init_base(self) -> None:
         """Initialize common attributes - may be based on xknx device instance."""
@@ -122,6 +164,8 @@ class _KnxCover(CoverEntity, RestoreEntity):
         response arrives; for non-readable ones it is the only source of state.
         """
         await super().async_added_to_hass()
+        if self._position_publisher is not None:
+            self._position_publisher.xknx.devices.async_add(self._position_publisher)
         if (last_state := await self.async_get_last_state()) is None or (
             last_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
         ):
@@ -133,6 +177,54 @@ class _KnxCover(CoverEntity, RestoreEntity):
             tilt_position := last_state.attributes.get(ATTR_CURRENT_TILT_POSITION)
         ) is not None:
             self._device.angle.value = 100 - tilt_position
+        if (
+            self._position_publisher is not None
+            and (position := self._payload_position()) is not None
+        ):
+            # seed the publisher so it can answer a read before the first travel
+            self._published_position = position
+            await self._position_publisher.set(position)
+
+    @override
+    async def async_will_remove_from_hass(self) -> None:
+        """Remove the position publisher from xknx."""
+        if self._position_publisher is not None:
+            self._position_publisher.xknx.devices.async_remove(self._position_publisher)
+        await super().async_will_remove_from_hass()
+
+    def _payload_position(self) -> int | None:
+        """Return the position in the group address value domain.
+
+        The travel calculator counts 0 as open. For an actuator configured with
+        invert_position the group address counts the other way round - xknx does
+        that in the RemoteValueScaling ranges, which this device does not use.
+        """
+        if (position := self._device.current_position()) is None:
+            return None
+        if self._device.position_current.range_from == 100:
+            return 100 - position
+        return position
+
+    @override
+    def after_update_callback(self, device: XknxDevice) -> None:
+        """Publish the position when it changed.
+
+        current_position() is the KNX side value already - cover.py inverts it
+        with `100 - pos` when reading, so no conversion is needed here.
+
+        The last published value is cached to avoid creating a task on every
+        travel calculator update; only a real change is worth a telegram.
+        """
+        if (
+            self._position_publisher is not None
+            and (position := self._payload_position()) is not None
+            and position != self._published_position
+        ):
+            self._published_position = position
+            self.hass.async_create_task(
+                self._position_publisher.set(position, skip_unchanged=True)
+            )
+        super().after_update_callback(device)
 
     @property
     @override
@@ -250,8 +342,10 @@ class KnxYamlCover(_KnxCover, KnxYamlEntity):
             group_address_long=config.get(CoverSchema.CONF_MOVE_LONG_ADDRESS),
             group_address_short=config.get(CoverSchema.CONF_MOVE_SHORT_ADDRESS),
             group_address_stop=config.get(CoverSchema.CONF_STOP_ADDRESS),
-            group_address_position_state=config.get(
-                CoverSchema.CONF_POSITION_STATE_ADDRESS
+            group_address_position_state=(
+                None
+                if config[CoverConf.POSITION_STATE_SEND]
+                else config.get(CoverSchema.CONF_POSITION_STATE_ADDRESS)
             ),
             group_address_angle=config.get(CoverSchema.CONF_ANGLE_ADDRESS),
             group_address_angle_state=config.get(CoverSchema.CONF_ANGLE_STATE_ADDRESS),
@@ -272,6 +366,15 @@ class KnxYamlCover(_KnxCover, KnxYamlEntity):
             entity_config=config,
         )
         self.init_base()
+        if config[CoverConf.POSITION_STATE_SEND] and (
+            state_ga := config.get(CoverSchema.CONF_POSITION_STATE_ADDRESS)
+        ):
+            self._position_publisher = _create_position_publisher(
+                knx_module.xknx,
+                name=config[CONF_NAME],
+                group_address=_first_ga(state_ga),
+                cooldown=POSITION_SEND_COOLDOWN,
+            )
         if custom_device_class := config.get(CONF_DEVICE_CLASS):
             self._attr_device_class = custom_device_class
 
@@ -288,7 +391,11 @@ def _create_ui_cover(xknx: XKNX, knx_config: ConfigType, name: str) -> XknxCover
         group_address_short=conf.get_write_and_passive(CONF_GA_STEP),
         group_address_stop=conf.get_write_and_passive(CONF_GA_STOP),
         group_address_position=conf.get_write_and_passive(CONF_GA_POSITION_SET),
-        group_address_position_state=conf.get_state_and_passive(CONF_GA_POSITION_STATE),
+        group_address_position_state=(
+            None
+            if conf.get(CoverConf.POSITION_STATE_SEND)
+            else conf.get_state_and_passive(CONF_GA_POSITION_STATE)
+        ),
         group_address_angle=conf.get_write(CONF_GA_ANGLE),
         group_address_angle_state=conf.get_state_and_passive(CONF_GA_ANGLE),
         travel_time_down=conf.get(CoverConf.TRAVELLING_TIME_DOWN),
@@ -317,4 +424,15 @@ class KnxUiCover(_KnxCover, KnxUiEntity):
         self._device = _create_ui_cover(
             knx_module.xknx, config[DOMAIN], config[CONF_ENTITY][CONF_NAME]
         )
+        knx_conf = ConfigExtractor(config[DOMAIN])
+        if (
+            knx_conf.get(CoverConf.POSITION_STATE_SEND)
+            and (state_ga := knx_conf.get_state(CONF_GA_POSITION_STATE)) is not None
+        ):
+            self._position_publisher = _create_position_publisher(
+                knx_module.xknx,
+                name=config[CONF_ENTITY][CONF_NAME],
+                group_address=state_ga,
+                cooldown=POSITION_SEND_COOLDOWN,
+            )
         self.init_base()

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -185,6 +185,11 @@ class _KnxCover(CoverEntity, RestoreEntity):
             # seed the publisher so it can answer a read before the first travel
             self._published_position = position
             await self._position_publisher.set(position)
+            # Mark the value as current. The cooldown task compares against
+            # `last_payload`, which is only updated once the outgoing telegram has
+            # been processed - during startup that can lag past the cooldown, and
+            # the restored position would then go out a second time.
+            self._position_publisher.initialize_value(position)
 
     @override
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -36,6 +36,7 @@ from homeassistant.helpers.typing import ConfigType
 
 from .const import CONF_SYNC_STATE, DOMAIN, KNX_MODULE_KEY, CoverConf
 from .entity import (
+    KnxEntityIdentifier,
     KnxUiEntity,
     KnxUiEntityPlatformController,
     KnxYamlEntity,
@@ -127,6 +128,10 @@ class _KnxCover(CoverEntity, RestoreEntity):
     """Representation of a KNX cover."""
 
     _device: XknxCover
+    # provided by the KNX entity mixin, which is only applied in the concrete
+    # YAML and UI classes below - declared here so this mixin can use them
+    _knx_module: KNXModule
+    _knx_entity_identifier: KnxEntityIdentifier | None
     _position_publisher: XknxExposeSensor | None = None
     _published_position: int | None = None
 

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -185,11 +185,11 @@ class _KnxCover(CoverEntity, RestoreEntity):
             # seed the publisher so it can answer a read before the first travel
             self._published_position = position
             await self._position_publisher.set(position)
-            # Mark the value as current. The cooldown task compares against
-            # `last_payload`, which is only updated once the outgoing telegram has
-            # been processed - during startup that can lag past the cooldown, and
-            # the restored position would then go out a second time.
-            self._position_publisher.initialize_value(position)
+            # Mark the value as current. The cooldown task compares against the
+            # remote value's `last_payload`, which is only updated once the outgoing
+            # telegram has been processed - during startup that can lag past the
+            # cooldown, and the restored position would then go out a second time.
+            self._position_publisher.sensor_value.value = position
 
     @override
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -189,7 +189,7 @@ class _KnxCover(CoverEntity, RestoreEntity):
             # remote value's `last_payload`, which is only updated once the outgoing
             # telegram has been processed - during startup that can lag past the
             # cooldown, and the restored position would then go out a second time.
-            self._position_publisher.sensor_value.value = position
+            self._position_publisher.initialize_value(position)
 
     @override
     async def async_will_remove_from_hass(self) -> None:

--- a/homeassistant/components/knx/cover.py
+++ b/homeassistant/components/knx/cover.py
@@ -167,6 +167,7 @@ class _KnxCover(CoverEntity, RestoreEntity):
         if self._position_publisher is not None:
             self._device.register_device_updated_cb(self._publish_position)
             self._position_publisher.xknx.devices.async_add(self._position_publisher)
+            self._register_publisher_addresses()
         if (last_state := await self.async_get_last_state()) is None or (
             last_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE)
         ):
@@ -197,8 +198,30 @@ class _KnxCover(CoverEntity, RestoreEntity):
         if self._position_publisher is not None:
             self._device.unregister_device_updated_cb(self._publish_position)
             self._position_publisher.xknx.devices.async_remove(self._position_publisher)
+            self._register_publisher_addresses(remove=True)
             self._position_publisher = None
         await super().async_will_remove_from_hass()
+
+    def _register_publisher_addresses(self, remove: bool = False) -> None:
+        """Add or remove the publisher address in the group address map.
+
+        The publisher is a separate xknx device, so its address is not part of
+        `self._device.group_addresses()` - the only source the base class uses
+        (`entity.py`). Without this the address would be missing from
+        `knx/get_entities_by_group`, and DataSecure issues on it would be
+        dropped as unconfigured (`repairs.py`).
+        """
+        if self._position_publisher is None or self._knx_entity_identifier is None:
+            return
+        register = (
+            self._knx_module.remove_from_group_address_entities
+            if remove
+            else self._knx_module.add_to_group_address_entities
+        )
+        register(
+            group_addresses=self._position_publisher.group_addresses(),
+            identifier=self._knx_entity_identifier,
+        )
 
     def _payload_position(self) -> int | None:
         """Return the position in the group address value domain.

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -451,6 +451,7 @@ class CoverSchema(KNXPlatformSchema):
                 vol.Optional(CONF_POSITION_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_ANGLE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_ANGLE_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CoverConf.POSITION_STATE_SEND, default=False): cv.boolean,
                 vol.Optional(
                     CoverConf.TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
                 ): cv.positive_float,
@@ -475,6 +476,20 @@ class CoverSchema(KNXPlatformSchema):
             msg=(
                 f"At least one of '{CONF_MOVE_LONG_ADDRESS}' or"
                 f" '{CONF_POSITION_ADDRESS}' is required."
+            ),
+        ),
+        vol.Any(
+            vol.Schema(
+                {vol.Required(CoverConf.POSITION_STATE_SEND): False},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            vol.Schema(
+                {vol.Required(CONF_POSITION_STATE_ADDRESS): object},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            msg=(
+                f"'{CoverConf.POSITION_STATE_SEND}' requires"
+                f" '{CONF_POSITION_STATE_ADDRESS}'."
             ),
         ),
     )

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -501,6 +501,7 @@ class CoverSchema(KNXPlatformSchema):
                 vol.Optional(CONF_POSITION_STATE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_ANGLE_ADDRESS): ga_list_validator,
                 vol.Optional(CONF_ANGLE_STATE_ADDRESS): ga_list_validator,
+                vol.Optional(CoverConf.POSITION_STATE_SEND, default=False): cv.boolean,
                 vol.Optional(
                     CoverConf.TRAVELLING_TIME_DOWN, default=DEFAULT_TRAVEL_TIME
                 ): cv.positive_float,
@@ -528,6 +529,20 @@ class CoverSchema(KNXPlatformSchema):
             msg=(
                 f"At least one of '{CONF_MOVE_LONG_ADDRESS}' or"
                 f" '{CONF_POSITION_ADDRESS}' is required."
+            ),
+        ),
+        vol.Any(
+            vol.Schema(
+                {vol.Required(CoverConf.POSITION_STATE_SEND): False},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            vol.Schema(
+                {vol.Required(CONF_POSITION_STATE_ADDRESS): object},
+                extra=vol.ALLOW_EXTRA,
+            ),
+            msg=(
+                f"'{CoverConf.POSITION_STATE_SEND}' requires"
+                f" '{CONF_POSITION_STATE_ADDRESS}'."
             ),
         ),
     )

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -237,6 +237,9 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
             vol.Optional(CONF_GA_POSITION_STATE): GASelector(
                 write=False, valid_dpt="5.001"
             ),
+            vol.Optional(
+                CoverConf.POSITION_STATE_SEND, default=False
+            ): selector.BooleanSelector(),
             vol.Optional(CoverConf.INVERT_POSITION): selector.BooleanSelector(),
             "section_tilt_control": KNXSectionFlat(collapsible=True),
             vol.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
@@ -280,6 +283,24 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
         msg=(
             "At least one of 'Open/Close control' or"
             " 'Position - Set position' is required."
+        ),
+    ),
+    vol.Any(
+        vol.Schema(
+            {vol.Required(CoverConf.POSITION_STATE_SEND): False},
+            extra=vol.ALLOW_EXTRA,
+        ),
+        vol.Schema(
+            {
+                vol.Required(CONF_GA_POSITION_STATE): GASelector(
+                    write=False, state_required=True
+                )
+            },
+            extra=vol.ALLOW_EXTRA,
+        ),
+        msg=(
+            "'Actively send the calculated position' requires a"
+            " 'Current position' group address."
         ),
     ),
 )

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -253,6 +253,9 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
             probatio.Optional(CONF_GA_POSITION_STATE): GASelector(
                 write=False, valid_dpt="5.001"
             ),
+            probatio.Optional(
+                CoverConf.POSITION_STATE_SEND, default=False
+            ): selector.BooleanSelector(),
             probatio.Optional(CoverConf.INVERT_POSITION): selector.BooleanSelector(),
             "section_tilt_control": KNXSectionFlat(collapsible=True),
             probatio.Optional(CONF_GA_ANGLE): GASelector(valid_dpt="5.001"),
@@ -296,6 +299,24 @@ COVER_KNX_SCHEMA = AllSerializeFirst(
         msg=(
             "At least one of 'Open/Close control' or"
             " 'Position - Set position' is required."
+        ),
+    ),
+    probatio.Any(
+        probatio.Schema(
+            {probatio.Required(CoverConf.POSITION_STATE_SEND): False},
+            extra=probatio.ALLOW_EXTRA,
+        ),
+        probatio.Schema(
+            {
+                probatio.Required(CONF_GA_POSITION_STATE): GASelector(
+                    write=False, state_required=True
+                )
+            },
+            extra=probatio.ALLOW_EXTRA,
+        ),
+        msg=(
+            "'Actively send the calculated position' requires a"
+            " 'Current position' group address."
         ),
     ),
 )

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -684,6 +684,10 @@
               "description": "Default is UP (0) to open a cover and DOWN (1) to close a cover. Enable this to invert the open/close commands from/to your KNX actuator.",
               "label": "Invert open/close"
             },
+            "position_state_send": {
+              "label": "Actively send the calculated position",
+              "description": "Publish the position calculated by Home Assistant to the address above instead of listening on it. For actuators that do not report their position themselves, so displays can show it."
+            },
             "section_position_control": {
               "description": "Control cover position.",
               "title": "Position"

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -685,8 +685,8 @@
               "label": "Invert open/close"
             },
             "position_state_send": {
-              "label": "Actively send the calculated position",
-              "description": "Publish the position calculated by Home Assistant to the address above instead of listening on it. For actuators that do not report their position themselves, so displays can show it."
+              "description": "Publish the position calculated by Home Assistant to the address above instead of listening on it. This is meant for actuators that do not report their position themselves, so that displays can show it.",
+              "label": "Actively send the calculated position"
             },
             "section_position_control": {
               "description": "Control cover position.",

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -681,6 +681,10 @@
               "description": "Default is UP (0) to open a cover and DOWN (1) to close a cover. Enable this to invert the open/close commands from/to your KNX actuator.",
               "label": "Invert open/close"
             },
+            "position_state_send": {
+              "label": "Actively send the calculated position",
+              "description": "Publish the position calculated by Home Assistant to the address above instead of listening on it. For actuators that do not report their position themselves, so displays can show it."
+            },
             "section_position_control": {
               "description": "Control cover position.",
               "title": "Position"

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -682,8 +682,8 @@
               "label": "Invert open/close"
             },
             "position_state_send": {
-              "label": "Actively send the calculated position",
-              "description": "Publish the position calculated by Home Assistant to the address above instead of listening on it. For actuators that do not report their position themselves, so displays can show it."
+              "description": "Publish the position calculated by Home Assistant to the address above instead of listening on it. This is meant for actuators that do not report their position themselves, so that displays can show it.",
+              "label": "Actively send the calculated position"
             },
             "section_position_control": {
               "description": "Control cover position.",

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -915,6 +915,17 @@
         'type': 'knx_group_address',
       }),
       dict({
+        'default': False,
+        'name': 'position_state_send',
+        'optional': True,
+        'required': False,
+        'selector': dict({
+          'boolean': dict({
+          }),
+        }),
+        'type': 'ha_selector',
+      }),
+      dict({
         'name': 'invert_position',
         'optional': True,
         'required': False,

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -1,5 +1,6 @@
 """Test KNX cover."""
 
+import logging
 from typing import Any
 
 import pytest
@@ -10,6 +11,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
     CoverState,
 )
+from homeassistant.components.knx.const import CoverConf
 from homeassistant.components.knx.schema import CoverSchema
 from homeassistant.const import CONF_NAME, STATE_UNAVAILABLE, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
@@ -383,3 +385,135 @@ async def test_cover_ui_load(knx: KNXTestKit) -> None:
         | CoverEntityFeature.STOP
         | CoverEntityFeature.STOP_TILT,
     )
+
+
+async def test_cover_position_state_send(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test publishing the calculated position instead of listening on the address."""
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
+                CoverConf.TRAVELLING_TIME_UP: 10,
+                CoverConf.TRAVELLING_TIME_DOWN: 10,
+            }
+        }
+    )
+    # the restored position is published so a display can be answered before the
+    # first travel - 80 % open is 20 % for KNX, 51 of 255
+    await knx.assert_write("1/0/2", (0x33,))
+    # Home Assistant is the sender here, so the address is never read
+    await knx.assert_no_telegram()
+
+    await hass.services.async_call(
+        "cover", "close_cover", {"entity_id": "cover.test"}, blocking=True
+    )
+    await knx.assert_write("1/0/0", True)
+
+
+async def test_cover_position_state_send_inverted(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test the published value follows invert_position.
+
+    The travel calculator counts 0 as open. With invert_position the group address
+    counts the other way round, which xknx normally handles in the RemoteValueScaling
+    ranges - the publishing device does not use those.
+    """
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
+                CoverConf.INVERT_POSITION: True,
+            }
+        }
+    )
+    # 80 % open is 20 % for the travel calculator - an inverted actuator expects 204
+    await knx.assert_write("1/0/2", (0xCC,))
+
+
+async def test_cover_position_state_send_is_not_a_state_address(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test a telegram on the address does not update the position.
+
+    This is what caused a feedback loop with a manual `expose` configuration: Home
+    Assistant read its own telegram back as actuator feedback.
+    """
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
+            }
+        }
+    )
+    await knx.assert_write("1/0/2", (0x33,))
+
+    await knx.receive_write("1/0/2", (0xFF,))
+    state = hass.states.get("cover.test")
+    assert state.attributes[ATTR_CURRENT_POSITION] == 80
+
+
+async def test_cover_position_state_send_requires_address(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, knx: KNXTestKit
+) -> None:
+    """Test position_state_send without a position state address is rejected."""
+    with caplog.at_level(logging.ERROR):
+        await knx.setup_integration(
+            {
+                CoverSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                    CoverConf.POSITION_STATE_SEND: True,
+                }
+            }
+        )
+    assert "Invalid config for 'knx'" in caplog.text
+    assert hass.states.get("cover.test") is None
+
+
+async def test_cover_ui_position_state_send(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test publishing the position for a cover created from the UI."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.COVER,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_up_down": {"write": "1/0/0"},
+            "ga_position_state": {"state": "1/0/2"},
+            CoverConf.POSITION_STATE_SEND: True,
+            CoverConf.TRAVELLING_TIME_UP: 10,
+            CoverConf.TRAVELLING_TIME_DOWN: 10,
+        },
+    )
+    # the address is published to, so it is not read on creation
+    await knx.assert_no_telegram()
+
+    # and it is not a state address either - a telegram must not set the position
+    await knx.receive_write("1/0/2", (0xFF,))
+    state = hass.states.get("cover.test")
+    assert state.attributes.get(ATTR_CURRENT_POSITION) is None

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -21,6 +21,7 @@ from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
 from tests.common import async_capture_events, mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 
 async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -518,6 +519,38 @@ async def test_cover_ui_position_state_send(
     await knx.receive_write("1/0/2", (0xFF,))
     state = hass.states.get("cover.test")
     assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+
+
+async def test_cover_ui_position_state_send_requires_address(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the UI schema rejects position_state_send without a position state address."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "knx/validate_entity",
+            "platform": Platform.COVER,
+            "data": {
+                "entity": {"name": "test"},
+                "knx": {
+                    "ga_up_down": {"write": "1/0/0"},
+                    CoverConf.POSITION_STATE_SEND: True,
+                    CoverConf.TRAVELLING_TIME_UP: 10,
+                    CoverConf.TRAVELLING_TIME_DOWN: 10,
+                },
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    assert res["result"]["error_base"].startswith(
+        "'Actively send the calculated position' requires a"
+        " 'Current position' group address."
+    )
 
 
 async def test_cover_position_state_send_while_travelling(

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -517,3 +518,41 @@ async def test_cover_ui_position_state_send(
     await knx.receive_write("1/0/2", (0xFF,))
     state = hass.states.get("cover.test")
     assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+
+
+async def test_cover_position_state_send_while_travelling(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test the position is published when the travel calculator advances."""
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    # no send cooldown here: xknx creates no cooldown task for 0, so the publish is
+    # immediate and the test does not have to wait for real time to pass
+    with patch("homeassistant.components.knx.cover.POSITION_SEND_COOLDOWN", 0):
+        await knx.setup_integration(
+            {
+                CoverSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                    CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                    CoverConf.POSITION_STATE_SEND: True,
+                    CoverConf.TRAVELLING_TIME_UP: 10,
+                    CoverConf.TRAVELLING_TIME_DOWN: 10,
+                }
+            }
+        )
+    await knx.assert_write("1/0/2", (0x33,))
+
+    # the travel calculator is driven by xknx in the background, so advance it here
+    device = knx.xknx.devices["test"]
+    device.travelcalculator.set_position(60)
+    device.after_update()
+    await hass.async_block_till_done()
+    await knx.assert_write("1/0/2", (0x99,))
+
+    # standing still does not publish again
+    device.after_update()
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -2,6 +2,7 @@
 
 import logging
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -603,3 +604,41 @@ async def test_cover_ui_position_state_send(
     await knx.receive_write("1/0/2", (0xFF,))
     state = hass.states.get("cover.test")
     assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+
+
+async def test_cover_position_state_send_while_travelling(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test the position is published when the travel calculator advances."""
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    # no send cooldown here: xknx creates no cooldown task for 0, so the publish is
+    # immediate and the test does not have to wait for real time to pass
+    with patch("homeassistant.components.knx.cover.POSITION_SEND_COOLDOWN", 0):
+        await knx.setup_integration(
+            {
+                CoverSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                    CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                    CoverConf.POSITION_STATE_SEND: True,
+                    CoverConf.TRAVELLING_TIME_UP: 10,
+                    CoverConf.TRAVELLING_TIME_DOWN: 10,
+                }
+            }
+        )
+    await knx.assert_write("1/0/2", (0x33,))
+
+    # the travel calculator is driven by xknx in the background, so advance it here
+    device = knx.xknx.devices["test"]
+    device.travelcalculator.set_position(60)
+    device.after_update()
+    await hass.async_block_till_done()
+    await knx.assert_write("1/0/2", (0x99,))
+
+    # standing still does not publish again
+    device.after_update()
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -30,6 +30,7 @@ from .conftest import KNXTestKit
 
 from tests.common import async_capture_events, mock_restore_cache
 from tests.components.recorder.common import async_wait_recording_done
+from tests.typing import WebSocketGenerator
 
 
 async def test_cover_basic(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -604,6 +605,38 @@ async def test_cover_ui_position_state_send(
     await knx.receive_write("1/0/2", (0xFF,))
     state = hass.states.get("cover.test")
     assert state.attributes.get(ATTR_CURRENT_POSITION) is None
+
+
+async def test_cover_ui_position_state_send_requires_address(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test the UI schema rejects position_state_send without a position state address."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "knx/validate_entity",
+            "platform": Platform.COVER,
+            "data": {
+                "entity": {"name": "test"},
+                "knx": {
+                    "ga_up_down": {"write": "1/0/0"},
+                    CoverConf.POSITION_STATE_SEND: True,
+                    CoverConf.TRAVELLING_TIME_UP: 10,
+                    CoverConf.TRAVELLING_TIME_DOWN: 10,
+                },
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    assert res["result"]["error_base"].startswith(
+        "'Actively send the calculated position' requires a"
+        " 'Current position' group address."
+    )
 
 
 async def test_cover_position_state_send_while_travelling(

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -506,6 +506,11 @@ async def test_cover_position_state_send(hass: HomeAssistant, knx: KNXTestKit) -
     # Home Assistant is the sender here, so the address is never read
     await knx.assert_no_telegram()
 
+    # a display asking for the position is answered from the published value -
+    # that is what the publisher's respond_to_read is for
+    await knx.receive_read("1/0/2")
+    await knx.assert_response("1/0/2", (0x33,))
+
     await hass.services.async_call(
         "cover", "close_cover", {"entity_id": "cover.test"}, blocking=True
     )

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -1,5 +1,6 @@
 """Test KNX cover."""
 
+import logging
 from typing import Any
 
 import pytest
@@ -10,7 +11,7 @@ from homeassistant.components.cover import (
     CoverEntityFeature,
     CoverState,
 )
-from homeassistant.components.knx.const import CONF_SYNC_STATE
+from homeassistant.components.knx.const import CONF_SYNC_STATE, CoverConf
 from homeassistant.components.knx.schema import CoverSchema
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import (
@@ -470,3 +471,135 @@ async def test_cover_ui_load(knx: KNXTestKit) -> None:
         | CoverEntityFeature.STOP
         | CoverEntityFeature.STOP_TILT,
     )
+
+
+async def test_cover_position_state_send(hass: HomeAssistant, knx: KNXTestKit) -> None:
+    """Test publishing the calculated position instead of listening on the address."""
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
+                CoverConf.TRAVELLING_TIME_UP: 10,
+                CoverConf.TRAVELLING_TIME_DOWN: 10,
+            }
+        }
+    )
+    # the restored position is published so a display can be answered before the
+    # first travel - 80 % open is 20 % for KNX, 51 of 255
+    await knx.assert_write("1/0/2", (0x33,))
+    # Home Assistant is the sender here, so the address is never read
+    await knx.assert_no_telegram()
+
+    await hass.services.async_call(
+        "cover", "close_cover", {"entity_id": "cover.test"}, blocking=True
+    )
+    await knx.assert_write("1/0/0", True)
+
+
+async def test_cover_position_state_send_inverted(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test the published value follows invert_position.
+
+    The travel calculator counts 0 as open. With invert_position the group address
+    counts the other way round, which xknx normally handles in the RemoteValueScaling
+    ranges - the publishing device does not use those.
+    """
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
+                CoverConf.INVERT_POSITION: True,
+            }
+        }
+    )
+    # 80 % open is 20 % for the travel calculator - an inverted actuator expects 204
+    await knx.assert_write("1/0/2", (0xCC,))
+
+
+async def test_cover_position_state_send_is_not_a_state_address(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test a telegram on the address does not update the position.
+
+    This is what caused a feedback loop with a manual `expose` configuration: Home
+    Assistant read its own telegram back as actuator feedback.
+    """
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
+            }
+        }
+    )
+    await knx.assert_write("1/0/2", (0x33,))
+
+    await knx.receive_write("1/0/2", (0xFF,))
+    state = hass.states.get("cover.test")
+    assert state.attributes[ATTR_CURRENT_POSITION] == 80
+
+
+async def test_cover_position_state_send_requires_address(
+    hass: HomeAssistant, caplog: pytest.LogCaptureFixture, knx: KNXTestKit
+) -> None:
+    """Test position_state_send without a position state address is rejected."""
+    with caplog.at_level(logging.ERROR):
+        await knx.setup_integration(
+            {
+                CoverSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                    CoverConf.POSITION_STATE_SEND: True,
+                }
+            }
+        )
+    assert "Invalid config for 'knx'" in caplog.text
+    assert hass.states.get("cover.test") is None
+
+
+async def test_cover_ui_position_state_send(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test publishing the position for a cover created from the UI."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.COVER,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_up_down": {"write": "1/0/0"},
+            "ga_position_state": {"state": "1/0/2"},
+            CoverConf.POSITION_STATE_SEND: True,
+            CoverConf.TRAVELLING_TIME_UP: 10,
+            CoverConf.TRAVELLING_TIME_DOWN: 10,
+        },
+    )
+    # the address is published to, so it is not read on creation
+    await knx.assert_no_telegram()
+
+    # and it is not a state address either - a telegram must not set the position
+    await knx.receive_write("1/0/2", (0xFF,))
+    state = hass.states.get("cover.test")
+    assert state.attributes.get(ATTR_CURRENT_POSITION) is None

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -1,10 +1,11 @@
 """Test KNX cover."""
 
-import asyncio
+from datetime import timedelta
 import logging
 from typing import Any
 from unittest.mock import patch
 
+from freezegun.api import FrozenDateTimeFactory
 import pytest
 
 from homeassistant.components.cover import (
@@ -14,6 +15,7 @@ from homeassistant.components.cover import (
     CoverState,
 )
 from homeassistant.components.knx.const import CONF_SYNC_STATE, CoverConf
+from homeassistant.components.knx.cover import POSITION_SEND_COOLDOWN
 from homeassistant.components.knx.schema import CoverSchema
 from homeassistant.components.recorder.history import get_significant_states
 from homeassistant.const import (
@@ -29,7 +31,11 @@ from homeassistant.util import dt as dt_util
 from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
-from tests.common import async_capture_events, mock_restore_cache
+from tests.common import (
+    async_capture_events,
+    async_fire_time_changed,
+    mock_restore_cache,
+)
 from tests.components.recorder.common import async_wait_recording_done
 from tests.typing import WebSocketGenerator
 
@@ -507,7 +513,7 @@ async def test_cover_position_state_send(hass: HomeAssistant, knx: KNXTestKit) -
 
 
 async def test_cover_position_state_send_restored_position_only_once(
-    hass: HomeAssistant, knx: KNXTestKit
+    hass: HomeAssistant, knx: KNXTestKit, freezer: FrozenDateTimeFactory
 ) -> None:
     """Test the restored position is published once, not again after the cooldown.
 
@@ -519,22 +525,22 @@ async def test_cover_position_state_send_restored_position_only_once(
         hass,
         (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
     )
-    # a short but non-zero cooldown: zero would create no cooldown task at all,
+    # a cooldown is needed here: with zero xknx creates no cooldown task at all,
     # and it is exactly that task which used to send the duplicate
-    with patch("homeassistant.components.knx.cover.POSITION_SEND_COOLDOWN", 0.01):
-        await knx.setup_integration(
-            {
-                CoverSchema.PLATFORM: {
-                    CONF_NAME: "test",
-                    CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
-                    CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
-                    CoverConf.POSITION_STATE_SEND: True,
-                }
+    await knx.setup_integration(
+        {
+            CoverSchema.PLATFORM: {
+                CONF_NAME: "test",
+                CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                CoverConf.POSITION_STATE_SEND: True,
             }
-        )
+        }
+    )
     await knx.assert_write("1/0/2", (0x33,))
 
-    await asyncio.sleep(0.05)  # past the cooldown
+    freezer.tick(timedelta(seconds=POSITION_SEND_COOLDOWN))
+    async_fire_time_changed(hass)
     await hass.async_block_till_done()
     await knx.assert_no_telegram()
 

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -1,5 +1,6 @@
 """Test KNX cover."""
 
+import asyncio
 import logging
 from typing import Any
 from unittest.mock import patch
@@ -503,6 +504,39 @@ async def test_cover_position_state_send(hass: HomeAssistant, knx: KNXTestKit) -
         "cover", "close_cover", {"entity_id": "cover.test"}, blocking=True
     )
     await knx.assert_write("1/0/0", True)
+
+
+async def test_cover_position_state_send_restored_position_only_once(
+    hass: HomeAssistant, knx: KNXTestKit
+) -> None:
+    """Test the restored position is published once, not again after the cooldown.
+
+    The cooldown task compares against the remote value's `last_payload`, which is
+    only updated once the outgoing telegram has been processed. During startup that
+    can lag past the cooldown, and the seeded position would go out a second time.
+    """
+    mock_restore_cache(
+        hass,
+        (State("cover.test", CoverState.OPEN, {ATTR_CURRENT_POSITION: 80}),),
+    )
+    # a short but non-zero cooldown: zero would create no cooldown task at all,
+    # and it is exactly that task which used to send the duplicate
+    with patch("homeassistant.components.knx.cover.POSITION_SEND_COOLDOWN", 0.01):
+        await knx.setup_integration(
+            {
+                CoverSchema.PLATFORM: {
+                    CONF_NAME: "test",
+                    CoverSchema.CONF_MOVE_LONG_ADDRESS: "1/0/0",
+                    CoverSchema.CONF_POSITION_STATE_ADDRESS: "1/0/2",
+                    CoverConf.POSITION_STATE_SEND: True,
+                }
+            }
+        )
+    await knx.assert_write("1/0/2", (0x33,))
+
+    await asyncio.sleep(0.05)  # past the cooldown
+    await hass.async_block_till_done()
+    await knx.assert_no_telegram()
 
 
 async def test_cover_position_state_send_inverted(

--- a/tests/components/knx/test_cover.py
+++ b/tests/components/knx/test_cover.py
@@ -715,3 +715,50 @@ async def test_cover_position_state_send_while_travelling(
     device.after_update()
     await hass.async_block_till_done()
     await knx.assert_no_telegram()
+
+
+async def test_cover_position_state_send_address_is_mapped_to_entity(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test the publisher address is registered for the cover entity.
+
+    The publisher is a separate xknx device, so its address is not part of the
+    cover device's `group_addresses()` that the base entity registers. Without
+    an explicit registration `knx/get_entities_by_group` would omit a configured
+    address and DataSecure issues on it would be dropped as unconfigured.
+    """
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+    test_entity = await create_ui_entity(
+        platform=Platform.COVER,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_up_down": {"write": "1/0/0"},
+            "ga_position_state": {"state": "1/0/2"},
+            CoverConf.POSITION_STATE_SEND: True,
+            CoverConf.TRAVELLING_TIME_UP: 10,
+            CoverConf.TRAVELLING_TIME_DOWN: 10,
+        },
+    )
+    await knx.assert_no_telegram()
+
+    await client.send_json_auto_id({"type": "knx/get_entities_by_group"})
+    res = await client.receive_json()
+    assert res["success"], res
+    group_mapping = res["result"]
+    assert "1/0/2" in group_mapping
+    assert group_mapping["1/0/2"][0]["unique_id"] == test_entity.unique_id
+
+    # and it is unregistered again with the entity
+    await client.send_json_auto_id(
+        {"type": "knx/delete_entity", "entity_id": test_entity.entity_id}
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    await client.send_json_auto_id({"type": "knx/get_entities_by_group"})
+    res = await client.receive_json()
+    assert res["success"], res
+    assert "1/0/2" not in res["result"]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

**Proposed change**

Adds an optional boolean `position_state_send` to the KNX `cover` platform. When it is set, Home Assistant publishes the position the travel calculator already provides to the configured `position_state_address`, instead of listening on it — the address is then not registered as an xknx position state at all.

Nothing new is calculated. That position already exists, because it is what the entity reports as `current_position`; this option only makes it available on the bus.

This is for shutter actuators that do not report their position. There the travel calculator is the only source of a position, and KNX wall displays have no way to learn it unless something sends it to them.

**Where this matters**

Newer actuators calculate the position themselves and report it — for those none of this is needed. It is the older ones, and plenty of them are still in service, where the wall display stays empty or shows something wrong. Getting correct positions for shutters and awnings back onto those displays turned out to be a surprisingly large improvement in daily use, for something that costs no more than publishing a value which already exists.

**Why not `expose`**

`expose` can do this today, and that is how I ran it. It was silently broken for months, in four independent ways, and every one of them comes from having to re-implement knowledge the platform already holds:

- The inversion has to be hand-written. `cover.py` already knows it — `current_cover_position` returns `100 - pos` with the comment "In KNX 0 is open, 100 is closed". In the template I got the scale wrong (`{{ 100-(value*100) }}`, assuming 0…1), which produces `-2100` at position 22 → `ConversionError` for DPT 5.001 and the telegram is dropped. Only positions 0 and 1 ever produced a valid value.
- `cooldown` is in seconds. I had `100` on a door that travels 20 s — one telegram at the start, then silence.
- `respond_to_read` was off, so after a display restart nobody answered its read request.
- I pointed the expose at the cover's own `position_state_address`. Home Assistant then reads its own telegram back as actuator feedback and resets the travel calculator. Measured on the same shutter, two runs each: **3 resp. 15 position direction reversals per travel, and a 20 s travel took 39 s** in Home Assistant's calculation. The shutter was long closed while the entity still reported "closing, 1 %" — and that stale value is what the display received.

With the switch, that last configuration is structurally impossible: if Home Assistant publishes the position, it does not listen on the address, and the combination it rules out is meaningless anyway — whoever calculates the position has nobody to listen to.

**Implementation**

No new concept and no xknx change: the publisher is a second xknx device (`ExposeSensor`, DPT 5.001) carried by the cover entity and handled exactly like the existing `ClimateMode` sub-device — created in the constructor, added to `xknx.devices` in `async_added_to_hass`, removed in `async_will_remove_from_hass`.

What it sends is the value in the group address domain, taking `invert_position` into account. The restored position is published once at startup, so a display can be answered before the first travel. Telegrams while travelling are throttled to one every two seconds; the first value always goes out immediately, which is what makes a button press visible on the display.

Setting the switch without a `position_state_address` is rejected by the schema, in YAML and in the UI.

**Testing**

Five tests added: startup publishing and that the address is never read, the inverted case (internal 20 must be payload 204, not 51), that a telegram on the address does not change the position, the schema rejection, and the UI path. Entity store schema snapshot updated (+11 lines, additions only).

Full KNX suite green — 483 tests, 22 snapshots — `ruff check` and `ruff format --check` clean with 0.16.0, `script.hassfest` reports `Invalid integrations: 0`.

Running in my installation on 2026.8 with 23 KNX covers, four of them using the switch, verified against the bus: monotone position ramps, zero direction reversals, end position reached exactly at the configured travel time, and a read request answered by Home Assistant after a restart without any travel.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
