### PR TITLE
Import DOMAIN constants in Alexa

### DIFF
--- a/homeassistant/components/alexa/capabilities.py
+++ b/homeassistant/components/alexa/capabilities.py
@@ -5,19 +5,15 @@ import logging
 from typing import Any, override
 
 from homeassistant.components import (
-    button,
     climate,
     cover,
     fan,
     humidifier,
-    image_processing,
-    input_button,
     input_number,
     light,
     media_player,
     number,
     remote,
-    timer,
     vacuum,
     valve,
     water_heater,
@@ -27,8 +23,21 @@ from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelState,
     CodeFormat,
 )
-from homeassistant.components.climate import HVACMode
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN, HVACMode
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.image_processing import DOMAIN as IMAGE_PROCESSING_DOMAIN
+from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
+from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
 from homeassistant.components.lock import LockState
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import (
     ATTR_CODE_FORMAT,
     ATTR_SUPPORTED_FEATURES,
@@ -437,19 +446,19 @@ class AlexaPowerController(AlexaCapability):
         if name != "powerState":
             raise UnsupportedProperty(name)
 
-        if self.entity.domain == climate.DOMAIN:
+        if self.entity.domain == CLIMATE_DOMAIN:
             is_on = self.entity.state != climate.HVACMode.OFF
-        elif self.entity.domain == fan.DOMAIN:
+        elif self.entity.domain == FAN_DOMAIN:
             is_on = self.entity.state == fan.STATE_ON
-        elif self.entity.domain == humidifier.DOMAIN:
+        elif self.entity.domain == HUMIDIFIER_DOMAIN:
             is_on = self.entity.state == humidifier.STATE_ON
-        elif self.entity.domain == remote.DOMAIN:
+        elif self.entity.domain == REMOTE_DOMAIN:
             is_on = self.entity.state not in (STATE_OFF, STATE_UNKNOWN)
-        elif self.entity.domain == vacuum.DOMAIN:
+        elif self.entity.domain == VACUUM_DOMAIN:
             is_on = self.entity.state == vacuum.VacuumActivity.CLEANING
-        elif self.entity.domain == timer.DOMAIN:
+        elif self.entity.domain == TIMER_DOMAIN:
             is_on = self.entity.state != STATE_IDLE
-        elif self.entity.domain == water_heater.DOMAIN:
+        elif self.entity.domain == WATER_HEATER_DOMAIN:
             is_on = self.entity.state not in (STATE_OFF, STATE_UNKNOWN)
         else:
             is_on = self.entity.state != STATE_OFF
@@ -867,7 +876,7 @@ class AlexaPlaybackController(AlexaCapability):
         operations: dict[
             cover.CoverEntityFeature | media_player.MediaPlayerEntityFeature, str
         ]
-        if self.entity.domain == cover.DOMAIN:
+        if self.entity.domain == COVER_DOMAIN:
             operations = {cover.CoverEntityFeature.STOP: "Stop"}
         else:
             operations = {
@@ -1002,10 +1011,10 @@ class AlexaTemperatureSensor(AlexaCapability):
             ATTR_UNIT_OF_MEASUREMENT, self.hass.config.units.temperature_unit
         )
         temp: str | None = self.entity.state
-        if self.entity.domain == climate.DOMAIN:
+        if self.entity.domain == CLIMATE_DOMAIN:
             unit = self.hass.config.units.temperature_unit
             temp = self.entity.attributes.get(climate.ATTR_CURRENT_TEMPERATURE)
-        elif self.entity.domain == water_heater.DOMAIN:
+        elif self.entity.domain == WATER_HEATER_DOMAIN:
             unit = self.hass.config.units.temperature_unit
             temp = self.entity.attributes.get(water_heater.ATTR_CURRENT_TEMPERATURE)
 
@@ -1189,14 +1198,14 @@ class AlexaThermostatController(AlexaCapability):
         """Return what properties this entity supports."""
         properties = [{"name": "thermostatMode"}]
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
-        if self.entity.domain == climate.DOMAIN:
+        if self.entity.domain == CLIMATE_DOMAIN:
             if supported & climate.ClimateEntityFeature.TARGET_TEMPERATURE_RANGE:
                 properties.append({"name": "lowerSetpoint"})
                 properties.append({"name": "upperSetpoint"})
             if supported & climate.ClimateEntityFeature.TARGET_TEMPERATURE:
                 properties.append({"name": "targetSetpoint"})
         elif (
-            self.entity.domain == water_heater.DOMAIN
+            self.entity.domain == WATER_HEATER_DOMAIN
             and supported & water_heater.WaterHeaterEntityFeature.TARGET_TEMPERATURE
         ):
             properties.append({"name": "targetSetpoint"})
@@ -1219,7 +1228,7 @@ class AlexaThermostatController(AlexaCapability):
             return None
 
         if name == "thermostatMode":
-            if self.entity.domain == water_heater.DOMAIN:
+            if self.entity.domain == WATER_HEATER_DOMAIN:
                 return None
             preset = self.entity.attributes.get(climate.ATTR_PRESET_MODE)
 
@@ -1273,7 +1282,7 @@ class AlexaThermostatController(AlexaCapability):
         ThermostatMode Value must be AUTO, COOL, HEAT, ECO, OFF, or CUSTOM.
         Water heater devices do not return thermostat modes.
         """
-        if self.entity.domain == water_heater.DOMAIN:
+        if self.entity.domain == WATER_HEATER_DOMAIN:
             return None
 
         hvac_modes = self.entity.attributes.get(climate.ATTR_HVAC_MODES) or []
@@ -1508,19 +1517,19 @@ class AlexaModeController(AlexaCapability):
             raise UnsupportedProperty(name)
 
         # Fan Direction
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_DIRECTION}":
             mode = self.entity.attributes.get(fan.ATTR_DIRECTION, None)
             if mode in (fan.DIRECTION_FORWARD, fan.DIRECTION_REVERSE, STATE_UNKNOWN):
                 return f"{fan.ATTR_DIRECTION}.{mode}"
 
         # Fan preset_mode
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}":
             mode = self.entity.attributes.get(fan.ATTR_PRESET_MODE, None)
             if mode in self.entity.attributes.get(fan.ATTR_PRESET_MODES, ()):
                 return f"{fan.ATTR_PRESET_MODE}.{mode}"
 
         # Humidifier mode
-        if self.instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_MODE}":
+        if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}":
             mode = self.entity.attributes.get(humidifier.ATTR_MODE)
             modes: list[str] = (
                 self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES) or []
@@ -1529,13 +1538,13 @@ class AlexaModeController(AlexaCapability):
                 return f"{humidifier.ATTR_MODE}.{mode}"
 
         # Remote Activity
-        if self.instance == f"{remote.DOMAIN}.{remote.ATTR_ACTIVITY}":
+        if self.instance == f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}":
             activity = self.entity.attributes.get(remote.ATTR_CURRENT_ACTIVITY, None)
             if activity in self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST, []):
                 return f"{remote.ATTR_ACTIVITY}.{activity}"
 
         # Water heater operation mode
-        if self.instance == f"{water_heater.DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
+        if self.instance == f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
             operation_mode = self.entity.attributes.get(
                 water_heater.ATTR_OPERATION_MODE
             )
@@ -1546,7 +1555,7 @@ class AlexaModeController(AlexaCapability):
                 return f"{water_heater.ATTR_OPERATION_MODE}.{operation_mode}"
 
         # Cover Position
-        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
             # Return state instead of position when using ModeController.
             mode = self.entity.state
             if mode in (
@@ -1559,7 +1568,7 @@ class AlexaModeController(AlexaCapability):
                 return f"{cover.ATTR_POSITION}.{mode}"
 
         # Valve position state
-        if self.instance == f"{valve.DOMAIN}.state":
+        if self.instance == f"{VALVE_DOMAIN}.state":
             # Return state instead of position when using ModeController.
             state = self.entity.state
             if state in (
@@ -1586,7 +1595,7 @@ class AlexaModeController(AlexaCapability):
         """Return capabilityResources object."""
 
         # Fan Direction Resource
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_DIRECTION}":
             self._resource = AlexaModeResource(
                 [AlexaGlobalCatalog.SETTING_DIRECTION], False
             )
@@ -1599,7 +1608,7 @@ class AlexaModeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Fan preset_mode
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}":
             self._resource = AlexaModeResource(
                 [AlexaGlobalCatalog.SETTING_PRESET], False
             )
@@ -1617,7 +1626,7 @@ class AlexaModeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Humidifier modes
-        if self.instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_MODE}":
+        if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}":
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
             modes = self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES) or []
             for mode in modes:
@@ -1631,7 +1640,7 @@ class AlexaModeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Water heater operation modes
-        if self.instance == f"{water_heater.DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
+        if self.instance == f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
             operation_modes = (
                 self.entity.attributes.get(water_heater.ATTR_OPERATION_LIST) or []
@@ -1651,7 +1660,7 @@ class AlexaModeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Remote Resource
-        if self.instance == f"{remote.DOMAIN}.{remote.ATTR_ACTIVITY}":
+        if self.instance == f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}":
             # Use the mode controller for a remote because the input controller
             # only allows a preset of names as an input.
             self._resource = AlexaModeResource([AlexaGlobalCatalog.SETTING_MODE], False)
@@ -1669,7 +1678,7 @@ class AlexaModeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Cover Position Resources
-        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
             self._resource = AlexaModeResource(
                 ["Position", AlexaGlobalCatalog.SETTING_OPENING], False
             )
@@ -1688,7 +1697,7 @@ class AlexaModeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Valve position resources
-        if self.instance == f"{valve.DOMAIN}.state":
+        if self.instance == f"{VALVE_DOMAIN}.state":
             supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
             self._resource = AlexaModeResource(
                 ["Preset", AlexaGlobalCatalog.SETTING_PRESET], False
@@ -1721,7 +1730,7 @@ class AlexaModeController(AlexaCapability):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         # Cover Position
-        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
             lower_labels = [AlexaSemantics.ACTION_LOWER]
             raise_labels = [AlexaSemantics.ACTION_RAISE]
             self._semantics = AlexaSemantics()
@@ -1753,7 +1762,7 @@ class AlexaModeController(AlexaCapability):
             return self._semantics.serialize_semantics()
 
         # Valve Position
-        if self.instance == f"{valve.DOMAIN}.state":
+        if self.instance == f"{VALVE_DOMAIN}.state":
             close_labels = [AlexaSemantics.ACTION_CLOSE]
             open_labels = [AlexaSemantics.ACTION_OPEN]
             self._semantics = AlexaSemantics()
@@ -1861,43 +1870,43 @@ class AlexaRangeController(AlexaCapability):
             return None
 
         # Cover Position
-        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
             return self.entity.attributes.get(cover.ATTR_CURRENT_POSITION)
 
         # Cover Tilt
-        if self.instance == f"{cover.DOMAIN}.tilt":
+        if self.instance == f"{COVER_DOMAIN}.tilt":
             return self.entity.attributes.get(cover.ATTR_CURRENT_TILT_POSITION)
 
         # Fan speed percentage
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
             supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
             if supported and fan.FanEntityFeature.SET_SPEED:
                 return self.entity.attributes.get(fan.ATTR_PERCENTAGE)
             return 100 if self.entity.state == fan.STATE_ON else 0
 
         # Humidifier target humidity
-        if self.instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}":
+        if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
             # If the humidifier is turned off the target humidity attribute is not set.
             # We return 0 to make clear we do not know the current value.
             return self.entity.attributes.get(humidifier.ATTR_HUMIDITY, 0)
 
         # Input Number Value
-        if self.instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
+        if self.instance == f"{INPUT_NUMBER_DOMAIN}.{input_number.ATTR_VALUE}":
             return float(self.entity.state)
 
         # Number Value
-        if self.instance == f"{number.DOMAIN}.{number.ATTR_VALUE}":
+        if self.instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
             return float(self.entity.state)
 
         # Vacuum Fan Speed
-        if self.instance == f"{vacuum.DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
+        if self.instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
             speed_list = self.entity.attributes.get(vacuum.ATTR_FAN_SPEED_LIST)
             speed = self.entity.attributes.get(vacuum.ATTR_FAN_SPEED)
             if speed_list is not None and speed is not None:
                 return next((i for i, v in enumerate(speed_list) if v == speed), None)
 
         # Valve Position
-        if self.instance == f"{valve.DOMAIN}.{valve.ATTR_POSITION}":
+        if self.instance == f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}":
             return self.entity.attributes.get(valve.ATTR_CURRENT_POSITION)
 
         return None
@@ -1915,7 +1924,7 @@ class AlexaRangeController(AlexaCapability):
         """Return capabilityResources object."""
 
         # Fan Speed Percentage Resources
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
             percentage_step = self.entity.attributes.get(fan.ATTR_PERCENTAGE_STEP)
             self._resource = AlexaPresetResource(
                 labels=["Percentage", AlexaGlobalCatalog.SETTING_FAN_SPEED],
@@ -1929,7 +1938,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Humidifier Target Humidity Resources
-        if self.instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}":
+        if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
             self._resource = AlexaPresetResource(
                 labels=["Humidity", "Percentage", "Target humidity"],
                 min_value=self.entity.attributes.get(humidifier.ATTR_MIN_HUMIDITY, 10),
@@ -1940,7 +1949,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Cover Position Resources
-        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
             self._resource = AlexaPresetResource(
                 ["Position", AlexaGlobalCatalog.SETTING_OPENING],
                 min_value=0,
@@ -1951,7 +1960,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Cover Tilt Resources
-        if self.instance == f"{cover.DOMAIN}.tilt":
+        if self.instance == f"{COVER_DOMAIN}.tilt":
             self._resource = AlexaPresetResource(
                 ["Tilt", "Angle", AlexaGlobalCatalog.SETTING_DIRECTION],
                 min_value=0,
@@ -1962,7 +1971,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Input Number Value
-        if self.instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
+        if self.instance == f"{INPUT_NUMBER_DOMAIN}.{input_number.ATTR_VALUE}":
             min_value = float(self.entity.attributes[input_number.ATTR_MIN])
             max_value = float(self.entity.attributes[input_number.ATTR_MAX])
             precision = float(self.entity.attributes.get(input_number.ATTR_STEP, 1))
@@ -1984,7 +1993,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Number Value
-        if self.instance == f"{number.DOMAIN}.{number.ATTR_VALUE}":
+        if self.instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
             min_value = float(self.entity.attributes[number.ATTR_MIN])
             max_value = float(self.entity.attributes[number.ATTR_MAX])
             precision = float(self.entity.attributes.get(number.ATTR_STEP, 1))
@@ -2006,7 +2015,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Vacuum Fan Speed Resources
-        if self.instance == f"{vacuum.DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
+        if self.instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
             speed_list = self.entity.attributes[vacuum.ATTR_FAN_SPEED_LIST]
             max_value = len(speed_list) - 1
             self._resource = AlexaPresetResource(
@@ -2026,7 +2035,7 @@ class AlexaRangeController(AlexaCapability):
             return self._resource.serialize_capability_resources()
 
         # Valve Position Resources
-        if self.instance == f"{valve.DOMAIN}.{valve.ATTR_POSITION}":
+        if self.instance == f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}":
             self._resource = AlexaPresetResource(
                 ["Opening", AlexaGlobalCatalog.SETTING_OPENING],
                 min_value=0,
@@ -2044,7 +2053,7 @@ class AlexaRangeController(AlexaCapability):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
         # Cover Position
-        if self.instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+        if self.instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
             lower_labels = [AlexaSemantics.ACTION_LOWER]
             raise_labels = [AlexaSemantics.ACTION_RAISE]
             self._semantics = AlexaSemantics()
@@ -2069,7 +2078,7 @@ class AlexaRangeController(AlexaCapability):
             return self._semantics.serialize_semantics()
 
         # Cover Tilt
-        if self.instance == f"{cover.DOMAIN}.tilt":
+        if self.instance == f"{COVER_DOMAIN}.tilt":
             self._semantics = AlexaSemantics()
             self._semantics.add_action_to_directive(
                 [AlexaSemantics.ACTION_CLOSE], "SetRangeValue", {"rangeValue": 0}
@@ -2084,7 +2093,7 @@ class AlexaRangeController(AlexaCapability):
             return self._semantics.serialize_semantics()
 
         # Fan Speed Percentage
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
             lower_labels = [AlexaSemantics.ACTION_LOWER]
             raise_labels = [AlexaSemantics.ACTION_RAISE]
             self._semantics = AlexaSemantics()
@@ -2098,7 +2107,7 @@ class AlexaRangeController(AlexaCapability):
             return self._semantics.serialize_semantics()
 
         # Target Humidity Percentage
-        if self.instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}":
+        if self.instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
             lower_labels = [AlexaSemantics.ACTION_LOWER]
             raise_labels = [AlexaSemantics.ACTION_RAISE]
             self._semantics = AlexaSemantics()
@@ -2114,7 +2123,7 @@ class AlexaRangeController(AlexaCapability):
             return self._semantics.serialize_semantics()
 
         # Valve Position
-        if self.instance == f"{valve.DOMAIN}.{valve.ATTR_POSITION}":
+        if self.instance == f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}":
             close_labels = [AlexaSemantics.ACTION_CLOSE]
             open_labels = [AlexaSemantics.ACTION_OPEN]
             self._semantics = AlexaSemantics()
@@ -2207,12 +2216,12 @@ class AlexaToggleController(AlexaCapability):
             raise UnsupportedProperty(name)
 
         # Fan Oscillating
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}":
             is_on = bool(self.entity.attributes.get(fan.ATTR_OSCILLATING))
             return "ON" if is_on else "OFF"
 
         # Stop Valve
-        if self.instance == f"{valve.DOMAIN}.stop":
+        if self.instance == f"{VALVE_DOMAIN}.stop":
             return "OFF"
 
         return None
@@ -2222,13 +2231,13 @@ class AlexaToggleController(AlexaCapability):
         """Return capabilityResources object."""
 
         # Fan Oscillating Resource
-        if self.instance == f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}":
+        if self.instance == f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}":
             self._resource = AlexaCapabilityResource(
                 [AlexaGlobalCatalog.SETTING_OSCILLATE, "Rotate", "Rotation"]
             )
             return self._resource.serialize_capability_resources()
 
-        if self.instance == f"{valve.DOMAIN}.stop":
+        if self.instance == f"{VALVE_DOMAIN}.stop":
             self._resource = AlexaCapabilityResource(["Stop"])
             return self._resource.serialize_capability_resources()
 
@@ -2438,12 +2447,12 @@ class AlexaEventDetectionSensor(AlexaCapability):
         if state in (STATE_UNAVAILABLE, STATE_UNKNOWN, None):
             return None
 
-        if self.entity.domain == image_processing.DOMAIN:
+        if self.entity.domain == IMAGE_PROCESSING_DOMAIN:
             if int(state):
                 human_presence = "DETECTED"
         elif state == STATE_ON or self.entity.domain in [
-            input_button.DOMAIN,
-            button.DOMAIN,
+            INPUT_BUTTON_DOMAIN,
+            BUTTON_DOMAIN,
         ]:
             human_presence = "DETECTED"
 
@@ -2458,7 +2467,7 @@ class AlexaEventDetectionSensor(AlexaCapability):
                 "humanPresence": {
                     "featureAvailability": "ENABLED",
                     "supportsNotDetected": self.entity.domain
-                    not in [input_button.DOMAIN, button.DOMAIN],
+                    not in [INPUT_BUTTON_DOMAIN, BUTTON_DOMAIN],
                 }
             },
         }

--- a/homeassistant/components/alexa/entities.py
+++ b/homeassistant/components/alexa/entities.py
@@ -5,36 +5,52 @@ import logging
 from typing import TYPE_CHECKING, Any, override
 
 from homeassistant.components import (
-    alarm_control_panel,
-    alert,
-    automation,
     binary_sensor,
-    button,
     camera,
     climate,
     cover,
     event,
     fan,
-    group,
     humidifier,
-    image_processing,
-    input_boolean,
-    input_button,
-    input_number,
     light,
-    lock,
     media_player,
-    number,
     remote,
-    scene,
-    script,
-    sensor,
     switch,
-    timer,
     vacuum,
     valve,
     water_heater,
 )
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
+from homeassistant.components.alert import DOMAIN as ALERT_DOMAIN
+from homeassistant.components.automation import DOMAIN as AUTOMATION_DOMAIN
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.image_processing import DOMAIN as IMAGE_PROCESSING_DOMAIN
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
+from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
+from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
+from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import (
     ATTR_DEVICE_CLASS,
     ATTR_SUPPORTED_FEATURES,
@@ -392,9 +408,9 @@ def async_get_entities(
     return entities
 
 
-@ENTITY_ADAPTERS.register(alert.DOMAIN)
-@ENTITY_ADAPTERS.register(automation.DOMAIN)
-@ENTITY_ADAPTERS.register(group.DOMAIN)
+@ENTITY_ADAPTERS.register(ALERT_DOMAIN)
+@ENTITY_ADAPTERS.register(AUTOMATION_DOMAIN)
+@ENTITY_ADAPTERS.register(GROUP_DOMAIN)
 class GenericCapabilities(AlexaEntity):
     """A generic, on/off device.
 
@@ -404,7 +420,7 @@ class GenericCapabilities(AlexaEntity):
     @override
     def default_display_categories(self) -> list[str]:
         """Return the display categories for this entity."""
-        if self.entity.domain == automation.DOMAIN:
+        if self.entity.domain == AUTOMATION_DOMAIN:
             return [DisplayCategory.ACTIVITY_TRIGGER]
 
         return [DisplayCategory.OTHER]
@@ -417,15 +433,15 @@ class GenericCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(input_boolean.DOMAIN)
-@ENTITY_ADAPTERS.register(switch.DOMAIN)
+@ENTITY_ADAPTERS.register(INPUT_BOOLEAN_DOMAIN)
+@ENTITY_ADAPTERS.register(SWITCH_DOMAIN)
 class SwitchCapabilities(AlexaEntity):
     """Class to represent Switch capabilities."""
 
     @override
     def default_display_categories(self) -> list[str]:
         """Return the display categories for this entity."""
-        if self.entity.domain == input_boolean.DOMAIN:
+        if self.entity.domain == INPUT_BOOLEAN_DOMAIN:
             return [DisplayCategory.OTHER]
 
         device_class = self.entity.attributes.get(ATTR_DEVICE_CLASS)
@@ -443,8 +459,8 @@ class SwitchCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(button.DOMAIN)
-@ENTITY_ADAPTERS.register(input_button.DOMAIN)
+@ENTITY_ADAPTERS.register(BUTTON_DOMAIN)
+@ENTITY_ADAPTERS.register(INPUT_BUTTON_DOMAIN)
 class ButtonCapabilities(AlexaEntity):
     """Class to represent Button capabilities."""
 
@@ -462,15 +478,15 @@ class ButtonCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(climate.DOMAIN)
-@ENTITY_ADAPTERS.register(water_heater.DOMAIN)
+@ENTITY_ADAPTERS.register(CLIMATE_DOMAIN)
+@ENTITY_ADAPTERS.register(WATER_HEATER_DOMAIN)
 class ClimateCapabilities(AlexaEntity):
     """Class to represent Climate capabilities."""
 
     @override
     def default_display_categories(self) -> list[str]:
         """Return the display categories for this entity."""
-        if self.entity.domain == water_heater.DOMAIN:
+        if self.entity.domain == WATER_HEATER_DOMAIN:
             return [DisplayCategory.WATER_HEATER]
         return [DisplayCategory.THERMOSTAT]
 
@@ -481,12 +497,12 @@ class ClimateCapabilities(AlexaEntity):
         supported_features = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if (
             (
-                self.entity.domain == climate.DOMAIN
+                self.entity.domain == CLIMATE_DOMAIN
                 and climate.HVACMode.OFF
                 in (self.entity.attributes.get(climate.ATTR_HVAC_MODES) or [])
             )
             or (
-                self.entity.domain == climate.DOMAIN
+                self.entity.domain == CLIMATE_DOMAIN
                 and (
                     supported_features
                     & (
@@ -496,14 +512,14 @@ class ClimateCapabilities(AlexaEntity):
                 )
             )
             or (
-                self.entity.domain == water_heater.DOMAIN
+                self.entity.domain == WATER_HEATER_DOMAIN
                 and (supported_features & water_heater.WaterHeaterEntityFeature.ON_OFF)
             )
         ):
             yield AlexaPowerController(self.entity)
 
-        if self.entity.domain == climate.DOMAIN or (
-            self.entity.domain == water_heater.DOMAIN
+        if self.entity.domain == CLIMATE_DOMAIN or (
+            self.entity.domain == WATER_HEATER_DOMAIN
             and (
                 supported_features
                 & water_heater.WaterHeaterEntityFeature.OPERATION_MODE
@@ -512,7 +528,7 @@ class ClimateCapabilities(AlexaEntity):
             yield AlexaThermostatController(self.hass, self.entity)
             yield AlexaTemperatureSensor(self.hass, self.entity)
         if (
-            self.entity.domain == water_heater.DOMAIN
+            self.entity.domain == WATER_HEATER_DOMAIN
             and (
                 supported_features
                 & water_heater.WaterHeaterEntityFeature.OPERATION_MODE
@@ -521,13 +537,13 @@ class ClimateCapabilities(AlexaEntity):
         ):
             yield AlexaModeController(
                 self.entity,
-                instance=f"{water_heater.DOMAIN}.{water_heater.ATTR_OPERATION_MODE}",
+                instance=f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}",
             )
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(cover.DOMAIN)
+@ENTITY_ADAPTERS.register(COVER_DOMAIN)
 class CoverCapabilities(AlexaEntity):
     """Class to represent Cover capabilities."""
 
@@ -567,25 +583,25 @@ class CoverCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & cover.CoverEntityFeature.SET_POSITION:
             yield AlexaRangeController(
-                self.entity, instance=f"{cover.DOMAIN}.{cover.ATTR_POSITION}"
+                self.entity, instance=f"{COVER_DOMAIN}.{cover.ATTR_POSITION}"
             )
         elif supported & (
             cover.CoverEntityFeature.CLOSE | cover.CoverEntityFeature.OPEN
         ):
             yield AlexaModeController(
-                self.entity, instance=f"{cover.DOMAIN}.{cover.ATTR_POSITION}"
+                self.entity, instance=f"{COVER_DOMAIN}.{cover.ATTR_POSITION}"
             )
         if supported & cover.CoverEntityFeature.SET_TILT_POSITION:
-            yield AlexaRangeController(self.entity, instance=f"{cover.DOMAIN}.tilt")
+            yield AlexaRangeController(self.entity, instance=f"{COVER_DOMAIN}.tilt")
         if supported & (
             cover.CoverEntityFeature.STOP | cover.CoverEntityFeature.STOP_TILT
         ):
-            yield AlexaPlaybackController(self.entity, instance=f"{cover.DOMAIN}.stop")
+            yield AlexaPlaybackController(self.entity, instance=f"{COVER_DOMAIN}.stop")
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(event.DOMAIN)
+@ENTITY_ADAPTERS.register(EVENT_DOMAIN)
 class EventCapabilities(AlexaEntity):
     """Class to represent doorbel event capabilities."""
 
@@ -607,7 +623,7 @@ class EventCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(light.DOMAIN)
+@ENTITY_ADAPTERS.register(LIGHT_DOMAIN)
 class LightCapabilities(AlexaEntity):
     """Class to represent Light capabilities."""
 
@@ -633,7 +649,7 @@ class LightCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(fan.DOMAIN)
+@ENTITY_ADAPTERS.register(FAN_DOMAIN)
 class FanCapabilities(AlexaEntity):
     """Class to represent Fan capabilities."""
 
@@ -650,19 +666,19 @@ class FanCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & fan.FanEntityFeature.OSCILLATE:
             yield AlexaToggleController(
-                self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}"
+                self.entity, instance=f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}"
             )
             force_range_controller = False
         if supported & fan.FanEntityFeature.PRESET_MODE and self.entity.attributes.get(
             fan.ATTR_PRESET_MODES
         ):
             yield AlexaModeController(
-                self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}"
+                self.entity, instance=f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}"
             )
             force_range_controller = False
         if supported & fan.FanEntityFeature.DIRECTION:
             yield AlexaModeController(
-                self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}"
+                self.entity, instance=f"{FAN_DOMAIN}.{fan.ATTR_DIRECTION}"
             )
             force_range_controller = False
 
@@ -673,14 +689,14 @@ class FanCapabilities(AlexaEntity):
         # can only be set to 0% or 100%.
         if force_range_controller or supported & fan.FanEntityFeature.SET_SPEED:
             yield AlexaRangeController(
-                self.entity, instance=f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}"
+                self.entity, instance=f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}"
             )
 
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(remote.DOMAIN)
+@ENTITY_ADAPTERS.register(REMOTE_DOMAIN)
 class RemoteCapabilities(AlexaEntity):
     """Class to represent Remote capabilities."""
 
@@ -701,13 +717,13 @@ class RemoteCapabilities(AlexaEntity):
             and self.entity.attributes.get(remote.ATTR_ACTIVITY_LIST)
         ):
             yield AlexaModeController(
-                self.entity, instance=f"{remote.DOMAIN}.{remote.ATTR_ACTIVITY}"
+                self.entity, instance=f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}"
             )
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(humidifier.DOMAIN)
+@ENTITY_ADAPTERS.register(HUMIDIFIER_DOMAIN)
 class HumidifierCapabilities(AlexaEntity):
     """Class to represent Humidifier capabilities."""
 
@@ -725,17 +741,17 @@ class HumidifierCapabilities(AlexaEntity):
             supported & humidifier.HumidifierEntityFeature.MODES
         ) and self.entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES):
             yield AlexaModeController(
-                self.entity, instance=f"{humidifier.DOMAIN}.{humidifier.ATTR_MODE}"
+                self.entity, instance=f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}"
             )
         yield AlexaRangeController(
-            self.entity, instance=f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}"
+            self.entity, instance=f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}"
         )
 
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(lock.DOMAIN)
+@ENTITY_ADAPTERS.register(LOCK_DOMAIN)
 class LockCapabilities(AlexaEntity):
     """Class to represent Lock capabilities."""
 
@@ -752,7 +768,7 @@ class LockCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(media_player.DOMAIN)
+@ENTITY_ADAPTERS.register(MEDIA_PLAYER_DOMAIN)
 class MediaPlayerCapabilities(AlexaEntity):
     """Class to represent MediaPlayer capabilities."""
 
@@ -818,7 +834,7 @@ class MediaPlayerCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(scene.DOMAIN)
+@ENTITY_ADAPTERS.register(SCENE_DOMAIN)
 class SceneCapabilities(AlexaEntity):
     """Class to represent Scene capabilities."""
 
@@ -842,7 +858,7 @@ class SceneCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(script.DOMAIN)
+@ENTITY_ADAPTERS.register(SCRIPT_DOMAIN)
 class ScriptCapabilities(AlexaEntity):
     """Class to represent Script capabilities."""
 
@@ -858,7 +874,7 @@ class ScriptCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(sensor.DOMAIN)
+@ENTITY_ADAPTERS.register(SENSOR_DOMAIN)
 class SensorCapabilities(AlexaEntity):
     """Class to represent Sensor capabilities."""
 
@@ -882,7 +898,7 @@ class SensorCapabilities(AlexaEntity):
             yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(binary_sensor.DOMAIN)
+@ENTITY_ADAPTERS.register(BINARY_SENSOR_DOMAIN)
 class BinarySensorCapabilities(AlexaEntity):
     """Class to represent BinarySensor capabilities."""
 
@@ -951,7 +967,7 @@ class BinarySensorCapabilities(AlexaEntity):
         return None
 
 
-@ENTITY_ADAPTERS.register(alarm_control_panel.DOMAIN)
+@ENTITY_ADAPTERS.register(ALARM_CONTROL_PANEL_DOMAIN)
 class AlarmControlPanelCapabilities(AlexaEntity):
     """Class to represent Alarm capabilities."""
 
@@ -969,7 +985,7 @@ class AlarmControlPanelCapabilities(AlexaEntity):
             yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(image_processing.DOMAIN)
+@ENTITY_ADAPTERS.register(IMAGE_PROCESSING_DOMAIN)
 class ImageProcessingCapabilities(AlexaEntity):
     """Class to represent image_processing capabilities."""
 
@@ -986,8 +1002,8 @@ class ImageProcessingCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(input_number.DOMAIN)
-@ENTITY_ADAPTERS.register(number.DOMAIN)
+@ENTITY_ADAPTERS.register(INPUT_NUMBER_DOMAIN)
+@ENTITY_ADAPTERS.register(NUMBER_DOMAIN)
 class InputNumberCapabilities(AlexaEntity):
     """Class to represent number and input_number capabilities."""
 
@@ -1005,7 +1021,7 @@ class InputNumberCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(timer.DOMAIN)
+@ENTITY_ADAPTERS.register(TIMER_DOMAIN)
 class TimerCapabilities(AlexaEntity):
     """Class to represent Timer capabilities."""
 
@@ -1022,7 +1038,7 @@ class TimerCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(vacuum.DOMAIN)
+@ENTITY_ADAPTERS.register(VACUUM_DOMAIN)
 class VacuumCapabilities(AlexaEntity):
     """Class to represent vacuum capabilities."""
 
@@ -1046,7 +1062,7 @@ class VacuumCapabilities(AlexaEntity):
 
         if supported & vacuum.VacuumEntityFeature.FAN_SPEED:
             yield AlexaRangeController(
-                self.entity, instance=f"{vacuum.DOMAIN}.{vacuum.ATTR_FAN_SPEED}"
+                self.entity, instance=f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}"
             )
 
         if supported & vacuum.VacuumEntityFeature.PAUSE:
@@ -1059,7 +1075,7 @@ class VacuumCapabilities(AlexaEntity):
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(valve.DOMAIN)
+@ENTITY_ADAPTERS.register(VALVE_DOMAIN)
 class ValveCapabilities(AlexaEntity):
     """Class to represent Valve capabilities."""
 
@@ -1074,19 +1090,19 @@ class ValveCapabilities(AlexaEntity):
         supported = self.entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if supported & valve.ValveEntityFeature.SET_POSITION:
             yield AlexaRangeController(
-                self.entity, instance=f"{valve.DOMAIN}.{valve.ATTR_POSITION}"
+                self.entity, instance=f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}"
             )
         elif supported & (
             valve.ValveEntityFeature.CLOSE | valve.ValveEntityFeature.OPEN
         ):
-            yield AlexaModeController(self.entity, instance=f"{valve.DOMAIN}.state")
+            yield AlexaModeController(self.entity, instance=f"{VALVE_DOMAIN}.state")
         if supported & valve.ValveEntityFeature.STOP:
-            yield AlexaToggleController(self.entity, instance=f"{valve.DOMAIN}.stop")
+            yield AlexaToggleController(self.entity, instance=f"{VALVE_DOMAIN}.stop")
         yield AlexaEndpointHealth(self.hass, self.entity)
         yield Alexa(self.entity)
 
 
-@ENTITY_ADAPTERS.register(camera.DOMAIN)
+@ENTITY_ADAPTERS.register(CAMERA_DOMAIN)
 class CameraCapabilities(AlexaEntity):
     """Class to represent Camera capabilities."""
 

--- a/homeassistant/components/alexa/handlers.py
+++ b/homeassistant/components/alexa/handlers.py
@@ -14,7 +14,6 @@ from homeassistant.components import (
     climate,
     cover,
     fan,
-    group,
     humidifier,
     input_button,
     input_number,
@@ -27,6 +26,21 @@ from homeassistant.components import (
     valve,
     water_heater,
 )
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
+from homeassistant.components.input_number import DOMAIN as INPUT_NUMBER_DOMAIN
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.number import DOMAIN as NUMBER_DOMAIN
+from homeassistant.components.remote import DOMAIN as REMOTE_DOMAIN
+from homeassistant.components.timer import DOMAIN as TIMER_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 from homeassistant.const import (
     ATTR_ENTITY_ID,
     ATTR_ENTITY_PICTURE,
@@ -88,19 +102,19 @@ _LOGGER = logging.getLogger(__name__)
 DIRECTIVE_NOT_SUPPORTED = "Entity does not support directive"
 
 MIN_MAX_TEMP = {
-    climate.DOMAIN: {
+    CLIMATE_DOMAIN: {
         "min_temp": climate.ATTR_MIN_TEMP,
         "max_temp": climate.ATTR_MAX_TEMP,
     },
-    water_heater.DOMAIN: {
+    WATER_HEATER_DOMAIN: {
         "min_temp": water_heater.ATTR_MIN_TEMP,
         "max_temp": water_heater.ATTR_MAX_TEMP,
     },
 }
 
 SERVICE_SET_TEMPERATURE = {
-    climate.DOMAIN: climate.SERVICE_SET_TEMPERATURE,
-    water_heater.DOMAIN: water_heater.SERVICE_SET_TEMPERATURE,
+    CLIMATE_DOMAIN: climate.SERVICE_SET_TEMPERATURE,
+    WATER_HEATER_DOMAIN: water_heater.SERVICE_SET_TEMPERATURE,
 }
 
 HANDLERS: Registry[
@@ -176,30 +190,30 @@ async def async_api_turn_on(
 ) -> AlexaResponse:
     """Process a turn on request."""
     entity = directive.entity
-    if (domain := entity.domain) == group.DOMAIN:
+    if (domain := entity.domain) == GROUP_DOMAIN:
         domain = ha.DOMAIN
 
     service = SERVICE_TURN_ON
-    if domain == cover.DOMAIN:
+    if domain == COVER_DOMAIN:
         service = cover.SERVICE_OPEN_COVER
-    elif domain == climate.DOMAIN:
+    elif domain == CLIMATE_DOMAIN:
         service = climate.SERVICE_TURN_ON
-    elif domain == fan.DOMAIN:
+    elif domain == FAN_DOMAIN:
         service = fan.SERVICE_TURN_ON
-    elif domain == humidifier.DOMAIN:
+    elif domain == HUMIDIFIER_DOMAIN:
         service = humidifier.SERVICE_TURN_ON
-    elif domain == remote.DOMAIN:
+    elif domain == REMOTE_DOMAIN:
         service = remote.SERVICE_TURN_ON
-    elif domain == vacuum.DOMAIN:
+    elif domain == VACUUM_DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if (
             not supported & vacuum.VacuumEntityFeature.TURN_ON
             and supported & vacuum.VacuumEntityFeature.START
         ):
             service = vacuum.SERVICE_START
-    elif domain == timer.DOMAIN:
+    elif domain == TIMER_DOMAIN:
         service = timer.SERVICE_START
-    elif domain == media_player.DOMAIN:
+    elif domain == MEDIA_PLAYER_DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         power_features = (
             media_player.MediaPlayerEntityFeature.TURN_ON
@@ -229,30 +243,30 @@ async def async_api_turn_off(
     """Process a turn off request."""
     entity = directive.entity
     domain = entity.domain
-    if entity.domain == group.DOMAIN:
+    if entity.domain == GROUP_DOMAIN:
         domain = ha.DOMAIN
 
     service = SERVICE_TURN_OFF
-    if entity.domain == cover.DOMAIN:
+    if entity.domain == COVER_DOMAIN:
         service = cover.SERVICE_CLOSE_COVER
-    elif domain == climate.DOMAIN:
+    elif domain == CLIMATE_DOMAIN:
         service = climate.SERVICE_TURN_OFF
-    elif domain == fan.DOMAIN:
+    elif domain == FAN_DOMAIN:
         service = fan.SERVICE_TURN_OFF
-    elif domain == remote.DOMAIN:
+    elif domain == REMOTE_DOMAIN:
         service = remote.SERVICE_TURN_OFF
-    elif domain == humidifier.DOMAIN:
+    elif domain == HUMIDIFIER_DOMAIN:
         service = humidifier.SERVICE_TURN_OFF
-    elif domain == vacuum.DOMAIN:
+    elif domain == VACUUM_DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         if (
             not supported & vacuum.VacuumEntityFeature.TURN_OFF
             and supported & vacuum.VacuumEntityFeature.RETURN_HOME
         ):
             service = vacuum.SERVICE_RETURN_TO_BASE
-    elif domain == timer.DOMAIN:
+    elif domain == TIMER_DOMAIN:
         service = timer.SERVICE_CANCEL
-    elif domain == media_player.DOMAIN:
+    elif domain == MEDIA_PLAYER_DOMAIN:
         supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         power_features = (
             media_player.MediaPlayerEntityFeature.TURN_ON
@@ -428,9 +442,9 @@ async def async_api_activate(
     domain = entity.domain
 
     service = SERVICE_TURN_ON
-    if domain == button.DOMAIN:
+    if domain == BUTTON_DOMAIN:
         service = button.SERVICE_PRESS
-    elif domain == input_button.DOMAIN:
+    elif domain == INPUT_BUTTON_DOMAIN:
         service = input_button.SERVICE_PRESS
 
     await hass.services.async_call(
@@ -767,7 +781,7 @@ async def async_api_stop(
     entity = directive.entity
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
 
-    if entity.domain == cover.DOMAIN:
+    if entity.domain == COVER_DOMAIN:
         supported: int = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
         feature_services: dict[int, str] = {
             cover.CoverEntityFeature.STOP.value: cover.SERVICE_STOP_COVER,
@@ -1065,7 +1079,7 @@ async def async_api_set_thermostat_mode(
 
     response = directive.response()
     await hass.services.async_call(
-        climate.DOMAIN, service, data, blocking=False, context=context
+        CLIMATE_DOMAIN, service, data, blocking=False, context=context
     )
     response.add_context_property(
         {
@@ -1198,14 +1212,14 @@ async def async_api_set_mode(
     mode = directive.payload["mode"]
 
     # Fan Direction
-    if instance == f"{fan.DOMAIN}.{fan.ATTR_DIRECTION}":
+    if instance == f"{FAN_DOMAIN}.{fan.ATTR_DIRECTION}":
         direction = mode.split(".")[1]
         if direction in (fan.DIRECTION_REVERSE, fan.DIRECTION_FORWARD):
             service = fan.SERVICE_SET_DIRECTION
             data[fan.ATTR_DIRECTION] = direction
 
     # Fan preset_mode
-    elif instance == f"{fan.DOMAIN}.{fan.ATTR_PRESET_MODE}":
+    elif instance == f"{FAN_DOMAIN}.{fan.ATTR_PRESET_MODE}":
         preset_mode = mode.split(".")[1]
         preset_modes: list[str] | None = entity.attributes.get(fan.ATTR_PRESET_MODES)
         if (
@@ -1220,7 +1234,7 @@ async def async_api_set_mode(
             raise AlexaInvalidValueError(msg)
 
     # Humidifier mode
-    elif instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_MODE}":
+    elif instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_MODE}":
         mode = mode.split(".")[1]
         modes: list[str] | None = entity.attributes.get(humidifier.ATTR_AVAILABLE_MODES)
         if mode != PRESET_MODE_NA and modes and mode in modes:
@@ -1231,7 +1245,7 @@ async def async_api_set_mode(
             raise AlexaInvalidValueError(msg)
 
     # Remote Activity
-    elif instance == f"{remote.DOMAIN}.{remote.ATTR_ACTIVITY}":
+    elif instance == f"{REMOTE_DOMAIN}.{remote.ATTR_ACTIVITY}":
         activity = mode.split(".")[1]
         activities: list[str] | None = entity.attributes.get(remote.ATTR_ACTIVITY_LIST)
         if activity != PRESET_MODE_NA and activities and activity in activities:
@@ -1242,7 +1256,7 @@ async def async_api_set_mode(
             raise AlexaInvalidValueError(msg)
 
     # Water heater operation mode
-    elif instance == f"{water_heater.DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
+    elif instance == f"{WATER_HEATER_DOMAIN}.{water_heater.ATTR_OPERATION_MODE}":
         operation_mode = mode.split(".")[1]
         operation_modes: list[str] | None = entity.attributes.get(
             water_heater.ATTR_OPERATION_LIST
@@ -1262,7 +1276,7 @@ async def async_api_set_mode(
             raise AlexaInvalidValueError(msg)
 
     # Cover Position
-    elif instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+    elif instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
         position = mode.split(".")[1]
 
         if position == cover.CoverState.CLOSED:
@@ -1273,7 +1287,7 @@ async def async_api_set_mode(
             service = cover.SERVICE_STOP_COVER
 
     # Valve position state
-    elif instance == f"{valve.DOMAIN}.state":
+    elif instance == f"{VALVE_DOMAIN}.state":
         position = mode.split(".")[1]
 
         if position == valve.STATE_CLOSED:
@@ -1334,13 +1348,13 @@ async def async_api_toggle_on(
     data: dict[str, Any]
 
     # Fan Oscillating
-    if instance == f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}":
+    if instance == f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}":
         service = fan.SERVICE_OSCILLATE
         data = {
             ATTR_ENTITY_ID: entity.entity_id,
             fan.ATTR_OSCILLATING: True,
         }
-    elif instance == f"{valve.DOMAIN}.stop":
+    elif instance == f"{VALVE_DOMAIN}.stop":
         service = valve.SERVICE_STOP_VALVE
         data = {
             ATTR_ENTITY_ID: entity.entity_id,
@@ -1378,7 +1392,7 @@ async def async_api_toggle_off(
     domain = entity.domain
 
     # Fan Oscillating
-    if instance != f"{fan.DOMAIN}.{fan.ATTR_OSCILLATING}":
+    if instance != f"{FAN_DOMAIN}.{fan.ATTR_OSCILLATING}":
         raise AlexaInvalidDirectiveError(DIRECTIVE_NOT_SUPPORTED)
 
     service = fan.SERVICE_OSCILLATE
@@ -1421,7 +1435,7 @@ async def async_api_set_range(
     supported = entity.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
     # Cover Position
-    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+    if instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
         range_value = int(range_value)
         if supported & cover.CoverEntityFeature.CLOSE and range_value == 0:
             service = cover.SERVICE_CLOSE_COVER
@@ -1432,7 +1446,7 @@ async def async_api_set_range(
             data[cover.ATTR_POSITION] = range_value
 
     # Cover Tilt
-    elif instance == f"{cover.DOMAIN}.tilt":
+    elif instance == f"{COVER_DOMAIN}.tilt":
         range_value = int(range_value)
         if supported & cover.CoverEntityFeature.CLOSE_TILT and range_value == 0:
             service = cover.SERVICE_CLOSE_COVER_TILT
@@ -1443,7 +1457,7 @@ async def async_api_set_range(
             data[cover.ATTR_TILT_POSITION] = range_value
 
     # Fan Speed
-    elif instance == f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}":
+    elif instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
         range_value = int(range_value)
         if range_value == 0:
             service = fan.SERVICE_TURN_OFF
@@ -1454,13 +1468,13 @@ async def async_api_set_range(
             service = fan.SERVICE_TURN_ON
 
     # Humidifier target humidity
-    elif instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}":
+    elif instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
         range_value = int(range_value)
         service = humidifier.SERVICE_SET_HUMIDITY
         data[humidifier.ATTR_HUMIDITY] = range_value
 
     # Input Number Value
-    elif instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
+    elif instance == f"{INPUT_NUMBER_DOMAIN}.{input_number.ATTR_VALUE}":
         range_value = float(range_value)
         service = input_number.SERVICE_SET_VALUE
         min_value = float(entity.attributes[input_number.ATTR_MIN])
@@ -1468,7 +1482,7 @@ async def async_api_set_range(
         data[input_number.ATTR_VALUE] = min(max_value, max(min_value, range_value))
 
     # Input Number Value
-    elif instance == f"{number.DOMAIN}.{number.ATTR_VALUE}":
+    elif instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
         range_value = float(range_value)
         service = number.SERVICE_SET_VALUE
         min_value = float(entity.attributes[number.ATTR_MIN])
@@ -1476,7 +1490,7 @@ async def async_api_set_range(
         data[number.ATTR_VALUE] = min(max_value, max(min_value, range_value))
 
     # Vacuum Fan Speed
-    elif instance == f"{vacuum.DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
+    elif instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
         service = vacuum.SERVICE_SET_FAN_SPEED
         speed_list = entity.attributes[vacuum.ATTR_FAN_SPEED_LIST]
         speed = next(
@@ -1490,7 +1504,7 @@ async def async_api_set_range(
         data[vacuum.ATTR_FAN_SPEED] = speed
 
     # Valve Position
-    elif instance == f"{valve.DOMAIN}.{valve.ATTR_POSITION}":
+    elif instance == f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}":
         range_value = int(range_value)
         if supported & valve.ValveEntityFeature.CLOSE and range_value == 0:
             service = valve.SERVICE_CLOSE_VALVE
@@ -1538,7 +1552,7 @@ async def async_api_adjust_range(
     response_value: float | None = 0
 
     # Cover Position
-    if instance == f"{cover.DOMAIN}.{cover.ATTR_POSITION}":
+    if instance == f"{COVER_DOMAIN}.{cover.ATTR_POSITION}":
         range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = SERVICE_SET_COVER_POSITION
         if not (current := entity.attributes.get(cover.ATTR_CURRENT_POSITION)):
@@ -1553,7 +1567,7 @@ async def async_api_adjust_range(
             data[cover.ATTR_POSITION] = position
 
     # Cover Tilt
-    elif instance == f"{cover.DOMAIN}.tilt":
+    elif instance == f"{COVER_DOMAIN}.tilt":
         range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = SERVICE_SET_COVER_TILT_POSITION
         current = entity.attributes.get(cover.ATTR_TILT_POSITION)
@@ -1569,7 +1583,7 @@ async def async_api_adjust_range(
             data[cover.ATTR_TILT_POSITION] = tilt_position
 
     # Fan speed percentage
-    elif instance == f"{fan.DOMAIN}.{fan.ATTR_PERCENTAGE}":
+    elif instance == f"{FAN_DOMAIN}.{fan.ATTR_PERCENTAGE}":
         percentage_step = entity.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 20
         range_delta = (
             int(range_delta * percentage_step)
@@ -1587,7 +1601,7 @@ async def async_api_adjust_range(
             service = fan.SERVICE_TURN_OFF
 
     # Humidifier target humidity
-    elif instance == f"{humidifier.DOMAIN}.{humidifier.ATTR_HUMIDITY}":
+    elif instance == f"{HUMIDIFIER_DOMAIN}.{humidifier.ATTR_HUMIDITY}":
         percentage_step = 5
         range_delta = (
             int(range_delta * percentage_step)
@@ -1607,7 +1621,7 @@ async def async_api_adjust_range(
             data[humidifier.ATTR_HUMIDITY] = percentage
 
     # Input Number Value
-    elif instance == f"{input_number.DOMAIN}.{input_number.ATTR_VALUE}":
+    elif instance == f"{INPUT_NUMBER_DOMAIN}.{input_number.ATTR_VALUE}":
         range_delta = float(range_delta)
         service = input_number.SERVICE_SET_VALUE
         min_value = float(entity.attributes[input_number.ATTR_MIN])
@@ -1618,7 +1632,7 @@ async def async_api_adjust_range(
         )
 
     # Number Value
-    elif instance == f"{number.DOMAIN}.{number.ATTR_VALUE}":
+    elif instance == f"{NUMBER_DOMAIN}.{number.ATTR_VALUE}":
         range_delta = float(range_delta)
         service = number.SERVICE_SET_VALUE
         min_value = float(entity.attributes[number.ATTR_MIN])
@@ -1629,7 +1643,7 @@ async def async_api_adjust_range(
         )
 
     # Vacuum Fan Speed
-    elif instance == f"{vacuum.DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
+    elif instance == f"{VACUUM_DOMAIN}.{vacuum.ATTR_FAN_SPEED}":
         range_delta = int(range_delta)
         service = vacuum.SERVICE_SET_FAN_SPEED
         speed_list = entity.attributes[vacuum.ATTR_FAN_SPEED_LIST]
@@ -1646,7 +1660,7 @@ async def async_api_adjust_range(
         data[vacuum.ATTR_FAN_SPEED] = response_value = speed
 
     # Valve Position
-    elif instance == f"{valve.DOMAIN}.{valve.ATTR_POSITION}":
+    elif instance == f"{VALVE_DOMAIN}.{valve.ATTR_POSITION}":
         range_delta = int(range_delta * 20) if range_delta_default else int(range_delta)
         service = valve.SERVICE_SET_VALVE_POSITION
         if not (current := entity.attributes.get(valve.ATTR_POSITION)):
@@ -1801,7 +1815,7 @@ async def async_api_seek(
     }
 
     await hass.services.async_call(
-        media_player.DOMAIN,
+        MEDIA_PLAYER_DOMAIN,
         media_player.SERVICE_MEDIA_SEEK,
         data,
         blocking=False,
@@ -1877,10 +1891,10 @@ async def async_api_hold(
     entity = directive.entity
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
 
-    if entity.domain == timer.DOMAIN:
+    if entity.domain == TIMER_DOMAIN:
         service = timer.SERVICE_PAUSE
 
-    elif entity.domain == vacuum.DOMAIN:
+    elif entity.domain == VACUUM_DOMAIN:
         service = vacuum.SERVICE_START_PAUSE
 
     else:
@@ -1904,10 +1918,10 @@ async def async_api_resume(
     entity = directive.entity
     data: dict[str, Any] = {ATTR_ENTITY_ID: entity.entity_id}
 
-    if entity.domain == timer.DOMAIN:
+    if entity.domain == TIMER_DOMAIN:
         service = timer.SERVICE_START
 
-    elif entity.domain == vacuum.DOMAIN:
+    elif entity.domain == VACUUM_DOMAIN:
         service = vacuum.SERVICE_START_PAUSE
 
     else:

--- a/homeassistant/components/alexa/state_report.py
+++ b/homeassistant/components/alexa/state_report.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import aiohttp
 
-from homeassistant.components import event
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
 from homeassistant.const import (
     EVENT_STATE_CHANGED,
     STATE_ON,
@@ -341,7 +341,7 @@ async def async_enable_proactive_mode(
         if should_doorbell:
             old_state = data["old_state"]
             if (
-                new_state.domain == event.DOMAIN
+                new_state.domain == EVENT_DOMAIN
                 and valid_doorbell_timestamp(new_state.entity_id, new_state.state)
                 and (old_state is None or old_state.state != STATE_UNAVAILABLE)
                 and (old_state is None or old_state.state != new_state.state)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace the `component.DOMAIN` pattern in the Alexa integration with explicit
`from homeassistant.components.<component> import DOMAIN as <COMPONENT>_DOMAIN`
imports, following the convention already used elsewhere in the codebase.

Where a component module was only imported to reach its `DOMAIN`, it is dropped
from the aggregate import entirely (`alert`, `automation`, `button`, `event`,
`group`, `image_processing`, `input_boolean`, `input_button`, `lock`, `number`,
`scene`, `script`, `sensor`, `timer`).

Modules that are still referenced for other constants keep their
`from homeassistant.components import ...` module import; only the `DOMAIN`
access is migrated.

This is preliminary work for the attribute enum migration (#175836).

No functional change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #175836
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
