### PR TITLE
Scope hassfest Docker manifest.json discovery to documented locations

### DIFF
--- a/script/hassfest/docker/entrypoint.sh
+++ b/script/hassfest/docker/entrypoint.sh
@@ -14,19 +14,13 @@ for arg in "$@"; do
 done
 
 if [ "$core_path_provided" = false ]; then
-    # Only look for manifest.json in the locations Home Assistant and HACS
-    # actually document as valid for custom integrations:
-    #   - custom_components/<domain>/manifest.json (standard layout)
-    #   - ./manifest.json (HACS "content_in_root" layout)
-    # A repo-wide recursive find picks up unrelated manifest.json files that
-    # happen to share the filename (e.g. browser-extension manifests bundled
-    # alongside the integration), which are not Home Assistant manifests and
-    # cause confusing crashes when hassfest tries to validate them as such.
-    if [ -d custom_components ]; then
-        manifests=$(find custom_components -maxdepth 2 -name "manifest.json")
-    else
-        manifests=$(find . -maxdepth 1 -name "manifest.json")
-    fi
+    # Manifest discovery is limited to the two documented custom-integration
+    # locations rather than anywhere in the repo, to avoid misvalidating
+    # unrelated files that happen to share the filename.
+    manifests=$(
+        { [ -d custom_components ] && find custom_components -mindepth 2 -maxdepth 2 -name "manifest.json"
+          find . -maxdepth 1 -name "manifest.json"; } 2>/dev/null
+    )
 
     for manifest in $manifests; do
         manifest_path=$(realpath "${manifest}")

--- a/script/hassfest/docker/entrypoint.sh
+++ b/script/hassfest/docker/entrypoint.sh
@@ -14,8 +14,21 @@ for arg in "$@"; do
 done
 
 if [ "$core_path_provided" = false ]; then
-    # Enable recursive globbing using find
-    for manifest in $(find . -name "manifest.json"); do
+    # Only look for manifest.json in the locations Home Assistant and HACS
+    # actually document as valid for custom integrations:
+    #   - custom_components/<domain>/manifest.json (standard layout)
+    #   - ./manifest.json (HACS "content_in_root" layout)
+    # A repo-wide recursive find picks up unrelated manifest.json files that
+    # happen to share the filename (e.g. browser-extension manifests bundled
+    # alongside the integration), which are not Home Assistant manifests and
+    # cause confusing crashes when hassfest tries to validate them as such.
+    if [ -d custom_components ]; then
+        manifests=$(find custom_components -maxdepth 2 -name "manifest.json")
+    else
+        manifests=$(find . -maxdepth 1 -name "manifest.json")
+    fi
+
+    for manifest in $manifests; do
         manifest_path=$(realpath "${manifest}")
         integrations="$integrations --integration-path ${manifest_path%/*}"
     done


### PR DESCRIPTION
## Proposed change

hassfest's Docker entrypoint (`script/hassfest/docker/entrypoint.sh`) discovers integrations for custom-component repos with a repo-wide recursive `find . -name "manifest.json"`, then treats every match as an integration manifest and validates it as such with no check that it's actually a Home Assistant manifest.

This breaks when a repo legitimately contains an unrelated file that happens to be named `manifest.json` elsewhere in the tree. In the case that surfaced this (see home-assistant/actions#147), a HACS custom-component repo also ships a companion browser-extension add-on with its own WebExtension `manifest.json` several directories away from `custom_components/<domain>/manifest.json`. That unrelated file doesn't have the keys hassfest expects (`domain`, `codeowners`, etc.), so instead of being ignored it caused a confusing `KeyError` crash deep inside the plugin pipeline.

Per the documented layouts, a custom-component repo's manifest can only legitimately live in one of two places:
- `custom_components/<domain>/manifest.json` (standard layout - developers.home-assistant.io/docs/creating_integration_file_structure)
- `manifest.json` at the repo root, when HACS's `content_in_root: true` option is used (hacs.xyz/docs/publish/integration)

This PR checks both documented locations independently (bounded `-maxdepth`/`-mindepth` searches) instead of an unbounded repo-wide `find`, so unrelated `manifest.json` files elsewhere in the tree are no longer swept up and misvalidated. Repos using either or both documented layouts are unaffected.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: home-assistant/actions#147
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [x] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr