### PR TITLE
Fix OpenDisplay connecting to every discovered device on startup

### DIFF
--- a/homeassistant/components/opendisplay/config_flow.py
+++ b/homeassistant/components/opendisplay/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for OpenDisplay integration."""
 
+import asyncio
 from collections.abc import Mapping
 import logging
 from typing import TYPE_CHECKING, Any, override
@@ -29,6 +30,8 @@ _LOGGER = logging.getLogger(__name__)
 
 _ENCRYPTION_KEY_VALIDATOR = vol.All(str.strip, str.lower, vol.Match(r"^[0-9a-f]{32}$"))
 
+CONNECT_TIMEOUT = 45
+
 
 class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for OpenDisplay."""
@@ -46,10 +49,22 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
         if ble_device is None:
             raise BLEConnectionError(f"Could not find connectable device for {address}")
 
-        async with OpenDisplayDevice(
-            mac_address=address, ble_device=ble_device, encryption_key=encryption_key
-        ) as device:
-            await device.read_firmware_version()
+        # A device that stops responding mid-probe would otherwise hold both the
+        # dialog and one of the adapter's connection slots indefinitely.
+        try:
+            async with (
+                asyncio.timeout(CONNECT_TIMEOUT),
+                OpenDisplayDevice(
+                    mac_address=address,
+                    ble_device=ble_device,
+                    encryption_key=encryption_key,
+                ) as device,
+            ):
+                await device.read_firmware_version()
+        except TimeoutError as err:
+            raise BLEConnectionError(
+                f"Connection probe exceeded {CONNECT_TIMEOUT}s"
+            ) from err
 
     @override
     async def async_step_bluetooth(
@@ -61,32 +76,37 @@ class OpenDisplayConfigFlow(ConfigFlow, domain=DOMAIN):
         self._discovery_info = discovery_info
         self.context["title_placeholders"] = {"name": discovery_info.name}
 
-        try:
-            await self._async_test_connection(discovery_info.address)
-        except AuthenticationRequiredError:
-            return await self.async_step_encryption_key()
-        except OpenDisplayError:
-            return self.async_abort(reason="cannot_connect")
-        except Exception:
-            _LOGGER.exception("Unexpected error")
-            return self.async_abort(reason="unknown")
-
         return await self.async_step_bluetooth_confirm()
 
     async def async_step_bluetooth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Confirm discovery."""
+        """Confirm discovery and verify the device responds."""
         assert self._discovery_info is not None
+        errors: dict[str, str] = {}
 
-        if user_input is None:
-            self._set_confirm_only()
-            return self.async_show_form(
-                step_id="bluetooth_confirm",
-                description_placeholders=self.context["title_placeholders"],
-            )
+        # The device is only contacted once the user confirms: every unconfigured
+        # device in range is discovered on every restart, and probing them all
+        # would exhaust the adapter's connection slots.
+        if user_input is not None:
+            try:
+                await self._async_test_connection(self._discovery_info.address)
+            except AuthenticationRequiredError:
+                return await self.async_step_encryption_key()
+            except OpenDisplayError:
+                errors["base"] = "cannot_connect"
+            except Exception:
+                _LOGGER.exception("Unexpected error")
+                errors["base"] = "unknown"
+            else:
+                return self.async_create_entry(title=self._discovery_info.name, data={})
 
-        return self.async_create_entry(title=self._discovery_info.name, data={})
+        self._set_confirm_only()
+        return self.async_show_form(
+            step_id="bluetooth_confirm",
+            description_placeholders=self.context["title_placeholders"],
+            errors=errors,
+        )
 
     @override
     async def async_step_user(

--- a/tests/components/opendisplay/test_config_flow.py
+++ b/tests/components/opendisplay/test_config_flow.py
@@ -1,6 +1,8 @@
 """Test the OpenDisplay config flow."""
 
+import asyncio
 from collections.abc import Generator
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from opendisplay import (
@@ -13,13 +15,15 @@ from opendisplay import (
 import pytest
 
 from homeassistant import config_entries
+from homeassistant.components.opendisplay.config_flow import CONNECT_TIMEOUT
 from homeassistant.components.opendisplay.const import CONF_ENCRYPTION_KEY, DOMAIN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.util import dt as dt_util
 
 from . import ENCRYPTION_KEY, NOT_OPENDISPLAY_SERVICE_INFO, VALID_SERVICE_INFO
 
-from tests.common import MockConfigEntry
+from tests.common import MockConfigEntry, async_fire_time_changed
 
 
 @pytest.fixture(autouse=True)
@@ -100,7 +104,7 @@ async def test_bluetooth_confirm_connection_error(
     exception: Exception,
     expected_reason: str,
 ) -> None:
-    """Test confirm step aborts when connection fails before showing the form."""
+    """Test the confirm step shows an error and allows a retry when connecting fails."""
     mock_opendisplay_device.__aenter__.side_effect = exception
 
     result = await hass.config_entries.flow.async_init(
@@ -108,27 +112,87 @@ async def test_bluetooth_confirm_connection_error(
         context={"source": config_entries.SOURCE_BLUETOOTH},
         data=VALID_SERVICE_INFO,
     )
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == expected_reason
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    assert result["errors"] == {"base": expected_reason}
+
+    mock_opendisplay_device.__aenter__.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+
+
+async def test_bluetooth_discovery_does_not_connect(
+    hass: HomeAssistant,
+    mock_opendisplay_device_class: MagicMock,
+) -> None:
+    """Test that discovery alone never opens a connection to the device."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=VALID_SERVICE_INFO,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bluetooth_confirm"
+    mock_opendisplay_device_class.assert_not_called()
 
 
 async def test_bluetooth_confirm_ble_device_not_found(
     hass: HomeAssistant,
 ) -> None:
-    """Test confirm step aborts when BLE device is not found."""
+    """Test the confirm step reports an error when the BLE device is not found."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=VALID_SERVICE_INFO,
+    )
+
     with patch(
         "homeassistant.components.opendisplay.config_flow.async_ble_device_from_address",
         return_value=None,
     ):
-        result = await hass.config_entries.flow.async_init(
-            DOMAIN,
-            context={"source": config_entries.SOURCE_BLUETOOTH},
-            data=VALID_SERVICE_INFO,
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], user_input={}
         )
 
-    assert result["type"] is FlowResultType.ABORT
-    assert result["reason"] == "cannot_connect"
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_bluetooth_confirm_connection_timeout(
+    hass: HomeAssistant,
+    mock_opendisplay_device: MagicMock,
+) -> None:
+    """Test that a device which stops responding does not hang the flow."""
+
+    async def _never_returns(*args: object, **kwargs: object) -> None:
+        await asyncio.Event().wait()
+
+    mock_opendisplay_device.read_firmware_version.side_effect = _never_returns
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_BLUETOOTH},
+        data=VALID_SERVICE_INFO,
+    )
+
+    task = hass.async_create_task(
+        hass.config_entries.flow.async_configure(result["flow_id"], user_input={})
+    )
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=CONNECT_TIMEOUT))
+    result = await task
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "cannot_connect"}
 
 
 async def test_user_step_with_devices(hass: HomeAssistant) -> None:
@@ -265,6 +329,9 @@ async def test_bluetooth_discovery_encrypted_device(
         context={"source": config_entries.SOURCE_BLUETOOTH},
         data=VALID_SERVICE_INFO,
     )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
+    )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "encryption_key"
 
@@ -291,6 +358,9 @@ async def test_bluetooth_discovery_encrypted_invalid_key_format(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
         data=VALID_SERVICE_INFO,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
     assert result["step_id"] == "encryption_key"
 
@@ -325,6 +395,9 @@ async def test_bluetooth_discovery_encrypted_wrong_key(
         DOMAIN,
         context={"source": config_entries.SOURCE_BLUETOOTH},
         data=VALID_SERVICE_INFO,
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={}
     )
     assert result["step_id"] == "encryption_key"
 


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Currently, the bluetooth discovery step connects to an OpenDisplay device to read its firmware, but that causes a few problems:
- When a user has many OpenDisplay devices nearby those all "hog" every available BLE Connection slots and sometimes even get stuck without ever freeing them again.
- When an OpenDisplay device is freshly flashed and unconfigured HA tries connecting to it anyways and gets stuck, preventing the device from being able to be configured and also taking up a BLE slot indefinitely.

This PR fixes that by moving the connection to the confirm step.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
