### PR TITLE
Avoid a naive datetime.now() in nice_go

### DIFF
--- a/homeassistant/components/nice_go/config_flow.py
+++ b/homeassistant/components/nice_go/config_flow.py
@@ -1,8 +1,8 @@
 """Config flow for Nice G.O. integration."""
 
 from collections.abc import Mapping
-from datetime import datetime
 import logging
+import time
 from typing import Any, override
 
 from nice_go import AuthFailedError, NiceGOApi
@@ -59,7 +59,7 @@ class NiceGOConfigFlow(ConfigFlow, domain=DOMAIN):
                         CONF_EMAIL: user_input[CONF_EMAIL],
                         CONF_PASSWORD: user_input[CONF_PASSWORD],
                         CONF_REFRESH_TOKEN: refresh_token,
-                        CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),  # pylint: disable=home-assistant-enforce-naive-now
+                        CONF_REFRESH_TOKEN_CREATION_TIME: time.time(),
                     },
                 )
 
@@ -100,7 +100,7 @@ class NiceGOConfigFlow(ConfigFlow, domain=DOMAIN):
                     data={
                         **user_input,
                         CONF_REFRESH_TOKEN: refresh_token,
-                        CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),  # pylint: disable=home-assistant-enforce-naive-now
+                        CONF_REFRESH_TOKEN_CREATION_TIME: time.time(),
                     },
                     unique_id=user_input[CONF_EMAIL],
                 )

--- a/homeassistant/components/nice_go/coordinator.py
+++ b/homeassistant/components/nice_go/coordinator.py
@@ -3,9 +3,9 @@
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any, override
 
 from nice_go import (
@@ -174,7 +174,7 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
             self.refresh_token_creation_time + REFRESH_TOKEN_EXPIRY_TIME.total_seconds()
         )
         try:
-            if datetime.now().timestamp() >= expiry_time:  # pylint: disable=home-assistant-enforce-naive-now
+            if time.time() >= expiry_time:
                 await self.update_refresh_token()
             else:
                 await self.api.authenticate_refresh(
@@ -205,7 +205,7 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
         data = {
             **self.config_entry.data,
             CONF_REFRESH_TOKEN: refresh_token,
-            CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),  # pylint: disable=home-assistant-enforce-naive-now
+            CONF_REFRESH_TOKEN_CREATION_TIME: time.time(),
         }
         self.hass.config_entries.async_update_entry(self.config_entry, data=data)
 

--- a/homeassistant/components/nice_go/coordinator.py
+++ b/homeassistant/components/nice_go/coordinator.py
@@ -3,9 +3,9 @@
 import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
 import json
 import logging
+import time
 from typing import TYPE_CHECKING, Any, override
 
 from nice_go import (
@@ -152,7 +152,7 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
                 + REFRESH_TOKEN_EXPIRY_TIME.total_seconds()
             )
             try:
-                if datetime.now().timestamp() >= expiry_time:  # pylint: disable=home-assistant-enforce-naive-now
+                if time.time() >= expiry_time:
                     await self.update_refresh_token()
                 else:
                     await self.api.authenticate_refresh(
@@ -196,7 +196,7 @@ class NiceGOUpdateCoordinator(DataUpdateCoordinator[dict[str, NiceGODevice]]):
         data = {
             **self.config_entry.data,
             CONF_REFRESH_TOKEN: refresh_token,
-            CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),  # pylint: disable=home-assistant-enforce-naive-now
+            CONF_REFRESH_TOKEN_CREATION_TIME: time.time(),
         }
         self.hass.config_entries.async_update_entry(self.config_entry, data=data)
 

--- a/tests/components/nice_go/conftest.py
+++ b/tests/components/nice_go/conftest.py
@@ -1,7 +1,7 @@
 """Common fixtures for the Nice G.O. tests."""
 
 from collections.abc import Generator
-from datetime import datetime
+import time
 from unittest.mock import AsyncMock, patch
 
 from nice_go import Barrier, BarrierState, ConnectionState
@@ -74,7 +74,7 @@ def mock_config_entry() -> MockConfigEntry:
             CONF_EMAIL: "test-email",
             CONF_PASSWORD: "test-password",
             CONF_REFRESH_TOKEN: "test-refresh-token",
-            CONF_REFRESH_TOKEN_CREATION_TIME: datetime.now().timestamp(),  # pylint: disable=home-assistant-enforce-naive-now
+            CONF_REFRESH_TOKEN_CREATION_TIME: time.time(),
         },
         version=1,
         unique_id="test-email",


### PR DESCRIPTION
﻿## Proposed change

`CONF_REFRESH_TOKEN_CREATION_TIME` is stored in the config entry as a unix
timestamp, and the only thing that reads it back adds
`REFRESH_TOKEN_EXPIRY_TIME` to it and compares the result against the current
time. That is the relative time case from the issue, which is also why all four
call sites already ended in `.timestamp()`.

`time.time()` returns the same value directly, so the intermediate naive
datetime and the four `home-assistant-enforce-naive-now` suppressions go away.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177817
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


