### PR TITLE
Fix/tplink omada switch port refresh

### DIFF
--- a/homeassistant/components/tplink_omada/switch.py
+++ b/homeassistant/components/tplink_omada/switch.py
@@ -56,7 +56,7 @@ async def async_setup_entry(
         omada_client = controller.omada_client
         switch = await omada_client.get_switch(device)
         coordinator = controller.get_switch_port_coordinator(switch)
-        await coordinator.async_request_refresh()
+        await coordinator.async_refresh()
 
         entities: list[Entity] = []
         entities.extend(

--- a/tests/components/tplink_omada/test_switch.py
+++ b/tests/components/tplink_omada/test_switch.py
@@ -1,9 +1,11 @@
 """Tests for TP-Link Omada switch entities."""
 
+import asyncio
 from datetime import timedelta
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
 from syrupy.assertion import SnapshotAssertion
 from tplink_omada_client import SwitchPortSettings
 from tplink_omada_client.definitions import PoEMode
@@ -11,12 +13,14 @@ from tplink_omada_client.devices import (
     OmadaGateway,
     OmadaGatewayPortConfig,
     OmadaGatewayPortStatus,
+    OmadaListDevice,
     OmadaSwitch,
     OmadaSwitchPortDetails,
 )
 from tplink_omada_client.exceptions import InvalidDevice
 
 from homeassistant.components import switch
+from homeassistant.components.tplink_omada.const import DOMAIN
 from homeassistant.components.tplink_omada.coordinator import POLL_GATEWAY
 from homeassistant.const import ATTR_ENTITY_ID
 from homeassistant.core import HomeAssistant, ServiceResponse
@@ -27,6 +31,54 @@ from tests.common import MockConfigEntry, async_fire_time_changed
 
 UPDATE_INTERVAL = timedelta(seconds=10)
 POLL_INTERVAL = timedelta(seconds=POLL_GATEWAY + 10)
+
+
+@pytest.mark.usefixtures("mock_omada_client")
+async def test_switch_port_setup_does_not_depend_on_debounced_refresh(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_omada_site_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+) -> None:
+    """Test switch port setup waits for coordinator data."""
+    mock_config_entry.add_to_hass(hass)
+    switch_setup_started = asyncio.Event()
+    original_get_switch = mock_omada_site_client.get_switch.return_value
+    original_get_switch_ports = mock_omada_site_client.get_switch_ports.return_value
+    sensor_port_refresh_started = asyncio.Event()
+    get_switch_calls = 0
+    get_switch_ports_calls = 0
+
+    async def get_switch(device: OmadaListDevice) -> OmadaSwitch:
+        nonlocal get_switch_calls
+        get_switch_calls += 1
+        if get_switch_calls == 2:
+            switch_setup_started.set()
+            await sensor_port_refresh_started.wait()
+        return original_get_switch
+
+    async def get_switch_ports(
+        network_switch: OmadaSwitch,
+    ) -> list[OmadaSwitchPortDetails]:
+        nonlocal get_switch_ports_calls
+        get_switch_ports_calls += 1
+        if get_switch_ports_calls == 1:
+            sensor_port_refresh_started.set()
+            await switch_setup_started.wait()
+            await asyncio.sleep(0.1)
+        return original_get_switch_ports
+
+    mock_omada_site_client.get_switch.side_effect = get_switch
+    mock_omada_site_client.get_switch_ports.side_effect = get_switch_ports
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    entity_id = entity_registry.async_get_entity_id(
+        "switch", DOMAIN, "54-AF-97-00-00-01_000000000000000000000001_poe"
+    )
+    assert entity_id is not None
+    assert hass.states.get(entity_id) is not None
 
 
 async def test_poe_switches(


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->
None

## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Use a direct coordinator refresh during TP-Link Omada switch port setup instead of requesting a debounced refresh.
This avoids a timing issue where `coordinator.data` could still be `None` when `switch.py` creates port switch entities.
A regression test was added for this setup path.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes https://github.com/home-assistant/core/issues/177755
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [X] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
