### PR TITLE
Bump voip-utils to 0.4.2

### DIFF
--- a/homeassistant/components/voip/assist_satellite.py
+++ b/homeassistant/components/voip/assist_satellite.py
@@ -340,12 +340,6 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
                 ):
                     # Caller hung up
                     _LOGGER.debug("Hang up")
-                    self._announcement = None
-                    if self._run_pipeline_task is not None:
-                        _LOGGER.debug("Cancelling running pipeline")
-                        self._run_pipeline_task.cancel()
-                    if not self._call_end_future.done():
-                        self._call_end_future.set_result(None)
                     self.disconnect()
                     break
 
@@ -373,11 +367,23 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
         if self._check_hangup_task is not None:
             self._check_hangup_task.cancel()
             self._check_hangup_task = None
+        # Clean up announcement state in case it wasn't cleaned up by the check
+        # hangup task
+        self.voip_device.set_is_active(False)
+        self._announcement = None
+        if self._run_pipeline_task is not None:
+            _LOGGER.debug("Cancelling running pipeline")
+            self._run_pipeline_task.cancel()
+        if not self._call_end_future.done():
+            self._call_end_future.set_result(None)
+        self._last_chunk_time = None
         self._rtp_port = None
+        _LOGGER.debug("VOIP disconnected")
 
     def connection_made(self, transport):
         """Server is ready."""
         super().connection_made(transport)
+        self.voip_device.set_is_active(True)
         self._last_chunk_time = time.monotonic()
         # Check if caller hung up
         self._check_hangup_task = self.config_entry.async_create_background_task(
@@ -419,7 +425,6 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
         _LOGGER.debug("Starting pipeline")
 
         self.async_set_context(Context(user_id=self.config_entry.data["user"]))
-        self.voip_device.set_is_active(True)
 
         async def stt_stream():
             retry: bool = True
@@ -471,7 +476,6 @@ class VoipAssistSatellite(VoIPEntity, AssistSatelliteEntity, RtpDatagramProtocol
             # Stop audio stream
             await self._audio_queue.put(None)
 
-            self.voip_device.set_is_active(False)
             self._run_pipeline_task = None
             _LOGGER.debug("Pipeline finished")
 

--- a/homeassistant/components/voip/manifest.json
+++ b/homeassistant/components/voip/manifest.json
@@ -9,5 +9,5 @@
   "iot_class": "local_push",
   "loggers": ["voip_utils"],
   "quality_scale": "internal",
-  "requirements": ["voip-utils==0.4.0"]
+  "requirements": ["voip-utils==0.4.2"]
 }

--- a/requirements_all.txt
+++ b/requirements_all.txt
@@ -3333,7 +3333,7 @@ vizaio==0.3.2
 vobject==0.9.9
 
 # homeassistant.components.voip
-voip-utils==0.4.0
+voip-utils==0.4.2
 
 # homeassistant.components.volkszaehler
 volkszaehler==0.4.0

--- a/tests/components/voip/test_voip.py
+++ b/tests/components/voip/test_voip.py
@@ -39,6 +39,21 @@ def mock_tts_cache_dir_autouse(mock_tts_cache_dir: Path) -> None:
     """Mock the TTS cache dir with empty dir."""
 
 
+@pytest.fixture
+def satellite(
+    hass: HomeAssistant,
+    voip_device: VoIPDevice,
+):
+    """Create VoipAssistSatellite for use in tests."""
+    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
+    assert isinstance(satellite, VoipAssistSatellite)
+
+    yield satellite
+
+    if satellite.voip_device.is_active:
+        satellite.disconnect()
+
+
 def _empty_wav(framerate=16000) -> bytes:
     """Return bytes of an empty WAV file."""
     with io.BytesIO() as wav_io:
@@ -157,6 +172,7 @@ async def test_satellite_prepared(
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
     call_info: CallInfo,
+    satellite: VoipAssistSatellite,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that satellite is prepared for a call."""
@@ -176,9 +192,6 @@ async def test_satellite_prepared(
         wake_word_id=None,
     )
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
-
     with (
         patch(
             "homeassistant.components.voip.voip.async_get_pipeline",
@@ -193,13 +206,12 @@ async def test_pipeline(
     hass: HomeAssistant,
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
     call_info: CallInfo,
 ) -> None:
     """Test that pipeline function is called from RTP protocol."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
     voip_user_id = satellite.config_entry.data["user"]
     assert voip_user_id
 
@@ -368,13 +380,13 @@ async def test_pipeline(
 
 
 async def test_stt_stream_timeout(
-    hass: HomeAssistant, voip_devices: VoIPDevices, voip_device: VoIPDevice
+    hass: HomeAssistant,
+    voip_devices: VoIPDevices,
+    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test timeout in STT stream during pipeline run."""
     assert await async_setup_component(hass, DOMAIN, {})
-
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
 
     done = asyncio.Event()
 
@@ -406,14 +418,10 @@ async def test_stt_stream_timeout(
 
 async def test_tts_timeout(
     hass: HomeAssistant,
-    voip_devices: VoIPDevices,
-    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test that TTS will time out based on its length."""
     assert await async_setup_component(hass, DOMAIN, {})
-
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
 
     done = asyncio.Event()
 
@@ -505,15 +513,12 @@ async def test_tts_timeout(
 
 async def test_tts_wrong_extension(
     hass: HomeAssistant,
-    voip_devices: VoIPDevices,
-    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test that TTS will only stream WAV audio."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
-    assert isinstance(satellite, VoipAssistSatellite)
 
     done = asyncio.Event()
 
@@ -572,6 +577,8 @@ async def test_tts_wrong_extension(
 
         satellite._send_tts = AsyncMock(side_effect=send_tts)  # type: ignore[method-assign]
 
+        satellite.send_audio = Mock()
+
         satellite.connection_made(Mock())
 
         # silence
@@ -598,15 +605,12 @@ async def test_tts_wrong_extension(
 
 async def test_tts_wrong_wav_format(
     hass: HomeAssistant,
-    voip_devices: VoIPDevices,
-    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test that TTS will only stream WAV audio with a specific format."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
-    assert isinstance(satellite, VoipAssistSatellite)
 
     done = asyncio.Event()
 
@@ -665,6 +669,8 @@ async def test_tts_wrong_wav_format(
 
         satellite._send_tts = AsyncMock(side_effect=send_tts)  # type: ignore[method-assign]
 
+        satellite.send_audio = Mock()
+
         satellite.connection_made(Mock())
 
         # silence
@@ -691,15 +697,14 @@ async def test_tts_wrong_wav_format(
 
 async def test_empty_tts_output(
     hass: HomeAssistant,
-    voip_devices: VoIPDevices,
-    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test that TTS will not stream when output is empty."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
-    assert isinstance(satellite, VoipAssistSatellite)
+
+    done = asyncio.Event()
 
     async def async_pipeline_from_audio_stream(*args, **kwargs):
         stt_stream = kwargs["stt_stream"]
@@ -738,6 +743,7 @@ async def test_empty_tts_output(
                 data={"tts_output": {}},
             )
         )
+        done.set()
 
     with (
         patch(
@@ -748,6 +754,8 @@ async def test_empty_tts_output(
             "homeassistant.components.voip.assist_satellite.VoipAssistSatellite._send_tts",
         ) as mock_send_tts,
     ):
+        satellite.send_audio = Mock()
+
         satellite.connection_made(Mock())
 
         # silence
@@ -769,22 +777,18 @@ async def test_empty_tts_output(
 
         # Wait for mock pipeline to finish
         async with asyncio.timeout(2):
-            await satellite._tts_done.wait()
+            await done.wait()
 
         mock_send_tts.assert_not_called()
 
 
 async def test_pipeline_error(
     hass: HomeAssistant,
-    voip_devices: VoIPDevices,
-    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test that a pipeline error causes the error tone to be played."""
     assert await async_setup_component(hass, DOMAIN, {})
-
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
 
     done = asyncio.Event()
     played_audio_bytes = b""
@@ -832,12 +836,11 @@ async def test_announce(
     config_entry: MockConfigEntry,
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test announcement."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
     assert (
         satellite.supported_features
         & assist_satellite.AssistSatelliteEntityFeature.ANNOUNCE
@@ -901,12 +904,11 @@ async def test_voip_id_is_ip_address(
     config_entry: MockConfigEntry,
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test announcement when VoIP is an IP address instead of a SIP header."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
     assert (
         satellite.supported_features
         & assist_satellite.AssistSatelliteEntityFeature.ANNOUNCE
@@ -960,14 +962,11 @@ async def test_voip_id_is_ip_address(
 async def test_announce_timeout(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
-    voip_devices: VoIPDevices,
-    voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test announcement when user does not pick up the phone in time."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
     assert (
         satellite.supported_features
         & assist_satellite.AssistSatelliteEntityFeature.ANNOUNCE
@@ -1000,17 +999,93 @@ async def test_announce_timeout(
 
 
 @pytest.mark.usefixtures("socket_enabled")
-async def test_start_conversation(
+async def test_announce_disconnect(
     hass: HomeAssistant,
     config_entry: MockConfigEntry,
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
+) -> None:
+    """Test announcement."""
+    assert await async_setup_component(hass, DOMAIN, {})
+
+    assert (
+        satellite.supported_features
+        & assist_satellite.AssistSatelliteEntityFeature.ANNOUNCE
+    )
+
+    with pytest.raises(HomeAssistantError) as err:
+        await hass.services.async_call(
+            "assist_satellite",
+            "announce",
+            service_data={"media_id": "http://example.com"},
+            blocking=True,
+            target={
+                "entity_id": satellite.entity_id,
+            },
+        )
+    assert err.value.translation_domain == "voip"
+    assert err.value.translation_key == "non_tts_announcement"
+
+    mock_tts_result_stream = MockResultStream(hass, "wav", _empty_wav())
+    announcement = assist_satellite.AssistSatelliteAnnouncement(
+        message="test announcement",
+        media_id=_MEDIA_ID,
+        tts_token=mock_tts_result_stream.token,
+        original_media_id=_MEDIA_ID,
+        media_id_source="tts",
+    )
+
+    # Protocol has already been mocked, but "outgoing_call" is not async
+    mock_protocol: AsyncMock = config_entry.runtime_data.domain_data.protocol
+    mock_protocol.outgoing_call = Mock()
+
+    with (
+        patch(
+            "homeassistant.components.voip.assist_satellite.VoipAssistSatellite._send_tts",
+        ) as mock_send_tts,
+    ):
+        announce_task = hass.async_create_background_task(
+            satellite.async_announce(announcement), "voip_announce"
+        )
+        await asyncio.sleep(0)
+        satellite.connection_made(Mock())
+        mock_protocol.outgoing_call.assert_called_once()
+
+        # Trigger announcement
+        satellite.on_chunk(bytes(_ONE_SECOND))
+        await asyncio.sleep(0.2)
+        satellite.on_chunk(bytes(_ONE_SECOND))
+        await asyncio.sleep(0.2)
+        satellite.on_chunk(bytes(_ONE_SECOND))
+        await asyncio.sleep(0.2)
+
+        assert satellite._announcement is announcement
+        assert voip_device.is_active
+
+        # Disconnect before the hangup checker gets a chance to disconnect.
+        satellite.disconnect()
+
+        assert satellite._announcement is None
+        assert not voip_device.is_active
+
+        async with asyncio.timeout(2):
+            await announce_task
+
+        mock_send_tts.assert_called_once_with(
+            mock_tts_result_stream, wait_for_tone=False
+        )
+
+
+@pytest.mark.usefixtures("socket_enabled")
+async def test_start_conversation(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test start conversation."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
-    assert isinstance(satellite, VoipAssistSatellite)
     assert (
         satellite.supported_features
         & assist_satellite.AssistSatelliteEntityFeature.START_CONVERSATION
@@ -1114,13 +1189,12 @@ async def test_start_conversation_user_doesnt_pick_up(
     config_entry: MockConfigEntry,
     voip_devices: VoIPDevices,
     voip_device: VoIPDevice,
+    satellite: VoipAssistSatellite,
 ) -> None:
     """Test start conversation when the user doesn't pick up."""
     assert await async_setup_component(hass, DOMAIN, {})
 
-    satellite = async_get_satellite_entity(hass, voip.DOMAIN, voip_device.voip_id)
     satellite.addr = ("192.168.1.1", 12345)
-    assert isinstance(satellite, VoipAssistSatellite)
     assert (
         satellite.supported_features
         & assist_satellite.AssistSatelliteEntityFeature.START_CONVERSATION


### PR DESCRIPTION
* Bump voip-utils to 0.4.2 https://github.com/home-assistant-libs/voip-utils/compare/v0.4.0...v0.4.2
* Make sure announcement state is cleaned up on disconnect and tie the VOIP device active state to the connection lifecycle instead of the assist pipeline.
* Move pipeline task clearing and end call future setting to the disconnect method instead of being in the hang up checker. Add a test for when disconnect is called before the hang up checker detects a hang up and ensure state is appropriately reset.
* Add test fixture for VOIP satellite

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
* Bump voip-utils to 0.4.2
* Make sure announcement state is cleaned up on disconnect and tie the VOIP device active state to the connection lifecycle instead of the assist pipeline.
* Move pipeline task clearing and end call future setting to the disconnect method instead of being in the hang up checker. Add a test for when disconnect is called before the hang up checker detects a hang up and ensure state is appropriately reset.
* Add test fixture for VOIP satellite

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [x] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #178211 #177916 #177914
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [x] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [x] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [x] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
