### PR TITLE
Use entity attribute enums in group

### DIFF
--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -18,7 +18,6 @@ from homeassistant.components.cover import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
@@ -32,6 +31,7 @@ from homeassistant.const import (
     SERVICE_STOP_COVER_TILT,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -148,7 +148,7 @@ class CoverGroup(GroupEntity, CoverEntity):
                 values.discard(entity_id)
             return
 
-        features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        features = new_state.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
 
         if features & (CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE):
             self._covers[KEY_OPEN_CLOSE].add(entity_id)

--- a/homeassistant/components/group/cover.py
+++ b/homeassistant/components/group/cover.py
@@ -5,14 +5,13 @@ from typing import Any, override
 import voluptuous as vol
 
 from homeassistant.components.cover import (
-    ATTR_CURRENT_POSITION,
-    ATTR_CURRENT_TILT_POSITION,
     ATTR_POSITION,
     ATTR_TILT_POSITION,
     DOMAIN as COVER_DOMAIN,
     PLATFORM_SCHEMA as COVER_PLATFORM_SCHEMA,
     CoverEntity,
     CoverEntityFeature,
+    CoverEntityStateAttribute,
     CoverState,
 )
 from homeassistant.config_entries import ConfigEntry
@@ -313,14 +312,14 @@ class CoverGroup(GroupEntity, CoverEntity):
         all_position_states = [self.hass.states.get(x) for x in position_covers]
         position_states: list[State] = list(filter(None, all_position_states))
         self._attr_current_cover_position = reduce_attribute(
-            position_states, ATTR_CURRENT_POSITION
+            position_states, CoverEntityStateAttribute.CURRENT_POSITION
         )
 
         tilt_covers = self._tilts[KEY_POSITION]
         all_tilt_states = [self.hass.states.get(x) for x in tilt_covers]
         tilt_states: list[State] = list(filter(None, all_tilt_states))
         self._attr_current_cover_tilt_position = reduce_attribute(
-            tilt_states, ATTR_CURRENT_TILT_POSITION
+            tilt_states, CoverEntityStateAttribute.CURRENT_TILT_POSITION
         )
 
         supported_features = CoverEntityFeature(0)

--- a/homeassistant/components/group/entity.py
+++ b/homeassistant/components/group/entity.py
@@ -6,11 +6,11 @@ import logging
 from typing import Any, override
 
 from homeassistant.const import (
-    ATTR_ASSUMED_STATE,
     ATTR_ENTITY_ID,
-    ATTR_GROUP_ENTITIES,
     STATE_OFF,
     STATE_ON,
+    EntityCapabilityAttribute,
+    EntityStateAttribute,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
@@ -39,7 +39,9 @@ _LOGGER = logging.getLogger(__name__)
 class GroupEntity(Entity):
     """Representation of a Group of entities."""
 
-    _unrecorded_attributes = frozenset({ATTR_ENTITY_ID, ATTR_GROUP_ENTITIES})
+    _unrecorded_attributes = frozenset(
+        {ATTR_ENTITY_ID, EntityCapabilityAttribute.GROUP_ENTITIES}
+    )
 
     _attr_should_poll = False
     _entity_ids: list[str]
@@ -127,7 +129,7 @@ class GroupEntity(Entity):
         for entity_id in self._entity_ids:
             if (state := self.hass.states.get(entity_id)) is None:
                 continue
-            if state.attributes.get(ATTR_ASSUMED_STATE):
+            if state.attributes.get(EntityStateAttribute.ASSUMED_STATE):
                 self._attr_assumed_state = True
                 return
 
@@ -430,7 +432,9 @@ class Group(Entity):
         domain = new_state.domain
         state = new_state.state
         registry = self._registry
-        self._assumed[entity_id] = bool(new_state.attributes.get(ATTR_ASSUMED_STATE))
+        self._assumed[entity_id] = bool(
+            new_state.attributes.get(EntityStateAttribute.ASSUMED_STATE)
+        )
 
         if domain not in registry.on_states_by_domain:
             # Handle the group of a group case
@@ -462,11 +466,12 @@ class Group(Entity):
             return
 
         if tr_state is None or (
-            self._assumed_state and not tr_state.attributes.get(ATTR_ASSUMED_STATE)
+            self._assumed_state
+            and not tr_state.attributes.get(EntityStateAttribute.ASSUMED_STATE)
         ):
             self._assumed_state = self.mode(self._assumed.values())
 
-        elif tr_state.attributes.get(ATTR_ASSUMED_STATE):
+        elif tr_state.attributes.get(EntityStateAttribute.ASSUMED_STATE):
             self._assumed_state = True
 
         num_on_states = len(self._on_states)

--- a/homeassistant/components/group/event.py
+++ b/homeassistant/components/group/event.py
@@ -6,22 +6,21 @@ from typing import Any, override
 import voluptuous as vol
 
 from homeassistant.components.event import (
-    ATTR_EVENT_TYPE,
-    ATTR_EVENT_TYPES,
     DOMAIN as EVENT_DOMAIN,
     PLATFORM_SCHEMA as EVENT_PLATFORM_SCHEMA,
     EventEntity,
+    EventEntityCapabilityAttribute,
+    EventEntityStateAttribute,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    ATTR_DEVICE_CLASS,
     ATTR_ENTITY_ID,
-    ATTR_FRIENDLY_NAME,
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import Event, EventStateChangedData, HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -142,16 +141,20 @@ class EventGroup(GroupEntity, EventEntity):
                 and old_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
                 and (new_state := event.data["new_state"])
                 and new_state.state not in (STATE_UNAVAILABLE, STATE_UNKNOWN)
-                and (event_type := new_state.attributes.get(ATTR_EVENT_TYPE))
+                and (
+                    event_type := new_state.attributes.get(
+                        EventEntityStateAttribute.EVENT_TYPE
+                    )
+                )
             ):
                 event_attributes = new_state.attributes.copy()
 
                 # We should not propagate the event properties as
                 # fired event attributes.
-                del event_attributes[ATTR_EVENT_TYPE]
-                del event_attributes[ATTR_EVENT_TYPES]
-                event_attributes.pop(ATTR_DEVICE_CLASS, None)
-                event_attributes.pop(ATTR_FRIENDLY_NAME, None)
+                del event_attributes[EventEntityStateAttribute.EVENT_TYPE]
+                del event_attributes[EventEntityCapabilityAttribute.EVENT_TYPES]
+                event_attributes.pop(EntityStateAttribute.DEVICE_CLASS, None)
+                event_attributes.pop(EntityStateAttribute.FRIENDLY_NAME, None)
 
                 # Fire the group event
                 self._trigger_event(event_type, event_attributes)
@@ -185,7 +188,8 @@ class EventGroup(GroupEntity, EventEntity):
         self._attr_event_types = list(
             set(
                 itertools.chain.from_iterable(
-                    state.attributes.get(ATTR_EVENT_TYPES, []) for state in states
+                    state.attributes.get(EventEntityCapabilityAttribute.EVENT_TYPES, [])
+                    for state in states
                 )
             )
         )

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -11,7 +11,6 @@ from homeassistant.components.fan import (
     ATTR_DIRECTION,
     ATTR_OSCILLATING,
     ATTR_PERCENTAGE,
-    ATTR_PERCENTAGE_STEP,
     DOMAIN as FAN_DOMAIN,
     PLATFORM_SCHEMA as FAN_PLATFORM_SCHEMA,
     SERVICE_OSCILLATE,
@@ -21,17 +20,18 @@ from homeassistant.components.fan import (
     SERVICE_TURN_ON,
     FanEntity,
     FanEntityFeature,
+    FanEntityStateAttribute,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -166,7 +166,9 @@ class FanGroup(GroupEntity, FanEntity):
             for values in self._fans.values():
                 values.discard(entity_id)
         else:
-            features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+            features = new_state.attributes.get(
+                EntityStateAttribute.SUPPORTED_FEATURES, 0
+            )
             for feature in SUPPORTED_FLAGS:
                 if features & feature:
                     self._fans[feature].add(entity_id)
@@ -289,11 +291,20 @@ class FanGroup(GroupEntity, FanEntity):
         self._percentage = reduce_attribute(percentage_states, ATTR_PERCENTAGE)
         if (
             percentage_states
-            and percentage_states[0].attributes.get(ATTR_PERCENTAGE_STEP)
-            and attribute_equal(percentage_states, ATTR_PERCENTAGE_STEP)
+            and percentage_states[0].attributes.get(
+                FanEntityStateAttribute.PERCENTAGE_STEP
+            )
+            and attribute_equal(
+                percentage_states, FanEntityStateAttribute.PERCENTAGE_STEP
+            )
         ):
             self._speed_count = (
-                round(100 / percentage_states[0].attributes[ATTR_PERCENTAGE_STEP])
+                round(
+                    100
+                    / percentage_states[0].attributes[
+                        FanEntityStateAttribute.PERCENTAGE_STEP
+                    ]
+                )
                 or 100
             )
         else:

--- a/homeassistant/components/group/fan.py
+++ b/homeassistant/components/group/fan.py
@@ -288,7 +288,9 @@ class FanGroup(GroupEntity, FanEntity):
         percentage_states = self._async_states_by_support_flag(
             FanEntityFeature.SET_SPEED
         )
-        self._percentage = reduce_attribute(percentage_states, ATTR_PERCENTAGE)
+        self._percentage = reduce_attribute(
+            percentage_states, FanEntityStateAttribute.PERCENTAGE
+        )
         if (
             percentage_states
             and percentage_states[0].attributes.get(

--- a/homeassistant/components/group/light.py
+++ b/homeassistant/components/group/light.py
@@ -10,31 +10,27 @@ import voluptuous as vol
 from homeassistant.components import light
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
-    ATTR_COLOR_MODE,
     ATTR_COLOR_TEMP_KELVIN,
     ATTR_EFFECT,
-    ATTR_EFFECT_LIST,
     ATTR_FLASH,
     ATTR_HS_COLOR,
-    ATTR_MAX_COLOR_TEMP_KELVIN,
-    ATTR_MIN_COLOR_TEMP_KELVIN,
     ATTR_RGB_COLOR,
     ATTR_RGBW_COLOR,
     ATTR_RGBWW_COLOR,
-    ATTR_SUPPORTED_COLOR_MODES,
     ATTR_TRANSITION,
     ATTR_WHITE,
     ATTR_XY_COLOR,
     PLATFORM_SCHEMA as LIGHT_PLATFORM_SCHEMA,
     ColorMode,
     LightEntity,
+    LightEntityCapabilityAttribute,
     LightEntityFeature,
+    LightEntityStateAttribute,
     filter_supported_color_modes,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
@@ -43,6 +39,7 @@ from homeassistant.const import (
     STATE_ON,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -227,36 +224,46 @@ class LightGroup(GroupEntity, LightEntity):
             self._attr_is_on = self.mode(state.state == STATE_ON for state in states)
 
         self._attr_available = any(state.state != STATE_UNAVAILABLE for state in states)
-        self._attr_brightness = reduce_attribute(on_states, ATTR_BRIGHTNESS)
+        self._attr_brightness = reduce_attribute(
+            on_states, LightEntityStateAttribute.BRIGHTNESS
+        )
 
         self._attr_hs_color = reduce_attribute(
-            on_states, ATTR_HS_COLOR, reduce=mean_circle
+            on_states, LightEntityStateAttribute.HS_COLOR, reduce=mean_circle
         )
         self._attr_rgb_color = reduce_attribute(
-            on_states, ATTR_RGB_COLOR, reduce=mean_tuple
+            on_states, LightEntityStateAttribute.RGB_COLOR, reduce=mean_tuple
         )
         self._attr_rgbw_color = reduce_attribute(
-            on_states, ATTR_RGBW_COLOR, reduce=mean_tuple
+            on_states, LightEntityStateAttribute.RGBW_COLOR, reduce=mean_tuple
         )
         self._attr_rgbww_color = reduce_attribute(
-            on_states, ATTR_RGBWW_COLOR, reduce=mean_tuple
+            on_states, LightEntityStateAttribute.RGBWW_COLOR, reduce=mean_tuple
         )
         self._attr_xy_color = reduce_attribute(
-            on_states, ATTR_XY_COLOR, reduce=mean_tuple
+            on_states, LightEntityStateAttribute.XY_COLOR, reduce=mean_tuple
         )
 
         self._attr_color_temp_kelvin = reduce_attribute(
-            on_states, ATTR_COLOR_TEMP_KELVIN
+            on_states, LightEntityStateAttribute.COLOR_TEMP_KELVIN
         )
         self._attr_min_color_temp_kelvin = reduce_attribute(
-            states, ATTR_MIN_COLOR_TEMP_KELVIN, default=2000, reduce=min
+            states,
+            LightEntityCapabilityAttribute.MIN_COLOR_TEMP_KELVIN,
+            default=2000,
+            reduce=min,
         )
         self._attr_max_color_temp_kelvin = reduce_attribute(
-            states, ATTR_MAX_COLOR_TEMP_KELVIN, default=6500, reduce=max
+            states,
+            LightEntityCapabilityAttribute.MAX_COLOR_TEMP_KELVIN,
+            default=6500,
+            reduce=max,
         )
 
         self._attr_effect_list = None
-        all_effect_lists = list(find_state_attributes(states, ATTR_EFFECT_LIST))
+        all_effect_lists = list(
+            find_state_attributes(states, LightEntityCapabilityAttribute.EFFECT_LIST)
+        )
         if all_effect_lists:
             # Merge all effects from all effect_lists with a union merge.
             self._attr_effect_list = list(set().union(*all_effect_lists))
@@ -266,7 +273,9 @@ class LightGroup(GroupEntity, LightEntity):
                 self._attr_effect_list.insert(0, "None")
 
         self._attr_effect = None
-        all_effects = list(find_state_attributes(on_states, ATTR_EFFECT))
+        all_effects = list(
+            find_state_attributes(on_states, LightEntityStateAttribute.EFFECT)
+        )
         if all_effects:
             # Report the most common effect.
             effects_count = Counter(itertools.chain(all_effects))
@@ -274,7 +283,9 @@ class LightGroup(GroupEntity, LightEntity):
 
         supported_color_modes = {ColorMode.ONOFF}
         all_supported_color_modes = list(
-            find_state_attributes(states, ATTR_SUPPORTED_COLOR_MODES)
+            find_state_attributes(
+                states, LightEntityCapabilityAttribute.SUPPORTED_COLOR_MODES
+            )
         )
         if all_supported_color_modes:
             # Merge all color modes.
@@ -284,7 +295,9 @@ class LightGroup(GroupEntity, LightEntity):
         self._attr_supported_color_modes = supported_color_modes
 
         self._attr_color_mode = ColorMode.UNKNOWN
-        all_color_modes = list(find_state_attributes(on_states, ATTR_COLOR_MODE))
+        all_color_modes = list(
+            find_state_attributes(on_states, LightEntityStateAttribute.COLOR_MODE)
+        )
         if all_color_modes:
             # Report the most common color mode, select brightness and onoff last
             color_mode_count = Counter(itertools.chain(all_color_modes))
@@ -304,7 +317,9 @@ class LightGroup(GroupEntity, LightEntity):
                 self._attr_color_mode = next(iter(supported_color_modes))
 
         self._attr_supported_features = LightEntityFeature(0)
-        for support in find_state_attributes(states, ATTR_SUPPORTED_FEATURES):
+        for support in find_state_attributes(
+            states, EntityStateAttribute.SUPPORTED_FEATURES
+        ):
             # Merge supported features by emulating support for every feature
             # we find.
             self._attr_supported_features |= support

--- a/homeassistant/components/group/media_player.py
+++ b/homeassistant/components/group/media_player.py
@@ -19,13 +19,13 @@ from homeassistant.components.media_player import (
     SERVICE_PLAY_MEDIA,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
+    MediaPlayerEntityStateAttribute,
     MediaPlayerState,
     MediaType,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
@@ -42,6 +42,7 @@ from homeassistant.const import (
     SERVICE_VOLUME_SET,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import (
     CALLBACK_TYPE,
@@ -174,7 +175,9 @@ class MediaPlayerGroup(MediaPlayerEntity):
                 players.discard(entity_id)
             return
 
-        new_features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        new_features = new_state.attributes.get(
+            EntityStateAttribute.SUPPORTED_FEATURES, 0
+        )
         if new_features & MediaPlayerEntityFeature.CLEAR_PLAYLIST:
             self._features[KEY_CLEAR_PLAYLIST].add(entity_id)
         else:
@@ -441,7 +444,9 @@ class MediaPlayerGroup(MediaPlayerEntity):
     async def async_volume_up(self) -> None:
         """Turn volume up for media player(s)."""
         for entity in self._features[KEY_VOLUME]:
-            volume_level = self.hass.states.get(entity).attributes["volume_level"]  # type: ignore[union-attr]
+            volume_level = self.hass.states.get(entity).attributes[  # type: ignore[union-attr]
+                MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL
+            ]
             if volume_level < 1:
                 await self.async_set_volume_level(min(1, volume_level + 0.1))
 
@@ -449,7 +454,9 @@ class MediaPlayerGroup(MediaPlayerEntity):
     async def async_volume_down(self) -> None:
         """Turn volume down for media player(s)."""
         for entity in self._features[KEY_VOLUME]:
-            volume_level = self.hass.states.get(entity).attributes["volume_level"]  # type: ignore[union-attr]
+            volume_level = self.hass.states.get(entity).attributes[  # type: ignore[union-attr]
+                MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL
+            ]
             if volume_level > 0:
                 await self.async_set_volume_level(max(0, volume_level - 0.1))
 

--- a/homeassistant/components/group/notify.py
+++ b/homeassistant/components/group/notify.py
@@ -21,11 +21,11 @@ from homeassistant.components.notify import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
     CONF_ACTION,
     CONF_ENTITIES,
     CONF_SERVICE,
     STATE_UNAVAILABLE,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -213,7 +213,7 @@ class NotifyGroup(GroupEntity, NotifyEntity):
             state = self.hass.states.get(entity_id)
             if (
                 state is None
-                or not state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+                or not state.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
                 & NotifyEntityFeature.TITLE
             ):
                 self._attr_supported_features &= ~NotifyEntityFeature.TITLE

--- a/homeassistant/components/group/sensor.py
+++ b/homeassistant/components/group/sensor.py
@@ -36,6 +36,7 @@ from homeassistant.const import (
     CONF_UNIT_OF_MEASUREMENT,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.exceptions import HomeAssistantError
@@ -401,7 +402,7 @@ class SensorGroup(GroupEntity, SensorEntity):
                 states.append(state.state)
                 try:
                     numeric_state = float(state.state)
-                    uom = state.attributes.get("unit_of_measurement")
+                    uom = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
 
                     # Convert the state to the native unit of
                     # measurement when we have valid units
@@ -455,7 +456,9 @@ class SensorGroup(GroupEntity, SensorEntity):
                             entity_id,
                             state.state,
                             self.device_class,
-                            state.attributes.get("unit_of_measurement"),
+                            state.attributes.get(
+                                EntityStateAttribute.UNIT_OF_MEASUREMENT
+                            ),
                             self.entity_id,
                         )
             else:

--- a/homeassistant/components/group/valve.py
+++ b/homeassistant/components/group/valve.py
@@ -5,18 +5,17 @@ from typing import Any, override
 import voluptuous as vol
 
 from homeassistant.components.valve import (
-    ATTR_CURRENT_POSITION,
     ATTR_POSITION,
     DOMAIN as VALVE_DOMAIN,
     PLATFORM_SCHEMA as VALVE_PLATFORM_SCHEMA,
     ValveEntity,
     ValveEntityFeature,
+    ValveEntityStateAttribute,
     ValveState,
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
-    ATTR_SUPPORTED_FEATURES,
     CONF_ENTITIES,
     CONF_NAME,
     CONF_UNIQUE_ID,
@@ -26,6 +25,7 @@ from homeassistant.const import (
     SERVICE_STOP_VALVE,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
+    EntityStateAttribute,
 )
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers import config_validation as cv, entity_registry as er
@@ -136,7 +136,7 @@ class ValveGroup(GroupEntity, ValveEntity):
                 values.discard(entity_id)
             return
 
-        features = new_state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
+        features = new_state.attributes.get(EntityStateAttribute.SUPPORTED_FEATURES, 0)
 
         if features & (ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE):
             self._valves[KEY_OPEN_CLOSE].add(entity_id)
@@ -233,7 +233,10 @@ class ValveGroup(GroupEntity, ValveEntity):
         self._attr_reports_position = False
         self._update_assumed_state_from_members()
         for state in states:
-            if state.attributes.get(ATTR_CURRENT_POSITION) is not None:
+            if (
+                state.attributes.get(ValveEntityStateAttribute.CURRENT_POSITION)
+                is not None
+            ):
                 self._attr_reports_position = True
             if state.state == ValveState.OPEN:
                 self._attr_is_closed = False
@@ -255,7 +258,7 @@ class ValveGroup(GroupEntity, ValveEntity):
             self._attr_is_closed = None
 
         self._attr_current_valve_position = reduce_attribute(
-            states, ATTR_CURRENT_POSITION
+            states, ValveEntityStateAttribute.CURRENT_POSITION
         )
 
         supported_features = ValveEntityFeature(0)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Group aggregates member entities, reading their state and capability attributes. These reads now use the attribute enums instead of `ATTR_*` constants / bare strings, across the group platforms:

- Base `EntityStateAttribute`: `ASSUMED_STATE` (entity.py), `SUPPORTED_FEATURES` (cover/fan/valve/notify/media_player/light), `DEVICE_CLASS`/`FRIENDLY_NAME` (event.py), `UNIT_OF_MEASUREMENT` (sensor.py); `EntityCapabilityAttribute.GROUP_ENTITIES` (entity.py).
- Platform enums: `FanEntityStateAttribute.PERCENTAGE_STEP`, `ValveEntityStateAttribute.CURRENT_POSITION`, `EventEntityStateAttribute.EVENT_TYPE` / `EventEntityCapabilityAttribute.EVENT_TYPES`, `MediaPlayerEntityStateAttribute.MEDIA_VOLUME_LEVEL`, and the light color/effect/mode reads via `LightEntityStateAttribute` / `LightEntityCapabilityAttribute`.

Left as-is: keys that are service-call data or schemas, not state attributes — the `light.turn_on` `FORWARDED_ATTRIBUTES` set and `ATTR_TRANSITION`/`ATTR_FLASH`/`ATTR_WHITE` forwarding in light.py, the `media_player` volume/service data, and `ATTR_ENTITY_ID` (which has no enum member).

Part of #175836.


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
