### PR TITLE
Fix Blink hardware_id rejected by OAuth v2 authorize endpoint

### DIFF
--- a/homeassistant/components/blink/__init__.py
+++ b/homeassistant/components/blink/__init__.py
@@ -14,7 +14,7 @@ from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
 
-from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, PLATFORMS
+from .const import DEFAULT_SCAN_INTERVAL, DOMAIN, LEGACY_HARDWARE_ID, PLATFORMS
 from .coordinator import BlinkConfigEntry, BlinkUpdateCoordinator
 from .services import async_setup_services
 
@@ -50,12 +50,22 @@ async def async_migrate_entry(hass: HomeAssistant, entry: BlinkConfigEntry) -> b
     if entry.version == 2:
         await _reauth_flow_wrapper(hass, entry, data)
         return False
-    if entry.version == 3:
+
+    version = entry.version
+    if version == 3:
         # Migrate device_id to hardware_id for blinkpy 0.25.x OAuth2 compatibility
         if "device_id" in data:
             data["hardware_id"] = data.pop("device_id")
-            hass.config_entries.async_update_entry(entry, data=data, version=4)
-        return True
+        version = 4
+    if version == 4:
+        # Blink's OAuth endpoint now rejects LEGACY_HARDWARE_ID (HTTP 406).
+        # Drop it so blinkpy generates a fresh per-install UUID on next setup.
+        if data.get("hardware_id") == LEGACY_HARDWARE_ID:
+            data.pop("hardware_id", None)
+        version = 5
+
+    if version != entry.version or data != dict(entry.data):
+        hass.config_entries.async_update_entry(entry, data=data, version=version)
     return True
 
 

--- a/homeassistant/components/blink/config_flow.py
+++ b/homeassistant/components/blink/config_flow.py
@@ -19,7 +19,7 @@ from homeassistant.core import callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
-from .const import DOMAIN, HARDWARE_ID
+from .const import DOMAIN, LEGACY_HARDWARE_ID
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,17 +43,38 @@ async def _send_blink_2fa_pin(blink: Blink, pin: str | None) -> None:
 class BlinkConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a Blink config flow."""
 
-    VERSION = 4
+    VERSION = 5
 
     def __init__(self) -> None:
         """Initialize the blink flow."""
         self.auth: Auth | None = None
         self.blink: Blink | None = None
 
+    def _existing_hardware_id(self) -> str | None:
+        """Return the hardware_id already on file for a reauth/reconfigure.
+
+        Blink's OAuth endpoint rejects LEGACY_HARDWARE_ID, so that value is
+        never reused. Absent a usable stored id (including new setups),
+        return None and let blinkpy.Auth generate a fresh per-install UUID.
+        """
+        if self.source == SOURCE_REAUTH:
+            entry = self._get_reauth_entry()
+        elif self.source == SOURCE_RECONFIGURE:
+            entry = self._get_reconfigure_entry()
+        else:
+            return None
+        hardware_id = entry.data.get("hardware_id")
+        if hardware_id and hardware_id != LEGACY_HARDWARE_ID:
+            return hardware_id
+        return None
+
     async def _handle_user_input(self, user_input: dict[str, Any]):
         """Handle user input."""
+        login_data: dict[str, Any] = {**user_input}
+        if hardware_id := self._existing_hardware_id():
+            login_data["hardware_id"] = hardware_id
         self.auth = Auth(
-            {**user_input, "hardware_id": HARDWARE_ID},
+            login_data,
             no_prompt=True,
             session=async_get_clientsession(self.hass),
         )

--- a/homeassistant/components/blink/const.py
+++ b/homeassistant/components/blink/const.py
@@ -3,7 +3,12 @@
 from homeassistant.const import Platform
 
 DOMAIN = "blink"
-HARDWARE_ID = "Home Assistant"
+# Every HA install used to send this literal as its OAuth hardware_id.
+# Blink's authorize endpoint now rejects it (HTTP 406); config_flow.py and
+# __init__.py's migration use this only to detect and replace old stored
+# values with a per-install UUID, which blinkpy generates automatically
+# when hardware_id is omitted.
+LEGACY_HARDWARE_ID = "Home Assistant"
 
 CONF_MIGRATE = "migrate"
 CONF_CAMERA = "camera"

--- a/tests/components/blink/conftest.py
+++ b/tests/components/blink/conftest.py
@@ -85,7 +85,7 @@ def mock_config_fixture():
         data={
             CONF_USERNAME: "test_user",
             CONF_PASSWORD: "Password",
-            "hardware_id": "Home Assistant",
+            "hardware_id": "e1233333-0909-09cd-777a-123456789012",
             "uid": "BlinkCamera_e1233333e2-0909-09cd-777a-123456789012",
             "token": "A_token",
             "unique_id": "an_email@email.com",
@@ -95,5 +95,5 @@ def mock_config_fixture():
             "account_id": 654321,
         },
         entry_id=str(uuid4()),
-        version=4,
+        version=5,
     )

--- a/tests/components/blink/test_config_flow.py
+++ b/tests/components/blink/test_config_flow.py
@@ -1,6 +1,6 @@
 """Test the Blink config flow."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from blinkpy.auth import BlinkTwoFARequiredError, LoginError, TokenRefreshFailed
 from blinkpy.blinkpy import BlinkSetupError
@@ -279,3 +279,135 @@ async def test_reauth_shows_user_step(hass: HomeAssistant) -> None:
     result = await mock_entry.start_reauth_flow(hass)
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "reauth_confirm"
+
+
+async def test_form_user_omits_hardware_id(hass: HomeAssistant) -> None:
+    """Test initial setup omits hardware_id, letting blinkpy generate a UUID.
+
+    Blink's OAuth endpoint rejects the old hardcoded "Home Assistant"
+    literal; a fresh install has no prior hardware_id to reuse.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+
+    mock_auth = MagicMock()
+    mock_auth.login_attributes = {
+        "username": "blink@example.com",
+        "password": "example",
+        "hardware_id": "11111111-1111-1111-1111-111111111111",
+    }
+
+    with (
+        patch(
+            "homeassistant.components.blink.config_flow.Auth",
+            return_value=mock_auth,
+        ) as mock_auth_class,
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.start",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry", return_value=True
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "example"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.CREATE_ENTRY
+    login_data = mock_auth_class.call_args[0][0]
+    assert "hardware_id" not in login_data
+
+
+async def test_reauth_reuses_existing_hardware_id(hass: HomeAssistant) -> None:
+    """Test reauth passes along the previously stored, valid hardware_id."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "blink@example.com",
+            "password": "invalid_password",
+            "hardware_id": "existing-valid-uuid",
+        },
+        version=5,
+    )
+    mock_entry.add_to_hass(hass)
+    result = await mock_entry.start_reauth_flow(hass)
+
+    mock_auth = MagicMock()
+    mock_auth.login_attributes = {
+        "username": "blink@example.com",
+        "password": "new_password",
+        "hardware_id": "existing-valid-uuid",
+    }
+
+    with (
+        patch(
+            "homeassistant.components.blink.config_flow.Auth",
+            return_value=mock_auth,
+        ) as mock_auth_class,
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.start",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry", return_value=True
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    assert result2["reason"] == "reauth_successful"
+    login_data = mock_auth_class.call_args[0][0]
+    assert login_data["hardware_id"] == "existing-valid-uuid"
+
+
+async def test_reauth_does_not_reuse_legacy_hardware_id(hass: HomeAssistant) -> None:
+    """Test reauth does not resend the rejected legacy hardware_id."""
+    mock_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "username": "blink@example.com",
+            "password": "invalid_password",
+            "hardware_id": "Home Assistant",
+        },
+        version=4,
+    )
+    mock_entry.add_to_hass(hass)
+    result = await mock_entry.start_reauth_flow(hass)
+
+    mock_auth = MagicMock()
+    mock_auth.login_attributes = {
+        "username": "blink@example.com",
+        "password": "new_password",
+        "hardware_id": "22222222-2222-2222-2222-222222222222",
+    }
+
+    with (
+        patch(
+            "homeassistant.components.blink.config_flow.Auth",
+            return_value=mock_auth,
+        ) as mock_auth_class,
+        patch(
+            "homeassistant.components.blink.config_flow.Blink.start",
+            return_value=True,
+        ),
+        patch(
+            "homeassistant.components.blink.async_setup_entry", return_value=True
+        ),
+    ):
+        result2 = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {"username": "blink@example.com", "password": "new_password"},
+        )
+        await hass.async_block_till_done()
+
+    assert result2["type"] is FlowResultType.ABORT
+    login_data = mock_auth_class.call_args[0][0]
+    assert "hardware_id" not in login_data

--- a/tests/components/blink/test_init.py
+++ b/tests/components/blink/test_init.py
@@ -116,16 +116,21 @@ async def test_migrate(
     assert entry.state is ConfigEntryState.MIGRATION_ERROR
 
 
-async def test_migrate_v3_to_v4(
+async def test_migrate_v3_to_v5(
     hass: HomeAssistant,
     mock_blink_api: MagicMock,
     mock_blink_auth_api: MagicMock,
     mock_config_entry: MockConfigEntry,
 ) -> None:
-    """Test migration from version 3 to 4 (device_id to hardware_id)."""
+    """Test migration from version 3 to 5.
+
+    device_id is renamed to hardware_id (v3->v4), then the legacy
+    "Home Assistant" value carried over from device_id is dropped (v4->v5)
+    since Blink's OAuth endpoint rejects it.
+    """
     mock_config_entry.add_to_hass(hass)
 
-    # Set up v3 config entry with device_id
+    # Set up v3 config entry with device_id set to the legacy literal
     data = {**mock_config_entry.data}
     data.pop("hardware_id", None)
     data["device_id"] = "Home Assistant"
@@ -139,7 +144,50 @@ async def test_migrate_v3_to_v4(
     await hass.async_block_till_done()
     entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
     assert entry.state is ConfigEntryState.LOADED
-    assert entry.version == 4
-    assert "hardware_id" in entry.data
+    assert entry.version == 5
     assert "device_id" not in entry.data
-    assert entry.data["hardware_id"] == "Home Assistant"
+    assert "hardware_id" not in entry.data
+
+
+async def test_migrate_v4_drops_legacy_hardware_id(
+    hass: HomeAssistant,
+    mock_blink_api: MagicMock,
+    mock_blink_auth_api: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test migrating a v4 entry whose hardware_id is the rejected legacy value."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        version=4,
+        data={**mock_config_entry.data, "hardware_id": "Home Assistant"},
+    )
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 5
+    assert "hardware_id" not in entry.data
+
+
+async def test_migrate_v5_leaves_valid_hardware_id(
+    hass: HomeAssistant,
+    mock_blink_api: MagicMock,
+    mock_blink_auth_api: MagicMock,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a v4 entry with an already-valid hardware_id is left untouched."""
+    mock_config_entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(
+        mock_config_entry,
+        version=4,
+        data={**mock_config_entry.data, "hardware_id": "some-valid-uuid"},
+    )
+
+    assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+    entry = hass.config_entries.async_get_entry(mock_config_entry.entry_id)
+    assert entry.state is ConfigEntryState.LOADED
+    assert entry.version == 5
+    assert entry.data["hardware_id"] == "some-valid-uuid"


### PR DESCRIPTION
Blink's OAuth authorize endpoint (api.oauth.blink.com) now returns HTTP 406 for the hardcoded hardware_id "Home Assistant" that every Home Assistant installation has sent since the OAuth v2 migration, while an arbitrary UUID is accepted. This breaks the Blink integration for all users at the very first OAuth step, before credentials are even checked, surfacing as a generic invalid/unknown auth error.

blinkpy's Auth class already generates a random UUID automatically when no hardware_id is supplied, so stop overriding it with the shared literal:

- Initial setup omits hardware_id entirely, letting blinkpy mint a fresh per-install UUID that gets persisted on the created entry.
- Reauth/reconfigure reuse the hardware_id already stored on the entry (if it isn't the legacy literal), so Blink keeps seeing a stable device identity across reauths instead of a new one every time.
- A new config entry migration (v4 -> v5) drops a stored hardware_id equal to the legacy literal so existing installs self-heal on next setup without requiring reauth.

Fixes #177284

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #177284
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
