### PR TITLE
Avoid a naive datetime.now() in fyta

### DIFF
--- a/homeassistant/components/fyta/coordinator.py
+++ b/homeassistant/components/fyta/coordinator.py
@@ -1,8 +1,9 @@
 """Coordinator for FYTA integration."""
 
 from collections.abc import Callable
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
+import time
 from typing import override
 
 from fyta_cli.fyta_connector import FytaConnector
@@ -56,7 +57,7 @@ class FytaCoordinator(DataUpdateCoordinator[dict[int, Plant]]):
 
         if (
             self.fyta.expiration is None
-            or self.fyta.expiration.timestamp() < datetime.now().timestamp()  # pylint: disable=home-assistant-enforce-naive-now
+            or self.fyta.expiration.timestamp() < time.time()
         ):
             await self.renew_authentication()
 

--- a/homeassistant/components/fyta/image.py
+++ b/homeassistant/components/fyta/image.py
@@ -2,7 +2,6 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
-from datetime import datetime
 import logging
 from typing import Final, override
 
@@ -17,6 +16,7 @@ from homeassistant.components.image import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.util import dt as dt_util
 
 from .coordinator import FytaConfigEntry, FytaCoordinator
 from .entity import FytaPlantEntity
@@ -119,5 +119,5 @@ class FytaPlantImageEntity(FytaPlantEntity, ImageEntity):
 
         if url != self._attr_image_url:
             self._cached_image = None
-            self._attr_image_last_updated = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
+            self._attr_image_last_updated = dt_util.utcnow()
         return url

--- a/tests/components/fyta/test_image.py
+++ b/tests/components/fyta/test_image.py
@@ -15,6 +15,7 @@ from homeassistant.components.image import ImageEntity
 from homeassistant.const import STATE_UNAVAILABLE, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
 
 from . import setup_platform
 
@@ -147,6 +148,9 @@ async def test_update_image(
 
     assert image_entity.image_url == "http://www.plant_picture.com/picture1"
     assert image_state_1 != image_state_2
+
+    # The state is image_last_updated serialized, so it has to carry a timezone
+    assert dt_util.parse_datetime(image_state_2.state).tzinfo is not None
 
 
 async def test_update_user_image_error(


### PR DESCRIPTION
﻿## Proposed change

Two unrelated uses in this integration.

In the coordinator, the token expiry check compares
`self.fyta.expiration.timestamp()` against the current time, which is the
relative time case: `time.time()` gives the same number without the
intermediate naive datetime.

In the image platform, `_attr_image_last_updated` is different. `ImageEntity`
turns it into the entity state through `isoformat()`, so a naive value produces
a state string with no UTC offset. Every other image platform in core sets this
with `dt_util.utcnow()`, so this one now does the same.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177800
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
