### PR TITLE
Don't let an unhashable sensor attribute stop statistics compilation

### DIFF
--- a/homeassistant/components/sensor/recorder.py
+++ b/homeassistant/components/sensor/recorder.py
@@ -103,6 +103,31 @@ UNITS_CHANGED_ISSUE = "units_changed"
 MEAN_TYPE_CHANGED_ISSUE = "mean_type_changed"
 
 
+def _is_hashable(value: Any) -> bool:
+    """Return True if the value can be used as a dict key or a set member.
+
+    State attributes are not validated, so an integration can set them to a value of
+    any type. The state class, unit of measurement and device class are all used as
+    dict keys or set members when compiling statistics, which raises TypeError for a
+    value which is not hashable.
+    """
+    try:
+        hash(value)
+    except TypeError:
+        return False
+    return True
+
+
+def _parse_state_class(state_class: Any) -> SensorStateClass | None:
+    """Parse the state class attribute of a sensor, None if it is not valid."""
+    if type(state_class) is SensorStateClass:
+        return state_class
+    if not _is_hashable(state_class):
+        # try_parse_enum is cached, so it raises TypeError for an unhashable value
+        return None
+    return try_parse_enum(SensorStateClass, state_class)
+
+
 def _get_sensor_states(hass: HomeAssistant) -> list[State]:
     """Get the current state of all sensors for which to compile statistics."""
     instance = get_instance(hass)
@@ -118,10 +143,12 @@ def _get_sensor_states(hass: HomeAssistant) -> list[State]:
                 SensorEntityCapabilityAttribute.STATE_CLASS
             )
         )
-        and (
-            type(state_class) is SensorStateClass
-            or try_parse_enum(SensorStateClass, state_class)
-        )
+        and _parse_state_class(state_class)
+        # A sensor whose unit or device class is not hashable can't have statistics
+        # compiled for it, and must be excluded here so it does not break the whole
+        # compilation run
+        and _is_hashable(state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT))
+        and _is_hashable(state.attributes.get(EntityStateAttribute.DEVICE_CLASS))
         and (not entity_filter or entity_filter(state.entity_id))
     ]
 
@@ -258,6 +285,9 @@ def _get_unit_class(
     The unit class is determined from the device class and unit if possible,
     otherwise from the unit.
     """
+    if not _is_hashable(device_class) or not _is_hashable(unit):
+        # This is reached from paths which pass unvalidated state attributes
+        return None
     if (
         device_class
         and (conv := UNIT_CONVERTERS.get(device_class))
@@ -890,9 +920,8 @@ def _update_issues(
     for state in sensor_states:
         entity_id = state.entity_id
         numeric = _is_numeric(state)
-        state_class = try_parse_enum(
-            SensorStateClass,
-            state.attributes.get(SensorEntityCapabilityAttribute.STATE_CLASS),
+        state_class = _parse_state_class(
+            state.attributes.get(SensorEntityCapabilityAttribute.STATE_CLASS)
         )
         state_unit = state.attributes.get(EntityStateAttribute.UNIT_OF_MEASUREMENT)
         state_unit_class = _get_unit_class(
@@ -1061,9 +1090,8 @@ def validate_statistics(
 
     for state in sensor_states:
         entity_id = state.entity_id
-        state_class = try_parse_enum(
-            SensorStateClass,
-            state.attributes.get(SensorEntityCapabilityAttribute.STATE_CLASS),
+        state_class = _parse_state_class(
+            state.attributes.get(SensorEntityCapabilityAttribute.STATE_CLASS)
         )
 
         if entity_id in metadatas:

--- a/tests/components/sensor/test_recorder.py
+++ b/tests/components/sensor/test_recorder.py
@@ -365,6 +365,119 @@ async def test_compile_hourly_statistics(
     assert "Error while processing event StatisticsTask" not in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        ("state_class", ["measurement"]),
+        ("unit_of_measurement", ["°C"]),
+        ("device_class", ["temperature"]),
+    ],
+)
+async def test_compile_hourly_statistics_unhashable_attribute(
+    hass: HomeAssistant,
+    caplog: pytest.LogCaptureFixture,
+    attribute: str,
+    value: Any,
+) -> None:
+    """Test statistics are compiled when another sensor has an unhashable attribute.
+
+    State attributes are not validated, so an integration can set any of these to a
+    value which is not hashable. Statistics compilation uses them as dict keys and set
+    members, so the resulting TypeError escapes the session which has already inserted
+    this cycle's statistics for every sensor, discarding all of them.
+    """
+    zero = get_start_time(dt_util.utcnow())
+    await async_setup_component(hass, DOMAIN, {})
+    # Wait for the sensor recorder platform to be added
+    await async_recorder_block_till_done(hass)
+    attributes = {
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": "°C",
+    }
+    with freeze_time(zero) as freezer:
+        await async_record_states(hass, freezer, zero, "sensor.test1", attributes)
+    with freeze_time(zero) as freezer:
+        await async_record_states(
+            hass, freezer, zero, "sensor.broken", {**attributes, attribute: value}
+        )
+    await async_wait_recording_done(hass)
+
+    do_adhoc_statistics(hass, start=zero)
+    await async_wait_recording_done(hass)
+
+    assert "Error while processing event StatisticsTask" not in caplog.text
+    # The unrelated sensor's statistics must not be discarded
+    stats = statistics_during_period(hass, zero, period="5minute")
+    assert "sensor.test1" in stats
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        ("state_class", ["measurement"]),
+        ("unit_of_measurement", ["°C"]),
+        ("device_class", ["temperature"]),
+    ],
+)
+async def test_list_statistic_ids_unhashable_attribute(
+    hass: HomeAssistant,
+    attribute: str,
+    value: Any,
+) -> None:
+    """Test listing statistic ids when a sensor has an unhashable attribute."""
+    await async_setup_component(hass, DOMAIN, {})
+    # Wait for the sensor recorder platform to be added
+    await async_recorder_block_till_done(hass)
+    attributes = {
+        "device_class": "temperature",
+        "state_class": "measurement",
+        "unit_of_measurement": "°C",
+    }
+    hass.states.async_set("sensor.test1", 10, attributes=attributes)
+    hass.states.async_set(
+        "sensor.broken", 10, attributes={**attributes, attribute: value}
+    )
+    await async_wait_recording_done(hass)
+
+    statistic_ids = await async_list_statistic_ids(hass)
+    assert [entry["statistic_id"] for entry in statistic_ids] == ["sensor.test1"]
+
+
+@pytest.mark.parametrize(
+    ("attribute", "value"),
+    [
+        ("state_class", ["measurement"]),
+        ("unit_of_measurement", ["°C"]),
+        ("device_class", ["temperature"]),
+    ],
+)
+async def test_validate_statistics_unhashable_attribute(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    attribute: str,
+    value: Any,
+) -> None:
+    """Test validating statistics when a sensor has an unhashable attribute."""
+    await async_setup_component(hass, DOMAIN, {})
+    await async_recorder_block_till_done(hass)
+    client = await hass_ws_client()
+
+    hass.states.async_set(
+        "sensor.broken",
+        10,
+        attributes={
+            "device_class": "temperature",
+            "state_class": "measurement",
+            "unit_of_measurement": "°C",
+            attribute: value,
+        },
+    )
+    await hass.async_block_till_done()
+
+    await assert_validation_result(hass, client, {}, {})
+
+
 async def test_compile_hourly_statistics_angle(
     hass: HomeAssistant,
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
## Proposed change

Sensor state attributes are not validated, so an integration can set `state_class`,
`unit_of_measurement` or `device_class` to a value of any type. Statistics compilation
uses all three as dict keys or set members, so a value which is not hashable — a list,
a dict — raises `TypeError` instead of being ignored.

The damage is not limited to the offending sensor. The exception escapes the
`session_scope` in `_compile_statistics`, which has already inserted this cycle's
statistics rows for *every* sensor, so the whole transaction is rolled back. Statistics
then stop for the entire instance, every cycle, for as long as the attribute is set.
Nothing surfaces in the UI; the user sees an empty energy dashboard and no new
statistics.

Three public entry points are affected, and each is covered by a test here:

| entry point | reached from | raises in |
|---|---|---|
| `compile_statistics` | the 5-minute statistics task | `_get_sensor_states`, `_normalize_states` → `_get_unit_class` / `_get_units` |
| `list_statistic_ids` | `recorder/list_statistic_ids` (energy dashboard, more-info dialog) | `_get_sensor_states`, `_get_unit_class` |
| `validate_statistics` / `update_statistics_issues` | `recorder/validate_statistics`, and the hourly issue pass at minute :50 | `_update_issues` → `try_parse_enum` / `_get_unit_class` |

Note that `update_statistics_issues` and `validate_statistics` read
`hass.states.all(DOMAIN)` directly rather than going through `_get_sensor_states`, so
filtering in one place is not sufficient.

### The change

A sensor whose attributes cannot be hashed is skipped, which is how a `state_class`
that cannot be parsed is already handled:

- `_get_sensor_states` excludes it, which protects `compile_statistics` (including
  `_normalize_states` and `_get_units`) and `list_statistic_ids`.
- `_get_unit_class` returns `None`, which is what it already returns for an
  unrecognised unit. This covers the callers that pass unvalidated attributes.
- `_parse_state_class` replaces the three direct `try_parse_enum(SensorStateClass, …)`
  calls on raw attribute values.

The check is hashability rather than `isinstance(…, str)` on purpose. Hashability is
exactly what the lookups require, so every value that works today keeps working — a
unit of `5` is still accepted, as it is on `dev` — and only values that currently raise
change behaviour.

`_parse_state_class` has to do the hashability check at the call site rather than inside
`try_parse_enum`, because `try_parse_enum` is `@lru_cache`d: the `TypeError` comes from
computing the cache key, before the function body runs. That is why the tracebacks in
the linked issues end at the call site with no frame inside `try_parse_enum`, and it
means widening the `contextlib.suppress` in `homeassistant/util/enum.py` would not fix
this.

### Reproducing it

No fault injection and no special configuration — one authenticated REST call against a
healthy instance is enough:

```
POST /api/states/sensor.example
{"state": "1", "attributes": {"state_class": "measurement", "unit_of_measurement": []}}
```

Statistics for every sensor stop from the next cycle, and resume within one cycle of the
attribute being removed. A template sensor whose unit template renders to a
non-string reaches the same state without any API client involved.

### How this was found

This came out of an [Antithesis](https://antithesis.com) test harness that runs Home
Assistant Core against MariaDB under fault injection, with properties asserting that
statistics keep compiling and that recorder reads do not fail from mishandling a
database failure. Home Assistant itself was not modified — the in-process probe is a
custom component, so nothing here depends on patched core code. This particular defect
turned out to need no faults at all; the workload reached it by setting attributes over
the REST API.

Searching the issue tracker afterwards turned up two independent user reports of the
`state_class` variant with the identical traceback, both auto-closed as stale without a
fix. The `unit_of_measurement` and `device_class` variants appear not to have been
reported before.

Verified against `dev` at 2650b82ed8d9. All three attributes still reproduce there.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #158494
- This PR is related to issue: #158201 (same traceback, also closed as stale)
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
