### PR TITLE
Avoid a naive datetime.now() in google

### DIFF
--- a/homeassistant/components/google/__init__.py
+++ b/homeassistant/components/google/__init__.py
@@ -1,8 +1,9 @@
 """Support for Google - Calendar Event Devices."""
 
 from collections.abc import Mapping
-from datetime import datetime, timedelta
+from datetime import timedelta
 import logging
+import time
 from typing import Any
 
 import aiohttp
@@ -109,10 +110,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: GoogleConfigEntry) -> bo
     # Force a token refresh to fix a bug where tokens were persisted with
     # expires_in (relative time delta) and expires_at (absolute time) swapped.
     # A google session token typically only lasts a few days between refresh.
-    now = datetime.now()  # pylint: disable=home-assistant-enforce-naive-now
-    if session.token["expires_at"] >= (now + timedelta(days=365)).timestamp():
+    now = time.time()
+    if session.token["expires_at"] >= now + timedelta(days=365).total_seconds():
         session.token["expires_in"] = 0
-        session.token["expires_at"] = now.timestamp()
+        session.token["expires_at"] = now
     try:
         await session.async_ensure_token_valid()
     except OAuth2TokenRequestReauthError as err:

--- a/homeassistant/components/google/diagnostics.py
+++ b/homeassistant/components/google/diagnostics.py
@@ -1,6 +1,5 @@
 """Provides diagnostics for google calendar."""
 
-import datetime
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
@@ -45,7 +44,6 @@ async def async_get_config_entry_diagnostics(
     payload: dict[str, Any] = {
         "now": dt_util.now().isoformat(),
         "timezone": str(dt_util.get_default_time_zone()),
-        "system_timezone": str(datetime.datetime.now().astimezone().tzinfo),  # pylint: disable=home-assistant-enforce-naive-now
     }
 
     store = config_entry.runtime_data.store

--- a/homeassistant/components/google/diagnostics.py
+++ b/homeassistant/components/google/diagnostics.py
@@ -44,6 +44,7 @@ async def async_get_config_entry_diagnostics(
     payload: dict[str, Any] = {
         "now": dt_util.now().isoformat(),
         "timezone": str(dt_util.get_default_time_zone()),
+        "system_timezone": str(dt_util.naive_now().astimezone().tzinfo),
     }
 
     store = config_entry.runtime_data.store

--- a/tests/components/google/snapshots/test_diagnostics.ambr
+++ b/tests/components/google/snapshots/test_diagnostics.ambr
@@ -76,7 +76,6 @@
         'sync_token_version': 2,
       }),
     }),
-    'system_timezone': 'tzlocal()',
     'timezone': 'America/Regina',
   })
 # ---

--- a/tests/components/google/snapshots/test_diagnostics.ambr
+++ b/tests/components/google/snapshots/test_diagnostics.ambr
@@ -76,6 +76,7 @@
         'sync_token_version': 2,
       }),
     }),
+    'system_timezone': 'tzlocal()',
     'timezone': 'America/Regina',
   })
 # ---

--- a/tests/components/google/test_config_flow.py
+++ b/tests/components/google/test_config_flow.py
@@ -4,6 +4,7 @@ import asyncio
 from collections.abc import Callable
 import datetime
 from http import HTTPStatus
+import time
 from typing import Any
 from unittest.mock import Mock, patch
 
@@ -173,11 +174,7 @@ async def test_full_flow_application_creds(
     data = result["data"]
     assert "token" in data
     assert 0 < data["token"]["expires_in"] < 8 * 86400
-    assert (
-        datetime.datetime.now().timestamp()  # pylint: disable=home-assistant-enforce-naive-now
-        <= data["token"]["expires_at"]
-        < (datetime.datetime.now() + datetime.timedelta(days=8)).timestamp()  # pylint: disable=home-assistant-enforce-naive-now
-    )
+    assert time.time() <= data["token"]["expires_at"] < time.time() + 8 * 86400
     data["token"].pop("expires_at")
     data["token"].pop("expires_in")
     assert data == {


### PR DESCRIPTION
﻿## Proposed change

Two unrelated uses in this integration.

`async_setup_entry` has a sanity check for tokens that were persisted with
`expires_in` and `expires_at` swapped. It only does epoch arithmetic, and both
uses of the naive datetime immediately went through `.timestamp()`, so
`time.time()` gives the same numbers directly.

In diagnostics, only the naive call is replaced, by `dt_util.naive_now()`. The
`system_timezone` field stays: it exists to make a mismatch between the
configured time zone and the system one visible, which is how a missing
`dt_util` call shows up in a diagnostics dump. `naive_now()` is documented as
now in system local time and implemented as `datetime.now()`, so the reported
value is unchanged.

An earlier revision of this PR dropped the field. That was wrong, as
@allenporter pointed out on the equivalent change for `local_calendar`
(#178237).

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #177803
- This PR is related to issue: part of home-assistant/epics#117
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr


