### PR TITLE
Avoid a naive datetime.now() in starline

### DIFF
--- a/homeassistant/components/starline/account.py
+++ b/homeassistant/components/starline/account.py
@@ -1,7 +1,8 @@
 """StarLine Account."""
 
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import timedelta
+import time
 from typing import Any
 
 from starline import StarlineApi, StarlineDevice
@@ -47,7 +48,7 @@ class StarlineAccount:
 
     def _check_slnet_token(self, interval: int) -> None:
         """Check SLNet token expiration and update if needed."""
-        now = datetime.now().timestamp()  # pylint: disable=home-assistant-enforce-naive-now
+        now = time.time()
         slnet_token_expires = self._config_entry.data[DATA_EXPIRES]
 
         if now + interval > slnet_token_expires:


### PR DESCRIPTION
## Proposed change

`_check_slnet_token` compares the current time against `DATA_EXPIRES` from the
config entry. That value comes back from the StarLine API as a unix timestamp,
which is why the existing code immediately called `.timestamp()` on the naive
datetime it had just built.

Since only seconds are compared, this is the relative time case from the issue:
`time.time()` produces the same number directly, so the intermediate naive
datetime and its `home-assistant-enforce-naive-now` suppression can go away.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177829
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


