### PR TITLE
Avoid a naive datetime.now() in plant

### DIFF
--- a/homeassistant/components/plant/__init__.py
+++ b/homeassistant/components/plant/__init__.py
@@ -6,7 +6,7 @@ PENDING A DESIGN EVALUATION.
 
 from collections import deque
 from contextlib import suppress
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
 from typing import Any, override
 
@@ -389,7 +389,7 @@ class DailyHistory:
 
     def add_measurement(self, value, timestamp=None):
         """Add a new measurement for a certain day."""
-        day = (timestamp or datetime.now()).date()  # pylint: disable=home-assistant-enforce-naive-now
+        day = (timestamp or dt_util.utcnow()).date()
         if not isinstance(value, (int, float)):
             return
         if self._days is None:

--- a/tests/components/plant/test_init.py
+++ b/tests/components/plant/test_init.py
@@ -1,6 +1,6 @@
 """Unit tests for platform/plant.py."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 from homeassistant.components import plant
 from homeassistant.components.recorder import Recorder
@@ -14,6 +14,7 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant, State
 from homeassistant.setup import async_setup_component
+from homeassistant.util import dt as dt_util
 
 from tests.components.recorder.common import async_wait_recording_done
 
@@ -230,7 +231,7 @@ def test_daily_history_one_day(hass: HomeAssistant) -> None:
 def test_daily_history_multiple_days(hass: HomeAssistant) -> None:
     """Test storing data for different days."""
     dh = plant.DailyHistory(3)
-    today = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+    today = dt_util.utcnow()
     today_minus_1 = today - timedelta(days=1)
     today_minus_2 = today_minus_1 - timedelta(days=1)
     today_minus_3 = today_minus_2 - timedelta(days=1)


### PR DESCRIPTION
## Proposed change

`DailyHistory.add_measurement` takes an optional `timestamp` and falls back to a
naive `datetime.now()` when it is not given.

Both call sites pass `State.last_updated`, which is an aware UTC datetime, so
the naive local fallback was the only value of a different kind reaching
`.date()`. `dt_util.utcnow()` keeps the default consistent with what the callers
actually pass, and it matches the `dt_util.utcnow()` already used further up in
this module for `start_date`.

The `home-assistant-enforce-naive-now` suppression goes away with it.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177821
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


