### PR TITLE
Add KNX select entity UI configuration

### DIFF
--- a/homeassistant/components/knx/const.py
+++ b/homeassistant/components/knx/const.py
@@ -209,6 +209,7 @@ SUPPORTED_PLATFORMS_UI: Final = {
     Platform.NOTIFY,
     Platform.NUMBER,
     Platform.SCENE,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.TEXT,
@@ -283,3 +284,16 @@ class SceneConf:
     """Common config keys for scene."""
 
     SCENE_NUMBER: Final = "scene_number"
+
+
+class SelectConf:
+    """Config keys for select."""
+
+    # shared between YAML and UI
+    OPTIONS: Final = "options"
+    OPTION: Final = "option"
+    # UI only
+    OPTIONS_SOURCE: Final = "options_source"
+    GA_ENUM: Final = "ga_enum"
+    GA_CUSTOM: Final = "ga_custom"
+    CUSTOM_OPTIONS: Final = "custom_options"

--- a/homeassistant/components/knx/dpt.py
+++ b/homeassistant/components/knx/dpt.py
@@ -4,7 +4,14 @@ from collections.abc import Mapping
 from functools import cache
 from typing import Literal, NotRequired, TypedDict, cast
 
-from xknx.dpt import DPTBase, DPTComplex, DPTComplexFieldSchema, DPTEnum, DPTNumeric
+from xknx.dpt import (
+    DPTBase,
+    DPTBinary,
+    DPTComplex,
+    DPTComplexFieldSchema,
+    DPTEnum,
+    DPTNumeric,
+)
 from xknx.dpt.dpt_16 import DPTString
 
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
@@ -63,6 +70,17 @@ def get_supported_dpts() -> Mapping[str, DPTInfo]:
             _add_complex_details(info, cast(type[DPTComplex], dpt_class))
         dpts[dpt_number_str] = info
     return dpts
+
+
+def raw_payload_length(dpt_cls: type[DPTBase]) -> int:
+    """Return the payload length to use for a `RawValue` of a DPT.
+
+    DPT 1, 2 and 3 are integrated in the APDU header. Their transcoders report a
+    bit count while `RawValue` uses `0` to mark such binary payloads.
+    """
+    if dpt_cls.payload_type is DPTBinary:
+        return 0
+    return dpt_cls.payload_length
 
 
 def _ha_dpt_class(dpt_cls: type[DPTBase]) -> HaDptClass:

--- a/homeassistant/components/knx/schema.py
+++ b/homeassistant/components/knx/schema.py
@@ -71,6 +71,7 @@ from .const import (
     FanZeroMode,
     NumberConf,
     SceneConf,
+    SelectConf,
 )
 from .dpt import get_supported_dpts
 from .validation import (
@@ -139,8 +140,8 @@ def select_options_sub_validator(entity_config: OrderedDict) -> OrderedDict:
     payloads_seen = set()
     payload_length = entity_config[CONF_PAYLOAD_LENGTH]
 
-    for opt in entity_config[SelectSchema.CONF_OPTIONS]:
-        option = opt[SelectSchema.CONF_OPTION]
+    for opt in entity_config[SelectConf.OPTIONS]:
+        option = opt[SelectConf.OPTION]
         payload = opt[CONF_PAYLOAD]
         if payload > (max_payload := _max_payload_value(payload_length)):
             raise vol.Invalid(
@@ -831,9 +832,6 @@ class SelectSchema(KNXPlatformSchema):
 
     PLATFORM = Platform.SELECT
 
-    CONF_OPTION = "option"
-    CONF_OPTIONS = "options"
-
     ENTITY_SCHEMA = vol.All(
         _entity_base_schema(PLATFORM).extend(
             {
@@ -842,9 +840,9 @@ class SelectSchema(KNXPlatformSchema):
                 vol.Required(CONF_PAYLOAD_LENGTH): vol.All(
                     vol.Coerce(int), vol.Range(min=0, max=14)
                 ),
-                vol.Required(CONF_OPTIONS): [
+                vol.Required(SelectConf.OPTIONS): [
                     {
-                        vol.Required(CONF_OPTION): vol.Coerce(str),
+                        vol.Required(SelectConf.OPTION): vol.Coerce(str),
                         vol.Required(CONF_PAYLOAD): cv.positive_int,
                     }
                 ],

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -1,5 +1,6 @@
 """Support for KNX select entities."""
 
+import logging
 from typing import override
 
 from xknx.devices import RawValue
@@ -43,6 +44,8 @@ from .entity import (
 from .knx_module import KNXModule
 from .storage.const import CONF_ENTITY
 from .storage.util import ConfigExtractor
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -149,6 +152,13 @@ class _KNXSelect(SelectEntity, RestoreEntity):
                 key for key, value in self._option_payloads.items() if value == payload
             )
         except StopIteration:
+            if payload is not None:
+                _LOGGER.debug(
+                    "No option configured for payload %s of %s: %s",
+                    payload,
+                    self.entity_id,
+                    self._device.remote_value.telegram,
+                )
             return None
 
     @override

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -2,8 +2,8 @@
 
 from typing import override
 
-from xknx import XKNX
-from xknx.devices import Device as XknxDevice, RawValue
+from xknx.devices import RawValue
+from xknx.dpt import DPTBase, DPTEnum
 
 from homeassistant import config_entries
 from homeassistant.components.select import SelectEntity
@@ -15,7 +15,10 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+from homeassistant.helpers.entity_platform import (
+    AddConfigEntryEntitiesCallback,
+    async_get_current_platform,
+)
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.typing import ConfigType
 
@@ -24,12 +27,21 @@ from .const import (
     CONF_RESPOND_TO_READ,
     CONF_STATE_ADDRESS,
     CONF_SYNC_STATE,
+    CONF_VALUE,
+    DOMAIN,
     KNX_ADDRESS,
     KNX_MODULE_KEY,
+    SelectConf,
 )
-from .entity import KnxYamlEntity, build_yaml_unique_id
+from .entity import (
+    KnxUiEntity,
+    KnxUiEntityPlatformController,
+    KnxYamlEntity,
+    build_yaml_unique_id,
+)
 from .knx_module import KNXModule
-from .schema import SelectSchema
+from .storage.const import CONF_ENTITY
+from .storage.util import ConfigExtractor
 
 
 async def async_setup_entry(
@@ -39,43 +51,78 @@ async def async_setup_entry(
 ) -> None:
     """Set up select(s) for KNX platform."""
     knx_module = hass.data[KNX_MODULE_KEY]
-    config: list[ConfigType] = knx_module.config_yaml[Platform.SELECT]
+    platform = async_get_current_platform()
+    knx_module.config_store.add_platform(
+        platform=Platform.SELECT,
+        controller=KnxUiEntityPlatformController(
+            knx_module=knx_module,
+            entity_platform=platform,
+            entity_class=KnxUiSelect,
+        ),
+    )
 
-    async_add_entities(KNXSelect(knx_module, entity_config) for entity_config in config)
+    entities: list[KnxYamlEntity | KnxUiEntity] = []
+    if yaml_platform_config := knx_module.config_yaml.get(Platform.SELECT):
+        entities.extend(
+            KnxYamlSelect(knx_module, entity_config)
+            for entity_config in yaml_platform_config
+        )
+    if ui_config := knx_module.config_store.data["entities"].get(Platform.SELECT):
+        entities.extend(
+            KnxUiSelect(knx_module, unique_id, config)
+            for unique_id, config in ui_config.items()
+        )
+    if entities:
+        async_add_entities(entities)
 
 
-def _create_raw_value(xknx: XKNX, config: ConfigType) -> RawValue:
-    """Return a KNX RawValue to be used within XKNX."""
-    return RawValue(
-        xknx,
-        name=config[CONF_NAME],
-        payload_length=config[CONF_PAYLOAD_LENGTH],
-        group_address=config[KNX_ADDRESS],
-        group_address_state=config.get(CONF_STATE_ADDRESS),
-        respond_to_read=config[CONF_RESPOND_TO_READ],
-        sync_state=config[CONF_SYNC_STATE],
+def _payload_from_value(transcoder: type[DPTBase], value: object) -> int:
+    """Encode a value to its raw integer payload using the DPT transcoder."""
+    return int.from_bytes(
+        transcoder.validate_payload(transcoder.to_knx(value)), byteorder="big"
     )
 
 
-class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
+def _options_from_enum_dpt(dpt: str) -> tuple[dict[str, int], int]:
+    """Return option payloads and payload length of an enum DPT."""
+    transcoder: type[DPTEnum] | None = DPTEnum.parse_transcoder(dpt)
+    assert transcoder is not None  # already checked by validation
+    option_payloads = {
+        member.name.lower(): member.value for member in transcoder.data_type
+    }
+    return option_payloads, transcoder.payload_length
+
+
+def _options_from_custom_config(
+    options: list[ConfigType], dpt: str | None
+) -> tuple[dict[str, int], int]:
+    """Return option payloads and payload length of manually configured options.
+
+    Options are either typed values encoded by the DPT, or raw payloads. All
+    options share one payload length - enforced by the entity store schema.
+    """
+    transcoder: type[DPTBase] | None = (
+        DPTBase.parse_transcoder(dpt) if dpt is not None else None
+    )
+    payload_length = transcoder.payload_length if transcoder is not None else None
+    option_payloads: dict[str, int] = {}
+    for option in options:
+        name = option[SelectConf.OPTION]
+        if CONF_VALUE in option:
+            assert transcoder is not None  # typed values require a DPT
+            option_payloads[name] = _payload_from_value(transcoder, option[CONF_VALUE])
+        else:
+            option_payloads[name] = int(option[CONF_PAYLOAD], 16)
+            payload_length = option[CONF_PAYLOAD_LENGTH]
+    assert payload_length is not None  # set from the DPT or a raw option
+    return option_payloads, payload_length
+
+
+class _KNXSelect(SelectEntity, RestoreEntity):
     """Representation of a KNX select."""
 
     _device: RawValue
-
-    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
-        """Initialize a KNX select."""
-        self._device = _create_raw_value(knx_module.xknx, config)
-        super().__init__(
-            knx_module=knx_module,
-            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
-            entity_config=config,
-        )
-        self._option_payloads: dict[str, int] = {
-            option[SelectSchema.CONF_OPTION]: option[CONF_PAYLOAD]
-            for option in config[SelectSchema.CONF_OPTIONS]
-        }
-        self._attr_options = list(self._option_payloads)
-        self._attr_current_option = None
+    _option_payloads: dict[str, int]
 
     @override
     async def async_added_to_hass(self) -> None:
@@ -88,13 +135,11 @@ class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
             ):
                 self._device.remote_value.update_value(option)
 
+    @property
     @override
-    def after_update_callback(self, device: XknxDevice) -> None:
-        """Call after device was updated."""
-        self._attr_current_option = self.option_from_payload(
-            self._device.remote_value.value
-        )
-        super().after_update_callback(device)
+    def current_option(self) -> str | None:
+        """Return the currently selected option."""
+        return self.option_from_payload(self._device.remote_value.value)
 
     def option_from_payload(self, payload: int | None) -> str | None:
         """Return the option a given payload is assigned to."""
@@ -110,3 +155,74 @@ class KNXSelect(KnxYamlEntity, SelectEntity, RestoreEntity):
         """Change the selected option."""
         payload = self._option_payloads[option]
         await self._device.set(payload)
+
+
+class KnxYamlSelect(_KNXSelect, KnxYamlEntity):
+    """Representation of a KNX select configured via YAML."""
+
+    _device: RawValue
+
+    def __init__(self, knx_module: KNXModule, config: ConfigType) -> None:
+        """Initialize a KNX select."""
+        self._device = RawValue(
+            knx_module.xknx,
+            name=config[CONF_NAME],
+            payload_length=config[CONF_PAYLOAD_LENGTH],
+            group_address=config[KNX_ADDRESS],
+            group_address_state=config.get(CONF_STATE_ADDRESS),
+            respond_to_read=config[CONF_RESPOND_TO_READ],
+            sync_state=config[CONF_SYNC_STATE],
+        )
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=build_yaml_unique_id(self._device.remote_value.group_address),
+            entity_config=config,
+        )
+        self._option_payloads = {
+            option[SelectConf.OPTION]: option[CONF_PAYLOAD]
+            for option in config[SelectConf.OPTIONS]
+        }
+        self._attr_options = list(self._option_payloads)
+
+
+class KnxUiSelect(_KNXSelect, KnxUiEntity):
+    """Representation of a KNX select configured via the UI."""
+
+    _device: RawValue
+
+    def __init__(
+        self, knx_module: KNXModule, unique_id: str, config: ConfigType
+    ) -> None:
+        """Initialize a KNX select."""
+        knx_conf = ConfigExtractor(config[DOMAIN])
+        source = knx_conf.get(SelectConf.OPTIONS_SOURCE)
+        # the group address key tells how options are defined
+        if SelectConf.GA_ENUM in source:
+            ga_key = SelectConf.GA_ENUM
+            dpt = knx_conf.get_dpt(SelectConf.OPTIONS_SOURCE, ga_key)
+            assert dpt is not None  # already checked by validation
+            self._option_payloads, payload_length = _options_from_enum_dpt(dpt)
+        else:
+            ga_key = SelectConf.GA_CUSTOM
+            self._option_payloads, payload_length = _options_from_custom_config(
+                source[SelectConf.CUSTOM_OPTIONS],
+                knx_conf.get_dpt(SelectConf.OPTIONS_SOURCE, ga_key),
+            )
+
+        self._device = RawValue(
+            knx_module.xknx,
+            name=config[CONF_ENTITY][CONF_NAME],
+            payload_length=payload_length,
+            group_address=knx_conf.get_write(SelectConf.OPTIONS_SOURCE, ga_key),
+            group_address_state=knx_conf.get_state_and_passive(
+                SelectConf.OPTIONS_SOURCE, ga_key
+            ),
+            respond_to_read=knx_conf.get(CONF_RESPOND_TO_READ),
+            sync_state=knx_conf.get(CONF_SYNC_STATE),
+        )
+        super().__init__(
+            knx_module=knx_module,
+            unique_id=unique_id,
+            entity_config=config[CONF_ENTITY],
+        )
+        self._attr_options = list(self._option_payloads)

--- a/homeassistant/components/knx/select.py
+++ b/homeassistant/components/knx/select.py
@@ -33,6 +33,7 @@ from .const import (
     KNX_MODULE_KEY,
     SelectConf,
 )
+from .dpt import raw_payload_length
 from .entity import (
     KnxUiEntity,
     KnxUiEntityPlatformController,
@@ -90,7 +91,7 @@ def _options_from_enum_dpt(dpt: str) -> tuple[dict[str, int], int]:
     option_payloads = {
         member.name.lower(): member.value for member in transcoder.data_type
     }
-    return option_payloads, transcoder.payload_length
+    return option_payloads, raw_payload_length(transcoder)
 
 
 def _options_from_custom_config(
@@ -104,7 +105,7 @@ def _options_from_custom_config(
     transcoder: type[DPTBase] | None = (
         DPTBase.parse_transcoder(dpt) if dpt is not None else None
     )
-    payload_length = transcoder.payload_length if transcoder is not None else None
+    payload_length = raw_payload_length(transcoder) if transcoder is not None else None
     option_payloads: dict[str, int] = {}
     for option in options:
         name = option[SelectConf.OPTION]

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -55,7 +55,7 @@ from ..const import (
     SceneConf,
     SelectConf,
 )
-from ..dpt import get_supported_dpts
+from ..dpt import get_supported_dpts, raw_payload_length
 from ..validation import validate_number_attributes, validate_sensor_attributes
 from .const import (
     CONF_ALWAYS_CALLBACK,
@@ -607,7 +607,7 @@ def _select_options_sub_validator(config: dict) -> dict:
 
     dpt = source[SelectConf.GA_CUSTOM].get(CONF_DPT)
     transcoder = DPTBase.parse_transcoder(dpt) if dpt is not None else None
-    payload_length = transcoder.payload_length if transcoder is not None else None
+    payload_length = raw_payload_length(transcoder) if transcoder is not None else None
 
     options_seen: set[str] = set()
     payloads_seen: set[int] = set()

--- a/homeassistant/components/knx/storage/entity_store_schema.py
+++ b/homeassistant/components/knx/storage/entity_store_schema.py
@@ -1,5 +1,6 @@
 """KNX entity store schema."""
 
+from collections.abc import Hashable
 from enum import StrEnum, unique
 
 import voluptuous as vol
@@ -25,6 +26,7 @@ from homeassistant.const import (
     CONF_ENTITY_ID,
     CONF_MODE,
     CONF_NAME,
+    CONF_PAYLOAD,
     CONF_PLATFORM,
     CONF_UNIT_OF_MEASUREMENT,
     Platform,
@@ -51,6 +53,7 @@ from ..const import (
     FanZeroMode,
     NumberConf,
     SceneConf,
+    SelectConf,
 )
 from ..dpt import get_supported_dpts
 from ..validation import validate_number_attributes, validate_sensor_attributes
@@ -121,6 +124,7 @@ from .knx_selector import (
     GroupSelectOption,
     KnxPayloadSelector,
     KNXSectionFlat,
+    KnxSelectOptionsSelector,
     SyncStateSelector,
 )
 
@@ -572,6 +576,125 @@ SCENE_KNX_SCHEMA = vol.Schema(
     },
 )
 
+
+def _select_options_sub_validator(config: dict) -> dict:
+    """Validate select options against the configured DPT.
+
+    The `options_source` group selects one of two modes, distinguished by the
+    group address key:
+    - `ga_enum`: options are derived from a required enum DPT.
+    - `ga_custom`: options are configured manually, each as a typed value (needs
+      a DPT) or a raw payload. Payload ranges are validated per option by the
+      options selector.
+
+    All options are sent to the same group address, so they have to share a
+    single payload length - taken from the DPT if one is configured.
+    """
+    source = config[SelectConf.OPTIONS_SOURCE]
+    if SelectConf.GA_ENUM in source:
+        dpt = source[SelectConf.GA_ENUM].get(CONF_DPT)
+        if dpt is None or get_supported_dpts()[dpt]["dpt_class"] != "enum":
+            raise vol.Invalid(
+                "An enum data point type is required",
+                path=[SelectConf.OPTIONS_SOURCE, SelectConf.GA_ENUM],
+            )
+        return config
+
+    error_path: list[Hashable] = [SelectConf.OPTIONS_SOURCE, SelectConf.CUSTOM_OPTIONS]
+    options = source[SelectConf.CUSTOM_OPTIONS]
+    if not options:
+        raise vol.Invalid("At least one option is required", path=error_path)
+
+    dpt = source[SelectConf.GA_CUSTOM].get(CONF_DPT)
+    transcoder = DPTBase.parse_transcoder(dpt) if dpt is not None else None
+    payload_length = transcoder.payload_length if transcoder is not None else None
+
+    options_seen: set[str] = set()
+    payloads_seen: set[int] = set()
+    for option in options:
+        name = option[SelectConf.OPTION]
+        if name in options_seen:
+            raise vol.Invalid(f"Duplicate option not allowed: {name}", path=error_path)
+        options_seen.add(name)
+
+        if CONF_VALUE in option:
+            if transcoder is None:
+                raise vol.Invalid(
+                    f"A data point type is required for typed option '{name}'",
+                    path=error_path,
+                )
+            try:
+                payload = int.from_bytes(
+                    transcoder.validate_payload(transcoder.to_knx(option[CONF_VALUE])),
+                    byteorder="big",
+                )
+            except ConversionError as ex:
+                raise vol.Invalid(
+                    f"Value invalid for option '{name}' with DPT "
+                    f"{transcoder.dpt_number_str()}",
+                    path=error_path,
+                ) from ex
+        else:
+            option_length = option[CONF_PAYLOAD_LENGTH]
+            if payload_length is None:
+                payload_length = option_length
+            elif option_length != payload_length:
+                expected = (
+                    f"DPT {transcoder.dpt_number_str()}"
+                    if transcoder is not None
+                    else "the other options"
+                )
+                raise vol.Invalid(
+                    f"Payload length {option_length} of option '{name}' doesn't "
+                    f"match payload length {payload_length} of {expected}",
+                    path=error_path,
+                )
+            payload = int(option[CONF_PAYLOAD], 16)
+
+        if payload in payloads_seen:
+            raise vol.Invalid(
+                f"Duplicate payload not allowed for option '{name}'", path=error_path
+            )
+        payloads_seen.add(payload)
+    return config
+
+
+SELECT_KNX_SCHEMA = AllSerializeFirst(
+    vol.Schema(
+        {
+            vol.Required(SelectConf.OPTIONS_SOURCE): GroupSelect(
+                GroupSelectOption(
+                    translation_key="from_dpt",
+                    schema={
+                        vol.Required(SelectConf.GA_ENUM): GASelector(
+                            write_required=True, dpt=["enum"]
+                        ),
+                    },
+                ),
+                GroupSelectOption(
+                    translation_key="custom",
+                    schema={
+                        vol.Required(SelectConf.GA_CUSTOM): GASelector(
+                            write_required=True,
+                            dpt=["numeric", "enum", "complex", "string"],
+                            dpt_required=False,
+                        ),
+                        vol.Required(
+                            SelectConf.CUSTOM_OPTIONS
+                        ): KnxSelectOptionsSelector(ga_path=SelectConf.GA_CUSTOM),
+                    },
+                ),
+                collapsible=False,
+            ),
+            vol.Optional(
+                CONF_RESPOND_TO_READ, default=False
+            ): selector.BooleanSelector(),
+            vol.Optional(CONF_SYNC_STATE, default=True): SyncStateSelector(),
+        }
+    ),
+    _select_options_sub_validator,
+)
+
 SWITCH_KNX_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_GA_SWITCH): GASelector(write_required=True, valid_dpt="1"),
@@ -814,6 +937,7 @@ KNX_SCHEMA_FOR_PLATFORM = {
     Platform.NOTIFY: NOTIFY_KNX_SCHEMA,
     Platform.NUMBER: NUMBER_KNX_SCHEMA,
     Platform.SCENE: SCENE_KNX_SCHEMA,
+    Platform.SELECT: SELECT_KNX_SCHEMA,
     Platform.SENSOR: SENSOR_KNX_SCHEMA,
     Platform.SWITCH: SWITCH_KNX_SCHEMA,
     Platform.TEXT: TEXT_KNX_SCHEMA,

--- a/homeassistant/components/knx/storage/knx_selector.py
+++ b/homeassistant/components/knx/storage/knx_selector.py
@@ -8,7 +8,7 @@ import voluptuous as vol
 
 from homeassistant.const import CONF_PAYLOAD
 
-from ..const import CONF_PAYLOAD_LENGTH, CONF_VALUE
+from ..const import CONF_PAYLOAD_LENGTH, CONF_VALUE, SelectConf
 from ..dpt import HaDptClass, get_supported_dpts
 from ..validation import ga_validator, maybe_ga_validator, sync_state_validator
 from .const import CONF_DPT, CONF_GA_PASSIVE, CONF_GA_STATE, CONF_GA_WRITE
@@ -371,3 +371,45 @@ class KnxPayloadSelector(KNXSelectorBase):
                     )
         # CONF_VALUE branch needs subvalidator as we don't have the DPT available here
         return validated
+
+
+class KnxSelectOptionsSelector(KNXSelectorBase):
+    """Selector for a list of select options mapping names to payloads.
+
+    Each option pairs a name with a payload following the `KnxPayloadSelector`
+    contract (a typed `value` or a raw `payload` + `payload_length`), resolved
+    against the linked group address's DPT via `ga_path`.
+    """
+
+    selector_type = "knx_select_options"
+
+    def __init__(self, ga_path: str) -> None:
+        """Initialize the options selector."""
+        self.ga_path = ga_path
+        self._payload_selector = KnxPayloadSelector(ga_path=ga_path)
+        self.schema = vol.Schema([self._validate_option])
+
+    @override
+    def serialize(self) -> dict[str, Any]:
+        """Serialize the selector to a dictionary."""
+        return {
+            "type": self.selector_type,
+            "ga_path": self.ga_path,
+        }
+
+    def _validate_option(self, data: Any) -> dict[str, Any]:
+        """Validate a single option entry.
+
+        The typed `value` branch needs the DPT and is validated by the platform
+        sub-validator.
+        """
+        if not isinstance(data, dict):
+            raise vol.Invalid("Each option must be a dictionary")
+        option = data.get(SelectConf.OPTION)
+        if not isinstance(option, str) or not option:
+            raise vol.Invalid("Option name is required", path=[SelectConf.OPTION])
+        payload = {
+            key: value for key, value in data.items() if key != SelectConf.OPTION
+        }
+        validated = self._payload_selector(payload)
+        return {SelectConf.OPTION: option, **validated}

--- a/homeassistant/components/knx/strings.json
+++ b/homeassistant/components/knx/strings.json
@@ -924,6 +924,37 @@
             }
           }
         },
+        "select": {
+          "description": "The KNX select platform lets you present a list of named options and map each to a value sent to and read from the KNX bus.",
+          "knx": {
+            "options_source": {
+              "custom_options": {
+                "description": "Define the selectable options and the value each one sends.",
+                "label": "Options"
+              },
+              "description": "Choose how the selectable options are defined.",
+              "ga_custom": {
+                "description": "Group address the selected value is sent to and read from.",
+                "label": "[%key:component::knx::config_panel::common::group_address%]"
+              },
+              "ga_enum": {
+                "description": "[%key:component::knx::config_panel::entities::create::select::knx::options_source::ga_custom::description%]",
+                "label": "[%key:component::knx::config_panel::common::group_address%]"
+              },
+              "options": {
+                "custom": {
+                  "description": "Define the options and the value each one sends manually.",
+                  "label": "Custom options"
+                },
+                "from_dpt": {
+                  "description": "The options are derived from the values of an enum data point type.",
+                  "label": "Options from data point type"
+                }
+              },
+              "title": "Options"
+            }
+          }
+        },
         "sensor": {
           "description": "Read-only entity for numeric or string datapoints. Temperature, percent etc.",
           "knx": {
@@ -1089,6 +1120,10 @@
         "raw_length": "Payload length",
         "raw_length_description": "Length of the raw payload in bytes. For DPT 1, 2 and 3 use `0`.",
         "raw_payload": "Raw payload"
+      },
+      "knx-select-options-selector": {
+        "add_option": "Add option",
+        "option": "Option name"
       }
     }
   },

--- a/tests/components/knx/fixtures/config_store_select.json
+++ b/tests/components/knx/fixtures/config_store_select.json
@@ -1,0 +1,67 @@
+{
+  "version": 2,
+  "minor_version": 4,
+  "key": "knx/config_store.json",
+  "data": {
+    "entities": {
+      "select": {
+        "knx_es_01KCXYT0WEJEQQ13SGCY1NHCYS": {
+          "entity": {
+            "name": "test",
+            "device_info": null,
+            "entity_category": null
+          },
+          "knx": {
+            "options_source": {
+              "ga_custom": {
+                "write": "1/1/1",
+                "state": "2/2/2",
+                "passive": []
+              },
+              "custom_options": [
+                {
+                  "option": "No control",
+                  "payload": "0x0",
+                  "payload_length": 0
+                },
+                {
+                  "option": "Control - Off",
+                  "payload": "0x2",
+                  "payload_length": 0
+                },
+                {
+                  "option": "Control - On",
+                  "payload": "0x3",
+                  "payload_length": 0
+                }
+              ]
+            },
+            "respond_to_read": false,
+            "sync_state": true
+          }
+        },
+        "knx_es_01KCXYT0WEJEQQ13SGCY1NHCYT": {
+          "entity": {
+            "name": "from dpt",
+            "device_info": null,
+            "entity_category": null
+          },
+          "knx": {
+            "options_source": {
+              "ga_enum": {
+                "write": "3/3/3",
+                "state": "4/4/4",
+                "passive": [],
+                "dpt": "20.102"
+              }
+            },
+            "respond_to_read": false,
+            "sync_state": true
+          }
+        }
+      }
+    },
+    "expose": {},
+    "time_server": {}
+  }
+}

--- a/tests/components/knx/snapshots/test_websocket.ambr
+++ b/tests/components/knx/snapshots/test_websocket.ambr
@@ -2089,6 +2089,97 @@
     'type': 'result',
   })
 # ---
+# name: test_knx_get_schema[select]
+  dict({
+    'id': 1,
+    'result': list([
+      dict({
+        'collapsible': False,
+        'name': 'options_source',
+        'required': True,
+        'schema': list([
+          dict({
+            'schema': list([
+              dict({
+                'name': 'ga_enum',
+                'options': dict({
+                  'dptClasses': list([
+                    'enum',
+                  ]),
+                  'passive': True,
+                  'state': dict({
+                    'required': False,
+                  }),
+                  'write': dict({
+                    'required': True,
+                  }),
+                }),
+                'required': True,
+                'type': 'knx_group_address',
+              }),
+            ]),
+            'translation_key': 'from_dpt',
+            'type': 'knx_group_select_option',
+          }),
+          dict({
+            'schema': list([
+              dict({
+                'name': 'ga_custom',
+                'options': dict({
+                  'dptClasses': list([
+                    'numeric',
+                    'enum',
+                    'complex',
+                    'string',
+                  ]),
+                  'passive': True,
+                  'state': dict({
+                    'required': False,
+                  }),
+                  'write': dict({
+                    'required': True,
+                  }),
+                }),
+                'required': True,
+                'type': 'knx_group_address',
+              }),
+              dict({
+                'ga_path': 'ga_custom',
+                'name': 'custom_options',
+                'required': True,
+                'type': 'knx_select_options',
+              }),
+            ]),
+            'translation_key': 'custom',
+            'type': 'knx_group_select_option',
+          }),
+        ]),
+        'type': 'knx_group_select',
+      }),
+      dict({
+        'default': False,
+        'name': 'respond_to_read',
+        'optional': True,
+        'required': False,
+        'selector': dict({
+          'boolean': dict({
+          }),
+        }),
+        'type': 'ha_selector',
+      }),
+      dict({
+        'allow_false': False,
+        'default': True,
+        'name': 'sync_state',
+        'optional': True,
+        'required': False,
+        'type': 'knx_sync_state',
+      }),
+    ]),
+    'success': True,
+    'type': 'result',
+  })
+# ---
 # name: test_knx_get_schema[sensor]
   dict({
     'id': 1,

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -1,5 +1,6 @@
 """Test KNX select."""
 
+import logging
 from typing import Any
 
 import pytest
@@ -24,7 +25,9 @@ from tests.common import mock_restore_cache
 from tests.typing import WebSocketGenerator
 
 
-async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
+async def test_select_dpt_2_simple(
+    hass: HomeAssistant, knx: KNXTestKit, caplog: pytest.LogCaptureFixture
+) -> None:
     """Test simple KNX select."""
     _options = [
         {CONF_PAYLOAD: 0b00, SelectConf.OPTION: "No control"},
@@ -78,9 +81,17 @@ async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None
     assert state.state == "Control - On"
 
     # update from KNX with undefined value
-    await knx.receive_write(test_address, 0b01)
+    with caplog.at_level(logging.DEBUG):
+        await knx.receive_write(test_address, 0b01)
     state = hass.states.get("select.test")
     assert state.state is STATE_UNKNOWN
+    # the unconfigured payload and its telegram are logged for diagnosis
+    assert any(
+        "No option configured for payload 1 of select.test" in message
+        and test_address in message
+        for record in caplog.records
+        if (message := record.getMessage())
+    )
 
     # select invalid option
     with pytest.raises(ServiceValidationError):

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -1,5 +1,7 @@
 """Test KNX select."""
 
+from typing import Any
+
 import pytest
 
 from homeassistant.components.knx.const import (
@@ -8,23 +10,26 @@ from homeassistant.components.knx.const import (
     CONF_STATE_ADDRESS,
     CONF_SYNC_STATE,
     KNX_ADDRESS,
+    SelectConf,
 )
 from homeassistant.components.knx.schema import SelectSchema
-from homeassistant.const import CONF_NAME, CONF_PAYLOAD, STATE_UNKNOWN
+from homeassistant.const import CONF_NAME, CONF_PAYLOAD, STATE_UNKNOWN, Platform
 from homeassistant.core import HomeAssistant, State
 from homeassistant.exceptions import ServiceValidationError
 
+from . import KnxEntityGenerator
 from .conftest import KNXTestKit
 
 from tests.common import mock_restore_cache
+from tests.typing import WebSocketGenerator
 
 
 async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test simple KNX select."""
     _options = [
-        {CONF_PAYLOAD: 0b00, SelectSchema.CONF_OPTION: "No control"},
-        {CONF_PAYLOAD: 0b10, SelectSchema.CONF_OPTION: "Control - Off"},
-        {CONF_PAYLOAD: 0b11, SelectSchema.CONF_OPTION: "Control - On"},
+        {CONF_PAYLOAD: 0b00, SelectConf.OPTION: "No control"},
+        {CONF_PAYLOAD: 0b10, SelectConf.OPTION: "Control - Off"},
+        {CONF_PAYLOAD: 0b11, SelectConf.OPTION: "Control - On"},
     ]
     test_address = "1/1/1"
     await knx.setup_integration(
@@ -34,7 +39,7 @@ async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None
                 KNX_ADDRESS: test_address,
                 CONF_SYNC_STATE: False,
                 CONF_PAYLOAD_LENGTH: 0,
-                SelectSchema.CONF_OPTIONS: _options,
+                SelectConf.OPTIONS: _options,
             }
         }
     )
@@ -91,9 +96,9 @@ async def test_select_dpt_2_simple(hass: HomeAssistant, knx: KNXTestKit) -> None
 async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX select with passive_address and respond_to_read restoring state."""
     _options = [
-        {CONF_PAYLOAD: 0b00, SelectSchema.CONF_OPTION: "No control"},
-        {CONF_PAYLOAD: 0b10, SelectSchema.CONF_OPTION: "Control - Off"},
-        {CONF_PAYLOAD: 0b11, SelectSchema.CONF_OPTION: "Control - On"},
+        {CONF_PAYLOAD: 0b00, SelectConf.OPTION: "No control"},
+        {CONF_PAYLOAD: 0b10, SelectConf.OPTION: "Control - Off"},
+        {CONF_PAYLOAD: 0b11, SelectConf.OPTION: "Control - On"},
     ]
     test_address = "1/1/1"
     test_passive_address = "3/3/3"
@@ -107,7 +112,7 @@ async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit) -> Non
                 KNX_ADDRESS: [test_address, test_passive_address],
                 CONF_RESPOND_TO_READ: True,
                 CONF_PAYLOAD_LENGTH: 0,
-                SelectSchema.CONF_OPTIONS: _options,
+                SelectConf.OPTIONS: _options,
             }
         }
     )
@@ -128,9 +133,9 @@ async def test_select_dpt_2_restore(hass: HomeAssistant, knx: KNXTestKit) -> Non
 async def test_select_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> None:
     """Test KNX select with state_address restores state until bus read completes."""
     _options = [
-        {CONF_PAYLOAD: 0b00, SelectSchema.CONF_OPTION: "No control"},
-        {CONF_PAYLOAD: 0b10, SelectSchema.CONF_OPTION: "Control - Off"},
-        {CONF_PAYLOAD: 0b11, SelectSchema.CONF_OPTION: "Control - On"},
+        {CONF_PAYLOAD: 0b00, SelectConf.OPTION: "No control"},
+        {CONF_PAYLOAD: 0b10, SelectConf.OPTION: "Control - Off"},
+        {CONF_PAYLOAD: 0b11, SelectConf.OPTION: "Control - On"},
     ]
     test_address = "1/1/1"
     test_state_address = "2/2/2"
@@ -144,7 +149,7 @@ async def test_select_state_restore(hass: HomeAssistant, knx: KNXTestKit) -> Non
                 KNX_ADDRESS: test_address,
                 CONF_STATE_ADDRESS: test_state_address,
                 CONF_PAYLOAD_LENGTH: 0,
-                SelectSchema.CONF_OPTIONS: _options,
+                SelectConf.OPTIONS: _options,
             }
         }
     )
@@ -164,11 +169,11 @@ async def test_select_dpt_20_103_all_options(
 ) -> None:
     """Test KNX select with state_address, passive_address and respond_to_read."""
     _options = [
-        {CONF_PAYLOAD: 0, SelectSchema.CONF_OPTION: "Auto"},
-        {CONF_PAYLOAD: 1, SelectSchema.CONF_OPTION: "Legio protect"},
-        {CONF_PAYLOAD: 2, SelectSchema.CONF_OPTION: "Normal"},
-        {CONF_PAYLOAD: 3, SelectSchema.CONF_OPTION: "Reduced"},
-        {CONF_PAYLOAD: 4, SelectSchema.CONF_OPTION: "Off"},
+        {CONF_PAYLOAD: 0, SelectConf.OPTION: "Auto"},
+        {CONF_PAYLOAD: 1, SelectConf.OPTION: "Legio protect"},
+        {CONF_PAYLOAD: 2, SelectConf.OPTION: "Normal"},
+        {CONF_PAYLOAD: 3, SelectConf.OPTION: "Reduced"},
+        {CONF_PAYLOAD: 4, SelectConf.OPTION: "Off"},
     ]
     test_address = "1/1/1"
     test_state_address = "2/2/2"
@@ -182,7 +187,7 @@ async def test_select_dpt_20_103_all_options(
                 CONF_STATE_ADDRESS: test_state_address,
                 CONF_RESPOND_TO_READ: True,
                 CONF_PAYLOAD_LENGTH: 1,
-                SelectSchema.CONF_OPTIONS: _options,
+                SelectConf.OPTIONS: _options,
             }
         }
     )
@@ -219,3 +224,246 @@ async def test_select_dpt_20_103_all_options(
     await knx.receive_write(test_passive_address, (4,))
     state = hass.states.get("select.test")
     assert state.state == "Off"
+
+
+async def test_select_ui_create_custom_raw(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test creating a select with custom raw options from the UI."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [
+                    {"option": "No control", "payload": "0x0", "payload_length": 0},
+                    {"option": "Control - Off", "payload": "0x2", "payload_length": 0},
+                    {"option": "Control - On", "payload": "0x3", "payload_length": 0},
+                ],
+            },
+            "sync_state": True,
+        },
+    )
+    knx.assert_state("select.test", STATE_UNKNOWN)
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "Control - On"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", 0x3)
+    knx.assert_state("select.test", "Control - On")
+
+    # update from KNX
+    await knx.receive_write("1/1/1", 0x2)
+    knx.assert_state("select.test", "Control - Off")
+
+
+async def test_select_ui_create_custom_typed(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test creating a select with custom typed options for a DPT address."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "options_source": {
+                "ga_custom": {"write": "1/1/1", "dpt": "5.010"},
+                "custom_options": [
+                    {"option": "Low", "value": 10},
+                    {"option": "High", "value": 200},
+                ],
+            },
+            "sync_state": True,
+        },
+    )
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "High"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", (200,))
+    knx.assert_state("select.test", "High")
+
+
+async def test_select_ui_create_custom_mixed(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test creating a select mixing typed and raw options for a DPT address."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "options_source": {
+                "ga_custom": {"write": "1/1/1", "dpt": "5.010"},
+                "custom_options": [
+                    {"option": "Typed", "value": 10},
+                    # raw payload matching the DPTs payload length
+                    {"option": "Raw", "payload": "0x14", "payload_length": 1},
+                ],
+            },
+            "sync_state": True,
+        },
+    )
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "Raw"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", (0x14,))
+    knx.assert_state("select.test", "Raw")
+
+
+async def test_select_ui_create_from_dpt(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test creating a select whose options are derived from an enum DPT."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "options_source": {
+                "ga_enum": {"write": "1/1/1", "state": "2/2/2", "dpt": "20.102"},
+            },
+            "sync_state": True,
+        },
+    )
+    # options are derived from DPT 20.102 (HVAC operation mode)
+    await knx.assert_read("2/2/2")
+    await knx.receive_response("2/2/2", (1,))
+    knx.assert_state("select.test", "comfort")
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "standby"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", (2,))
+    knx.assert_state("select.test", "standby")
+
+
+async def test_select_ui_load(knx: KNXTestKit) -> None:
+    """Test loading selects for both option sources from storage."""
+    await knx.setup_integration(config_store_fixture="config_store_select.json")
+
+    await knx.assert_read("2/2/2", response=0x2, ignore_order=True)
+    knx.assert_state("select.test", "Control - Off")
+
+    await knx.assert_read("4/4/4", response=(1,), ignore_order=True)
+    knx.assert_state("select.from_dpt", "comfort")
+
+
+@pytest.mark.parametrize(
+    "knx_config",
+    [
+        {  # enum mode without a DPT
+            "options_source": {"ga_enum": {"write": "1/1/1"}},
+        },
+        {  # enum mode with non-enum DPT
+            "options_source": {"ga_enum": {"write": "1/1/1", "dpt": "5.001"}},
+        },
+        {  # custom mode without options
+            "options_source": {"ga_custom": {"write": "1/1/1"}, "custom_options": []},
+        },
+        {  # custom raw options without payload length
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [{"option": "A", "payload": "0x1"}],
+            },
+        },
+        {  # raw payload out of bound for length
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [
+                    {"option": "A", "payload": "0x40", "payload_length": 0}
+                ],
+            },
+        },
+        {  # duplicate option name
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [
+                    {"option": "A", "payload": "0x1", "payload_length": 1},
+                    {"option": "A", "payload": "0x2", "payload_length": 1},
+                ],
+            },
+        },
+        {  # duplicate payload
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [
+                    {"option": "A", "payload": "0x1", "payload_length": 1},
+                    {"option": "B", "payload": "0x1", "payload_length": 1},
+                ],
+            },
+        },
+        {  # invalid typed value for DPT
+            "options_source": {
+                "ga_custom": {"write": "1/1/1", "dpt": "5.001"},
+                "custom_options": [{"option": "A", "value": 101}],
+            },
+        },
+        {  # payload lengths of options don't match each other
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [
+                    {"option": "A", "payload": "0x1", "payload_length": 1},
+                    {"option": "B", "payload": "0x1234", "payload_length": 2},
+                ],
+            },
+        },
+        {  # payload length doesn't match the DPT
+            "options_source": {
+                "ga_custom": {"write": "1/1/1", "dpt": "5.010"},
+                "custom_options": [
+                    {"option": "A", "payload": "0x1234", "payload_length": 2}
+                ],
+            },
+        },
+        {  # typed option without a DPT
+            "options_source": {
+                "ga_custom": {"write": "1/1/1"},
+                "custom_options": [{"option": "A", "value": 1}],
+            },
+        },
+    ],
+)
+async def test_select_ui_create_invalid(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    hass_ws_client: WebSocketGenerator,
+    knx_config: dict[str, Any],
+) -> None:
+    """Test creating a select with invalid data."""
+    await knx.setup_integration()
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {
+            "type": "knx/create_entity",
+            "platform": Platform.SELECT,
+            "data": {
+                "entity": {"name": "test"},
+                "knx": knx_config,
+            },
+        }
+    )
+    res = await client.receive_json()
+    assert res["success"], res
+    assert res["result"]["success"] is False

--- a/tests/components/knx/test_select.py
+++ b/tests/components/knx/test_select.py
@@ -359,6 +359,78 @@ async def test_select_ui_create_from_dpt(
     knx.assert_state("select.test", "standby")
 
 
+async def test_select_ui_create_from_binary_dpt(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test a select derived from a binary enum DPT sending binary telegrams."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "options_source": {
+                "ga_enum": {"write": "1/1/1", "state": "2/2/2", "dpt": "1.001"},
+            },
+            "sync_state": True,
+        },
+    )
+    # DPT 1 is integrated in the APDU header - not sent as byte array
+    await knx.assert_read("2/2/2", response=True)
+    knx.assert_state("select.test", "on")
+
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "off"},
+        blocking=True,
+    )
+    await knx.assert_write("1/1/1", False)
+    knx.assert_state("select.test", "off")
+
+
+async def test_select_ui_create_custom_binary_dpt(
+    hass: HomeAssistant,
+    knx: KNXTestKit,
+    create_ui_entity: KnxEntityGenerator,
+) -> None:
+    """Test custom options for a binary complex DPT."""
+    await knx.setup_integration()
+    await create_ui_entity(
+        platform=Platform.SELECT,
+        entity_data={"name": "test"},
+        knx_data={
+            "options_source": {
+                "ga_custom": {"write": "1/1/1", "dpt": "2.001"},
+                "custom_options": [
+                    {
+                        "option": "No control",
+                        "value": {"control": False, "value": "off"},
+                    },
+                    {
+                        "option": "Control - On",
+                        "value": {"control": True, "value": "on"},
+                    },
+                ],
+            },
+            "sync_state": True,
+        },
+    )
+    await hass.services.async_call(
+        "select",
+        "select_option",
+        {"entity_id": "select.test", "option": "Control - On"},
+        blocking=True,
+    )
+    # DPT 2.001 is a 2 bit payload - `control` and `value` bit set
+    await knx.assert_write("1/1/1", 0b11)
+    knx.assert_state("select.test", "Control - On")
+
+    await knx.receive_write("1/1/1", 0b00)
+    knx.assert_state("select.test", "No control")
+
+
 async def test_select_ui_load(knx: KNXTestKit) -> None:
     """Test loading selects for both option sources from storage."""
     await knx.setup_integration(config_store_fixture="config_store_select.json")


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Allow configuring KNX select entities from the UI in addition to YAML.

The options of a select entity can be defined in two ways, offered as a group select and distinguished by the group address key:
- "Options from data point type" (`ga_enum`): the options are derived from the values of a required enum DPT.
- "Custom options" (`ga_custom`): the options are defined manually, each either as a typed value encoded by the addresses DPT, or as a raw payload. All options share one payload length as they are sent to the same group address.

select.py is refactored into a shared base with separate YAML and UI entity classes, mirroring the other UI capable platforms. Config keys shared between YAML and UI live in a new SelectConf class.

This feature will need to have https://github.com/XKNX/knx-frontend/pull/434 merged and released.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: https://github.com/XKNX/knx-frontend/pull/434
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
