### PR TITLE
Require admin to change Mikrotik interface state

### DIFF
--- a/homeassistant/components/mikrotik/switch.py
+++ b/homeassistant/components/mikrotik/switch.py
@@ -1,5 +1,6 @@
 """Support for Mikrotik routers switches."""
 
+from dataclasses import dataclass
 from typing import Any, Final, override
 
 from homeassistant.components.switch import (
@@ -9,6 +10,7 @@ from homeassistant.components.switch import (
 )
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import MikrotikConfigEntry, mikrotik_config_entry_errors
@@ -17,18 +19,27 @@ from .entity import MikrotikDeviceEntity
 PARALLEL_UPDATES = 0
 
 
+@dataclass(frozen=True, kw_only=True)
+class MikrotikSwitchEntityDescription(SwitchEntityDescription):
+    """Class describing Mikrotik switch entities."""
+
+    admin_only: bool = False
+
+
 SENSORS: Final = (
-    SwitchEntityDescription(
+    MikrotikSwitchEntityDescription(
         key="ether",
         translation_key="ether",
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
+        admin_only=True,
     ),
-    SwitchEntityDescription(
+    MikrotikSwitchEntityDescription(
         key="wlan",
         translation_key="wlan",
         device_class=SwitchDeviceClass.SWITCH,
         entity_category=EntityCategory.CONFIG,
+        admin_only=True,
     ),
 )
 
@@ -55,14 +66,28 @@ async def async_setup_entry(
 class MikrotikSwitchEntity(MikrotikDeviceEntity, SwitchEntity):
     """Switch device."""
 
+    entity_description: MikrotikSwitchEntityDescription
+
     @property
     @override
     def is_on(self) -> bool | None:
         """Return the state of the switch."""
         return not self._interface.get("disabled")
 
+    async def _async_check_admin(self) -> None:
+        """Raise if the switch is being operated by a non-admin user."""
+        context = self.async_get_recent_context()
+        if context is None or context.user_id is None:
+            return
+        user = await self.hass.auth.async_get_user(context.user_id)
+        if user is None or not user.is_admin:
+            raise Unauthorized(context=context)
+
     async def _set_state(self, action: str) -> None:
         """Toggle the state of the switch."""
+        if self.entity_description.admin_only:
+            await self._async_check_admin()
+
         with mikrotik_config_entry_errors():
             await self.hass.async_add_executor_job(
                 self.coordinator.api.command,

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -1297,15 +1297,13 @@ class Entity(
             if custom:
                 attr |= custom
 
-        context = self.async_get_recent_context()
-
         # Intentionally called with positional args for performance reasons
         self.hass.states.async_set_internal(
             self.entity_id,
             state,
             attr,
             self.force_update,
-            context,
+            self.async_get_recent_context(),
             self._state_info,
             time_now,
         )

--- a/homeassistant/helpers/entity.py
+++ b/homeassistant/helpers/entity.py
@@ -972,6 +972,20 @@ class Entity(
         self._context = context
         self._context_set = time.time()
 
+    @callback
+    def async_get_recent_context(self) -> Context | None:
+        """Return the context the entity operates under if it is still recent.
+
+        A context which is no longer recent is discarded and None is returned.
+        """
+        if (
+            self._context_set is not None
+            and timer() - self._context_set > CONTEXT_RECENT_TIME_SECONDS
+        ):
+            self._context = None
+            self._context_set = None
+        return self._context
+
     async def async_update_ha_state(self, force_refresh: bool = False) -> None:
         """Update Home Assistant with current state of entity.
 
@@ -1283,12 +1297,7 @@ class Entity(
             if custom:
                 attr |= custom
 
-        if (
-            self._context_set is not None
-            and time_now - self._context_set > CONTEXT_RECENT_TIME_SECONDS
-        ):
-            self._context = None
-            self._context_set = None
+        context = self.async_get_recent_context()
 
         # Intentionally called with positional args for performance reasons
         self.hass.states.async_set_internal(
@@ -1296,7 +1305,7 @@ class Entity(
             state,
             attr,
             self.force_update,
-            self._context,
+            context,
             self._state_info,
             time_now,
         )

--- a/tests/components/mikrotik/test_switch.py
+++ b/tests/components/mikrotik/test_switch.py
@@ -1,24 +1,26 @@
 """Tests for the Mikrotik switch platform."""
 
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
+from homeassistant.auth.const import GROUP_ID_USER
 from homeassistant.components.switch import (
     DOMAIN as SWITCH_DOMAIN,
     SERVICE_TURN_OFF,
     SERVICE_TURN_ON,
 )
 from homeassistant.const import ATTR_ENTITY_ID, STATE_OFF, STATE_ON, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import Context, HomeAssistant
+from homeassistant.exceptions import Unauthorized
 from homeassistant.helpers import entity_registry as er
 
 from . import setup_mikrotik_entry
 from .const import BRIDGE1_INTERFACE, ETHER1_INTERFACE, INTERFACE_DATA, WLAN1_INTERFACE
 
-from tests.common import snapshot_platform
+from tests.common import MockUser, snapshot_platform
 
 
 async def test_switch_entities_created(
@@ -102,3 +104,35 @@ async def test_switch_turn_on_off(
 
     assert (state := hass.states.get(entity_id))
     assert state.state == final_state
+
+
+async def test_switch_requires_admin_user(
+    hass: HomeAssistant, mock_api: MagicMock
+) -> None:
+    """Test a non-admin user cannot change the state of an interface."""
+    user_group = await hass.auth.async_get_group(GROUP_ID_USER)
+    user = MockUser(groups=[user_group]).add_to_hass(hass)
+
+    with patch("homeassistant.components.mikrotik.PLATFORMS", [Platform.SWITCH]):
+        await setup_mikrotik_entry(hass, interface_data=[ETHER1_INTERFACE])
+
+    entity_id = "switch.ether1_ethernet"
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_ON
+
+    with pytest.raises(Unauthorized):
+        await hass.services.async_call(
+            SWITCH_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+            context=Context(user_id=user.id),
+        )
+
+    assert (
+        call("/interface/disable", **{".id": ETHER1_INTERFACE[".id"]})
+        not in mock_api.mock_calls
+    )
+
+    assert (state := hass.states.get(entity_id))
+    assert state.state == STATE_ON

--- a/tests/helpers/test_entity.py
+++ b/tests/helpers/test_entity.py
@@ -693,6 +693,25 @@ async def test_set_context_expired(hass: HomeAssistant) -> None:
     assert ent._context_set is None
 
 
+async def test_get_recent_context(hass: HomeAssistant) -> None:
+    """Test getting the context only while it is recent."""
+    context = Context()
+    ent = entity.Entity()
+    ent.hass = hass
+    ent.entity_id = "hello.world"
+
+    assert ent.async_get_recent_context() is None
+
+    ent.async_set_context(context)
+    assert ent.async_get_recent_context() is context
+
+    with patch("homeassistant.helpers.entity.CONTEXT_RECENT_TIME_SECONDS", -5):
+        assert ent.async_get_recent_context() is None
+
+    assert ent._context is None
+    assert ent._context_set is None
+
+
 async def test_warn_disabled(
     hass: HomeAssistant, caplog: pytest.LogCaptureFixture
 ) -> None:


### PR DESCRIPTION
## Breaking change

<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

Not a breaking change: the Mikrotik switch platform was merged after the beta cut, so no release has ever exposed these switches to non-admin users.

## Proposed change

Mikrotik interface switches change router configuration, so operating them should be restricted to administrators.

A new `MikrotikSwitchEntityDescription` adds an `admin_only` flag, set on the `ether` and `wlan` descriptions. When the flag is set, `_set_state` resolves the user behind the entity's context and raises `Unauthorized` unless they are an admin. A context without a `user_id` is left permitted, matching how `entity_service_call` treats user-less contexts.

The check needs the context the entity currently operates under, but only while it is still recent — `Entity._context` is sticky and `_async_write_ha_state` already had inline logic to discard it after `CONTEXT_RECENT_TIME_SECONDS`. That logic is extracted into `Entity.async_get_recent_context()`, which `_async_write_ha_state` now calls, and which the Mikrotik switch uses to make its authorization decision.

## Type of change

<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: ``https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure``

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr