### PR TITLE
Don't raise AssertionError from the recorder connect listener

### DIFF
--- a/homeassistant/components/recorder/core.py
+++ b/homeassistant/components/recorder/core.py
@@ -1381,10 +1381,16 @@ class Recorder(threading.Thread):
         self, dbapi_connection: DBAPIConnection, connection_record: Any
     ) -> None:
         """Dbapi specific connection settings."""
-        assert self.engine is not None
+        if (engine := self.engine) is None:
+            # _close_connection disposes the engine and drops our reference to it, but
+            # dispose() only empties the pool: the engine stays usable, so anything
+            # still holding a reference to it can check out a fresh DBAPI connection
+            # and get here. There is no longer an engine of ours to configure it for.
+            _LOGGER.debug("Ignoring connection setup for a closed database connection")
+            return
         if database_engine := setup_connection_for_dialect(
             self,
-            self.engine.dialect.name,
+            engine.dialect.name,
             dbapi_connection,
             not self._completed_first_database_setup,
         ):

--- a/tests/components/recorder/test_init.py
+++ b/tests/components/recorder/test_init.py
@@ -2821,3 +2821,27 @@ async def test_setting_up_recorder_fails_entity_registry_listener(
         "The recorder entity registry listener must be installed before "
         "async_track_entity_registry_updated_event is called" in caplog.text
     )
+
+
+async def test_setup_connection_after_connection_closed(
+    hass: HomeAssistant, setup_recorder: None
+) -> None:
+    """Test the connect listener does not raise once the engine is gone.
+
+    _close_connection disposes the engine and drops our reference to it, but dispose()
+    only empties the pool: the engine stays usable, so anything still holding a
+    reference to it can check out a fresh DBAPI connection. That fires the connect
+    listener, which is still registered, with self.engine already set to None.
+    """
+    instance = recorder.get_instance(hass)
+    assert instance.engine is not None
+
+    def _setup_connection_without_an_engine() -> None:
+        with instance.engine.connect() as connection:
+            dbapi_connection = connection._dbapi_connection
+            with patch.object(instance, "engine", None):
+                # There is no engine of ours left to configure the connection for,
+                # which is not a reason to raise into whatever caused the checkout
+                instance._setup_recorder_connection(dbapi_connection, Mock())
+
+    await instance.async_add_executor_job(_setup_connection_without_an_engine)


### PR DESCRIPTION
## Proposed change

`_setup_recorder_connection` is registered as a SQLAlchemy `connect` listener in
`_setup_connection`, and it is never removed:

```python
        self.engine = create_engine(self.db_url, **kwargs, future=True)
        ...
        sqlalchemy_event.listen(self.engine, "connect", self._setup_recorder_connection)
```

`_close_connection` disposes that engine and drops the reference to it:

```python
    def _close_connection(self) -> None:
        """Close the connection."""
        if self.engine:
            self.engine.dispose()
            self.engine = None
        self._get_session = None
```

`dispose()` empties the pool but does not make the engine unusable — that is the
documented behaviour, and a fresh checkout afterwards simply creates a new DBAPI
connection. So anything still holding a reference to that engine can trigger the
`connect` event after `self.engine` is already `None`, and the listener's

```python
        assert self.engine is not None
```

escapes as a bare `AssertionError` into whatever caused the checkout. A disposed engine
is precisely the case that has to create a fresh connection, which is what makes this
reachable rather than theoretical.

This surfaced as an `AssertionError` out of the `recorder/statistics_during_period`
WebSocket command, in the window after the recorder had closed its connection following
a database failure but while its WebSocket commands were still registered. A read API
returning an internal assertion failure is not a graceful way to report "the recorder
is not currently connected".

### The change

Return early instead of asserting. If the recorder no longer has an engine, there is
nothing of ours to configure the connection for, and that is not a reason to raise into
an unrelated caller. A debug log records it.

I first tried removing the listener in `_close_connection`, which is arguably the tidier
lifecycle fix, but `sqlalchemy_event.remove` raises `InvalidRequestError` when the target
never had the listener registered, and 16 existing recorder tests set `self.engine` to a
`Mock`. Making production code depend on that bookkeeping — and adjusting those tests to
suit it — seemed worse than the four-line guard. Happy to switch if you would rather have
the listener removed.

### How this was found

This came out of an [Antithesis](https://antithesis.com) test harness that runs Home
Assistant Core against MariaDB in a separate container, with the platform injecting
network partitions, packet delay and process termination while a workload drives the REST
and WebSocket APIs. Home Assistant itself was not modified — the in-process probe is a
custom component, so nothing here depends on patched core code. A property asserting that
a recorder read never fails from mishandling a database failure caught the
`AssertionError` five times across two runs.

The added test reproduces it directly without fault injection: close the connection, then
check out from the engine that was disposed.

Searching the issue tracker did not turn up an existing report for this, so nothing is
linked below.

Verified against `dev` at 2650b82ed8d9, where the added test fails with `AssertionError`
at `core.py:1384`.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request:
- Link to developer documentation pull request:
- Link to frontend pull request:

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
