### PR TITLE
Add KNX select platform to the UI configuration panel

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -204,6 +204,7 @@ SUPPORTED_PLATFORMS_UI: Final = {
     Platform.NOTIFY,
     Platform.NUMBER,
     Platform.SCENE,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.TEXT,

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -93,7 +93,8 @@ def _number_limit_sub_validator(config: dict) -> dict:
     return validate_number_attributes(transcoder, config)
 
 
-def _max_payload_value(payload_length: int) -> int:
+def max_payload_value(payload_length: int) -> int:
+    """Return the highest payload a raw value of that length can carry."""
     if payload_length == 0:
         return 0x3F
     return int(256**payload_length) - 1
@@ -121,7 +122,7 @@ def button_payload_sub_validator(entity_config: OrderedDict) -> OrderedDict:
 
     _payload = entity_config[CONF_PAYLOAD]
     _payload_length = entity_config[CONF_PAYLOAD_LENGTH]
-    if _payload > (max_payload := _max_payload_value(_payload_length)):
+    if _payload > (max_payload := max_payload_value(_payload_length)):
         raise vol.Invalid(
             f"'payload: {_payload}' exceeds possible maximum for "
             f"payload_length {_payload_length}: {max_payload}"
@@ -138,7 +139,7 @@ def select_options_sub_validator(entity_config: OrderedDict) -> OrderedDict:
     for opt in entity_config[SelectSchema.CONF_OPTIONS]:
         option = opt[SelectSchema.CONF_OPTION]
         payload = opt[CONF_PAYLOAD]
-        if payload > (max_payload := _max_payload_value(payload_length)):
+        if payload > (max_payload := max_payload_value(payload_length)):
             raise vol.Invalid(
                 f"'payload: {payload}' for 'option: {option}' exceeds possible"
                 f" maximum of 'payload_length: {payload_length}': {max_payload}"

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -97,9 +97,9 @@ class _KnxSelect(SelectEntity, RestoreEntity):
         if last_state := await self.async_get_last_state():
             if (
                 last_state.state not in (STATE_UNKNOWN, STATE_UNAVAILABLE)
-                and (option := self._option_payloads.get(last_state.state)) is not None
+                and (payload := self._option_payloads.get(last_state.state)) is not None
             ):
-                self._device.remote_value.update_value(option)
+                self._device.remote_value.update_value(payload)
 
     def option_from_payload(self, payload: int | None) -> str | None:
         """Return the option a given payload is assigned to."""

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -8,6 +8,7 @@ from homeassistant import config_entries
 from homeassistant.components.select import SelectEntity
 from homeassistant.const import (
     CONF_NAME,
+    CONF_OPTIONS,
     CONF_PAYLOAD,
     STATE_UNAVAILABLE,
     STATE_UNKNOWN,
@@ -38,7 +39,7 @@ from .entity import (
 )
 from .knx_module import KNXModule
 from .schema import SelectSchema
-from .storage.const import CONF_ENTITY, CONF_GA_SELECT, CONF_OPTION, CONF_OPTIONS
+from .storage.const import CONF_ENTITY, CONF_GA_SELECT, CONF_OPTION
 from .storage.util import ConfigExtractor
 
 

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -1,9 +1,8 @@
 """Support for KNX select entities."""
 
-from typing import override
+from typing import Any, override
 
-from xknx import XKNX
-from xknx.devices import Device as XknxDevice, RawValue
+from xknx.devices import RawValue
 
 from homeassistant import config_entries
 from homeassistant.components.select import SelectEntity
@@ -15,7 +14,10 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    async_get_current_platform,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
@@ -24,12 +26,20 @@ from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
     CONF_SYNC_STATE,
+    DOMAIN,
     KNX_ADDRESS,
     KNX_MODULE_KEY,
 )
-from .entity import KnxYamlEntity, build_yaml_unique_id
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
 from .schema import SelectSchema
+from .storage.const import CONF_ENTITY, CONF_GA_SELECT, CONF_OPTION, CONF_OPTIONS
+from .storage.util import ConfigExtractor
 
 
 async def async_setup_entry(
@@ -39,43 +49,46 @@ async def async_setup_entry(
 ) -> None:
     """Set up select(s) for KNX platform."""
     knx_module = hass.data[KNX_MODULE_KEY]
-    config: list[ConfigType] = knx_module.config_yaml[Platform.SELECT]
-
-    async_add_entities(KNXSelect(knx_module, entity_config) for entity_config in config)
-
-
-def _create_raw_value(xknx: XKNX, config: ConfigType) -> RawValue:
-    """Return a KNX RawValue to be used within XKNX."""
-    return RawValue(
-        xknx,
-        name=config[CONF_NAME],
-        payload_length=config[CONF_PAYLOAD_LENGTH],
-        group_address=config[KNX_ADDRESS],
-        group_address_state=config.get(CONF_STATE_ADDRESS),
-        respond_to_read=config[CONF_RESPOND_TO_READ],
-        sync_state=config[CONF_SYNC_STATE],
+    platform = async_get_current_platform()
+    knx_module.config_store.add_platform(
+        platform=Platform.SELECT,
+        controller=KnxUiEntityPlatformController(
+            knx_module=knx_module,
+            entity_platform=platform,
+            entity_class=KnxUiSelect,
+        ),
     )
 
+    entities: list[KnxYamlEntity | KnxUiEntity] = []
+    if yaml_platform_config := knx_module.config_yaml.get(Platform.SELECT):
+        entities.extend(
+            KnxYamlSelect(knx_module, entity_config)
+            for entity_config in yaml_platform_config
+        )
+    if ui_config := knx_module.config_store.data["entities"].get(Platform.SELECT):
+        entities.extend(
+            KnxUiSelect(knx_module, unique_id, config)
+            for unique_id, config in ui_config.items()
+        )
+    if entities:
+        async_add_entities(entities)
 
-class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
+
+class _KnxSelect(SelectEntity, RestoreEntity):
     """Representation of a KNX select."""
 
     _device: RawValue
+    _option_payloads: dict[str, int]
 
-    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
-        """Initialize a KNX select."""
-        self._device = _create_raw_value(knx_module.xknx, config)
-        super().__init__(
-            knx_module=knx_module,
-            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
-            entity_config=config,
-        )
-        self._option_payloads: dict[str, int] = {
-            option[SelectSchema.CONF_OPTION]: option[CONF_PAYLOAD]
-            for option in config[SelectSchema.CONF_OPTIONS]
-        }
+    def init_base(self) -> None:
+        """Initialize attributes shared by the YAML and UI variants."""
         self._attr_options = list(self._option_payloads)
-        self._attr_current_option = None
+
+    @property
+    @override
+    def current_option(self) -> str | None:
+        """Return the option the current payload is assigned to."""
+        return self.option_from_payload(self._device.remote_value.value)
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -87,14 +100,6 @@ class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
                 and (option := self._option_payloads.get(last_state.state)) is not None
             ):
                 self._device.remote_value.update_value(option)
-
-    @override
-    def after_update_callback(self, device: XknxDevice) -> None:
-        """Call after device was updated."""
-        self._attr_current_option = self.option_from_payload(
-            self._device.remote_value.value
-        )
-        super().after_update_callback(device)
 
     def option_from_payload(self, payload: int | None) -> str | None:
         """Return the option a given payload is assigned to."""
@@ -110,3 +115,62 @@ class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
         """Change the selected option."""
         payload = self._option_payloads[option]
         await self._device.set(payload)
+
+
+class KnxYamlSelect(_KnxSelect, KnxYamlEntity):
+    """Representation of a KNX select configured from YAML."""
+
+    _device: RawValue
+
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
+        """Initialize a KNX select."""
+        self._device = RawValue(
+            knx_module.xknx,
+            name=config[CONF_NAME],
+            payload_length=config[CONF_PAYLOAD_LENGTH],
+            group_address=config[KNX_ADDRESS],
+            group_address_state=config.get(CONF_STATE_ADDRESS),
+            respond_to_read=config[CONF_RESPOND_TO_READ],
+            sync_state=config[CONF_SYNC_STATE],
+        )
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
+            entity_config=config,
+        )
+        self._option_payloads = {
+            option[SelectSchema.CONF_OPTION]: option[CONF_PAYLOAD]
+            for option in config[SelectSchema.CONF_OPTIONS]
+        }
+        self.init_base()
+
+
+class KnxUiSelect(_KnxSelect, KnxUiEntity):
+    """Representation of a KNX select configured from the UI."""
+
+    _device: RawValue
+
+    def __init__(
+        self, knx_module: KNXModule, unique_id: str, config: dict[str, Any]
+    ) -> None:
+        """Initialize a KNX select."""
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=unique_id,
+            entity_config=config[CONF_ENTITY],
+        )
+        knx_conf = ConfigExtractor(config[DOMAIN])
+        self._device = RawValue(
+            knx_module.xknx,
+            name=config[CONF_ENTITY][CONF_NAME],
+            payload_length=knx_conf.get(CONF_PAYLOAD_LENGTH),
+            group_address=knx_conf.get_write(CONF_GA_SELECT),
+            group_address_state=knx_conf.get_state_and_passive(CONF_GA_SELECT),
+            respond_to_read=knx_conf.get(CONF_RESPOND_TO_READ),
+            sync_state=knx_conf.get(CONF_SYNC_STATE),
+        )
+        self._option_payloads = {
+            option[CONF_OPTION]: option[CONF_PAYLOAD]
+            for option in knx_conf.get(CONF_OPTIONS)
+        }
+        self.init_base()

--- a/homeassistant/components/knx/storage/const.py
+++ b/homeassistant/components/knx/storage/const.py
@@ -78,6 +78,11 @@ CONF_GA_SATURATION: Final = "ga_saturation"
 # Scene
 CONF_GA_SCENE: Final = "ga_scene"
 
+# Select
+CONF_GA_SELECT: Final = "ga_select"
+CONF_OPTIONS: Final = "options"
+CONF_OPTION: Final = "option"
+
 # Sensor
 CONF_ALWAYS_CALLBACK: Final = "always_callback"
 

--- a/homeassistant/components/knx/storage/const.py
+++ b/homeassistant/components/knx/storage/const.py
@@ -80,7 +80,7 @@ CONF_GA_SCENE: Final = "ga_scene"
 
 # Select
 CONF_GA_SELECT: Final = "ga_select"
-CONF_OPTIONS: Final = "options"
+# CONF_OPTIONS comes from homeassistant.const
 CONF_OPTION: Final = "option"
 
 # Sensor

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -662,12 +662,17 @@ SELECT_KNX_SCHEMA = AllSerializeFirst(
     vol.Schema(
         {
             vol.Required(CONF_PAYLOAD_LENGTH): vol.Coerce(int),
-            vol.Required(CONF_OPTIONS): [
-                vol.Schema(
-                    {vol.Required(CONF_PAYLOAD): vol.Coerce(int)},
-                    extra=vol.ALLOW_EXTRA,
-                )
-            ],
+            # An empty list would yield an entity that can never be set. YAML
+            # accepts it, but nothing can rely on that here yet.
+            vol.Required(CONF_OPTIONS): vol.All(
+                [
+                    vol.Schema(
+                        {vol.Required(CONF_PAYLOAD): vol.Coerce(int)},
+                        extra=vol.ALLOW_EXTRA,
+                    )
+                ],
+                vol.Length(min=1),
+            ),
         },
         extra=vol.ALLOW_EXTRA,
     ),

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -607,7 +607,15 @@ def _select_options_validator(config: dict[str, Any]) -> dict[str, Any]:
 SELECT_KNX_SCHEMA = AllSerializeFirst(
     vol.Schema(
         {
-            vol.Required(CONF_GA_SELECT): GASelector(write_required=True),
+            # A select sends raw payloads, so any DPT is acceptable and none is
+            # needed. The classes are still declared because the frontend accepts
+            # no group address at all when none of validDPTs, dptClasses or
+            # dptSelect is given - same reason as for the button platform.
+            vol.Required(CONF_GA_SELECT): GASelector(
+                write_required=True,
+                dpt=["numeric", "enum", "complex", "string"],
+                dpt_required=False,
+            ),
             vol.Required(CONF_PAYLOAD_LENGTH, default=0): selector.NumberSelector(
                 selector.NumberSelectorConfig(
                     min=0, max=14, step=1, mode=selector.NumberSelectorMode.BOX

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_MODE,
     CONF_NAME,
+    CONF_OPTIONS,
     CONF_PAYLOAD,
     CONF_PLATFORM,
     CONF_UNIT_OF_MEASUREMENT,
@@ -116,7 +117,6 @@ from .const import (
     CONF_GA_WHITE_SWITCH,
     CONF_IGNORE_AUTO_MODE,
     CONF_OPTION,
-    CONF_OPTIONS,
     CONF_SPEED,
     CONF_TARGET_TEMPERATURE,
 )

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -1,6 +1,7 @@
 """KNX entity store schema."""
 
 from enum import StrEnum, unique
+from typing import Any
 
 import voluptuous as vol
 from xknx.dpt import DPTBase, DPTBinary, DPTNumeric
@@ -25,6 +26,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_MODE,
     CONF_NAME,
+    CONF_PAYLOAD,
     CONF_PLATFORM,
     CONF_UNIT_OF_MEASUREMENT,
     Platform,
@@ -95,6 +97,7 @@ from .const import (
     CONF_GA_RED_SWITCH,
     CONF_GA_SATURATION,
     CONF_GA_SCENE,
+    CONF_GA_SELECT,
     CONF_GA_SEND,
     CONF_GA_SENSOR,
     CONF_GA_SETPOINT_SHIFT,
@@ -111,6 +114,8 @@ from .const import (
     CONF_GA_WHITE_BRIGHTNESS,
     CONF_GA_WHITE_SWITCH,
     CONF_IGNORE_AUTO_MODE,
+    CONF_OPTION,
+    CONF_OPTIONS,
     CONF_SPEED,
     CONF_TARGET_TEMPERATURE,
 )
@@ -572,6 +577,79 @@ SCENE_KNX_SCHEMA = vol.Schema(
     },
 )
 
+
+def _select_options_validator(config: dict[str, Any]) -> dict[str, Any]:
+    """Reject options that can not be told apart or do not fit the payload.
+
+    Mirrors select_options_sub_validator for YAML configuration.
+    """
+    payload_length: int = config[CONF_PAYLOAD_LENGTH]
+    max_payload = 0x3F if payload_length == 0 else 256**payload_length - 1
+    options_seen: set[str] = set()
+    payloads_seen: set[int] = set()
+    for item in config[CONF_OPTIONS]:
+        option = item[CONF_OPTION]
+        payload = item[CONF_PAYLOAD]
+        if payload > max_payload:
+            raise vol.Invalid(
+                f"'payload: {payload}' for 'option: {option}' exceeds possible"
+                f" maximum of 'payload_length: {payload_length}': {max_payload}"
+            )
+        if option in options_seen:
+            raise vol.Invalid(f"duplicate item for 'option' not allowed: {option}")
+        options_seen.add(option)
+        if payload in payloads_seen:
+            raise vol.Invalid(f"duplicate item for 'payload' not allowed: {payload}")
+        payloads_seen.add(payload)
+    return config
+
+
+SELECT_KNX_SCHEMA = AllSerializeFirst(
+    vol.Schema(
+        {
+            vol.Required(CONF_GA_SELECT): GASelector(write_required=True),
+            vol.Required(CONF_PAYLOAD_LENGTH, default=0): selector.NumberSelector(
+                selector.NumberSelectorConfig(
+                    min=0, max=14, step=1, mode=selector.NumberSelectorMode.BOX
+                )
+            ),
+            vol.Required(CONF_OPTIONS): selector.ObjectSelector(
+                selector.ObjectSelectorConfig(
+                    fields={
+                        CONF_OPTION: {
+                            "selector": {"text": {}},
+                            "required": True,
+                        },
+                        CONF_PAYLOAD: {
+                            "selector": {
+                                "number": {
+                                    "min": 0,
+                                    "mode": selector.NumberSelectorMode.BOX,
+                                }
+                            },
+                            "required": True,
+                        },
+                    },
+                    multiple=True,
+                    label_field=CONF_OPTION,
+                    translation_key=(
+                        "component.knx.config_panel.entities.create.select.knx.options"
+                    ),
+                ),
+            ),
+            vol.Optional(
+                CONF_RESPOND_TO_READ, default=False
+            ): selector.BooleanSelector(),
+            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        },
+    ),
+    # NumberSelector yields a float - RawValue needs an int.
+    vol.Schema(
+        {vol.Required(CONF_PAYLOAD_LENGTH): vol.Coerce(int)}, extra=vol.ALLOW_EXTRA
+    ),
+    _select_options_validator,
+)
+
 SWITCH_KNX_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
@@ -814,6 +892,7 @@ KNX_SCHEMA_FOR_PLATFORM = {
     Platform.NOTIFY: NOTIFY_KNX_SCHEMA,
     Platform.NUMBER: NUMBER_KNX_SCHEMA,
     Platform.SCENE: SCENE_KNX_SCHEMA,
+    Platform.SELECT: SELECT_KNX_SCHEMA,
     Platform.SENSOR: SENSOR_KNX_SCHEMA,
     Platform.SWITCH: SWITCH_KNX_SCHEMA,
     Platform.TEXT: TEXT_KNX_SCHEMA,

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -55,6 +55,7 @@ from ..const import (
     SceneConf,
 )
 from ..dpt import get_supported_dpts
+from ..schema import max_payload_value
 from ..validation import validate_number_attributes, validate_sensor_attributes
 from .const import (
     CONF_ALWAYS_CALLBACK,
@@ -584,7 +585,7 @@ def _select_options_validator(config: dict[str, Any]) -> dict[str, Any]:
     Mirrors select_options_sub_validator for YAML configuration.
     """
     payload_length: int = config[CONF_PAYLOAD_LENGTH]
-    max_payload = 0x3F if payload_length == 0 else 256**payload_length - 1
+    max_payload = max_payload_value(payload_length)
     options_seen: set[str] = set()
     payloads_seen: set[int] = set()
     for item in config[CONF_OPTIONS]:
@@ -640,6 +641,9 @@ SELECT_KNX_SCHEMA = AllSerializeFirst(
                     },
                     multiple=True,
                     label_field=CONF_OPTION,
+                    # so a collapsed row shows which payload it sends without
+                    # having to be opened
+                    description_field=CONF_PAYLOAD,
                     translation_key=(
                         "component.knx.config_panel.entities.create.select.knx.options"
                     ),
@@ -651,9 +655,21 @@ SELECT_KNX_SCHEMA = AllSerializeFirst(
             vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
         },
     ),
-    # NumberSelector yields a float - RawValue needs an int.
+    # The selectors yield floats and accept numeric strings, while RawValue needs
+    # ints and the validator below compares payloads against a maximum. An
+    # ObjectSelector validates each field but discards the coerced value, so the
+    # payloads have to be coerced here - cv.positive_int does it for YAML.
     vol.Schema(
-        {vol.Required(CONF_PAYLOAD_LENGTH): vol.Coerce(int)}, extra=vol.ALLOW_EXTRA
+        {
+            vol.Required(CONF_PAYLOAD_LENGTH): vol.Coerce(int),
+            vol.Required(CONF_OPTIONS): [
+                vol.Schema(
+                    {vol.Required(CONF_PAYLOAD): vol.Coerce(int)},
+                    extra=vol.ALLOW_EXTRA,
+                )
+            ],
+        },
+        extra=vol.ALLOW_EXTRA,
     ),
     _select_options_validator,
 )

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -924,6 +924,31 @@
             }
           }
         },
+        "select": {
+          "description": "The KNX select platform allows selecting a value from a list of options. Each option is assigned a raw payload, so group objects without a standard DPT - like forced control - can be operated.",
+          "knx": {
+            "ga_select": {
+              "description": "Group address the payload of the selected option is sent to.",
+              "label": "Select"
+            },
+            "options": {
+              "description": "Name and payload of every selectable option. Payloads must be unique.",
+              "fields": {
+                "option": {
+                  "name": "Option"
+                },
+                "payload": {
+                  "name": "Payload"
+                }
+              },
+              "label": "Options"
+            },
+            "payload_length": {
+              "description": "Number of bytes sent to the group address. Use 0 for payloads of up to 6 bit - that is what small group objects like DPT 1, 2 and 3 use, for example forced control.",
+              "label": "Payload length"
+            }
+          }
+        },
         "sensor": {
           "description": "Read-only entity for numeric or string datapoints. Temperature, percent etc.",
           "knx": {

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -2096,6 +2096,12 @@
       dict({
         'name': 'ga_select',
         'options': dict({
+          'dptClasses': list([
+            'numeric',
+            'enum',
+            'complex',
+            'string',
+          ]),
           'passive': True,
           'state': dict({
             'required': False,

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -2089,6 +2089,95 @@
     'type': 'result',
   })
 # ---
+# name: test_knx_get_schema[select]
+  dict({
+    'id': 1,
+    'result': list([
+      dict({
+        'name': 'ga_select',
+        'options': dict({
+          'passive': True,
+          'state': dict({
+            'required': False,
+          }),
+          'write': dict({
+            'required': True,
+          }),
+        }),
+        'required': True,
+        'type': 'knx_group_address',
+      }),
+      dict({
+        'default': 0,
+        'name': 'payload_length',
+        'required': True,
+        'selector': dict({
+          'number': dict({
+            'max': 14.0,
+            'min': 0.0,
+            'mode': 'box',
+            'step': 1.0,
+          }),
+        }),
+        'type': 'ha_selector',
+      }),
+      dict({
+        'name': 'options',
+        'required': True,
+        'selector': dict({
+          'object': dict({
+            'fields': dict({
+              'option': dict({
+                'required': True,
+                'selector': dict({
+                  'text': dict({
+                    'multiline': False,
+                    'multiple': False,
+                  }),
+                }),
+              }),
+              'payload': dict({
+                'required': True,
+                'selector': dict({
+                  'number': dict({
+                    'min': 0.0,
+                    'mode': 'box',
+                    'step': 1.0,
+                  }),
+                }),
+              }),
+            }),
+            'label_field': 'option',
+            'multiple': True,
+            'translation_key': 'component.knx.config_panel.entities.create.select.knx.options',
+          }),
+        }),
+        'type': 'ha_selector',
+      }),
+      dict({
+        'default': False,
+        'name': 'respond_to_read',
+        'optional': True,
+        'required': False,
+        'selector': dict({
+          'boolean': dict({
+          }),
+        }),
+        'type': 'ha_selector',
+      }),
+      dict({
+        'allow_false': False,
+        'default': True,
+        'name': 'sync_state',
+        'optional': True,
+        'required': False,
+        'type': 'knx_sync_state',
+      }),
+    ]),
+    'success': True,
+    'type': 'result',
+  })
+# ---
 # name: test_knx_get_schema[sensor]
   dict({
     'id': 1,

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -2132,6 +2132,7 @@
         'required': True,
         'selector': dict({
           'object': dict({
+            'description_field': 'payload',
             'fields': dict({
               'option': dict({
                 'required': True,

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -10,13 +10,15 @@ from homeassistant.components.knx.const import (
     KNX_ADDRESS,
 )
 from homeassistant.components.knx.schema import SelectSchema
-from homeassistant.const import CONF_NAME, CONF_PAYLOAD, STATE_UNKNOWN
+from homeassistant.const import CONF_NAME, CONF_PAYLOAD, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 
+from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
 from tests.common import mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 
 async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
@@ -219,3 +221,87 @@ async def test_select_dpt_20_103_all_options(
     await knx.receive_write(test_passive_address, (4,))
     state = hass.states.get("select.test")
     assert state.state == "Off"
+
+
+async def test_select_ui_create(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test a select created from the UI - forced control of a shutter (DPT 2)."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_select": {"write": "1/1/1", "state": "2/2/2"},
+            "payload_length": 0,
+            "options": [
+                {"option": "No control", "payload": 0},
+                {"option": "Force up", "payload": 2},
+                {"option": "Force down", "payload": 3},
+            ],
+            "respond_to_read": False,
+            "sync_state": True,
+        },
+    )
+    await knx.assert_read("2/2/2")
+    await knx.receive_response("2/2/2", 2)
+    knx.assert_state("select.test", "Force up")
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "Force down"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", 3)
+    knx.assert_state("select.test", "Force down")
+
+
+@pytest.mark.parametrize(
+    ("options", "error_start"),
+    [
+        (
+            [{"option": "A", "payload": 0}, {"option": "A", "payload": 1}],
+            "duplicate item for 'option' not allowed: A",
+        ),
+        (
+            [{"option": "A", "payload": 1}, {"option": "B", "payload": 1}],
+            "duplicate item for 'payload' not allowed: 1",
+        ),
+        (
+            [{"option": "A", "payload": 64}],
+            "'payload: 64' for 'option: A' exceeds possible maximum",
+        ),
+    ],
+    ids=["duplicate_option", "duplicate_payload", "payload_too_large"],
+)
+async def test_select_ui_invalid_options(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    options: list[dict[str, str | int]],
+    error_start: str,
+) -> None:
+    """Test the UI schema rejects options that can not be told apart."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "knx/validate_entity",
+            "platform": Platform.SELECT,
+            "data": {
+                "entity": {"name": "test"},
+                "knx": {
+                    "ga_select": {"write": "1/1/1"},
+                    "payload_length": 0,
+                    "options": options,
+                },
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False
+    assert res["result"]["error_base"].startswith(error_start)

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -279,12 +279,14 @@ async def test_select_ui_create(
             [{"option": "A", "payload": "70"}],
             "'payload: 70' for 'option: A' exceeds possible maximum",
         ),
+        ([], "length of value must be at least 1"),
     ],
     ids=[
         "duplicate_option",
         "duplicate_payload",
         "payload_too_large",
         "payload_string_too_large",
+        "no_options",
     ],
 )
 async def test_select_ui_invalid_options(

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -274,8 +274,18 @@ async def test_select_ui_create(
             [{"option": "A", "payload": 64}],
             "'payload: 64' for 'option: A' exceeds possible maximum",
         ),
+        (
+            # coerced to an int first, so the maximum is reported, not a type error
+            [{"option": "A", "payload": "70"}],
+            "'payload: 70' for 'option: A' exceeds possible maximum",
+        ),
     ],
-    ids=["duplicate_option", "duplicate_payload", "payload_too_large"],
+    ids=[
+        "duplicate_option",
+        "duplicate_payload",
+        "payload_too_large",
+        "payload_string_too_large",
+    ],
 )
 async def test_select_ui_invalid_options(
     hass: HomeAssistant,
@@ -305,3 +315,79 @@ async def test_select_ui_invalid_options(
     assert res["success"], res
     assert res["result"]["success"] is False
     assert res["result"]["error_base"].startswith(error_start)
+
+
+async def test_select_ui_payload_is_coerced_to_int(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test non-integer payloads are truncated, like cv.positive_int does for YAML."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_select": {"write": "1/1/1"},
+            "payload_length": 0,
+            # the number field in the frontend allows this - it must not reach xknx
+            "options": [
+                {"option": "A", "payload": 1.0},
+                {"option": "B", "payload": 2.5},
+            ],
+        },
+    )
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "B"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", 2)
+    knx.assert_state("select.test", "B")
+
+
+async def test_select_ui_update(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+    hass_ws_client: WebSocketGenerator,
+) -> None:
+    """Test a stored configuration can be read back and saved again unchanged."""
+    await knx.setup_integration()
+    entity = await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "ga_select": {"write": "1/1/1"},
+            "payload_length": 0,
+            "options": [{"option": "A", "payload": 0}, {"option": "B", "payload": 2}],
+        },
+    )
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": "knx/get_entity_config", "entity_id": entity.entity_id}
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    stored = res["result"]["data"]
+
+    await client.send_json_auto_id(
+        {
+            "type": "knx/update_entity",
+            "platform": Platform.SELECT,
+            "entity_id": entity.entity_id,
+            "data": stored,
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is True, res["result"]
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": entity.entity_id, "option": "B"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", 2)


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->

## Proposed change

`select` was the only KNX platform that could be configured in YAML but not in the KNX
configuration panel — the other fifteen are already there. This adds it.

The interesting part is `options`. A KNX select maps a list of names to raw payloads, so the panel
needs a repeatable pair of fields rather than a single value. That is what
`ObjectSelector(fields=…, multiple=True)` provides, and the frontend already renders it, including
reordering — so no frontend change is required. `label_field` and `description_field` make a
collapsed row show both the option name and the payload it sends.

What this unlocks are the group objects that have no useful standard DPT and therefore no dedicated
platform: forced control (DPT 2) is the common one. I have eighteen of these — shutter and blind
forced control, an awning lock, two heating circuit pump overrides, a pool UV priority-off and a
rainwater pump runtime — and until now every one of them had to live in YAML while everything else
in the installation moved to the panel years ago.

The platform code is split into `_KnxSelect` / `KnxYamlSelect` / `KnxUiSelect` following `cover.py`
and `switch.py`. `current_option` became a property derived from the xknx value instead of an
attribute cached in `after_update_callback`, which is what `switch`, `fan`, `light` and `number`
already do.

Validation mirrors `select_options_sub_validator` and reuses its `max_payload_value` helper, so the
YAML and UI paths cannot drift: duplicate names, duplicate payloads and payloads that do not fit
the configured length are rejected with the same messages. Payloads are coerced to `int` in the
storage schema because `ObjectSelector` validates its fields but discards the coerced values, and
`cv.positive_int` does the same for YAML.

### One thing a reviewer should know

**The DPT on `ga_select` is stored but never used.** A select sends raw payloads, so it works with
any group address regardless of the address' DPT — including the DPT 2 objects this is mostly for.
The DPT classes are declared anyway, because a `knx_group_address` selector that declares none of
`validDPTs`, `dptClasses` or `dptSelect` makes the frontend reject *every* address:
`_getAcceptedDPTs()` returns an empty list and nothing matches it. The `button` platform sets the
precedent for raw payloads (`dpt_required=False`) and I followed it, but unlike `button` nothing
here consumes the value — picking a DPT only narrows the address dropdown. If you would prefer an
explicit "any address" mode in the selector, say so; that is a knx-frontend change and I am happy
to open it there instead.

One asymmetry worth pointing out: the storage schema requires at least one option, while YAML still accepts an empty list. An entity without options can never be set, but tightening YAML would break existing configurations, and nothing relies on that leniency in the panel yet.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
