### PR TITLE
Avoid a naive datetime.now() in tesla_fleet

### DIFF
--- a/homeassistant/components/tesla_fleet/coordinator.py
+++ b/homeassistant/components/tesla_fleet/coordinator.py
@@ -1,6 +1,6 @@
 """Tesla Fleet Data Coordinator."""
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 from random import randint
 from time import time
 from typing import TYPE_CHECKING, Any, override
@@ -32,7 +32,9 @@ from .const import DOMAIN, ENERGY_HISTORY_FIELDS, LOGGER, TeslaFleetState
 
 VEHICLE_INTERVAL_SECONDS = 600
 VEHICLE_INTERVAL = timedelta(seconds=VEHICLE_INTERVAL_SECONDS)
-VEHICLE_WAIT = timedelta(minutes=15)
+VEHICLE_WAIT_SECONDS = 900
+VEHICLE_WAIT = timedelta(seconds=VEHICLE_WAIT_SECONDS)
+VEHICLE_STUCK_SECONDS = 1200
 
 ENERGY_INTERVAL_SECONDS = 60
 ENERGY_INTERVAL = timedelta(seconds=ENERGY_INTERVAL_SECONDS)
@@ -112,7 +114,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     config_entry: TeslaFleetConfigEntry
     updated_once: bool
     pre2021: bool
-    last_active: datetime
+    last_active: float
     endpoints: list[VehicleDataEndpoint]
 
     def __init__(
@@ -134,7 +136,7 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self.api = api
         self.data = flatten(product)
         self.updated_once = False
-        self.last_active = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+        self.last_active = time()
         self.endpoints = (
             ENDPOINTS
             if location
@@ -185,13 +187,13 @@ class TeslaFleetVehicleDataCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 or data["vehicle_state"].get("sentry_mode")
             ):
                 # Vehicle is active, reset timer
-                self.last_active = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+                self.last_active = time()
             else:
-                elapsed = datetime.now() - self.last_active  # pylint: disable=home-assistant-enforce-naive-now
-                if elapsed > timedelta(minutes=20):
+                elapsed = time() - self.last_active
+                if elapsed > VEHICLE_STUCK_SECONDS:
                     # Vehicle didn't sleep, try again in 15 minutes
-                    self.last_active = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
-                elif elapsed > timedelta(minutes=15):
+                    self.last_active = time()
+                elif elapsed > VEHICLE_WAIT_SECONDS:
                     # Let vehicle go to sleep now
                     self.update_interval = VEHICLE_WAIT
 


### PR DESCRIPTION
﻿## Proposed change

`VehicleDataCoordinator.last_active` only exists so the coordinator can tell how
long a pre-2021 vehicle has been idle, since those cannot put themselves to
sleep. Nothing renders or stores it, and it is only ever subtracted from the
current time, so this is the relative time case from the issue.

It becomes a `float` from `time()`, which this module already imports and uses
elsewhere. The two thresholds are now named second constants next to the
existing `VEHICLE_INTERVAL_SECONDS`, so the comparison stays readable without a
`timedelta` on either side.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177836
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr

