### PR TITLE
Remove system_timezone in local_calendar diagnostics

### DIFF
--- a/homeassistant/components/local_calendar/diagnostics.py
+++ b/homeassistant/components/local_calendar/diagnostics.py
@@ -1,6 +1,5 @@
 """Provides diagnostics for local calendar."""
 
-import datetime
 from typing import Any
 
 from ical.diagnostics import redact_ics
@@ -18,7 +17,6 @@ async def async_get_config_entry_diagnostics(
     payload: dict[str, Any] = {
         "now": dt_util.now().isoformat(),
         "timezone": str(dt_util.get_default_time_zone()),
-        "system_timezone": str(datetime.datetime.now().astimezone().tzinfo),  # pylint: disable=home-assistant-enforce-naive-now
     }
     store = config_entry.runtime_data
     ics = await store.async_load()

--- a/homeassistant/components/local_calendar/diagnostics.py
+++ b/homeassistant/components/local_calendar/diagnostics.py
@@ -17,6 +17,7 @@ async def async_get_config_entry_diagnostics(
     payload: dict[str, Any] = {
         "now": dt_util.now().isoformat(),
         "timezone": str(dt_util.get_default_time_zone()),
+        "system_timezone": str(dt_util.naive_now().astimezone().tzinfo),
     }
     store = config_entry.runtime_data
     ics = await store.async_load()

--- a/tests/components/local_calendar/snapshots/test_diagnostics.ambr
+++ b/tests/components/local_calendar/snapshots/test_diagnostics.ambr
@@ -18,7 +18,6 @@
       END:VCALENDAR
     ''',
     'now': '2023-03-13T13:05:00-06:00',
-    'system_timezone': 'tzlocal()',
     'timezone': 'America/Regina',
   })
 # ---
@@ -26,7 +25,6 @@
   dict({
     'ics': '',
     'now': '2023-03-13T13:05:00-06:00',
-    'system_timezone': 'tzlocal()',
     'timezone': 'America/Regina',
   })
 # ---

--- a/tests/components/local_calendar/snapshots/test_diagnostics.ambr
+++ b/tests/components/local_calendar/snapshots/test_diagnostics.ambr
@@ -18,6 +18,7 @@
       END:VCALENDAR
     ''',
     'now': '2023-03-13T13:05:00-06:00',
+    'system_timezone': 'tzlocal()',
     'timezone': 'America/Regina',
   })
 # ---
@@ -25,6 +26,7 @@
   dict({
     'ics': '',
     'now': '2023-03-13T13:05:00-06:00',
+    'system_timezone': 'tzlocal()',
     'timezone': 'America/Regina',
   })
 # ---


### PR DESCRIPTION
﻿## Proposed change

`local_calendar` diagnostics reported the system time zone through a naive
`datetime.now()`, with `home-assistant-enforce-naive-now` suppressed on the
line.

The field itself stays. It exists so that a mismatch between the configured
time zone and the one the system reports is visible in diagnostics, which is
what surfaces calendar code that skipped `dt_util`. Only the naive call is
replaced, by `dt_util.naive_now()` — documented as now in system local time and
implemented as `datetime.now()`, so the reported value does not change and the
suppression is no longer needed.

An earlier revision of this PR removed the field instead. Thanks @allenporter
for the correction.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177813
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


