### PR TITLE
Import DOMAIN constants in Google Assistant

### DIFF
--- a/homeassistant/components/google_assistant/const.py
+++ b/homeassistant/components/google_assistant/const.py
@@ -1,32 +1,41 @@
 """Constants for Google Assistant."""
 
 from homeassistant.components import (
-    alarm_control_panel,
     binary_sensor,
-    button,
-    camera,
-    climate,
     cover,
     event,
-    fan,
-    group,
     humidifier,
-    input_boolean,
-    input_button,
-    input_select,
-    lawn_mower,
-    light,
-    lock,
     media_player,
-    scene,
-    script,
-    select,
     sensor,
     switch,
-    vacuum,
-    valve,
-    water_heater,
 )
+from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
+)
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.humidifier import DOMAIN as HUMIDIFIER_DOMAIN
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
+from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
+from homeassistant.components.input_select import DOMAIN as INPUT_SELECT_DOMAIN
+from homeassistant.components.lawn_mower import DOMAIN as LAWN_MOWER_DOMAIN
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN
+from homeassistant.components.media_player import DOMAIN as MEDIA_PLAYER_DOMAIN
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
+from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN
+from homeassistant.components.water_heater import DOMAIN as WATER_HEATER_DOMAIN
 
 DOMAIN = "google_assistant"
 
@@ -140,71 +149,71 @@ EVENT_QUERY_RECEIVED = "google_assistant_query"
 EVENT_SYNC_RECEIVED = "google_assistant_sync"
 
 DOMAIN_TO_GOOGLE_TYPES = {
-    alarm_control_panel.DOMAIN: TYPE_ALARM,
-    binary_sensor.DOMAIN: TYPE_SENSOR,
-    button.DOMAIN: TYPE_SCENE,
-    camera.DOMAIN: TYPE_CAMERA,
-    climate.DOMAIN: TYPE_THERMOSTAT,
-    cover.DOMAIN: TYPE_BLINDS,
-    fan.DOMAIN: TYPE_FAN,
-    group.DOMAIN: TYPE_SWITCH,
-    humidifier.DOMAIN: TYPE_HUMIDIFIER,
-    input_boolean.DOMAIN: TYPE_SWITCH,
-    input_button.DOMAIN: TYPE_SCENE,
-    input_select.DOMAIN: TYPE_SENSOR,
-    lawn_mower.DOMAIN: TYPE_MOWER,
-    light.DOMAIN: TYPE_LIGHT,
-    lock.DOMAIN: TYPE_LOCK,
-    media_player.DOMAIN: TYPE_SETTOP,
-    scene.DOMAIN: TYPE_SCENE,
-    script.DOMAIN: TYPE_SCENE,
-    select.DOMAIN: TYPE_SENSOR,
-    sensor.DOMAIN: TYPE_SENSOR,
-    switch.DOMAIN: TYPE_SWITCH,
-    vacuum.DOMAIN: TYPE_VACUUM,
-    valve.DOMAIN: TYPE_VALVE,
-    water_heater.DOMAIN: TYPE_WATERHEATER,
+    ALARM_CONTROL_PANEL_DOMAIN: TYPE_ALARM,
+    BINARY_SENSOR_DOMAIN: TYPE_SENSOR,
+    BUTTON_DOMAIN: TYPE_SCENE,
+    CAMERA_DOMAIN: TYPE_CAMERA,
+    CLIMATE_DOMAIN: TYPE_THERMOSTAT,
+    COVER_DOMAIN: TYPE_BLINDS,
+    FAN_DOMAIN: TYPE_FAN,
+    GROUP_DOMAIN: TYPE_SWITCH,
+    HUMIDIFIER_DOMAIN: TYPE_HUMIDIFIER,
+    INPUT_BOOLEAN_DOMAIN: TYPE_SWITCH,
+    INPUT_BUTTON_DOMAIN: TYPE_SCENE,
+    INPUT_SELECT_DOMAIN: TYPE_SENSOR,
+    LAWN_MOWER_DOMAIN: TYPE_MOWER,
+    LIGHT_DOMAIN: TYPE_LIGHT,
+    LOCK_DOMAIN: TYPE_LOCK,
+    MEDIA_PLAYER_DOMAIN: TYPE_SETTOP,
+    SCENE_DOMAIN: TYPE_SCENE,
+    SCRIPT_DOMAIN: TYPE_SCENE,
+    SELECT_DOMAIN: TYPE_SENSOR,
+    SENSOR_DOMAIN: TYPE_SENSOR,
+    SWITCH_DOMAIN: TYPE_SWITCH,
+    VACUUM_DOMAIN: TYPE_VACUUM,
+    VALVE_DOMAIN: TYPE_VALVE,
+    WATER_HEATER_DOMAIN: TYPE_WATERHEATER,
 }
 
 DEVICE_CLASS_TO_GOOGLE_TYPES = {
-    (binary_sensor.DOMAIN, binary_sensor.BinarySensorDeviceClass.DOOR): TYPE_DOOR,
-    (binary_sensor.DOMAIN, binary_sensor.BinarySensorDeviceClass.LOCK): TYPE_SENSOR,
-    (binary_sensor.DOMAIN, binary_sensor.BinarySensorDeviceClass.OPENING): TYPE_SENSOR,
-    (binary_sensor.DOMAIN, binary_sensor.BinarySensorDeviceClass.WINDOW): TYPE_WINDOW,
+    (BINARY_SENSOR_DOMAIN, binary_sensor.BinarySensorDeviceClass.DOOR): TYPE_DOOR,
+    (BINARY_SENSOR_DOMAIN, binary_sensor.BinarySensorDeviceClass.LOCK): TYPE_SENSOR,
+    (BINARY_SENSOR_DOMAIN, binary_sensor.BinarySensorDeviceClass.OPENING): TYPE_SENSOR,
+    (BINARY_SENSOR_DOMAIN, binary_sensor.BinarySensorDeviceClass.WINDOW): TYPE_WINDOW,
     (
-        binary_sensor.DOMAIN,
+        BINARY_SENSOR_DOMAIN,
         binary_sensor.BinarySensorDeviceClass.GARAGE_DOOR,
     ): TYPE_GARAGE,
     (
-        binary_sensor.DOMAIN,
+        BINARY_SENSOR_DOMAIN,
         binary_sensor.BinarySensorDeviceClass.SMOKE,
     ): TYPE_SMOKE_DETECTOR,
     (
-        binary_sensor.DOMAIN,
+        BINARY_SENSOR_DOMAIN,
         binary_sensor.BinarySensorDeviceClass.CO,
     ): TYPE_CARBON_MONOXIDE_DETECTOR,
-    (cover.DOMAIN, cover.CoverDeviceClass.AWNING): TYPE_AWNING,
-    (cover.DOMAIN, cover.CoverDeviceClass.CURTAIN): TYPE_CURTAIN,
-    (cover.DOMAIN, cover.CoverDeviceClass.DOOR): TYPE_DOOR,
-    (cover.DOMAIN, cover.CoverDeviceClass.GARAGE): TYPE_GARAGE,
-    (cover.DOMAIN, cover.CoverDeviceClass.GATE): TYPE_GATE,
-    (cover.DOMAIN, cover.CoverDeviceClass.SHUTTER): TYPE_SHUTTER,
-    (cover.DOMAIN, cover.CoverDeviceClass.WINDOW): TYPE_WINDOW,
-    (event.DOMAIN, event.EventDeviceClass.DOORBELL): TYPE_DOORBELL,
+    (COVER_DOMAIN, cover.CoverDeviceClass.AWNING): TYPE_AWNING,
+    (COVER_DOMAIN, cover.CoverDeviceClass.CURTAIN): TYPE_CURTAIN,
+    (COVER_DOMAIN, cover.CoverDeviceClass.DOOR): TYPE_DOOR,
+    (COVER_DOMAIN, cover.CoverDeviceClass.GARAGE): TYPE_GARAGE,
+    (COVER_DOMAIN, cover.CoverDeviceClass.GATE): TYPE_GATE,
+    (COVER_DOMAIN, cover.CoverDeviceClass.SHUTTER): TYPE_SHUTTER,
+    (COVER_DOMAIN, cover.CoverDeviceClass.WINDOW): TYPE_WINDOW,
+    (EVENT_DOMAIN, event.EventDeviceClass.DOORBELL): TYPE_DOORBELL,
     (
-        humidifier.DOMAIN,
+        HUMIDIFIER_DOMAIN,
         humidifier.HumidifierDeviceClass.DEHUMIDIFIER,
     ): TYPE_DEHUMIDIFIER,
-    (humidifier.DOMAIN, humidifier.HumidifierDeviceClass.HUMIDIFIER): TYPE_HUMIDIFIER,
-    (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.RECEIVER): TYPE_RECEIVER,
-    (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.SPEAKER): TYPE_SPEAKER,
-    (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.TV): TYPE_TV,
-    (media_player.DOMAIN, media_player.MediaPlayerDeviceClass.PROJECTOR): TYPE_TV,
-    (sensor.DOMAIN, sensor.SensorDeviceClass.AQI): TYPE_SENSOR,
-    (sensor.DOMAIN, sensor.SensorDeviceClass.HUMIDITY): TYPE_SENSOR,
-    (sensor.DOMAIN, sensor.SensorDeviceClass.TEMPERATURE): TYPE_SENSOR,
-    (switch.DOMAIN, switch.SwitchDeviceClass.OUTLET): TYPE_OUTLET,
-    (switch.DOMAIN, switch.SwitchDeviceClass.SWITCH): TYPE_SWITCH,
+    (HUMIDIFIER_DOMAIN, humidifier.HumidifierDeviceClass.HUMIDIFIER): TYPE_HUMIDIFIER,
+    (MEDIA_PLAYER_DOMAIN, media_player.MediaPlayerDeviceClass.RECEIVER): TYPE_RECEIVER,
+    (MEDIA_PLAYER_DOMAIN, media_player.MediaPlayerDeviceClass.SPEAKER): TYPE_SPEAKER,
+    (MEDIA_PLAYER_DOMAIN, media_player.MediaPlayerDeviceClass.TV): TYPE_TV,
+    (MEDIA_PLAYER_DOMAIN, media_player.MediaPlayerDeviceClass.PROJECTOR): TYPE_TV,
+    (SENSOR_DOMAIN, sensor.SensorDeviceClass.AQI): TYPE_SENSOR,
+    (SENSOR_DOMAIN, sensor.SensorDeviceClass.HUMIDITY): TYPE_SENSOR,
+    (SENSOR_DOMAIN, sensor.SensorDeviceClass.TEMPERATURE): TYPE_SENSOR,
+    (SWITCH_DOMAIN, switch.SwitchDeviceClass.OUTLET): TYPE_OUTLET,
+    (SWITCH_DOMAIN, switch.SwitchDeviceClass.SWITCH): TYPE_SWITCH,
 }
 
 CHALLENGE_ACK_NEEDED = "ackNeeded"

--- a/homeassistant/components/google_assistant/trait.py
+++ b/homeassistant/components/google_assistant/trait.py
@@ -6,7 +6,6 @@ import logging
 from typing import Any, override
 
 from homeassistant.components import (
-    alarm_control_panel,
     binary_sensor,
     button,
     camera,
@@ -14,40 +13,64 @@ from homeassistant.components import (
     cover,
     event,
     fan,
-    group,
     humidifier,
-    input_boolean,
     input_button,
     input_select,
     lawn_mower,
     light,
     lock,
     media_player,
-    scene,
-    script,
     select,
     sensor,
-    switch,
     vacuum,
     valve,
     water_heater,
 )
 from homeassistant.components.alarm_control_panel import (
+    DOMAIN as ALARM_CONTROL_PANEL_DOMAIN,
     AlarmControlPanelEntityFeature,
     AlarmControlPanelState,
 )
-from homeassistant.components.camera import CameraEntityFeature
-from homeassistant.components.climate import ClimateEntityFeature
-from homeassistant.components.cover import CoverEntityFeature
-from homeassistant.components.fan import FanEntityFeature
-from homeassistant.components.humidifier import HumidifierEntityFeature
-from homeassistant.components.lawn_mower import LawnMowerEntityFeature
-from homeassistant.components.light import LightEntityFeature
-from homeassistant.components.lock import LockState
-from homeassistant.components.media_player import MediaPlayerEntityFeature, MediaType
-from homeassistant.components.vacuum import VacuumEntityFeature
-from homeassistant.components.valve import ValveEntityFeature
-from homeassistant.components.water_heater import WaterHeaterEntityFeature
+from homeassistant.components.binary_sensor import DOMAIN as BINARY_SENSOR_DOMAIN
+from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+from homeassistant.components.camera import DOMAIN as CAMERA_DOMAIN, CameraEntityFeature
+from homeassistant.components.climate import (
+    DOMAIN as CLIMATE_DOMAIN,
+    ClimateEntityFeature,
+)
+from homeassistant.components.cover import DOMAIN as COVER_DOMAIN, CoverEntityFeature
+from homeassistant.components.event import DOMAIN as EVENT_DOMAIN
+from homeassistant.components.fan import DOMAIN as FAN_DOMAIN, FanEntityFeature
+from homeassistant.components.group import DOMAIN as GROUP_DOMAIN
+from homeassistant.components.humidifier import (
+    DOMAIN as HUMIDIFIER_DOMAIN,
+    HumidifierEntityFeature,
+)
+from homeassistant.components.input_boolean import DOMAIN as INPUT_BOOLEAN_DOMAIN
+from homeassistant.components.input_button import DOMAIN as INPUT_BUTTON_DOMAIN
+from homeassistant.components.input_select import DOMAIN as INPUT_SELECT_DOMAIN
+from homeassistant.components.lawn_mower import (
+    DOMAIN as LAWN_MOWER_DOMAIN,
+    LawnMowerEntityFeature,
+)
+from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN, LightEntityFeature
+from homeassistant.components.lock import DOMAIN as LOCK_DOMAIN, LockState
+from homeassistant.components.media_player import (
+    DOMAIN as MEDIA_PLAYER_DOMAIN,
+    MediaPlayerEntityFeature,
+    MediaType,
+)
+from homeassistant.components.scene import DOMAIN as SCENE_DOMAIN
+from homeassistant.components.script import DOMAIN as SCRIPT_DOMAIN
+from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
+from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
+from homeassistant.components.vacuum import DOMAIN as VACUUM_DOMAIN, VacuumEntityFeature
+from homeassistant.components.valve import DOMAIN as VALVE_DOMAIN, ValveEntityFeature
+from homeassistant.components.water_heater import (
+    DOMAIN as WATER_HEATER_DOMAIN,
+    WaterHeaterEntityFeature,
+)
 from homeassistant.const import (
     ATTR_ASSUMED_STATE,
     ATTR_BATTERY_LEVEL,
@@ -180,13 +203,13 @@ TRAITS: list[type[_Trait]] = []
 FAN_SPEED_MAX_SPEED_COUNT = 5
 
 COVER_VALVE_STATES = {
-    cover.DOMAIN: {
+    COVER_DOMAIN: {
         "closed": cover.CoverState.CLOSED.value,
         "closing": cover.CoverState.CLOSING.value,
         "open": cover.CoverState.OPEN.value,
         "opening": cover.CoverState.OPENING.value,
     },
-    valve.DOMAIN: {
+    VALVE_DOMAIN: {
         "closed": valve.STATE_CLOSED,
         "closing": valve.STATE_CLOSING,
         "open": valve.STATE_OPEN,
@@ -195,48 +218,48 @@ COVER_VALVE_STATES = {
 }
 
 SERVICE_STOP_COVER_VALVE = {
-    cover.DOMAIN: cover.SERVICE_STOP_COVER,
-    valve.DOMAIN: valve.SERVICE_STOP_VALVE,
+    COVER_DOMAIN: cover.SERVICE_STOP_COVER,
+    VALVE_DOMAIN: valve.SERVICE_STOP_VALVE,
 }
 SERVICE_OPEN_COVER_VALVE = {
-    cover.DOMAIN: cover.SERVICE_OPEN_COVER,
-    valve.DOMAIN: valve.SERVICE_OPEN_VALVE,
+    COVER_DOMAIN: cover.SERVICE_OPEN_COVER,
+    VALVE_DOMAIN: valve.SERVICE_OPEN_VALVE,
 }
 SERVICE_CLOSE_COVER_VALVE = {
-    cover.DOMAIN: cover.SERVICE_CLOSE_COVER,
-    valve.DOMAIN: valve.SERVICE_CLOSE_VALVE,
+    COVER_DOMAIN: cover.SERVICE_CLOSE_COVER,
+    VALVE_DOMAIN: valve.SERVICE_CLOSE_VALVE,
 }
 SERVICE_TOGGLE_COVER_VALVE = {
-    cover.DOMAIN: cover.SERVICE_TOGGLE,
-    valve.DOMAIN: valve.SERVICE_TOGGLE,
+    COVER_DOMAIN: cover.SERVICE_TOGGLE,
+    VALVE_DOMAIN: valve.SERVICE_TOGGLE,
 }
 SERVICE_SET_POSITION_COVER_VALVE = {
-    cover.DOMAIN: cover.SERVICE_SET_COVER_POSITION,
-    valve.DOMAIN: valve.SERVICE_SET_VALVE_POSITION,
+    COVER_DOMAIN: cover.SERVICE_SET_COVER_POSITION,
+    VALVE_DOMAIN: valve.SERVICE_SET_VALVE_POSITION,
 }
 
 COVER_VALVE_CURRENT_POSITION = {
-    cover.DOMAIN: cover.ATTR_CURRENT_POSITION,
-    valve.DOMAIN: valve.ATTR_CURRENT_POSITION,
+    COVER_DOMAIN: cover.ATTR_CURRENT_POSITION,
+    VALVE_DOMAIN: valve.ATTR_CURRENT_POSITION,
 }
 
 COVER_VALVE_POSITION = {
-    cover.DOMAIN: cover.ATTR_POSITION,
-    valve.DOMAIN: valve.ATTR_POSITION,
+    COVER_DOMAIN: cover.ATTR_POSITION,
+    VALVE_DOMAIN: valve.ATTR_POSITION,
 }
 
 COVER_VALVE_SET_POSITION_FEATURE = {
-    cover.DOMAIN: CoverEntityFeature.SET_POSITION,
-    valve.DOMAIN: ValveEntityFeature.SET_POSITION,
+    COVER_DOMAIN: CoverEntityFeature.SET_POSITION,
+    VALVE_DOMAIN: ValveEntityFeature.SET_POSITION,
 }
 COVER_VALVE_STOP_FEATURE = {
-    cover.DOMAIN: CoverEntityFeature.STOP,
-    valve.DOMAIN: ValveEntityFeature.STOP,
+    COVER_DOMAIN: CoverEntityFeature.STOP,
+    VALVE_DOMAIN: ValveEntityFeature.STOP,
 }
 
-COVER_VALVE_DOMAINS = {cover.DOMAIN, valve.DOMAIN}
+COVER_VALVE_DOMAINS = {COVER_DOMAIN, VALVE_DOMAIN}
 
-FRIENDLY_DOMAIN = {cover.DOMAIN: "Cover", valve.DOMAIN: "Valve"}
+FRIENDLY_DOMAIN = {COVER_DOMAIN: "Cover", VALVE_DOMAIN: "Valve"}
 
 
 def register_trait[_TraitT: _Trait](trait: type[_TraitT]) -> type[_TraitT]:
@@ -328,7 +351,7 @@ class BrightnessTrait(_Trait):
     @override
     def supported(domain, features, device_class, attributes):
         """Test if state is supported."""
-        if domain == light.DOMAIN:
+        if domain == LIGHT_DOMAIN:
             color_modes = attributes.get(light.ATTR_SUPPORTED_COLOR_MODES)
             return light.brightness_supported(color_modes)
 
@@ -345,7 +368,7 @@ class BrightnessTrait(_Trait):
         domain = self.state.domain
         response = {}
 
-        if domain == light.DOMAIN:
+        if domain == LIGHT_DOMAIN:
             brightness = self.state.attributes.get(light.ATTR_BRIGHTNESS)
             if brightness is not None:
                 response["brightness"] = round(100 * (brightness / 255))
@@ -355,9 +378,9 @@ class BrightnessTrait(_Trait):
     @override
     async def execute(self, command, data, params, challenge):
         """Execute a brightness command."""
-        if self.state.domain == light.DOMAIN:
+        if self.state.domain == LIGHT_DOMAIN:
             await self.hass.services.async_call(
-                light.DOMAIN,
+                LIGHT_DOMAIN,
                 light.SERVICE_TURN_ON,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -384,7 +407,7 @@ class CameraStreamTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == camera.DOMAIN:
+        if domain == CAMERA_DOMAIN:
             return features & CameraEntityFeature.STREAM
 
         return False
@@ -428,7 +451,7 @@ class ObjectDetection(_Trait):
     def supported(domain, features, device_class, _) -> bool:
         """Test if state is supported."""
         return (
-            domain == event.DOMAIN and device_class == event.EventDeviceClass.DOORBELL
+            domain == EVENT_DOMAIN and device_class == event.EventDeviceClass.DOORBELL
         )
 
     @override
@@ -491,22 +514,22 @@ class OnOffTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == water_heater.DOMAIN and features & WaterHeaterEntityFeature.ON_OFF:
+        if domain == WATER_HEATER_DOMAIN and features & WaterHeaterEntityFeature.ON_OFF:
             return True
 
-        if domain == climate.DOMAIN and features & (
+        if domain == CLIMATE_DOMAIN and features & (
             ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
         ):
             return True
 
         return domain in (
-            group.DOMAIN,
-            input_boolean.DOMAIN,
-            switch.DOMAIN,
-            fan.DOMAIN,
-            light.DOMAIN,
-            media_player.DOMAIN,
-            humidifier.DOMAIN,
+            GROUP_DOMAIN,
+            INPUT_BOOLEAN_DOMAIN,
+            SWITCH_DOMAIN,
+            FAN_DOMAIN,
+            LIGHT_DOMAIN,
+            MEDIA_PLAYER_DOMAIN,
+            HUMIDIFIER_DOMAIN,
         )
 
     @override
@@ -524,7 +547,7 @@ class OnOffTrait(_Trait):
     @override
     async def execute(self, command, data, params, challenge):
         """Execute an OnOff command."""
-        if (domain := self.state.domain) == group.DOMAIN:
+        if (domain := self.state.domain) == GROUP_DOMAIN:
             service_domain = HOMEASSISTANT_DOMAIN
             service = SERVICE_TURN_ON if params["on"] else SERVICE_TURN_OFF
 
@@ -555,7 +578,7 @@ class ColorSettingTrait(_Trait):
     @override
     def supported(domain, features, device_class, attributes):
         """Test if state is supported."""
-        if domain != light.DOMAIN:
+        if domain != LIGHT_DOMAIN:
             return False
 
         color_modes = attributes.get(light.ATTR_SUPPORTED_COLOR_MODES)
@@ -632,7 +655,7 @@ class ColorSettingTrait(_Trait):
                 )
 
             await self.hass.services.async_call(
-                light.DOMAIN,
+                LIGHT_DOMAIN,
                 SERVICE_TURN_ON,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -650,7 +673,7 @@ class ColorSettingTrait(_Trait):
             )
 
             await self.hass.services.async_call(
-                light.DOMAIN,
+                LIGHT_DOMAIN,
                 SERVICE_TURN_ON,
                 {ATTR_ENTITY_ID: self.state.entity_id, light.ATTR_HS_COLOR: color},
                 blocking=not self.config.should_report_state,
@@ -663,7 +686,7 @@ class ColorSettingTrait(_Trait):
             brightness = color["value"] * 255
 
             await self.hass.services.async_call(
-                light.DOMAIN,
+                LIGHT_DOMAIN,
                 SERVICE_TURN_ON,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -690,10 +713,10 @@ class SceneTrait(_Trait):
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return domain in (
-            button.DOMAIN,
-            input_button.DOMAIN,
-            scene.DOMAIN,
-            script.DOMAIN,
+            BUTTON_DOMAIN,
+            INPUT_BUTTON_DOMAIN,
+            SCENE_DOMAIN,
+            SCRIPT_DOMAIN,
         )
 
     @override
@@ -711,9 +734,9 @@ class SceneTrait(_Trait):
     async def execute(self, command, data, params, challenge):
         """Execute a scene command."""
         service = SERVICE_TURN_ON
-        if self.state.domain == button.DOMAIN:
+        if self.state.domain == BUTTON_DOMAIN:
             service = button.SERVICE_PRESS
-        elif self.state.domain == input_button.DOMAIN:
+        elif self.state.domain == INPUT_BUTTON_DOMAIN:
             service = input_button.SERVICE_PRESS
 
         # Don't block for scripts or buttons, as they can be slow.
@@ -723,7 +746,7 @@ class SceneTrait(_Trait):
             {ATTR_ENTITY_ID: self.state.entity_id},
             blocking=(not self.config.should_report_state)
             and self.state.domain
-            not in (button.DOMAIN, input_button.DOMAIN, script.DOMAIN),
+            not in (BUTTON_DOMAIN, INPUT_BUTTON_DOMAIN, SCRIPT_DOMAIN),
             context=data.context,
         )
 
@@ -742,7 +765,7 @@ class DockTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain in (vacuum.DOMAIN, lawn_mower.DOMAIN)
+        return domain in (VACUUM_DOMAIN, LAWN_MOWER_DOMAIN)
 
     @override
     def sync_attributes(self) -> dict[str, Any]:
@@ -754,9 +777,9 @@ class DockTrait(_Trait):
         """Return dock query attributes."""
         domain = self.state.domain
         state = self.state.state
-        if domain == vacuum.DOMAIN:
+        if domain == VACUUM_DOMAIN:
             return {"isDocked": state == vacuum.VacuumActivity.DOCKED}
-        if domain == lawn_mower.DOMAIN:
+        if domain == LAWN_MOWER_DOMAIN:
             return {"isDocked": state == lawn_mower.LawnMowerActivity.DOCKED}
         raise NotImplementedError(f"Unsupported domain {domain}")
 
@@ -766,9 +789,9 @@ class DockTrait(_Trait):
         domain = self.state.domain
         service: str | None = None
 
-        if domain == vacuum.DOMAIN:
+        if domain == VACUUM_DOMAIN:
             service = vacuum.SERVICE_RETURN_TO_BASE
-        elif domain == lawn_mower.DOMAIN:
+        elif domain == LAWN_MOWER_DOMAIN:
             service = lawn_mower.SERVICE_DOCK
 
         if service:
@@ -795,7 +818,7 @@ class LocatorTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain == vacuum.DOMAIN and features & VacuumEntityFeature.LOCATE
+        return domain == VACUUM_DOMAIN and features & VacuumEntityFeature.LOCATE
 
     @override
     def sync_attributes(self) -> dict[str, Any]:
@@ -839,7 +862,7 @@ class EnergyStorageTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain == vacuum.DOMAIN and features & VacuumEntityFeature.BATTERY
+        return domain == VACUUM_DOMAIN and features & VacuumEntityFeature.BATTERY
 
     @override
     def sync_attributes(self) -> dict[str, Any]:
@@ -898,7 +921,7 @@ class StartStopTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain in (vacuum.DOMAIN, lawn_mower.DOMAIN):
+        if domain in (VACUUM_DOMAIN, LAWN_MOWER_DOMAIN):
             return True
 
         if (
@@ -913,7 +936,7 @@ class StartStopTrait(_Trait):
     def sync_attributes(self) -> dict[str, Any]:
         """Return StartStop attributes for a sync request."""
         domain = self.state.domain
-        if domain == vacuum.DOMAIN:
+        if domain == VACUUM_DOMAIN:
             sync_attributes = {
                 "pausable": self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
                 & VacuumEntityFeature.PAUSE
@@ -927,17 +950,17 @@ class StartStopTrait(_Trait):
                 area_registry = ar.async_get(self.hass)
                 if (
                     entry
-                    and vacuum.DOMAIN in entry.options
-                    and "area_mapping" in entry.options[vacuum.DOMAIN]
+                    and VACUUM_DOMAIN in entry.options
+                    and "area_mapping" in entry.options[VACUUM_DOMAIN]
                 ):
-                    area_mapping = entry.options[vacuum.DOMAIN]["area_mapping"]
+                    area_mapping = entry.options[VACUUM_DOMAIN]["area_mapping"]
                     for area_id in area_mapping:
                         area = area_registry.async_get_area(area_id)
                         if area:
                             available_zones.append(area.name)
                 sync_attributes["availableZones"] = available_zones
             return sync_attributes
-        if domain == lawn_mower.DOMAIN:
+        if domain == LAWN_MOWER_DOMAIN:
             return {
                 "pausable": self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
                 & LawnMowerEntityFeature.PAUSE
@@ -954,12 +977,12 @@ class StartStopTrait(_Trait):
         domain = self.state.domain
         state = self.state.state
 
-        if domain == vacuum.DOMAIN:
+        if domain == VACUUM_DOMAIN:
             return {
                 "isRunning": state == vacuum.VacuumActivity.CLEANING,
                 "isPaused": state == vacuum.VacuumActivity.PAUSED,
             }
-        if domain == lawn_mower.DOMAIN:
+        if domain == LAWN_MOWER_DOMAIN:
             return {
                 "isRunning": state == lawn_mower.LawnMowerActivity.MOWING,
                 "isPaused": state == lawn_mower.LawnMowerActivity.PAUSED,
@@ -989,10 +1012,10 @@ class StartStopTrait(_Trait):
     async def execute(self, command, data, params, challenge):
         """Execute a StartStop command."""
         domain = self.state.domain
-        if domain == vacuum.DOMAIN:
+        if domain == VACUUM_DOMAIN:
             await self._execute_vacuum(command, data, params, challenge)
             return
-        if domain == lawn_mower.DOMAIN:
+        if domain == LAWN_MOWER_DOMAIN:
             await self._execute_lawn_mower(command, data, params, challenge)
             return
         if domain in COVER_VALVE_DOMAINS:
@@ -1017,10 +1040,10 @@ class StartStopTrait(_Trait):
                     area_mapping: dict[str, list[str]] = {}
                     if (
                         entry
-                        and vacuum.DOMAIN in entry.options
-                        and "area_mapping" in entry.options[vacuum.DOMAIN]
+                        and VACUUM_DOMAIN in entry.options
+                        and "area_mapping" in entry.options[VACUUM_DOMAIN]
                     ):
-                        area_mapping = entry.options[vacuum.DOMAIN]["area_mapping"]
+                        area_mapping = entry.options[VACUUM_DOMAIN]["area_mapping"]
                     area_registry = ar.async_get(self.hass)
                     name_to_area_id = {
                         area.name: area.id
@@ -1149,10 +1172,10 @@ class TemperatureControlTrait(_Trait):
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         return (
-            domain == water_heater.DOMAIN
+            domain == WATER_HEATER_DOMAIN
             and features & WaterHeaterEntityFeature.TARGET_TEMPERATURE
         ) or (
-            domain == sensor.DOMAIN
+            domain == SENSOR_DOMAIN
             and device_class == sensor.SensorDeviceClass.TEMPERATURE
         )
 
@@ -1165,7 +1188,7 @@ class TemperatureControlTrait(_Trait):
         unit = self.hass.config.units.temperature_unit
         response["temperatureUnitForUX"] = _google_temp_unit(unit)
 
-        if domain == water_heater.DOMAIN:
+        if domain == WATER_HEATER_DOMAIN:
             min_temp = round(
                 TemperatureConverter.convert(
                     float(attrs[water_heater.ATTR_MIN_TEMP]),
@@ -1201,7 +1224,7 @@ class TemperatureControlTrait(_Trait):
         response = {}
         domain = self.state.domain
         unit = self.hass.config.units.temperature_unit
-        if domain == water_heater.DOMAIN:
+        if domain == WATER_HEATER_DOMAIN:
             target_temp = self.state.attributes[water_heater.ATTR_TEMPERATURE]
             current_temp = self.state.attributes[water_heater.ATTR_CURRENT_TEMPERATURE]
             if target_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
@@ -1224,7 +1247,7 @@ class TemperatureControlTrait(_Trait):
                 )
             return response
 
-        # domain == sensor.DOMAIN
+        # domain == SENSOR_DOMAIN
         current_temp = self.state.state
         if current_temp not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
             temp = round(
@@ -1245,7 +1268,7 @@ class TemperatureControlTrait(_Trait):
         domain = self.state.domain
         unit = self.hass.config.units.temperature_unit
 
-        if domain == water_heater.DOMAIN and command == COMMAND_SET_TEMPERATURE:
+        if domain == WATER_HEATER_DOMAIN and command == COMMAND_SET_TEMPERATURE:
             min_temp = self.state.attributes[water_heater.ATTR_MIN_TEMP]
             max_temp = self.state.attributes[water_heater.ATTR_MAX_TEMP]
             temp = TemperatureConverter.convert(
@@ -1260,7 +1283,7 @@ class TemperatureControlTrait(_Trait):
                 )
 
             await self.hass.services.async_call(
-                water_heater.DOMAIN,
+                WATER_HEATER_DOMAIN,
                 water_heater.SERVICE_SET_TEMPERATURE,
                 {ATTR_ENTITY_ID: self.state.entity_id, ATTR_TEMPERATURE: temp},
                 blocking=not self.config.should_report_state,
@@ -1315,7 +1338,7 @@ class TemperatureSettingTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain == climate.DOMAIN
+        return domain == CLIMATE_DOMAIN
 
     @property
     def climate_google_modes(self):
@@ -1474,7 +1497,7 @@ class TemperatureSettingTrait(_Trait):
                 )
 
             await self.hass.services.async_call(
-                climate.DOMAIN,
+                CLIMATE_DOMAIN,
                 climate.SERVICE_SET_TEMPERATURE,
                 {ATTR_ENTITY_ID: self.state.entity_id, ATTR_TEMPERATURE: temp},
                 blocking=not self.config.should_report_state,
@@ -1526,7 +1549,7 @@ class TemperatureSettingTrait(_Trait):
                 svc_data[ATTR_TEMPERATURE] = (temp_high + temp_low) / 2
 
             await self.hass.services.async_call(
-                climate.DOMAIN,
+                CLIMATE_DOMAIN,
                 climate.SERVICE_SET_TEMPERATURE,
                 svc_data,
                 blocking=not self.config.should_report_state,
@@ -1539,7 +1562,7 @@ class TemperatureSettingTrait(_Trait):
 
             if target_mode == "on":
                 await self.hass.services.async_call(
-                    climate.DOMAIN,
+                    CLIMATE_DOMAIN,
                     SERVICE_TURN_ON,
                     {ATTR_ENTITY_ID: self.state.entity_id},
                     blocking=not self.config.should_report_state,
@@ -1549,7 +1572,7 @@ class TemperatureSettingTrait(_Trait):
 
             if target_mode == "off":
                 await self.hass.services.async_call(
-                    climate.DOMAIN,
+                    CLIMATE_DOMAIN,
                     SERVICE_TURN_OFF,
                     {ATTR_ENTITY_ID: self.state.entity_id},
                     blocking=not self.config.should_report_state,
@@ -1559,7 +1582,7 @@ class TemperatureSettingTrait(_Trait):
 
             if target_mode in self.google_to_preset:
                 await self.hass.services.async_call(
-                    climate.DOMAIN,
+                    CLIMATE_DOMAIN,
                     climate.SERVICE_SET_PRESET_MODE,
                     {
                         climate.ATTR_PRESET_MODE: self.google_to_preset[target_mode],
@@ -1571,7 +1594,7 @@ class TemperatureSettingTrait(_Trait):
                 return
 
             await self.hass.services.async_call(
-                climate.DOMAIN,
+                CLIMATE_DOMAIN,
                 climate.SERVICE_SET_HVAC_MODE,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -1596,11 +1619,11 @@ class HumiditySettingTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == humidifier.DOMAIN:
+        if domain == HUMIDIFIER_DOMAIN:
             return True
 
         return (
-            domain == sensor.DOMAIN
+            domain == SENSOR_DOMAIN
             and device_class == sensor.SensorDeviceClass.HUMIDITY
         )
 
@@ -1611,12 +1634,12 @@ class HumiditySettingTrait(_Trait):
         attrs = self.state.attributes
         domain = self.state.domain
 
-        if domain == sensor.DOMAIN:
+        if domain == SENSOR_DOMAIN:
             device_class = attrs.get(ATTR_DEVICE_CLASS)
             if device_class == sensor.SensorDeviceClass.HUMIDITY:
                 response["queryOnlyHumiditySetting"] = True
 
-        elif domain == humidifier.DOMAIN:
+        elif domain == HUMIDIFIER_DOMAIN:
             response["humiditySetpointRange"] = {
                 "minPercent": round(
                     float(self.state.attributes[humidifier.ATTR_MIN_HUMIDITY])
@@ -1635,14 +1658,14 @@ class HumiditySettingTrait(_Trait):
         attrs = self.state.attributes
         domain = self.state.domain
 
-        if domain == sensor.DOMAIN:
+        if domain == SENSOR_DOMAIN:
             device_class = attrs.get(ATTR_DEVICE_CLASS)
             if device_class == sensor.SensorDeviceClass.HUMIDITY:
                 humidity_state = self.state.state
                 if humidity_state not in (STATE_UNKNOWN, STATE_UNAVAILABLE):
                     response["humidityAmbientPercent"] = round(float(humidity_state))
 
-        elif domain == humidifier.DOMAIN:
+        elif domain == HUMIDIFIER_DOMAIN:
             target_humidity: int | None = attrs.get(humidifier.ATTR_HUMIDITY)
             if target_humidity is not None:
                 response["humiditySetpointPercent"] = target_humidity
@@ -1655,14 +1678,14 @@ class HumiditySettingTrait(_Trait):
     @override
     async def execute(self, command, data, params, challenge):
         """Execute a humidity command."""
-        if self.state.domain == sensor.DOMAIN:
+        if self.state.domain == SENSOR_DOMAIN:
             raise SmartHomeError(
                 ERR_NOT_SUPPORTED, "Execute is not supported by sensor"
             )
 
         if command == COMMAND_SET_HUMIDITY:
             await self.hass.services.async_call(
-                humidifier.DOMAIN,
+                HUMIDIFIER_DOMAIN,
                 humidifier.SERVICE_SET_HUMIDITY,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -1687,7 +1710,7 @@ class LockUnlockTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain == lock.DOMAIN
+        return domain == LOCK_DOMAIN
 
     @staticmethod
     @override
@@ -1719,7 +1742,7 @@ class LockUnlockTrait(_Trait):
             service = lock.SERVICE_UNLOCK
 
         await self.hass.services.async_call(
-            lock.DOMAIN,
+            LOCK_DOMAIN,
             service,
             {ATTR_ENTITY_ID: self.state.entity_id},
             blocking=not self.config.should_report_state,
@@ -1760,7 +1783,7 @@ class ArmDisArmTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain == alarm_control_panel.DOMAIN
+        return domain == ALARM_CONTROL_PANEL_DOMAIN
 
     @staticmethod
     @override
@@ -1850,7 +1873,7 @@ class ArmDisArmTrait(_Trait):
             service = SERVICE_ALARM_DISARM
 
         await self.hass.services.async_call(
-            alarm_control_panel.DOMAIN,
+            ALARM_CONTROL_PANEL_DOMAIN,
             service,
             {
                 ATTR_ENTITY_ID: self.state.entity_id,
@@ -1888,7 +1911,7 @@ class FanSpeedTrait(_Trait):
     def __init__(self, hass, state, config):
         """Initialize a trait for a state."""
         super().__init__(hass, state, config)
-        if state.domain == fan.DOMAIN:
+        if state.domain == FAN_DOMAIN:
             speed_count = round(
                 100 / (self.state.attributes.get(fan.ATTR_PERCENTAGE_STEP) or 1.0)
             )
@@ -1903,9 +1926,9 @@ class FanSpeedTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == fan.DOMAIN:
+        if domain == FAN_DOMAIN:
             return features & FanEntityFeature.SET_SPEED
-        if domain == climate.DOMAIN:
+        if domain == CLIMATE_DOMAIN:
             return features & ClimateEntityFeature.FAN_MODE
         return False
 
@@ -1916,7 +1939,7 @@ class FanSpeedTrait(_Trait):
         speeds = []
         result: dict[str, Any] = {}
 
-        if domain == fan.DOMAIN:
+        if domain == FAN_DOMAIN:
             reversible = bool(
                 self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
                 & FanEntityFeature.DIRECTION
@@ -1945,7 +1968,7 @@ class FanSpeedTrait(_Trait):
                     }
                 )
 
-        elif domain == climate.DOMAIN:
+        elif domain == CLIMATE_DOMAIN:
             modes = self.state.attributes.get(climate.ATTR_FAN_MODES) or []
             for mode in modes:
                 speed = {
@@ -1970,11 +1993,11 @@ class FanSpeedTrait(_Trait):
         attrs = self.state.attributes
         domain = self.state.domain
         response = {}
-        if domain == climate.DOMAIN:
+        if domain == CLIMATE_DOMAIN:
             speed = attrs.get(climate.ATTR_FAN_MODE) or "off"
             response["currentFanSpeedSetting"] = speed
 
-        if domain == fan.DOMAIN:
+        if domain == FAN_DOMAIN:
             percent = attrs.get(fan.ATTR_PERCENTAGE) or 0
             if self._ordered_speed:
                 response["currentFanSpeedSetting"] = percentage_to_ordered_list_item(
@@ -1988,9 +2011,9 @@ class FanSpeedTrait(_Trait):
     async def execute_fanspeed(self, data, params):
         """Execute an SetFanSpeed command."""
         domain = self.state.domain
-        if domain == climate.DOMAIN:
+        if domain == CLIMATE_DOMAIN:
             await self.hass.services.async_call(
-                climate.DOMAIN,
+                CLIMATE_DOMAIN,
                 climate.SERVICE_SET_FAN_MODE,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2000,7 +2023,7 @@ class FanSpeedTrait(_Trait):
                 context=data.context,
             )
 
-        if domain == fan.DOMAIN:
+        if domain == FAN_DOMAIN:
             if self._ordered_speed and (fan_speed := params.get("fanSpeed")):
                 fan_speed_percent = ordered_list_item_to_percentage(
                     self._ordered_speed, fan_speed
@@ -2009,7 +2032,7 @@ class FanSpeedTrait(_Trait):
                 fan_speed_percent = params.get("fanSpeedPercent")
 
             await self.hass.services.async_call(
-                fan.DOMAIN,
+                FAN_DOMAIN,
                 fan.SERVICE_SET_PERCENTAGE,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2021,14 +2044,14 @@ class FanSpeedTrait(_Trait):
 
     async def execute_reverse(self, data, params):
         """Execute a Reverse command."""
-        if self.state.domain == fan.DOMAIN:
+        if self.state.domain == FAN_DOMAIN:
             if self.state.attributes.get(fan.ATTR_DIRECTION) == fan.DIRECTION_FORWARD:
                 direction = fan.DIRECTION_REVERSE
             else:
                 direction = fan.DIRECTION_FORWARD
 
             await self.hass.services.async_call(
-                fan.DOMAIN,
+                FAN_DOMAIN,
                 fan.SERVICE_SET_DIRECTION,
                 {ATTR_ENTITY_ID: self.state.entity_id, fan.ATTR_DIRECTION: direction},
                 blocking=not self.config.should_report_state,
@@ -2064,28 +2087,28 @@ class ModesTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == fan.DOMAIN and features & FanEntityFeature.PRESET_MODE:
+        if domain == FAN_DOMAIN and features & FanEntityFeature.PRESET_MODE:
             return True
 
-        if domain == input_select.DOMAIN:
+        if domain == INPUT_SELECT_DOMAIN:
             return True
 
-        if domain == select.DOMAIN:
+        if domain == SELECT_DOMAIN:
             return True
 
-        if domain == humidifier.DOMAIN and features & HumidifierEntityFeature.MODES:
+        if domain == HUMIDIFIER_DOMAIN and features & HumidifierEntityFeature.MODES:
             return True
 
-        if domain == light.DOMAIN and features & LightEntityFeature.EFFECT:
+        if domain == LIGHT_DOMAIN and features & LightEntityFeature.EFFECT:
             return True
 
         if (
-            domain == water_heater.DOMAIN
+            domain == WATER_HEATER_DOMAIN
             and features & WaterHeaterEntityFeature.OPERATION_MODE
         ):
             return True
 
-        if domain != media_player.DOMAIN:
+        if domain != MEDIA_PLAYER_DOMAIN:
             return False
 
         return features & MediaPlayerEntityFeature.SELECT_SOUND_MODE
@@ -2120,13 +2143,13 @@ class ModesTrait(_Trait):
         modes = []
 
         for domain, attr, name in (
-            (fan.DOMAIN, fan.ATTR_PRESET_MODES, "preset mode"),
-            (media_player.DOMAIN, media_player.ATTR_SOUND_MODE_LIST, "sound mode"),
-            (input_select.DOMAIN, input_select.ATTR_OPTIONS, "option"),
-            (select.DOMAIN, select.ATTR_OPTIONS, "option"),
-            (humidifier.DOMAIN, humidifier.ATTR_AVAILABLE_MODES, "mode"),
-            (light.DOMAIN, light.ATTR_EFFECT_LIST, "effect"),
-            (water_heater.DOMAIN, water_heater.ATTR_OPERATION_LIST, "operation mode"),
+            (FAN_DOMAIN, fan.ATTR_PRESET_MODES, "preset mode"),
+            (MEDIA_PLAYER_DOMAIN, media_player.ATTR_SOUND_MODE_LIST, "sound mode"),
+            (INPUT_SELECT_DOMAIN, input_select.ATTR_OPTIONS, "option"),
+            (SELECT_DOMAIN, select.ATTR_OPTIONS, "option"),
+            (HUMIDIFIER_DOMAIN, humidifier.ATTR_AVAILABLE_MODES, "mode"),
+            (LIGHT_DOMAIN, light.ATTR_EFFECT_LIST, "effect"),
+            (WATER_HEATER_DOMAIN, water_heater.ATTR_OPERATION_LIST, "operation mode"),
         ):
             if self.state.domain != domain:
                 continue
@@ -2146,23 +2169,23 @@ class ModesTrait(_Trait):
         response: dict[str, Any] = {}
         mode_settings = {}
 
-        if self.state.domain == fan.DOMAIN:
+        if self.state.domain == FAN_DOMAIN:
             if fan.ATTR_PRESET_MODES in attrs:
                 mode_settings["preset mode"] = attrs.get(fan.ATTR_PRESET_MODE)
-        elif self.state.domain == media_player.DOMAIN:
+        elif self.state.domain == MEDIA_PLAYER_DOMAIN:
             if media_player.ATTR_SOUND_MODE_LIST in attrs:
                 mode_settings["sound mode"] = attrs.get(media_player.ATTR_SOUND_MODE)
-        elif self.state.domain in (input_select.DOMAIN, select.DOMAIN):
+        elif self.state.domain in (INPUT_SELECT_DOMAIN, SELECT_DOMAIN):
             mode_settings["option"] = self.state.state
-        elif self.state.domain == humidifier.DOMAIN:
+        elif self.state.domain == HUMIDIFIER_DOMAIN:
             if ATTR_MODE in attrs:
                 mode_settings["mode"] = attrs.get(ATTR_MODE)
-        elif self.state.domain == water_heater.DOMAIN:
+        elif self.state.domain == WATER_HEATER_DOMAIN:
             if water_heater.ATTR_OPERATION_MODE in attrs:
                 mode_settings["operation mode"] = attrs.get(
                     water_heater.ATTR_OPERATION_MODE
                 )
-        elif self.state.domain == light.DOMAIN and (
+        elif self.state.domain == LIGHT_DOMAIN and (
             effect := attrs.get(light.ATTR_EFFECT)
         ):
             mode_settings["effect"] = effect
@@ -2178,10 +2201,10 @@ class ModesTrait(_Trait):
         """Execute a SetModes command."""
         settings = params.get("updateModeSettings")
 
-        if self.state.domain == fan.DOMAIN:
+        if self.state.domain == FAN_DOMAIN:
             preset_mode = settings["preset mode"]
             await self.hass.services.async_call(
-                fan.DOMAIN,
+                FAN_DOMAIN,
                 fan.SERVICE_SET_PRESET_MODE,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2192,10 +2215,10 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain == input_select.DOMAIN:
+        if self.state.domain == INPUT_SELECT_DOMAIN:
             option = settings["option"]
             await self.hass.services.async_call(
-                input_select.DOMAIN,
+                INPUT_SELECT_DOMAIN,
                 input_select.SERVICE_SELECT_OPTION,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2206,10 +2229,10 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain == select.DOMAIN:
+        if self.state.domain == SELECT_DOMAIN:
             option = settings["option"]
             await self.hass.services.async_call(
-                select.DOMAIN,
+                SELECT_DOMAIN,
                 select.SERVICE_SELECT_OPTION,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2220,10 +2243,10 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain == humidifier.DOMAIN:
+        if self.state.domain == HUMIDIFIER_DOMAIN:
             requested_mode = settings["mode"]
             await self.hass.services.async_call(
-                humidifier.DOMAIN,
+                HUMIDIFIER_DOMAIN,
                 humidifier.SERVICE_SET_MODE,
                 {
                     ATTR_MODE: requested_mode,
@@ -2234,10 +2257,10 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain == water_heater.DOMAIN:
+        if self.state.domain == WATER_HEATER_DOMAIN:
             requested_mode = settings["operation mode"]
             await self.hass.services.async_call(
-                water_heater.DOMAIN,
+                WATER_HEATER_DOMAIN,
                 water_heater.SERVICE_SET_OPERATION_MODE,
                 {
                     water_heater.ATTR_OPERATION_MODE: requested_mode,
@@ -2248,10 +2271,10 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain == light.DOMAIN:
+        if self.state.domain == LIGHT_DOMAIN:
             requested_effect = settings["effect"]
             await self.hass.services.async_call(
-                light.DOMAIN,
+                LIGHT_DOMAIN,
                 SERVICE_TURN_ON,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2262,11 +2285,11 @@ class ModesTrait(_Trait):
             )
             return
 
-        if self.state.domain == media_player.DOMAIN and (
+        if self.state.domain == MEDIA_PLAYER_DOMAIN and (
             sound_mode := settings.get("sound mode")
         ):
             await self.hass.services.async_call(
-                media_player.DOMAIN,
+                MEDIA_PLAYER_DOMAIN,
                 media_player.SERVICE_SELECT_SOUND_MODE,
                 {
                     ATTR_ENTITY_ID: self.state.entity_id,
@@ -2299,7 +2322,7 @@ class InputSelectorTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == media_player.DOMAIN and (
+        if domain == MEDIA_PLAYER_DOMAIN and (
             features & MediaPlayerEntityFeature.SELECT_SOURCE
         ):
             return True
@@ -2343,7 +2366,7 @@ class InputSelectorTrait(_Trait):
             raise SmartHomeError(ERR_UNSUPPORTED_INPUT, "Unsupported input")
 
         await self.hass.services.async_call(
-            media_player.DOMAIN,
+            MEDIA_PLAYER_DOMAIN,
             media_player.SERVICE_SELECT_SOURCE,
             {
                 ATTR_ENTITY_ID: self.state.entity_id,
@@ -2378,7 +2401,7 @@ class OpenCloseTrait(_Trait):
         if domain in COVER_VALVE_DOMAINS:
             return True
 
-        return domain == binary_sensor.DOMAIN and device_class in (
+        return domain == BINARY_SENSOR_DOMAIN and device_class in (
             binary_sensor.BinarySensorDeviceClass.DOOR,
             binary_sensor.BinarySensorDeviceClass.GARAGE_DOOR,
             binary_sensor.BinarySensorDeviceClass.LOCK,
@@ -2390,7 +2413,7 @@ class OpenCloseTrait(_Trait):
     @override
     def might_2fa(domain, features, device_class):
         """Return if the trait might ask for 2FA."""
-        return domain == cover.DOMAIN and device_class in OpenCloseTrait.COVER_2FA
+        return domain == COVER_DOMAIN and device_class in OpenCloseTrait.COVER_2FA
 
     @override
     def sync_attributes(self) -> dict[str, Any]:
@@ -2398,11 +2421,11 @@ class OpenCloseTrait(_Trait):
         response = {}
         features = self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
-        if self.state.domain == binary_sensor.DOMAIN:
+        if self.state.domain == BINARY_SENSOR_DOMAIN:
             response["queryOnlyOpenClose"] = True
             response["discreteOnlyOpenClose"] = True
         elif (
-            self.state.domain == cover.DOMAIN
+            self.state.domain == COVER_DOMAIN
             and features & CoverEntityFeature.SET_POSITION == 0
         ):
             response["discreteOnlyOpenClose"] = True
@@ -2413,7 +2436,7 @@ class OpenCloseTrait(_Trait):
             ):
                 response["queryOnlyOpenClose"] = True
         elif (
-            self.state.domain == valve.DOMAIN
+            self.state.domain == VALVE_DOMAIN
             and features & ValveEntityFeature.SET_POSITION == 0
         ):
             response["discreteOnlyOpenClose"] = True
@@ -2457,7 +2480,7 @@ class OpenCloseTrait(_Trait):
             else:
                 response["openPercent"] = 0
 
-        elif domain == binary_sensor.DOMAIN:
+        elif domain == BINARY_SENSOR_DOMAIN:
             if self.state.state == STATE_ON:
                 response["openPercent"] = 100
             else:
@@ -2533,7 +2556,7 @@ class VolumeTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if trait is supported."""
-        if domain == media_player.DOMAIN:
+        if domain == MEDIA_PLAYER_DOMAIN:
             return features & (
                 MediaPlayerEntityFeature.VOLUME_SET
                 | MediaPlayerEntityFeature.VOLUME_STEP
@@ -2577,7 +2600,7 @@ class VolumeTrait(_Trait):
 
     async def _set_volume_absolute(self, data, level):
         await self.hass.services.async_call(
-            media_player.DOMAIN,
+            MEDIA_PLAYER_DOMAIN,
             media_player.SERVICE_VOLUME_SET,
             {
                 ATTR_ENTITY_ID: self.state.entity_id,
@@ -2616,7 +2639,7 @@ class VolumeTrait(_Trait):
 
             for _ in range(relative):
                 await self.hass.services.async_call(
-                    media_player.DOMAIN,
+                    MEDIA_PLAYER_DOMAIN,
                     svc,
                     {ATTR_ENTITY_ID: self.state.entity_id},
                     blocking=not self.config.should_report_state,
@@ -2635,7 +2658,7 @@ class VolumeTrait(_Trait):
             raise SmartHomeError(ERR_NOT_SUPPORTED, "Command not supported")
 
         await self.hass.services.async_call(
-            media_player.DOMAIN,
+            MEDIA_PLAYER_DOMAIN,
             media_player.SERVICE_VOLUME_MUTE,
             {
                 ATTR_ENTITY_ID: self.state.entity_id,
@@ -2718,7 +2741,7 @@ class TransportControlTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        if domain == media_player.DOMAIN:
+        if domain == MEDIA_PLAYER_DOMAIN:
             for feature in MEDIA_COMMAND_SUPPORT_MAPPING.values():
                 if features & feature:
                     return True
@@ -2730,7 +2753,7 @@ class TransportControlTrait(_Trait):
         """Return opening direction."""
         response = {}
 
-        if self.state.domain == media_player.DOMAIN:
+        if self.state.domain == MEDIA_PLAYER_DOMAIN:
             features = self.state.attributes.get(ATTR_SUPPORTED_FEATURES, 0)
 
             support = []
@@ -2797,7 +2820,7 @@ class TransportControlTrait(_Trait):
             raise SmartHomeError(ERR_NOT_SUPPORTED, "Command not supported")
 
         await self.hass.services.async_call(
-            media_player.DOMAIN,
+            MEDIA_PLAYER_DOMAIN,
             service,
             service_attrs,
             blocking=not self.config.should_report_state,
@@ -2841,7 +2864,7 @@ class MediaStateTrait(_Trait):
     @override
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
-        return domain == media_player.DOMAIN
+        return domain == MEDIA_PLAYER_DOMAIN
 
     @override
     def sync_attributes(self) -> dict[str, Any]:
@@ -2872,7 +2895,7 @@ class ChannelTrait(_Trait):
     def supported(domain, features, device_class, _):
         """Test if state is supported."""
         if (
-            domain == media_player.DOMAIN
+            domain == MEDIA_PLAYER_DOMAIN
             and (features & MediaPlayerEntityFeature.PLAY_MEDIA)
             and device_class
             in (
@@ -2909,7 +2932,7 @@ class ChannelTrait(_Trait):
             )
 
         await self.hass.services.async_call(
-            media_player.DOMAIN,
+            MEDIA_PLAYER_DOMAIN,
             media_player.SERVICE_PLAY_MEDIA,
             {
                 ATTR_ENTITY_ID: self.state.entity_id,
@@ -2978,8 +3001,8 @@ class SensorStateTrait(_Trait):
     @override
     def supported(cls, domain, features, device_class, _):
         """Test if state is supported."""
-        return (domain == sensor.DOMAIN and device_class in cls.sensor_types) or (
-            domain == binary_sensor.DOMAIN and device_class in cls.binary_sensor_types
+        return (domain == SENSOR_DOMAIN and device_class in cls.sensor_types) or (
+            domain == BINARY_SENSOR_DOMAIN and device_class in cls.binary_sensor_types
         )
 
     @override
@@ -3003,7 +3026,7 @@ class SensorStateTrait(_Trait):
                 }
             return {"sensorStatesSupported": [sensor_state]}
 
-        if self.state.domain == sensor.DOMAIN:
+        if self.state.domain == SENSOR_DOMAIN:
             sensor_data = self.sensor_types.get(device_class)
             if device_class is None or sensor_data is None:
                 return {}
@@ -3042,7 +3065,7 @@ class SensorStateTrait(_Trait):
                 sensor_state["currentSensorState"] = current_state
             return {"currentSensorStateData": [sensor_state]}
 
-        if self.state.domain == sensor.DOMAIN:
+        if self.state.domain == SENSOR_DOMAIN:
             sensor_data = self.sensor_types.get(device_class)
             if device_class is None or sensor_data is None:
                 return {}


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace the `component.DOMAIN` pattern in the Google Assistant integration with explicit
`from homeassistant.components.<component> import DOMAIN as <COMPONENT>_DOMAIN`
imports, following the convention already used elsewhere in the codebase.

Where a component module was only imported to reach its `DOMAIN`, it is dropped
from the aggregate import entirely (`alarm_control_panel`, `button`, `camera`,
`climate`, `fan`, `group`, `input_boolean`, `input_button`, `input_select`,
`lawn_mower`, `light`, `lock`, `scene`, `script`, `select`, `vacuum`, `valve`,
`water_heater`).

Modules that are still referenced for other constants keep their
`from homeassistant.components import ...` module import; only the `DOMAIN`
access is migrated.

This is preliminary work for the attribute enum migration (#175836).

No functional change.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: #175836
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
