### PR TITLE
Avoid a naive datetime.now() in vesync

### DIFF
--- a/homeassistant/components/vesync/coordinator.py
+++ b/homeassistant/components/vesync/coordinator.py
@@ -1,7 +1,8 @@
 """Class to manage VeSync data updates."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
+import time
 from typing import override
 
 from pyvesync import VeSync
@@ -22,7 +23,7 @@ class VeSyncDataCoordinator(DataUpdateCoordinator[None]):
     """Class representing data coordinator for VeSync devices."""
 
     config_entry: VesyncConfigEntry
-    update_time: datetime | None = None
+    update_time: float | None = None
 
     def __init__(
         self, hass: HomeAssistant, config_entry: VesyncConfigEntry, manager: VeSync
@@ -43,9 +44,7 @@ class VeSyncDataCoordinator(DataUpdateCoordinator[None]):
         if self.update_time is None:
             return True
 
-        return datetime.now() - self.update_time >= timedelta(  # pylint: disable=home-assistant-enforce-naive-now
-            seconds=UPDATE_INTERVAL_ENERGY
-        )
+        return time.time() - self.update_time >= UPDATE_INTERVAL_ENERGY
 
     @override
     async def _async_update_data(self) -> None:
@@ -54,7 +53,7 @@ class VeSyncDataCoordinator(DataUpdateCoordinator[None]):
             await self.manager.update_all_devices()
 
             if self.should_update_energy():
-                self.update_time = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+                self.update_time = time.time()
                 for outlet in self.manager.devices.outlets:
                     await outlet.update_energy()
         except VeSyncError as err:

--- a/tests/components/vesync/test_coordinator.py
+++ b/tests/components/vesync/test_coordinator.py
@@ -1,0 +1,33 @@
+"""Tests for the VeSync coordinator."""
+
+from datetime import timedelta
+import time
+
+from freezegun.api import FrozenDateTimeFactory
+
+from homeassistant.components.vesync.const import UPDATE_INTERVAL_ENERGY
+from homeassistant.components.vesync.coordinator import VeSyncDataCoordinator
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+
+async def test_should_update_energy(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    manager,
+    freezer: FrozenDateTimeFactory,
+) -> None:
+    """Test energy data is only refreshed once per interval."""
+    coordinator = VeSyncDataCoordinator(hass, config_entry, manager)
+
+    # Nothing fetched yet
+    assert coordinator.should_update_energy()
+
+    coordinator.update_time = time.time()
+    assert not coordinator.should_update_energy()
+
+    freezer.tick(timedelta(seconds=UPDATE_INTERVAL_ENERGY - 1))
+    assert not coordinator.should_update_energy()
+
+    freezer.tick(timedelta(seconds=1))
+    assert coordinator.should_update_energy()

--- a/tests/components/vesync/test_coordinator.py
+++ b/tests/components/vesync/test_coordinator.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 import time
 
 from freezegun.api import FrozenDateTimeFactory
+from pyvesync import VeSync
 
 from homeassistant.components.vesync.const import UPDATE_INTERVAL_ENERGY
 from homeassistant.components.vesync.coordinator import VeSyncDataCoordinator
@@ -14,7 +15,7 @@ from homeassistant.core import HomeAssistant
 async def test_should_update_energy(
     hass: HomeAssistant,
     config_entry: ConfigEntry,
-    manager,
+    manager: VeSync,
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test energy data is only refreshed once per interval."""


### PR DESCRIPTION
## Proposed change

`VeSyncDataCoordinator.update_time` only records when the energy data was last
refreshed, so that `should_update_energy` can tell whether `UPDATE_INTERVAL_ENERGY`
seconds have passed. The value is never rendered, stored or compared against an
aware datetime, so this is the relative time case from the issue: a float is
enough and no time zone is involved.

`update_time` becomes a `float` from `time.time()`, the comparison drops the
`timedelta` wrapper since `UPDATE_INTERVAL_ENERGY` is already in seconds, and
both `home-assistant-enforce-naive-now` suppressions go away.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177840
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

