### PR TITLE
Use base entity attribute enums in MQTT base blocked attributes

### DIFF
--- a/homeassistant/components/mqtt/entity.py
+++ b/homeassistant/components/mqtt/entity.py
@@ -29,6 +29,8 @@ from homeassistant.const import (
     CONF_UNIQUE_ID,
     CONF_UNIT_OF_MEASUREMENT,
     CONF_VALUE_TEMPLATE,
+    EntityCapabilityAttribute,
+    EntityStateAttribute,
 )
 from homeassistant.core import Event, HassJobType, HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr, entity_registry as er
@@ -134,24 +136,24 @@ from .util import (
 _LOGGER = logging.getLogger(__name__)
 
 MQTT_ATTRIBUTES_BLOCKED = {
-    "assumed_state",
     "available",
-    "device_class",
     "device_info",
     "entity_category",
     "entity_id",
-    "entity_picture",
     "entity_registry_enabled_default",
     "extra_state_attributes",
     "force_update",
-    "group_entities",
-    "icon",
-    "friendly_name",
     "should_poll",
     "state",
-    "supported_features",
     "unique_id",
-    "unit_of_measurement",
+    EntityCapabilityAttribute.GROUP_ENTITIES,
+    EntityStateAttribute.ASSUMED_STATE,
+    EntityStateAttribute.DEVICE_CLASS,
+    EntityStateAttribute.ENTITY_PICTURE,
+    EntityStateAttribute.FRIENDLY_NAME,
+    EntityStateAttribute.ICON,
+    EntityStateAttribute.SUPPORTED_FEATURES,
+    EntityStateAttribute.UNIT_OF_MEASUREMENT,
 }
 
 PUBLISH_KWARGS = (CONF_MESSAGE_EXPIRY_INTERVAL,)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

The base `MQTT_ATTRIBUTES_BLOCKED` set in `entity.py` lists the entity attribute keys that may not be overwritten by a user-defined JSON attributes topic (applied on top of each platform's `_attributes_extra_blocked`). It was built from bare string literals.

The keys that correspond to shared entity attributes now use the base enums from `homeassistant.const`:
- `EntityStateAttribute`: `assumed_state`, `device_class`, `entity_picture`, `friendly_name`, `icon`, `supported_features`, `unit_of_measurement`.
- `EntityCapabilityAttribute`: `group_entities`.

The remaining entries (`available`, `device_info`, `entity_category`, `entity_id`, `entity_registry_enabled_default`, `extra_state_attributes`, `force_update`, `should_poll`, `state`, `unique_id`) are entity property/internal names with no attribute enum member and stay as string literals.

The enum members are `StrEnum` values, so the set contents and the membership check are unchanged at runtime.

Follow-up to #178139. Part of #175836.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

