### PR TITLE
Add Podcast Player integration

### DIFF
--- a/.strict-typing
+++ b/.strict-typing
@@ -452,6 +452,7 @@ homeassistant.components.person.*
 homeassistant.components.pi_hole.*
 homeassistant.components.ping.*
 homeassistant.components.plugwise.*
+homeassistant.components.podcast_player.*
 homeassistant.components.pooldose.*
 homeassistant.components.portainer.*
 homeassistant.components.powerfox.*

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1412,6 +1412,8 @@ CLAUDE.md @home-assistant/core
 /tests/components/plex/ @jjlawren
 /homeassistant/components/plugwise/ @CoMPaTech @bouwew
 /tests/components/plugwise/ @CoMPaTech @bouwew
+/homeassistant/components/podcast_player/ @armilancode
+/tests/components/podcast_player/ @armilancode
 /homeassistant/components/point/ @fredrike
 /tests/components/point/ @fredrike
 /homeassistant/components/pooldose/ @lmaertin

--- a/homeassistant/components/podcast_player/__init__.py
+++ b/homeassistant/components/podcast_player/__init__.py
@@ -1,50 +1,25 @@
 """The Podcast Player integration."""
 
-import asyncio
-from dataclasses import dataclass, field
+from aiopodcast import PodcastConnectionError, PodcastFeedError, PodcastHTTPError
 
-from aiopodcast import (
-    Podcast,
-    PodcastClient,
-    PodcastConnectionError,
-    PodcastFeedError,
-    PodcastHTTPError,
-)
-
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_URL
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
 
 from .client import create_client
 from .const import DOMAIN
+from .coordinator import PodcastConfigEntry, PodcastUpdateCoordinator
 
-
-@dataclass(slots=True)
-class PodcastRuntimeData:
-    """Runtime data for a podcast feed."""
-
-    client: PodcastClient
-    url: str
-    podcast: Podcast
-    _refresh_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
-
-    async def async_refresh(self) -> Podcast:
-        """Fetch the latest podcast feed."""
-        async with self._refresh_lock:
-            self.podcast = await self.client.async_fetch(self.url)
-            return self.podcast
-
-
-type PodcastConfigEntry = ConfigEntry[PodcastRuntimeData]
+PLATFORMS = [Platform.EVENT]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: PodcastConfigEntry) -> bool:
     """Set up a podcast feed from a config entry."""
     client = create_client(hass)
+    coordinator = PodcastUpdateCoordinator(hass, entry, client)
 
     try:
-        podcast = await client.async_fetch(entry.data[CONF_URL])
+        podcast = await coordinator.async_fetch()
     except (PodcastConnectionError, PodcastHTTPError) as err:
         raise ConfigEntryNotReady(
             translation_domain=DOMAIN,
@@ -56,14 +31,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: PodcastConfigEntry) -> b
             translation_key="invalid_feed",
         ) from err
 
-    entry.runtime_data = PodcastRuntimeData(
-        client=client,
-        url=entry.data[CONF_URL],
-        podcast=podcast,
-    )
+    coordinator.async_set_updated_data(podcast)
+    entry.runtime_data = coordinator
+
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: PodcastConfigEntry) -> bool:
     """Unload a podcast feed config entry."""
-    return True
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/homeassistant/components/podcast_player/__init__.py
+++ b/homeassistant/components/podcast_player/__init__.py
@@ -1,0 +1,69 @@
+"""The Podcast Player integration."""
+
+import asyncio
+from dataclasses import dataclass, field
+
+from aiopodcast import (
+    Podcast,
+    PodcastClient,
+    PodcastConnectionError,
+    PodcastFeedError,
+    PodcastHTTPError,
+)
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryError, ConfigEntryNotReady
+
+from .client import create_client
+from .const import DOMAIN
+
+
+@dataclass(slots=True)
+class PodcastRuntimeData:
+    """Runtime data for a podcast feed."""
+
+    client: PodcastClient
+    url: str
+    podcast: Podcast
+    _refresh_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def async_refresh(self) -> Podcast:
+        """Fetch the latest podcast feed."""
+        async with self._refresh_lock:
+            self.podcast = await self.client.async_fetch(self.url)
+            return self.podcast
+
+
+type PodcastConfigEntry = ConfigEntry[PodcastRuntimeData]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: PodcastConfigEntry) -> bool:
+    """Set up a podcast feed from a config entry."""
+    client = create_client(hass)
+
+    try:
+        podcast = await client.async_fetch(entry.data[CONF_URL])
+    except (PodcastConnectionError, PodcastHTTPError) as err:
+        raise ConfigEntryNotReady(
+            translation_domain=DOMAIN,
+            translation_key="feed_unavailable",
+        ) from err
+    except PodcastFeedError as err:
+        raise ConfigEntryError(
+            translation_domain=DOMAIN,
+            translation_key="invalid_feed",
+        ) from err
+
+    entry.runtime_data = PodcastRuntimeData(
+        client=client,
+        url=entry.data[CONF_URL],
+        podcast=podcast,
+    )
+    return True
+
+
+async def async_unload_entry(hass: HomeAssistant, entry: PodcastConfigEntry) -> bool:
+    """Unload a podcast feed config entry."""
+    return True

--- a/homeassistant/components/podcast_player/client.py
+++ b/homeassistant/components/podcast_player/client.py
@@ -1,0 +1,18 @@
+"""Client helpers for Podcast Player."""
+
+from aiopodcast import PodcastClient
+
+from homeassistant.const import __version__
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
+
+def create_client(hass: HomeAssistant) -> PodcastClient:
+    """Create a podcast client using Home Assistant's shared web session."""
+    return PodcastClient(
+        async_get_clientsession(hass),
+        headers={
+            "Accept": "application/atom+xml, application/rss+xml, application/xml, text/xml",
+            "User-Agent": f"HomeAssistant/{__version__}",
+        },
+    )

--- a/homeassistant/components/podcast_player/config_flow.py
+++ b/homeassistant/components/podcast_player/config_flow.py
@@ -1,0 +1,110 @@
+"""Config flow for Podcast Player."""
+
+import logging
+from typing import Any, override
+
+from aiopodcast import (
+    Podcast,
+    PodcastConnectionError,
+    PodcastFeedError,
+    PodcastHTTPError,
+)
+import voluptuous as vol
+from yarl import URL
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
+
+from .client import create_client
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STEP_USER_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_URL): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.URL, autocomplete="url")
+        )
+    }
+)
+
+
+class InvalidUrl(HomeAssistantError):
+    """Error to indicate an invalid feed URL."""
+
+
+def normalize_url(value: str) -> str:
+    """Validate and normalize a podcast feed URL."""
+    try:
+        url = URL(value)
+    except ValueError as err:
+        raise InvalidUrl from err
+
+    if (
+        url.scheme not in {"http", "https"}
+        or url.host is None
+        or url.user is not None
+        or url.password is not None
+    ):
+        raise InvalidUrl
+
+    return str(url.with_fragment(None))
+
+
+async def async_validate_input(hass: HomeAssistant, url: str) -> Podcast:
+    """Fetch and validate a podcast feed."""
+    return await create_client(hass).async_fetch(url)
+
+
+class PodcastPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Handle a config flow for Podcast Player."""
+
+    VERSION = 1
+
+    @override
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle the initial setup step."""
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            try:
+                url = normalize_url(user_input[CONF_URL])
+            except InvalidUrl:
+                errors[CONF_URL] = "invalid_url"
+            else:
+                self._async_abort_entries_match({CONF_URL: url})
+                try:
+                    podcast = await async_validate_input(self.hass, url)
+                except PodcastConnectionError, PodcastHTTPError:
+                    errors["base"] = "cannot_connect"
+                except PodcastFeedError:
+                    errors["base"] = "invalid_feed"
+                except Exception:
+                    _LOGGER.exception(
+                        "Unexpected exception while validating podcast feed"
+                    )
+                    errors["base"] = "unknown"
+                else:
+                    await self.async_set_unique_id(normalize_url(podcast.canonical_url))
+                    self._abort_if_unique_id_configured()
+                    return self.async_create_entry(
+                        title=podcast.title,
+                        data={CONF_URL: url},
+                    )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_USER_DATA_SCHEMA, user_input
+            ),
+            errors=errors,
+        )

--- a/homeassistant/components/podcast_player/config_flow.py
+++ b/homeassistant/components/podcast_player/config_flow.py
@@ -84,9 +84,10 @@ class PodcastPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                 self._async_abort_entries_match({CONF_URL: url})
                 try:
                     podcast = await async_validate_input(self.hass, url)
+                    canonical_url = normalize_url(podcast.canonical_url)
                 except PodcastConnectionError, PodcastHTTPError:
                     errors["base"] = "cannot_connect"
-                except PodcastFeedError:
+                except PodcastFeedError, InvalidUrl:
                     errors["base"] = "invalid_feed"
                 except Exception:
                     _LOGGER.exception(
@@ -94,7 +95,7 @@ class PodcastPlayerConfigFlow(ConfigFlow, domain=DOMAIN):
                     )
                     errors["base"] = "unknown"
                 else:
-                    await self.async_set_unique_id(normalize_url(podcast.canonical_url))
+                    await self.async_set_unique_id(canonical_url)
                     self._abort_if_unique_id_configured()
                     return self.async_create_entry(
                         title=podcast.title,

--- a/homeassistant/components/podcast_player/const.py
+++ b/homeassistant/components/podcast_player/const.py
@@ -1,0 +1,5 @@
+"""Constants for Podcast Player."""
+
+DOMAIN = "podcast_player"
+
+MAX_BROWSE_EPISODES = 250

--- a/homeassistant/components/podcast_player/const.py
+++ b/homeassistant/components/podcast_player/const.py
@@ -1,5 +1,10 @@
 """Constants for Podcast Player."""
 
-DOMAIN = "podcast_player"
+from datetime import timedelta
+from typing import Final
 
-MAX_BROWSE_EPISODES = 250
+DOMAIN: Final = "podcast_player"
+
+EVENT_NEW_EPISODE: Final = "new_episode"
+MAX_BROWSE_EPISODES: Final = 250
+SCAN_INTERVAL: Final = timedelta(hours=1)

--- a/homeassistant/components/podcast_player/coordinator.py
+++ b/homeassistant/components/podcast_player/coordinator.py
@@ -1,0 +1,56 @@
+"""Data update coordinator for Podcast Player."""
+
+import logging
+from typing import override
+
+from aiopodcast import Podcast, PodcastClient, PodcastFeedError
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+
+from .const import DOMAIN, SCAN_INTERVAL
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class PodcastUpdateCoordinator(DataUpdateCoordinator[Podcast]):
+    """Coordinate podcast feed updates."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry[PodcastUpdateCoordinator],
+        client: PodcastClient,
+    ) -> None:
+        """Initialize the podcast feed coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=entry,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            always_update=False,
+        )
+        self.entry = entry
+        self.client = client
+        self.url = entry.data[CONF_URL]
+
+    async def async_fetch(self) -> Podcast:
+        """Fetch the configured podcast feed."""
+        return await self.client.async_fetch(self.url)
+
+    @override
+    async def _async_update_data(self) -> Podcast:
+        """Fetch the latest podcast feed."""
+        try:
+            return await self.async_fetch()
+        except PodcastFeedError as err:
+            raise UpdateFailed(
+                translation_domain=DOMAIN,
+                translation_key="feed_unavailable",
+            ) from err
+
+
+type PodcastConfigEntry = ConfigEntry[PodcastUpdateCoordinator]

--- a/homeassistant/components/podcast_player/event.py
+++ b/homeassistant/components/podcast_player/event.py
@@ -1,0 +1,101 @@
+"""Event entities for Podcast Player."""
+
+from typing import override
+
+from aiopodcast import PodcastEpisode
+
+from homeassistant.components.event import EventEntity, EventEntityDescription
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN, EVENT_NEW_EPISODE
+from .coordinator import PodcastConfigEntry, PodcastUpdateCoordinator
+from .helpers import episode_identifier
+
+ATTR_DURATION_SECONDS = "duration_seconds"
+ATTR_EPISODE_ID = "episode_id"
+ATTR_MEDIA_CONTENT_ID = "media_content_id"
+ATTR_PUBLISHED = "published"
+ATTR_TITLE = "title"
+
+PARALLEL_UPDATES = 0
+
+ENTITY_DESCRIPTION = EventEntityDescription(
+    key="latest_episode",
+    translation_key="latest_episode",
+    event_types=[EVENT_NEW_EPISODE],
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: PodcastConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up the podcast episode event entity."""
+    async_add_entities([PodcastEpisodeEvent(entry.runtime_data)])
+
+
+class PodcastEpisodeEvent(CoordinatorEntity[PodcastUpdateCoordinator], EventEntity):
+    """Represent newly discovered podcast episodes."""
+
+    _attr_has_entity_name = True
+
+    def __init__(self, coordinator: PodcastUpdateCoordinator) -> None:
+        """Initialize the podcast episode event entity."""
+        super().__init__(coordinator)
+        self.entity_description = ENTITY_DESCRIPTION
+        self._attr_unique_id = f"{coordinator.entry.entry_id}_{ENTITY_DESCRIPTION.key}"
+        podcast = coordinator.data
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, coordinator.entry.entry_id)},
+            name=podcast.title,
+            manufacturer=podcast.author,
+            configuration_url=podcast.website_url,
+            entry_type=DeviceEntryType.SERVICE,
+        )
+
+    def _episode_attributes(self, episode: PodcastEpisode) -> dict[str, str | int]:
+        """Return compact attributes for a podcast episode event."""
+        episode_id = episode_identifier(episode)
+        attributes: dict[str, str | int] = {
+            ATTR_EPISODE_ID: episode_id,
+            ATTR_MEDIA_CONTENT_ID: (
+                f"media-source://{DOMAIN}/{self.coordinator.entry.entry_id}/{episode_id}"
+            ),
+            ATTR_TITLE: episode.title,
+        }
+        if episode.published is not None:
+            attributes[ATTR_PUBLISHED] = episode.published.isoformat()
+        if episode.duration_seconds is not None:
+            attributes[ATTR_DURATION_SECONDS] = episode.duration_seconds
+        return attributes
+
+    @callback
+    def _async_handle_latest_episode(self) -> None:
+        """Trigger an event when the latest episode changes."""
+        if not self.coordinator.data.episodes:
+            return
+
+        episode = self.coordinator.data.episodes[0]
+        attributes = self._episode_attributes(episode)
+        if self.state_attributes.get(ATTR_EPISODE_ID) == attributes[ATTR_EPISODE_ID]:
+            return
+
+        self._trigger_event(EVENT_NEW_EPISODE, attributes)
+        self.async_write_ha_state()
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Handle the entity being added to Home Assistant."""
+        await super().async_added_to_hass()
+        self._async_handle_latest_episode()
+
+    @callback
+    @override
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated podcast feed data."""
+        self._async_handle_latest_episode()
+        super()._handle_coordinator_update()

--- a/homeassistant/components/podcast_player/event.py
+++ b/homeassistant/components/podcast_player/event.py
@@ -42,6 +42,7 @@ class PodcastEpisodeEvent(CoordinatorEntity[PodcastUpdateCoordinator], EventEnti
     """Represent newly discovered podcast episodes."""
 
     _attr_has_entity_name = True
+    _attr_name = None
 
     def __init__(self, coordinator: PodcastUpdateCoordinator) -> None:
         """Initialize the podcast episode event entity."""

--- a/homeassistant/components/podcast_player/helpers.py
+++ b/homeassistant/components/podcast_player/helpers.py
@@ -1,0 +1,11 @@
+"""Shared helpers for Podcast Player."""
+
+import hashlib
+
+from aiopodcast import PodcastEpisode
+
+
+def episode_identifier(episode: PodcastEpisode) -> str:
+    """Return a stable identifier for a podcast episode."""
+    value = episode.guid or episode.enclosure.url
+    return hashlib.sha256(value.encode()).hexdigest()[:32]

--- a/homeassistant/components/podcast_player/manifest.json
+++ b/homeassistant/components/podcast_player/manifest.json
@@ -1,0 +1,12 @@
+{
+  "domain": "podcast_player",
+  "name": "Podcast Player",
+  "codeowners": ["@armilancode"],
+  "config_flow": true,
+  "documentation": "https://www.home-assistant.io/integrations/podcast_player",
+  "integration_type": "service",
+  "iot_class": "cloud_polling",
+  "loggers": ["aiopodcast"],
+  "quality_scale": "bronze",
+  "requirements": ["aio-podcast==0.1.0"]
+}

--- a/homeassistant/components/podcast_player/media_source.py
+++ b/homeassistant/components/podcast_player/media_source.py
@@ -2,6 +2,7 @@
 
 import mimetypes
 from typing import override
+from urllib.parse import urlsplit
 
 from aiopodcast import Podcast, PodcastEpisode
 
@@ -30,7 +31,7 @@ def _episode_mime_type(episode: PodcastEpisode) -> str:
     """Return the episode MIME type."""
     if episode.enclosure.mime_type:
         return episode.enclosure.mime_type.partition(";")[0].strip()
-    mime_type, _ = mimetypes.guess_type(episode.enclosure.url)
+    mime_type, _ = mimetypes.guess_type(urlsplit(episode.enclosure.url).path)
     return mime_type or "audio/mpeg"
 
 

--- a/homeassistant/components/podcast_player/media_source.py
+++ b/homeassistant/components/podcast_player/media_source.py
@@ -13,6 +13,7 @@ from homeassistant.components.media_source import (
     PlayMedia,
     Unresolvable,
 )
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN, MAX_BROWSE_EPISODES
@@ -59,10 +60,14 @@ class PodcastMediaSource(MediaSource):
         """Return loaded podcast entries."""
         return self.hass.config_entries.async_loaded_entries(DOMAIN)
 
+    def _entries(self) -> list[PodcastConfigEntry]:
+        """Return configured podcast entries."""
+        return self.hass.config_entries.async_entries(DOMAIN)
+
     def _entry(self, entry_id: str) -> PodcastConfigEntry | None:
-        """Return a loaded podcast entry by entry ID."""
+        """Return a configured podcast entry by entry ID."""
         return next(
-            (entry for entry in self._loaded_entries() if entry.entry_id == entry_id),
+            (entry for entry in self._entries() if entry.entry_id == entry_id),
             None,
         )
 
@@ -73,7 +78,9 @@ class PodcastMediaSource(MediaSource):
         if not entries:
             raise BrowseError(
                 translation_domain=DOMAIN,
-                translation_key="not_configured",
+                translation_key=(
+                    "feed_unavailable" if self._entries() else "not_configured"
+                ),
             )
 
         if not item.identifier:
@@ -108,6 +115,11 @@ class PodcastMediaSource(MediaSource):
             raise BrowseError(
                 translation_domain=DOMAIN,
                 translation_key="path_not_found",
+            )
+        if entry.state is not ConfigEntryState.LOADED:
+            raise BrowseError(
+                translation_domain=DOMAIN,
+                translation_key="feed_unavailable",
             )
 
         await entry.runtime_data.async_refresh()
@@ -153,6 +165,11 @@ class PodcastMediaSource(MediaSource):
             raise Unresolvable(
                 translation_domain=DOMAIN,
                 translation_key="episode_unavailable",
+            )
+        if entry.state is not ConfigEntryState.LOADED:
+            raise Unresolvable(
+                translation_domain=DOMAIN,
+                translation_key="feed_unavailable",
             )
 
         episode = _find_episode(entry.runtime_data.data, episode_id)

--- a/homeassistant/components/podcast_player/media_source.py
+++ b/homeassistant/components/podcast_player/media_source.py
@@ -1,0 +1,184 @@
+"""Expose podcasts as a media source."""
+
+import hashlib
+import mimetypes
+from typing import override
+
+from aiopodcast import Podcast, PodcastEpisode, PodcastFeedError
+
+from homeassistant.components.media_player import BrowseError, MediaClass, MediaType
+from homeassistant.components.media_source import (
+    BrowseMediaSource,
+    MediaSource,
+    MediaSourceItem,
+    PlayMedia,
+    Unresolvable,
+)
+from homeassistant.core import HomeAssistant
+
+from . import PodcastConfigEntry
+from .const import DOMAIN, MAX_BROWSE_EPISODES
+
+
+async def async_get_media_source(hass: HomeAssistant) -> PodcastMediaSource:
+    """Set up the Podcast Player media source."""
+    return PodcastMediaSource(hass)
+
+
+def _episode_identifier(episode: PodcastEpisode) -> str:
+    """Return a stable identifier for a podcast episode."""
+    value = episode.guid or episode.enclosure.url
+    return hashlib.sha256(value.encode()).hexdigest()[:32]
+
+
+def _episode_mime_type(episode: PodcastEpisode) -> str:
+    """Return the episode MIME type."""
+    if episode.enclosure.mime_type:
+        return episode.enclosure.mime_type.partition(";")[0].strip()
+    mime_type, _ = mimetypes.guess_type(episode.enclosure.url)
+    return mime_type or "audio/mpeg"
+
+
+def _find_episode(podcast: Podcast, identifier: str) -> PodcastEpisode | None:
+    """Find an episode by its media source identifier."""
+    return next(
+        (
+            episode
+            for episode in podcast.episodes
+            if _episode_identifier(episode) == identifier
+        ),
+        None,
+    )
+
+
+class PodcastMediaSource(MediaSource):
+    """Provide configured podcasts as a media source."""
+
+    name = "Podcasts"
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        """Initialize the podcast media source."""
+        super().__init__(DOMAIN)
+        self.hass = hass
+
+    def _loaded_entries(self) -> list[PodcastConfigEntry]:
+        """Return loaded podcast entries."""
+        return self.hass.config_entries.async_loaded_entries(DOMAIN)
+
+    def _entry(self, entry_id: str) -> PodcastConfigEntry | None:
+        """Return a loaded podcast entry by entry ID."""
+        return next(
+            (entry for entry in self._loaded_entries() if entry.entry_id == entry_id),
+            None,
+        )
+
+    @override
+    async def async_browse_media(self, item: MediaSourceItem) -> BrowseMediaSource:
+        """Browse configured podcasts and episodes."""
+        entries = self._loaded_entries()
+        if not entries:
+            raise BrowseError(
+                translation_domain=DOMAIN,
+                translation_key="not_configured",
+            )
+
+        if not item.identifier:
+            return BrowseMediaSource(
+                domain=DOMAIN,
+                identifier=None,
+                media_class=MediaClass.PODCAST,
+                media_content_type=MediaType.PODCAST,
+                title="Podcasts",
+                can_play=False,
+                can_expand=True,
+                children_media_class=MediaClass.PODCAST,
+                children=[
+                    BrowseMediaSource(
+                        domain=DOMAIN,
+                        identifier=entry.entry_id,
+                        media_class=MediaClass.PODCAST,
+                        media_content_type=MediaType.PODCAST,
+                        title=entry.title,
+                        can_play=False,
+                        can_expand=True,
+                        children_media_class=MediaClass.EPISODE,
+                        thumbnail=entry.runtime_data.podcast.artwork_url,
+                    )
+                    for entry in sorted(
+                        entries, key=lambda entry: entry.title.casefold()
+                    )
+                ],
+            )
+
+        if "/" in item.identifier or not (entry := self._entry(item.identifier)):
+            raise BrowseError(
+                translation_domain=DOMAIN,
+                translation_key="path_not_found",
+            )
+
+        try:
+            podcast = await entry.runtime_data.async_refresh()
+        except PodcastFeedError as err:
+            raise BrowseError(
+                translation_domain=DOMAIN,
+                translation_key="feed_unavailable",
+            ) from err
+
+        episodes = podcast.episodes[:MAX_BROWSE_EPISODES]
+        return BrowseMediaSource(
+            domain=DOMAIN,
+            identifier=entry.entry_id,
+            media_class=MediaClass.PODCAST,
+            media_content_type=MediaType.PODCAST,
+            title=podcast.title,
+            can_play=False,
+            can_expand=True,
+            children_media_class=MediaClass.EPISODE,
+            thumbnail=podcast.artwork_url,
+            not_shown=len(podcast.episodes) - len(episodes),
+            children=[
+                BrowseMediaSource(
+                    domain=DOMAIN,
+                    identifier=f"{entry.entry_id}/{_episode_identifier(episode)}",
+                    media_class=MediaClass.EPISODE,
+                    media_content_type=_episode_mime_type(episode),
+                    title=episode.title,
+                    can_play=True,
+                    can_expand=False,
+                    thumbnail=episode.artwork_url or podcast.artwork_url,
+                )
+                for episode in episodes
+            ],
+        )
+
+    @override
+    async def async_resolve_media(self, item: MediaSourceItem) -> PlayMedia:
+        """Resolve a podcast episode to its enclosure URL."""
+        entry_id, separator, episode_id = item.identifier.partition("/")
+        if not separator or not episode_id or not (entry := self._entry(entry_id)):
+            raise Unresolvable(
+                translation_domain=DOMAIN,
+                translation_key="episode_unavailable",
+            )
+
+        episode = _find_episode(entry.runtime_data.podcast, episode_id)
+        if episode is None:
+            try:
+                podcast = await entry.runtime_data.async_refresh()
+            except PodcastFeedError as err:
+                raise Unresolvable(
+                    translation_domain=DOMAIN,
+                    translation_key="feed_unavailable",
+                ) from err
+            episode = _find_episode(podcast, episode_id)
+
+        if episode is None:
+            raise Unresolvable(
+                translation_domain=DOMAIN,
+                translation_key="episode_unavailable",
+            )
+
+        return PlayMedia(
+            url=episode.enclosure.url,
+            mime_type=_episode_mime_type(episode),
+        )

--- a/homeassistant/components/podcast_player/media_source.py
+++ b/homeassistant/components/podcast_player/media_source.py
@@ -1,10 +1,9 @@
 """Expose podcasts as a media source."""
 
-import hashlib
 import mimetypes
 from typing import override
 
-from aiopodcast import Podcast, PodcastEpisode, PodcastFeedError
+from aiopodcast import Podcast, PodcastEpisode
 
 from homeassistant.components.media_player import BrowseError, MediaClass, MediaType
 from homeassistant.components.media_source import (
@@ -16,19 +15,14 @@ from homeassistant.components.media_source import (
 )
 from homeassistant.core import HomeAssistant
 
-from . import PodcastConfigEntry
 from .const import DOMAIN, MAX_BROWSE_EPISODES
+from .coordinator import PodcastConfigEntry
+from .helpers import episode_identifier
 
 
 async def async_get_media_source(hass: HomeAssistant) -> PodcastMediaSource:
     """Set up the Podcast Player media source."""
     return PodcastMediaSource(hass)
-
-
-def _episode_identifier(episode: PodcastEpisode) -> str:
-    """Return a stable identifier for a podcast episode."""
-    value = episode.guid or episode.enclosure.url
-    return hashlib.sha256(value.encode()).hexdigest()[:32]
 
 
 def _episode_mime_type(episode: PodcastEpisode) -> str:
@@ -45,7 +39,7 @@ def _find_episode(podcast: Podcast, identifier: str) -> PodcastEpisode | None:
         (
             episode
             for episode in podcast.episodes
-            if _episode_identifier(episode) == identifier
+            if episode_identifier(episode) == identifier
         ),
         None,
     )
@@ -102,7 +96,7 @@ class PodcastMediaSource(MediaSource):
                         can_play=False,
                         can_expand=True,
                         children_media_class=MediaClass.EPISODE,
-                        thumbnail=entry.runtime_data.podcast.artwork_url,
+                        thumbnail=entry.runtime_data.data.artwork_url,
                     )
                     for entry in sorted(
                         entries, key=lambda entry: entry.title.casefold()
@@ -116,13 +110,13 @@ class PodcastMediaSource(MediaSource):
                 translation_key="path_not_found",
             )
 
-        try:
-            podcast = await entry.runtime_data.async_refresh()
-        except PodcastFeedError as err:
+        await entry.runtime_data.async_refresh()
+        if not entry.runtime_data.last_update_success:
             raise BrowseError(
                 translation_domain=DOMAIN,
                 translation_key="feed_unavailable",
-            ) from err
+            ) from entry.runtime_data.last_exception
+        podcast = entry.runtime_data.data
 
         episodes = podcast.episodes[:MAX_BROWSE_EPISODES]
         return BrowseMediaSource(
@@ -139,7 +133,7 @@ class PodcastMediaSource(MediaSource):
             children=[
                 BrowseMediaSource(
                     domain=DOMAIN,
-                    identifier=f"{entry.entry_id}/{_episode_identifier(episode)}",
+                    identifier=f"{entry.entry_id}/{episode_identifier(episode)}",
                     media_class=MediaClass.EPISODE,
                     media_content_type=_episode_mime_type(episode),
                     title=episode.title,
@@ -161,15 +155,15 @@ class PodcastMediaSource(MediaSource):
                 translation_key="episode_unavailable",
             )
 
-        episode = _find_episode(entry.runtime_data.podcast, episode_id)
+        episode = _find_episode(entry.runtime_data.data, episode_id)
         if episode is None:
-            try:
-                podcast = await entry.runtime_data.async_refresh()
-            except PodcastFeedError as err:
+            await entry.runtime_data.async_refresh()
+            if not entry.runtime_data.last_update_success:
                 raise Unresolvable(
                     translation_domain=DOMAIN,
                     translation_key="feed_unavailable",
-                ) from err
+                ) from entry.runtime_data.last_exception
+            podcast = entry.runtime_data.data
             episode = _find_episode(podcast, episode_id)
 
         if episode is None:

--- a/homeassistant/components/podcast_player/quality_scale.yaml
+++ b/homeassistant/components/podcast_player/quality_scale.yaml
@@ -1,0 +1,114 @@
+rules:
+  # Bronze
+  action-setup:
+    status: exempt
+    comment: The integration does not register custom actions.
+  appropriate-polling:
+    status: exempt
+    comment: Feeds are fetched during setup and user-initiated browsing.
+  brands: done
+  common-modules: done
+  config-flow-test-coverage: done
+  config-flow: done
+  dependency-transparency: done
+  docs-actions:
+    status: exempt
+    comment: The integration does not register custom actions.
+  docs-conditions:
+    status: exempt
+    comment: The integration does not provide conditions.
+  docs-high-level-description: done
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: The integration does not provide triggers.
+  entity-event-setup:
+    status: exempt
+    comment: The integration does not create entities.
+  entity-unique-id:
+    status: exempt
+    comment: The integration does not create entities.
+  has-entity-name:
+    status: exempt
+    comment: The integration does not create entities.
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions:
+    status: exempt
+    comment: The integration does not register custom actions.
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: The integration does not provide configuration options.
+  docs-installation-parameters: done
+  entity-unavailable:
+    status: exempt
+    comment: The integration does not create entities.
+  integration-owner: done
+  log-when-unavailable:
+    status: exempt
+    comment: The integration does not create entities.
+  parallel-updates:
+    status: exempt
+    comment: The integration does not create entities.
+  reauthentication-flow:
+    status: exempt
+    comment: Podcast feeds do not require account authentication.
+  test-coverage: done
+
+  # Gold
+  devices:
+    status: exempt
+    comment: The integration does not create devices.
+  diagnostics: todo
+  discovery-update-info:
+    status: exempt
+    comment: Podcast feeds are configured by URL and are not discoverable.
+  discovery:
+    status: exempt
+    comment: Podcast feeds are configured by URL and are not discoverable.
+  docs-data-update: done
+  docs-examples: done
+  docs-known-limitations: done
+  docs-supported-devices:
+    status: exempt
+    comment: The integration does not support physical devices.
+  docs-supported-functions: done
+  docs-troubleshooting: done
+  docs-use-cases: done
+  dynamic-devices:
+    status: exempt
+    comment: The integration does not create devices.
+  entity-category:
+    status: exempt
+    comment: The integration does not create entities.
+  entity-device-class:
+    status: exempt
+    comment: The integration does not create entities.
+  entity-disabled-by-default:
+    status: exempt
+    comment: The integration does not create entities.
+  entity-translations:
+    status: exempt
+    comment: The integration does not create entities.
+  exception-translations: done
+  icon-translations:
+    status: exempt
+    comment: The integration does not create entities.
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: The integration has no cases requiring a repair issue.
+  stale-devices:
+    status: exempt
+    comment: The integration does not create devices.
+
+  # Platinum
+  async-dependency: done
+  inject-websession: done
+  strict-typing: done

--- a/homeassistant/components/podcast_player/quality_scale.yaml
+++ b/homeassistant/components/podcast_player/quality_scale.yaml
@@ -3,9 +3,7 @@ rules:
   action-setup:
     status: exempt
     comment: The integration does not register custom actions.
-  appropriate-polling:
-    status: exempt
-    comment: Feeds are fetched during setup and user-initiated browsing.
+  appropriate-polling: done
   brands: done
   common-modules: done
   config-flow-test-coverage: done
@@ -20,18 +18,10 @@ rules:
   docs-high-level-description: done
   docs-installation-instructions: done
   docs-removal-instructions: done
-  docs-triggers:
-    status: exempt
-    comment: The integration does not provide triggers.
-  entity-event-setup:
-    status: exempt
-    comment: The integration does not create entities.
-  entity-unique-id:
-    status: exempt
-    comment: The integration does not create entities.
-  has-entity-name:
-    status: exempt
-    comment: The integration does not create entities.
+  docs-triggers: done
+  entity-event-setup: done
+  entity-unique-id: done
+  has-entity-name: done
   runtime-data: done
   test-before-configure: done
   test-before-setup: done
@@ -46,25 +36,17 @@ rules:
     status: exempt
     comment: The integration does not provide configuration options.
   docs-installation-parameters: done
-  entity-unavailable:
-    status: exempt
-    comment: The integration does not create entities.
+  entity-unavailable: done
   integration-owner: done
-  log-when-unavailable:
-    status: exempt
-    comment: The integration does not create entities.
-  parallel-updates:
-    status: exempt
-    comment: The integration does not create entities.
+  log-when-unavailable: done
+  parallel-updates: done
   reauthentication-flow:
     status: exempt
     comment: Podcast feeds do not require account authentication.
   test-coverage: done
 
   # Gold
-  devices:
-    status: exempt
-    comment: The integration does not create devices.
+  devices: done
   diagnostics: todo
   discovery-update-info:
     status: exempt
@@ -83,30 +65,28 @@ rules:
   docs-use-cases: done
   dynamic-devices:
     status: exempt
-    comment: The integration does not create devices.
+    comment: Each config entry represents one fixed podcast service.
   entity-category:
     status: exempt
-    comment: The integration does not create entities.
+    comment: The latest episode event is the integration's primary entity.
   entity-device-class:
     status: exempt
-    comment: The integration does not create entities.
+    comment: No event device class represents a podcast episode.
   entity-disabled-by-default:
     status: exempt
-    comment: The integration does not create entities.
-  entity-translations:
-    status: exempt
-    comment: The integration does not create entities.
+    comment: The integration provides only one primary entity per config entry.
+  entity-translations: done
   exception-translations: done
   icon-translations:
     status: exempt
-    comment: The integration does not create entities.
+    comment: The event entity uses the default event icon.
   reconfiguration-flow: todo
   repair-issues:
     status: exempt
     comment: The integration has no cases requiring a repair issue.
   stale-devices:
     status: exempt
-    comment: The integration does not create devices.
+    comment: Each config entry represents one fixed podcast service.
 
   # Platinum
   async-dependency: done

--- a/homeassistant/components/podcast_player/strings.json
+++ b/homeassistant/components/podcast_player/strings.json
@@ -1,0 +1,41 @@
+{
+  "config": {
+    "abort": {
+      "already_configured": "This podcast feed is already configured."
+    },
+    "error": {
+      "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+      "invalid_feed": "The URL does not contain a playable podcast feed.",
+      "invalid_url": "Enter a valid HTTP or HTTPS URL without credentials.",
+      "unknown": "[%key:common::config_flow::error::unknown%]"
+    },
+    "step": {
+      "user": {
+        "data": {
+          "url": "[%key:common::config_flow::data::url%]"
+        },
+        "data_description": {
+          "url": "The full RSS or Atom feed URL for the podcast."
+        },
+        "description": "Enter the podcast feed URL."
+      }
+    }
+  },
+  "exceptions": {
+    "episode_unavailable": {
+      "message": "The podcast episode is no longer available."
+    },
+    "feed_unavailable": {
+      "message": "The podcast feed is currently unavailable."
+    },
+    "invalid_feed": {
+      "message": "The configured URL does not contain a playable podcast feed."
+    },
+    "not_configured": {
+      "message": "No podcast feeds are configured."
+    },
+    "path_not_found": {
+      "message": "The podcast media source path was not found."
+    }
+  }
+}

--- a/homeassistant/components/podcast_player/strings.json
+++ b/homeassistant/components/podcast_player/strings.json
@@ -24,7 +24,6 @@
   "entity": {
     "event": {
       "latest_episode": {
-        "name": "Latest episode",
         "state_attributes": {
           "duration_seconds": {
             "name": "Duration"

--- a/homeassistant/components/podcast_player/strings.json
+++ b/homeassistant/components/podcast_player/strings.json
@@ -21,6 +21,35 @@
       }
     }
   },
+  "entity": {
+    "event": {
+      "latest_episode": {
+        "name": "Latest episode",
+        "state_attributes": {
+          "duration_seconds": {
+            "name": "Duration"
+          },
+          "episode_id": {
+            "name": "Episode ID"
+          },
+          "event_type": {
+            "state": {
+              "new_episode": "New episode"
+            }
+          },
+          "media_content_id": {
+            "name": "Media content ID"
+          },
+          "published": {
+            "name": "Published"
+          },
+          "title": {
+            "name": "Title"
+          }
+        }
+      }
+    }
+  },
   "exceptions": {
     "episode_unavailable": {
       "message": "The podcast episode is no longer available."

--- a/homeassistant/generated/config_flows.py
+++ b/homeassistant/generated/config_flows.py
@@ -600,6 +600,7 @@ FLOWS = {
         "playstation_network",
         "plex",
         "plugwise",
+        "podcast_player",
         "point",
         "pooldose",
         "poolsense",

--- a/homeassistant/generated/integrations.json
+++ b/homeassistant/generated/integrations.json
@@ -5520,6 +5520,12 @@
       "config_flow": false,
       "iot_class": "cloud_polling"
     },
+    "podcast_player": {
+      "name": "Podcast Player",
+      "integration_type": "service",
+      "config_flow": true,
+      "iot_class": "cloud_polling"
+    },
     "point": {
       "name": "Minut Point",
       "integration_type": "hub",

--- a/mypy.ini
+++ b/mypy.ini
@@ -4277,6 +4277,16 @@ disallow_untyped_defs = true
 warn_return_any = true
 warn_unreachable = true
 
+[mypy-homeassistant.components.podcast_player.*]
+check_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+warn_return_any = true
+warn_unreachable = true
+
 [mypy-homeassistant.components.pooldose.*]
 check_untyped_defs = true
 disallow_incomplete_defs = true

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -177,6 +177,9 @@ aio-georss-gdacs==0.10
 # homeassistant.components.onewire
 aio-ownet==0.0.5
 
+# homeassistant.components.podcast_player
+aio-podcast==0.1.0
+
 # homeassistant.components.wattwaechter
 aio-wattwaechter==1.0.0
 

--- a/tests/components/podcast_player/__init__.py
+++ b/tests/components/podcast_player/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the Podcast Player integration."""

--- a/tests/components/podcast_player/conftest.py
+++ b/tests/components/podcast_player/conftest.py
@@ -1,0 +1,96 @@
+"""Fixtures for the Podcast Player integration tests."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aiopodcast import Podcast, PodcastClient, PodcastEnclosure, PodcastEpisode
+import pytest
+
+from homeassistant.components.podcast_player import PodcastConfigEntry
+from homeassistant.components.podcast_player.const import DOMAIN
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+TEST_URL = "https://example.com/feed.xml"
+TEST_CANONICAL_URL = "https://cdn.example.com/podcast.xml"
+
+
+@pytest.fixture
+def podcast() -> Podcast:
+    """Return a podcast feed."""
+    return Podcast(
+        source_url=TEST_URL,
+        canonical_url=TEST_CANONICAL_URL,
+        title="Example Podcast",
+        description="An example podcast",
+        author="Example Author",
+        website_url="https://example.com/podcast",
+        artwork_url="https://example.com/podcast.jpg",
+        episodes=(
+            PodcastEpisode(
+                title="First episode",
+                guid="episode-one",
+                description="The first episode",
+                published=datetime(2026, 8, 1, tzinfo=UTC),
+                duration_seconds=1800,
+                artwork_url="https://example.com/episode.jpg",
+                website_url="https://example.com/episodes/one",
+                enclosure=PodcastEnclosure(
+                    url="https://cdn.example.com/episode.mp3",
+                    mime_type="audio/mpeg",
+                    length=123456,
+                ),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
+def mock_client(podcast: Podcast) -> Generator[AsyncMock]:
+    """Return a mocked podcast client."""
+    client = MagicMock(spec=PodcastClient)
+    client.async_fetch = AsyncMock(return_value=podcast)
+    with patch(
+        "homeassistant.components.podcast_player.client.PodcastClient",
+        return_value=client,
+    ):
+        yield client
+
+
+@pytest.fixture
+def mock_config_entry() -> MockConfigEntry:
+    """Return a mocked podcast config entry."""
+    return MockConfigEntry(
+        domain=DOMAIN,
+        title="Example Podcast",
+        data={CONF_URL: TEST_URL},
+        unique_id=TEST_CANONICAL_URL,
+    )
+
+
+@pytest.fixture
+def mock_setup_entry() -> Generator[AsyncMock]:
+    """Mock setting up a podcast config entry."""
+    with patch(
+        "homeassistant.components.podcast_player.async_setup_entry",
+        return_value=True,
+    ) as mock_setup:
+        yield mock_setup
+
+
+@pytest.fixture
+async def init_integration(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+) -> PodcastConfigEntry:
+    """Set up the Podcast Player integration."""
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    return mock_config_entry

--- a/tests/components/podcast_player/test_config_flow.py
+++ b/tests/components/podcast_player/test_config_flow.py
@@ -1,10 +1,12 @@
 """Tests for the Podcast Player config flow."""
 
+from dataclasses import replace
 from unittest.mock import AsyncMock
 
 from aiopodcast import (
     FeedTooLargeError,
     InvalidFeedError,
+    Podcast,
     PodcastConnectionError,
     PodcastHTTPError,
 )
@@ -117,6 +119,24 @@ async def test_invalid_url(hass: HomeAssistant, url: str) -> None:
 
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {CONF_URL: "invalid_url"}
+
+
+async def test_invalid_canonical_url(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test rejecting a feed with an invalid canonical URL."""
+    mock_client.async_fetch.return_value = replace(podcast, canonical_url="not-a-url")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_URL: TEST_URL},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_feed"}
 
 
 @pytest.mark.parametrize(

--- a/tests/components/podcast_player/test_config_flow.py
+++ b/tests/components/podcast_player/test_config_flow.py
@@ -1,0 +1,148 @@
+"""Tests for the Podcast Player config flow."""
+
+from unittest.mock import AsyncMock
+
+from aiopodcast import (
+    FeedTooLargeError,
+    InvalidFeedError,
+    PodcastConnectionError,
+    PodcastHTTPError,
+)
+import pytest
+
+from homeassistant.components.podcast_player.const import DOMAIN
+from homeassistant.config_entries import SOURCE_USER
+from homeassistant.const import CONF_URL
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType
+
+from .conftest import TEST_CANONICAL_URL, TEST_URL
+
+from tests.common import MockConfigEntry
+
+
+async def test_form(hass: HomeAssistant) -> None:
+    """Test the initial form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {}
+
+
+async def test_create_entry(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    mock_setup_entry: AsyncMock,
+) -> None:
+    """Test creating a podcast feed entry."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_URL: f"{TEST_URL}#episodes"},
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Example Podcast"
+    assert result["data"] == {CONF_URL: TEST_URL}
+    assert result["result"].unique_id == TEST_CANONICAL_URL
+    mock_client.async_fetch.assert_awaited_once_with(TEST_URL)
+    mock_setup_entry.assert_awaited_once()
+
+
+async def test_duplicate_feed(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+) -> None:
+    """Test rejecting an already configured feed URL before fetching it."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="Example Podcast",
+        data={CONF_URL: TEST_URL},
+        unique_id="https://old.example.com/feed.xml",
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_URL: TEST_URL},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    mock_client.async_fetch.assert_not_awaited()
+
+
+async def test_duplicate_canonical_feed(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+) -> None:
+    """Test rejecting another URL that resolves to a configured feed."""
+    MockConfigEntry(
+        domain=DOMAIN,
+        title="Example Podcast",
+        data={CONF_URL: "https://example.com/alternate.xml"},
+        unique_id=TEST_CANONICAL_URL,
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_URL: TEST_URL},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+    mock_client.async_fetch.assert_awaited_once_with(TEST_URL)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "not-a-url",
+        "ftp://example.com/feed.xml",
+        "https://user:password@example.com/feed.xml",
+        "https://[invalid",
+    ],
+)
+async def test_invalid_url(hass: HomeAssistant, url: str) -> None:
+    """Test rejecting invalid podcast feed URLs."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_URL: url},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {CONF_URL: "invalid_url"}
+
+
+@pytest.mark.parametrize(
+    ("error", "flow_error"),
+    [
+        (PodcastConnectionError("Connection failed"), "cannot_connect"),
+        (PodcastHTTPError(503), "cannot_connect"),
+        (InvalidFeedError("Invalid feed"), "invalid_feed"),
+        (FeedTooLargeError(1024), "invalid_feed"),
+        (RuntimeError("Unexpected failure"), "unknown"),
+    ],
+)
+async def test_validation_errors(
+    hass: HomeAssistant,
+    mock_client: AsyncMock,
+    error: Exception,
+    flow_error: str,
+) -> None:
+    """Test errors while validating a podcast feed."""
+    mock_client.async_fetch.side_effect = error
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_USER},
+        data={CONF_URL: TEST_URL},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": flow_error}

--- a/tests/components/podcast_player/test_event.py
+++ b/tests/components/podcast_player/test_event.py
@@ -1,0 +1,257 @@
+"""Tests for Podcast Player event entities."""
+
+from dataclasses import replace
+from datetime import timedelta
+from unittest.mock import AsyncMock
+
+from aiopodcast import Podcast, PodcastConnectionError, PodcastEpisode
+
+from homeassistant.components.event import EventExtraStoredData
+from homeassistant.components.podcast_player.const import (
+    DOMAIN,
+    EVENT_NEW_EPISODE,
+    SCAN_INTERVAL,
+)
+from homeassistant.components.podcast_player.coordinator import PodcastConfigEntry
+from homeassistant.components.podcast_player.event import (
+    ATTR_DURATION_SECONDS,
+    ATTR_EPISODE_ID,
+    ATTR_MEDIA_CONTENT_ID,
+    ATTR_PUBLISHED,
+    ATTR_TITLE,
+)
+from homeassistant.components.podcast_player.helpers import episode_identifier
+from homeassistant.const import STATE_UNAVAILABLE, STATE_UNKNOWN
+from homeassistant.core import HomeAssistant, State
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.util import dt as dt_util
+
+from tests.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+    mock_restore_cache_with_extra_data,
+)
+
+ENTITY_ID = "event.example_podcast"
+
+
+def _new_episode(podcast: Podcast) -> PodcastEpisode:
+    """Return a new episode based on the fixture podcast."""
+    published = podcast.episodes[0].published
+    assert published is not None
+    return replace(
+        podcast.episodes[0],
+        title="Second episode",
+        guid="episode-two",
+        published=published + timedelta(days=1),
+        duration_seconds=2400,
+    )
+
+
+async def test_latest_episode_event(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    podcast: Podcast,
+    device_registry: dr.DeviceRegistry,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test the latest episode event and service device."""
+    state = hass.states.get(ENTITY_ID)
+
+    assert state is not None
+    episode = podcast.episodes[0]
+    episode_id = episode_identifier(episode)
+    assert episode.published is not None
+    assert state.attributes["event_type"] == EVENT_NEW_EPISODE
+    assert state.attributes[ATTR_TITLE] == episode.title
+    assert state.attributes[ATTR_EPISODE_ID] == episode_id
+    assert state.attributes[ATTR_PUBLISHED] == episode.published.isoformat()
+    assert state.attributes[ATTR_DURATION_SECONDS] == episode.duration_seconds
+    assert state.attributes[ATTR_MEDIA_CONTENT_ID] == (
+        f"media-source://{DOMAIN}/{init_integration.entry_id}/{episode_id}"
+    )
+    assert episode.enclosure.url not in state.attributes.values()
+
+    entity_entry = entity_registry.async_get(ENTITY_ID)
+    assert entity_entry is not None
+    assert entity_entry.unique_id == f"{init_integration.entry_id}_latest_episode"
+
+    assert entity_entry.device_id is not None
+    device_entry = device_registry.async_get(entity_entry.device_id)
+    assert device_entry is not None
+    assert device_entry.entry_type is dr.DeviceEntryType.SERVICE
+    assert device_entry.name == podcast.title
+    assert device_entry.manufacturer == podcast.author
+    assert device_entry.configuration_url == podcast.website_url
+
+
+async def test_poll_discovers_new_episode(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test polling triggers an event for a new latest episode."""
+    old_state = hass.states.get(ENTITY_ID)
+    assert old_state is not None
+    episode = _new_episode(podcast)
+    mock_client.async_fetch.return_value = replace(
+        podcast, episodes=(episode, *podcast.episodes)
+    )
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + SCAN_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state != old_state.state
+    assert state.attributes[ATTR_TITLE] == episode.title
+    assert state.attributes[ATTR_EPISODE_ID] == episode_identifier(episode)
+    assert mock_client.async_fetch.await_count == 2
+
+
+async def test_poll_does_not_repeat_latest_episode(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test polling an unchanged feed does not repeat the event."""
+    old_state = hass.states.get(ENTITY_ID)
+    assert old_state is not None
+
+    async_fire_time_changed(
+        hass, dt_util.utcnow() + SCAN_INTERVAL + timedelta(seconds=1)
+    )
+    await hass.async_block_till_done(wait_background_tasks=True)
+
+    assert hass.states.get(ENTITY_ID) == old_state
+    assert mock_client.async_fetch.await_count == 2
+
+
+async def test_restored_episode_is_not_repeated(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test restoring the latest episode prevents a duplicate event."""
+    episode = podcast.episodes[0]
+    episode_id = episode_identifier(episode)
+    assert episode.published is not None
+    attributes = {
+        ATTR_DURATION_SECONDS: episode.duration_seconds,
+        ATTR_EPISODE_ID: episode_id,
+        ATTR_MEDIA_CONTENT_ID: (
+            f"media-source://{DOMAIN}/{mock_config_entry.entry_id}/{episode_id}"
+        ),
+        ATTR_PUBLISHED: episode.published.isoformat(),
+        ATTR_TITLE: episode.title,
+    }
+    restored_timestamp = "2026-08-05T10:00:00+00:00"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(ENTITY_ID, restored_timestamp),
+                EventExtraStoredData(EVENT_NEW_EPISODE, attributes).as_dict(),
+            )
+        ],
+    )
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert dt_util.parse_datetime(state.state) == dt_util.parse_datetime(
+        restored_timestamp
+    )
+    assert state.attributes[ATTR_EPISODE_ID] == episode_id
+    mock_client.async_fetch.assert_awaited_once()
+
+
+async def test_event_unavailable_and_recovers(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test the event entity becomes unavailable and recovers."""
+    old_state = hass.states.get(ENTITY_ID)
+    assert old_state is not None
+    mock_client.async_fetch.side_effect = PodcastConnectionError("Connection failed")
+
+    await init_integration.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE
+
+    mock_client.async_fetch.side_effect = None
+    await init_integration.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == old_state.state
+
+    episode = _new_episode(podcast)
+    mock_client.async_fetch.return_value = replace(
+        podcast, episodes=(episode, *podcast.episodes)
+    )
+
+    await init_integration.runtime_data.async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state != STATE_UNAVAILABLE
+    assert state.attributes[ATTR_EPISODE_ID] == episode_identifier(episode)
+
+
+async def test_event_without_optional_episode_metadata(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test an event for an episode without optional metadata."""
+    episode = replace(
+        podcast.episodes[0],
+        guid=None,
+        published=None,
+        duration_seconds=None,
+    )
+    mock_client.async_fetch.return_value = replace(podcast, episodes=(episode,))
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.attributes[ATTR_EPISODE_ID] == episode_identifier(episode)
+    assert ATTR_PUBLISHED not in state.attributes
+    assert ATTR_DURATION_SECONDS not in state.attributes
+
+
+async def test_event_with_empty_feed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test setting up an event entity for a feed without episodes."""
+    mock_client.async_fetch.return_value = replace(podcast, episodes=())
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    state = hass.states.get(ENTITY_ID)
+    assert state is not None
+    assert state.state == STATE_UNKNOWN

--- a/tests/components/podcast_player/test_init.py
+++ b/tests/components/podcast_player/test_init.py
@@ -1,0 +1,68 @@
+"""Tests for the Podcast Player integration setup."""
+
+from unittest.mock import AsyncMock
+
+from aiopodcast import InvalidFeedError, PodcastConnectionError
+
+from homeassistant.components.podcast_player import PodcastRuntimeData
+from homeassistant.config_entries import ConfigEntryState
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_setup_entry(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test setting up a podcast feed."""
+    mock_config_entry.add_to_hass(hass)
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert isinstance(mock_config_entry.runtime_data, PodcastRuntimeData)
+    mock_client.async_fetch.assert_awaited_once()
+
+
+async def test_setup_retries_when_feed_is_unavailable(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test retrying setup when the feed is unavailable."""
+    mock_client.async_fetch.side_effect = PodcastConnectionError("Connection failed")
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_RETRY
+
+
+async def test_setup_fails_for_invalid_feed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test failing setup for a permanently invalid feed."""
+    mock_client.async_fetch.side_effect = InvalidFeedError("Invalid feed")
+    mock_config_entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.SETUP_ERROR
+
+
+async def test_unload_entry(
+    hass: HomeAssistant,
+    init_integration: MockConfigEntry,
+) -> None:
+    """Test unloading a podcast feed."""
+    assert await hass.config_entries.async_unload(init_integration.entry_id)
+    await hass.async_block_till_done()
+
+    assert init_integration.state is ConfigEntryState.NOT_LOADED

--- a/tests/components/podcast_player/test_init.py
+++ b/tests/components/podcast_player/test_init.py
@@ -4,8 +4,9 @@ from unittest.mock import AsyncMock
 
 from aiopodcast import InvalidFeedError, PodcastConnectionError
 
-from homeassistant.components.podcast_player import PodcastRuntimeData
+from homeassistant.components.podcast_player.coordinator import PodcastUpdateCoordinator
 from homeassistant.config_entries import ConfigEntryState
+from homeassistant.const import STATE_UNAVAILABLE
 from homeassistant.core import HomeAssistant
 
 from tests.common import MockConfigEntry
@@ -23,7 +24,7 @@ async def test_setup_entry(
     await hass.async_block_till_done()
 
     assert mock_config_entry.state is ConfigEntryState.LOADED
-    assert isinstance(mock_config_entry.runtime_data, PodcastRuntimeData)
+    assert isinstance(mock_config_entry.runtime_data, PodcastUpdateCoordinator)
     mock_client.async_fetch.assert_awaited_once()
 
 
@@ -62,7 +63,12 @@ async def test_unload_entry(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test unloading a podcast feed."""
+    assert hass.states.get("event.example_podcast") is not None
+
     assert await hass.config_entries.async_unload(init_integration.entry_id)
     await hass.async_block_till_done()
 
     assert init_integration.state is ConfigEntryState.NOT_LOADED
+    state = hass.states.get("event.example_podcast")
+    assert state is not None
+    assert state.state == STATE_UNAVAILABLE

--- a/tests/components/podcast_player/test_media_source.py
+++ b/tests/components/podcast_player/test_media_source.py
@@ -138,17 +138,52 @@ async def test_browse_without_configured_feed(hass: HomeAssistant) -> None:
     assert error.value.translation_key == "not_configured"
 
 
+async def test_browse_with_only_unloaded_feed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test browsing when the configured podcast feed is not loaded."""
+    mock_config_entry.add_to_hass(hass)
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(BrowseError) as error:
+        await source.async_browse_media(MediaSourceItem(hass, DOMAIN, "", None))
+
+    assert error.value.translation_key == "feed_unavailable"
+
+
+async def test_browse_unloaded_feed(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+) -> None:
+    """Test browsing a configured podcast feed that is not loaded."""
+    unloaded_entry = MockConfigEntry(
+        domain=DOMAIN,
+        title="Unavailable Podcast",
+        data={},
+    )
+    unloaded_entry.add_to_hass(hass)
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(BrowseError) as error:
+        await source.async_browse_media(
+            MediaSourceItem(hass, DOMAIN, unloaded_entry.entry_id, None)
+        )
+
+    assert error.value.translation_key == "feed_unavailable"
+
+
+@pytest.mark.parametrize("identifier", ["unknown", "unknown/path"])
 async def test_browse_unknown_path(
     hass: HomeAssistant,
     init_integration: PodcastConfigEntry,
+    identifier: str,
 ) -> None:
     """Test browsing an unknown podcast path."""
     source = await async_get_media_source(hass)
 
     with pytest.raises(BrowseError) as error:
-        await source.async_browse_media(
-            MediaSourceItem(hass, DOMAIN, "unknown/path", None)
-        )
+        await source.async_browse_media(MediaSourceItem(hass, DOMAIN, identifier, None))
 
     assert error.value.translation_key == "path_not_found"
 
@@ -188,6 +223,27 @@ async def test_resolve_unknown_episode(
         )
 
     assert error.value.translation_key == "episode_unavailable"
+
+
+async def test_resolve_unloaded_feed(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test resolving an episode from a feed that is not loaded."""
+    mock_config_entry.add_to_hass(hass)
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(Unresolvable) as error:
+        await source.async_resolve_media(
+            MediaSourceItem(
+                hass,
+                DOMAIN,
+                f"{mock_config_entry.entry_id}/episode",
+                None,
+            )
+        )
+
+    assert error.value.translation_key == "feed_unavailable"
 
 
 async def test_resolve_unavailable_feed(

--- a/tests/components/podcast_player/test_media_source.py
+++ b/tests/components/podcast_player/test_media_source.py
@@ -1,0 +1,227 @@
+"""Tests for the Podcast Player media source."""
+
+from dataclasses import replace
+from unittest.mock import AsyncMock
+
+from aiopodcast import Podcast, PodcastConnectionError, PodcastEnclosure
+import pytest
+
+from homeassistant.components.media_player import BrowseError, MediaClass
+from homeassistant.components.media_source import MediaSourceItem, Unresolvable
+from homeassistant.components.podcast_player import PodcastConfigEntry
+from homeassistant.components.podcast_player.const import DOMAIN, MAX_BROWSE_EPISODES
+from homeassistant.components.podcast_player.media_source import async_get_media_source
+from homeassistant.core import HomeAssistant
+
+from tests.common import MockConfigEntry
+
+
+async def test_browse_podcasts_and_episodes(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test browsing configured podcasts and episodes."""
+    source = await async_get_media_source(hass)
+
+    root = await source.async_browse_media(MediaSourceItem(hass, DOMAIN, "", None))
+
+    assert root.title == "Podcasts"
+    assert root.children_media_class is MediaClass.PODCAST
+    assert root.children is not None
+    assert len(root.children) == 1
+    podcast_item = root.children[0]
+    assert podcast_item.title == "Example Podcast"
+    assert podcast_item.identifier == init_integration.entry_id
+
+    feed = await source.async_browse_media(
+        MediaSourceItem(hass, DOMAIN, podcast_item.identifier, None)
+    )
+
+    assert feed.title == "Example Podcast"
+    assert feed.children_media_class is MediaClass.EPISODE
+    assert feed.not_shown == 0
+    assert feed.children is not None
+    assert len(feed.children) == 1
+    episode = feed.children[0]
+    assert episode.title == "First episode"
+    assert episode.can_play is True
+    assert episode.can_expand is False
+    assert episode.media_content_type == "audio/mpeg"
+    assert episode.thumbnail == "https://example.com/episode.jpg"
+    assert mock_client.async_fetch.await_count == 2
+
+
+async def test_resolve_episode(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+) -> None:
+    """Test resolving a podcast episode."""
+    source = await async_get_media_source(hass)
+    feed = await source.async_browse_media(
+        MediaSourceItem(hass, DOMAIN, init_integration.entry_id, None)
+    )
+    assert feed.children is not None
+
+    result = await source.async_resolve_media(
+        MediaSourceItem(hass, DOMAIN, feed.children[0].identifier, None)
+    )
+
+    assert result.url == "https://cdn.example.com/episode.mp3"
+    assert result.mime_type == "audio/mpeg"
+
+
+async def test_resolve_episode_with_inferred_mime_type(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test inferring an episode MIME type from its URL."""
+    enclosure = replace(podcast.episodes[0].enclosure, mime_type=None)
+    episode = replace(podcast.episodes[0], enclosure=enclosure)
+    mock_client.async_fetch.return_value = replace(podcast, episodes=(episode,))
+    mock_config_entry.add_to_hass(hass)
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+
+    source = await async_get_media_source(hass)
+    feed = await source.async_browse_media(
+        MediaSourceItem(hass, DOMAIN, mock_config_entry.entry_id, None)
+    )
+    assert feed.children is not None
+    result = await source.async_resolve_media(
+        MediaSourceItem(hass, DOMAIN, feed.children[0].identifier, None)
+    )
+
+    assert result.mime_type == "audio/mpeg"
+
+
+async def test_browse_limits_episode_count(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+    podcast: Podcast,
+) -> None:
+    """Test limiting large feed responses in the media browser."""
+    episode = podcast.episodes[0]
+    episodes = tuple(
+        replace(
+            episode,
+            title=f"Episode {index}",
+            guid=f"episode-{index}",
+            enclosure=PodcastEnclosure(
+                url=f"https://cdn.example.com/{index}.mp3",
+                mime_type="audio/mpeg",
+            ),
+        )
+        for index in range(MAX_BROWSE_EPISODES + 2)
+    )
+    mock_client.async_fetch.return_value = replace(podcast, episodes=episodes)
+    source = await async_get_media_source(hass)
+
+    feed = await source.async_browse_media(
+        MediaSourceItem(hass, DOMAIN, init_integration.entry_id, None)
+    )
+
+    assert feed.children is not None
+    assert len(feed.children) == MAX_BROWSE_EPISODES
+    assert feed.not_shown == 2
+
+
+async def test_browse_without_configured_feed(hass: HomeAssistant) -> None:
+    """Test browsing without a configured podcast feed."""
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(BrowseError) as error:
+        await source.async_browse_media(MediaSourceItem(hass, DOMAIN, "", None))
+
+    assert error.value.translation_key == "not_configured"
+
+
+async def test_browse_unknown_path(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+) -> None:
+    """Test browsing an unknown podcast path."""
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(BrowseError) as error:
+        await source.async_browse_media(
+            MediaSourceItem(hass, DOMAIN, "unknown/path", None)
+        )
+
+    assert error.value.translation_key == "path_not_found"
+
+
+async def test_browse_unavailable_feed(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test browsing a temporarily unavailable podcast feed."""
+    mock_client.async_fetch.side_effect = PodcastConnectionError("Connection failed")
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(BrowseError) as error:
+        await source.async_browse_media(
+            MediaSourceItem(hass, DOMAIN, init_integration.entry_id, None)
+        )
+
+    assert error.value.translation_key == "feed_unavailable"
+
+
+async def test_resolve_unknown_episode(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+) -> None:
+    """Test resolving an episode that no longer exists."""
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(Unresolvable) as error:
+        await source.async_resolve_media(
+            MediaSourceItem(
+                hass,
+                DOMAIN,
+                f"{init_integration.entry_id}/unknown",
+                None,
+            )
+        )
+
+    assert error.value.translation_key == "episode_unavailable"
+
+
+async def test_resolve_unavailable_feed(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+    mock_client: AsyncMock,
+) -> None:
+    """Test refreshing an unavailable feed while resolving a stale episode."""
+    mock_client.async_fetch.side_effect = PodcastConnectionError("Connection failed")
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(Unresolvable) as error:
+        await source.async_resolve_media(
+            MediaSourceItem(
+                hass,
+                DOMAIN,
+                f"{init_integration.entry_id}/unknown",
+                None,
+            )
+        )
+
+    assert error.value.translation_key == "feed_unavailable"
+
+
+async def test_resolve_invalid_identifier(
+    hass: HomeAssistant,
+    init_integration: PodcastConfigEntry,
+) -> None:
+    """Test resolving an invalid media source identifier."""
+    source = await async_get_media_source(hass)
+
+    with pytest.raises(Unresolvable) as error:
+        await source.async_resolve_media(
+            MediaSourceItem(hass, DOMAIN, init_integration.entry_id, None)
+        )
+
+    assert error.value.translation_key == "episode_unavailable"

--- a/tests/components/podcast_player/test_media_source.py
+++ b/tests/components/podcast_player/test_media_source.py
@@ -1,7 +1,7 @@
 """Tests for the Podcast Player media source."""
 
 from dataclasses import replace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 from aiopodcast import Podcast, PodcastConnectionError, PodcastEnclosure
 import pytest
@@ -78,22 +78,31 @@ async def test_resolve_episode_with_inferred_mime_type(
     podcast: Podcast,
 ) -> None:
     """Test inferring an episode MIME type from its URL."""
-    enclosure = replace(podcast.episodes[0].enclosure, mime_type=None)
+    enclosure = replace(
+        podcast.episodes[0].enclosure,
+        url="https://cdn.example.com/episode.mp3?token=secret#fragment",
+        mime_type=None,
+    )
     episode = replace(podcast.episodes[0], enclosure=enclosure)
     mock_client.async_fetch.return_value = replace(podcast, episodes=(episode,))
     mock_config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
 
     source = await async_get_media_source(hass)
-    feed = await source.async_browse_media(
-        MediaSourceItem(hass, DOMAIN, mock_config_entry.entry_id, None)
-    )
-    assert feed.children is not None
-    result = await source.async_resolve_media(
-        MediaSourceItem(hass, DOMAIN, feed.children[0].identifier, None)
-    )
+    with patch(
+        "homeassistant.components.podcast_player.media_source.mimetypes.guess_type",
+        return_value=("audio/mpeg", None),
+    ) as mock_guess_type:
+        feed = await source.async_browse_media(
+            MediaSourceItem(hass, DOMAIN, mock_config_entry.entry_id, None)
+        )
+        assert feed.children is not None
+        result = await source.async_resolve_media(
+            MediaSourceItem(hass, DOMAIN, feed.children[0].identifier, None)
+        )
 
     assert result.mime_type == "audio/mpeg"
+    mock_guess_type.assert_called_with("/episode.mp3")
 
 
 async def test_browse_limits_episode_count(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add Podcast Player as a config-entry-backed integration for public podcast RSS and Atom feeds. Each feed is configured as a separate entry, validated before creation and setup, and represented by one service device with a latest-episode event entity.

A shared coordinator refreshes the feed hourly and when users browse it. The event entity records a `new_episode` event only when the latest episode changes, restores its episode identifier across restarts to prevent duplicates, and exposes a media-source identifier for automations. The media source exposes up to 250 playable episodes per feed and resolves them to the publisher's direct enclosure URL.

The integration uses the typed asynchronous `aio-podcast` client with Home Assistant's shared HTTP session and does not register custom actions.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- Related architecture discussion: https://github.com/home-assistant/architecture/discussions/1428
- This PR fixes or closes issue: N/A
- This PR is related to issue: N/A
- Link to documentation pull request: https://github.com/home-assistant/home-assistant.io/pull/47251
- Link to developer documentation pull request: N/A
- Link to frontend pull request: N/A
- Link to Brands pull request: https://github.com/home-assistant/brands/pull/10917
- Dependency source: https://github.com/armilancode/aio-podcast
- Dependency release: https://github.com/armilancode/aio-podcast/releases/tag/v0.1.0

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [x] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr