### PR TITLE
Use entity attribute enums in logbook

### DIFF
--- a/homeassistant/components/logbook/helpers.py
+++ b/homeassistant/components/logbook/helpers.py
@@ -3,17 +3,19 @@
 from collections.abc import Callable, Collection, Mapping
 from typing import Any
 
-from homeassistant.components.sensor import ATTR_STATE_CLASS, NON_NUMERIC_DEVICE_CLASSES
+from homeassistant.components.sensor import (
+    NON_NUMERIC_DEVICE_CLASSES,
+    SensorEntityCapabilityAttribute,
+)
 from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
     ATTR_DEVICE_ID,
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
     ATTR_SERVICE_DATA,
-    ATTR_UNIT_OF_MEASUREMENT,
     EVENT_CALL_SERVICE,
     EVENT_LOGBOOK_ENTRY,
     EVENT_STATE_CHANGED,
+    EntityStateAttribute,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
@@ -254,7 +256,7 @@ def is_sensor_continuous(
     will filter out any sensors with a unit_of_measurement.
 
     If the state still exists in the state machine, this function still
-    checks for ATTR_UNIT_OF_MEASUREMENT since the live mode is not filtered
+    checks for EntityStateAttribute.UNIT_OF_MEASUREMENT since the live mode is not filtered
     by the SQL query.
     """
     # If it is in the state machine we can quick check if it
@@ -262,9 +264,11 @@ def is_sensor_continuous(
     # it does
     if (state := hass.states.get(entity_id)) and (attributes := state.attributes):
         return (
-            ATTR_UNIT_OF_MEASUREMENT in attributes
-            or ATTR_STATE_CLASS in attributes
-            or _device_class_is_numeric(attributes.get(ATTR_DEVICE_CLASS))
+            EntityStateAttribute.UNIT_OF_MEASUREMENT in attributes
+            or SensorEntityCapabilityAttribute.STATE_CLASS in attributes
+            or _device_class_is_numeric(
+                attributes.get(EntityStateAttribute.DEVICE_CLASS)
+            )
         )
     # If its not in the state machine, we need to check
     # the entity registry to see if its a sensor
@@ -276,7 +280,10 @@ def is_sensor_continuous(
     return bool(
         (entry := ent_reg.async_get(entity_id))
         and (
-            (entry.capabilities and entry.capabilities.get(ATTR_STATE_CLASS))
+            (
+                entry.capabilities
+                and entry.capabilities.get(SensorEntityCapabilityAttribute.STATE_CLASS)
+            )
             or _device_class_is_numeric(entry.device_class)
         )
     )
@@ -295,9 +302,11 @@ def _is_state_filtered(new_state: State, old_state: State) -> bool:
         or (
             new_state.domain == SENSOR_DOMAIN
             and (
-                ATTR_UNIT_OF_MEASUREMENT in new_state.attributes
-                or ATTR_STATE_CLASS in new_state.attributes
-                or _device_class_is_numeric(new_state.attributes.get(ATTR_DEVICE_CLASS))
+                EntityStateAttribute.UNIT_OF_MEASUREMENT in new_state.attributes
+                or SensorEntityCapabilityAttribute.STATE_CLASS in new_state.attributes
+                or _device_class_is_numeric(
+                    new_state.attributes.get(EntityStateAttribute.DEVICE_CLASS)
+                )
             )
         )
     )

--- a/homeassistant/components/logbook/models.py
+++ b/homeassistant/components/logbook/models.py
@@ -14,7 +14,7 @@ from homeassistant.components.recorder.models import (
     ulid_to_bytes_or_none,
     uuid_hex_to_bytes_or_none,
 )
-from homeassistant.const import ATTR_ICON, EVENT_STATE_CHANGED
+from homeassistant.const import EVENT_STATE_CHANGED, EntityStateAttribute
 from homeassistant.core import Context, Event, State, callback
 from homeassistant.util.event_type import EventType
 from homeassistant.util.json import json_loads
@@ -177,7 +177,7 @@ def async_event_to_row(event: Event) -> EventAsRow:
         context_parent_id_bin=ulid_to_bytes_or_none(context.parent_id),
         state=new_state.state,
         entity_id=new_state.entity_id,
-        icon=new_state.attributes.get(ATTR_ICON),
+        icon=new_state.attributes.get(EntityStateAttribute.ICON),
         attributes=new_state.attributes,
         context_only=None,
         data=event.data,

--- a/homeassistant/components/logbook/processor.py
+++ b/homeassistant/components/logbook/processor.py
@@ -29,11 +29,11 @@ from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
 from homeassistant.const import (
     ATTR_DOMAIN,
     ATTR_ENTITY_ID,
-    ATTR_FRIENDLY_NAME,
     ATTR_NAME,
     ATTR_SERVICE,
     EVENT_CALL_SERVICE,
     EVENT_LOGBOOK_ENTRY,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, split_entity_id
 from homeassistant.helpers import entity_registry as er
@@ -544,7 +544,9 @@ class EntityNameCache:
         if entity_id in self._names:
             return self._names[entity_id]
         if (current_state := self._hass.states.get(entity_id)) and (
-            friendly_name := current_state.attributes.get(ATTR_FRIENDLY_NAME)
+            friendly_name := current_state.attributes.get(
+                EntityStateAttribute.FRIENDLY_NAME
+            )
         ):
             self._names[entity_id] = friendly_name
         else:


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Logbook reads entity state and capability attributes when building and filtering log entries. These now use the attribute enums instead of `ATTR_*` constants:

- `EntityStateAttribute`: `ICON` (models.py), `FRIENDLY_NAME` (processor.py), `DEVICE_CLASS` and `UNIT_OF_MEASUREMENT` (helpers.py).
- `SensorEntityCapabilityAttribute.STATE_CLASS` for the sensor state class, read both from `state.attributes` and from the entity registry entry's `capabilities` (helpers.py).

Part of #175836.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
