### PR TITLE
Adding a tray self-cleaning button to compatible docks

### DIFF
--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -315,8 +315,6 @@ class RoborockDockActionButtonEntity(RoborockEntityV1, ButtonEntity):
     @override
     async def async_press(self) -> None:
         """Press the button."""
-        # `send` already raises HomeAssistantError with the command_failed
-        # translation key on a RoborockException.
         await self.send(
             self.entity_description.command,
             self.entity_description.param,

--- a/homeassistant/components/roborock/button.py
+++ b/homeassistant/components/roborock/button.py
@@ -5,9 +5,11 @@ from dataclasses import dataclass
 import logging
 from typing import Any, override
 
+from roborock.data import RoborockDockTypeCode
 from roborock.devices.traits.v1.consumeable import ConsumableAttribute
 from roborock.exceptions import RoborockException
 from roborock.roborock_message import RoborockZeoProtocol
+from roborock.roborock_typing import RoborockCommand
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.const import EntityCategory
@@ -35,6 +37,40 @@ from .entity import (
 _LOGGER = logging.getLogger(__name__)
 
 PARALLEL_UPDATES = 0
+
+
+SELF_CLEANING_TRAY_DOCKS = {
+    RoborockDockTypeCode.shell_3_dock,
+}
+"""Dock types known to support the cleaning tray self-clean routine."""
+
+
+def supports_tray_self_clean(coordinator: RoborockDataUpdateCoordinator) -> bool:
+    """Return True for docks with a self-cleaning cleaning tray."""
+    return coordinator.properties_api.status.dock_type in SELF_CLEANING_TRAY_DOCKS
+
+
+@dataclass(frozen=True, kw_only=True)
+class RoborockDockActionButtonDescription(ButtonEntityDescription):
+    """Describes a Roborock dock action button entity."""
+
+    command: RoborockCommand
+    param: dict[str, Any] | list[Any] | int | None = None
+    is_dock_entity: bool = True
+    is_supported: Callable[[RoborockDataUpdateCoordinator], bool] = lambda _: True
+
+
+DOCK_ACTION_BUTTON_DESCRIPTIONS = [
+    RoborockDockActionButtonDescription(
+        key="clean_cleaning_tray",
+        translation_key="clean_cleaning_tray",
+        # "Amethyst" is Roborock's internal name for the dock's cleaning tray
+        # self-clean routine. The entity is named after the user facing
+        # feature in the Roborock app instead.
+        command=RoborockCommand.APP_AMETHYST_SELF_CHECK,
+        is_supported=supports_tray_self_clean,
+    ),
+]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -154,6 +190,11 @@ async def async_setup_entry(
                 for description in CONSUMABLE_BUTTON_DESCRIPTIONS
                 if description.is_supported(coordinator)
             )
+            entities.extend(
+                RoborockDockActionButtonEntity(coordinator, description)
+                for description in DOCK_ACTION_BUTTON_DESCRIPTIONS
+                if description.is_supported(coordinator)
+            )
 
             async def async_add_routine_buttons() -> None:
                 try:
@@ -246,6 +287,40 @@ class RoborockButtonEntity(RoborockEntityV1, ButtonEntity):
                     "command": "RESET_CONSUMABLE",
                 },
             ) from err
+
+
+class RoborockDockActionButtonEntity(RoborockEntityV1, ButtonEntity):
+    """A class to define Roborock dock action button entities."""
+
+    entity_description: RoborockDockActionButtonDescription
+
+    def __init__(
+        self,
+        coordinator: RoborockDataUpdateCoordinator,
+        entity_description: RoborockDockActionButtonDescription,
+    ) -> None:
+        """Create a dock action button entity."""
+        device_info = (
+            coordinator.dock_device_info
+            if entity_description.is_dock_entity
+            else coordinator.device_info
+        )
+        super().__init__(
+            f"{entity_description.key}_{coordinator.duid_slug}",
+            device_info,
+            api=coordinator.properties_api.command,
+        )
+        self.entity_description = entity_description
+
+    @override
+    async def async_press(self) -> None:
+        """Press the button."""
+        # `send` already raises HomeAssistantError with the command_failed
+        # translation key on a RoborockException.
+        await self.send(
+            self.entity_description.command,
+            self.entity_description.param,
+        )
 
 
 class RoborockRoutineButtonEntity(RoborockEntity, ButtonEntity):

--- a/homeassistant/components/roborock/icons.json
+++ b/homeassistant/components/roborock/icons.json
@@ -21,6 +21,9 @@
       }
     },
     "button": {
+      "clean_cleaning_tray": {
+        "default": "mdi:tray-arrow-down"
+      },
       "reset_air_filter_consumable": {
         "default": "mdi:air-filter"
       },

--- a/homeassistant/components/roborock/strings.json
+++ b/homeassistant/components/roborock/strings.json
@@ -94,6 +94,9 @@
       }
     },
     "button": {
+      "clean_cleaning_tray": {
+        "name": "Clean cleaning tray"
+      },
       "empty_dustbin": {
         "name": "Empty dustbin"
       },


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
Adds a ```clean_cleaning_tray``` button to the Roborock integration that runs the dock's cleaning tray self-clean routine, using the existing ```RoborockCommand.APP_AMETHYST_SELF_CHECK``` command in python-roborock. No dependency change is required.

"Amethyst" appears to be Roborock's internal name for this routine. The entity is named after the user-facing feature in the Roborock app instead, and a code comment records the mapping.

The button is attached to the dock device rather than the vacuum, alongside the existing dock consumable buttons. It is only created for dock types known to have a self-cleaning tray, which currently means a single entry:

```python
SELF_CLEANING_TRAY_DOCKS = {
    RoborockDockTypeCode.shell_3_dock,
}
```

I have deliberately kept that set to the one dock I could verify against real hardware rather than guessing at other dock types. Other users can extend it as their docks are confirmed.

This is a step towards the "Dock controls" item listed as planned functionality in the integration documentation.
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [X] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

The command was not previously exposed anywhere. I identified it by probing candidate commands through ```vacuum.send_command``` against my own device and observing which one started the same cycle as the "clean the cleaning tray" button in the Roborock app.

Verified on a Roborock Qrevo (dock type 14 / shell_3_dock), firmware 02.29.22. Pressing the button starts the same tray self-clean cycle as the app. Tested end to end by running the patched integration as a custom component on that device: the button appears on the dock device, triggers the cycle, and is correctly absent when the dock type is changed to one not in ```SELF_CLEANING_TRAY_DOCKS```.

Happy to move this behind a dedicated trait method in python-roborock instead of sending a raw command, if maintainers prefer that direction — the existing consumable buttons already use trait methods, and this could follow.

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [X] I understand the code I am submitting and can explain how it works.
- [X] The code change is tested and works locally.
- [X] Local tests pass. **Your PR cannot be merged unless tests pass**
- [X] There is no commented out code in this PR.
- [X] I have followed the [development checklist][dev-checklist]
- [X] I have followed the [perfect PR recommendations][perfect-pr]
- [X] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [X] Tests have been added to verify that the new code works.
- [X] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [X] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
