### PR TITLE
Add quality_scale.yaml for Schlage

### DIFF
--- a/homeassistant/components/schlage/quality_scale.yaml
+++ b/homeassistant/components/schlage/quality_scale.yaml
@@ -37,7 +37,11 @@ rules:
   unique-config-entry: done
 
   # Silver
-  action-exceptions: done
+  action-exceptions:
+    status: todo
+    comment: |
+      The lock, switch, and select platform actions do not translate pyschlage
+      failures into HomeAssistantError.
   config-entry-unloading: done
   docs-configuration-parameters:
     status: exempt

--- a/homeassistant/components/schlage/quality_scale.yaml
+++ b/homeassistant/components/schlage/quality_scale.yaml
@@ -1,0 +1,100 @@
+rules:
+  # Bronze
+  action-setup: done
+  appropriate-polling: done
+  brands: done
+  common-modules: done
+  config-flow-test-coverage:
+    status: todo
+    comment: |
+      The error paths do not recover to a created config entry, and the unique
+      ID is not asserted in the user flow test.
+  config-flow: done
+  dependency-transparency: done
+  docs-actions: done
+  docs-conditions:
+    status: exempt
+    comment: This integration does not have any conditions.
+  docs-high-level-description:
+    status: todo
+    comment: |
+      The description does not explain what Schlage is or link to the
+      manufacturer.
+  docs-installation-instructions: done
+  docs-removal-instructions: done
+  docs-triggers:
+    status: exempt
+    comment: This integration does not have any triggers.
+  entity-event-setup:
+    status: exempt
+    comment: |
+      The Schlage cloud API is polled; entities do not subscribe to events.
+  entity-unique-id: done
+  has-entity-name: done
+  runtime-data: done
+  test-before-configure: done
+  test-before-setup: done
+  unique-config-entry: done
+
+  # Silver
+  action-exceptions: done
+  config-entry-unloading: done
+  docs-configuration-parameters:
+    status: exempt
+    comment: This integration does not have an options flow.
+  docs-installation-parameters: todo
+  entity-unavailable: done
+  integration-owner: done
+  log-when-unavailable: done
+  parallel-updates: todo
+  reauthentication-flow: done
+  test-coverage: done
+
+  # Gold
+  devices: done
+  diagnostics: done
+  discovery-update-info:
+    status: exempt
+    comment: |
+      Locks are reached exclusively through the Schlage cloud API and have no
+      discoverable presence on the local network.
+  discovery:
+    status: exempt
+    comment: |
+      Locks are enumerated from the user's Schlage cloud account. They do not
+      announce themselves over mDNS or SSDP and expose no local network
+      service to match against.
+  docs-data-update: done
+  docs-examples: todo
+  docs-known-limitations: todo
+  docs-supported-devices: todo
+  docs-supported-functions: todo
+  docs-troubleshooting: todo
+  docs-use-cases: todo
+  dynamic-devices: done
+  entity-category: done
+  entity-device-class: done
+  entity-disabled-by-default:
+    status: exempt
+    comment: |
+      Every entity maps to a lock feature a user is expected to want.
+  entity-translations:
+    status: todo
+    comment: Switch names are not sentence cased.
+  exception-translations: done
+  icon-translations: done
+  reconfiguration-flow: todo
+  repair-issues:
+    status: exempt
+    comment: |
+      Authentication failures are handled by the reauthentication flow; there
+      are no other user-actionable conditions to repair.
+  stale-devices: done
+  # Platinum
+  async-dependency:
+    status: todo
+    comment: pyschlage is a synchronous library built on requests.
+  inject-websession:
+    status: todo
+    comment: pyschlage is a synchronous library built on requests.
+  strict-typing: done

--- a/homeassistant/components/schlage/strings.json
+++ b/homeassistant/components/schlage/strings.json
@@ -1,4 +1,8 @@
 {
+  "common": {
+    "data_description_password": "The password of your Schlage account.",
+    "data_description_username": "The email address of your Schlage account."
+  },
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
@@ -14,6 +18,9 @@
         "data": {
           "password": "[%key:common::config_flow::data::password%]"
         },
+        "data_description": {
+          "password": "[%key:component::schlage::common::data_description_password%]"
+        },
         "description": "The Schlage integration needs to re-authenticate your account",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
@@ -21,6 +28,10 @@
         "data": {
           "password": "[%key:common::config_flow::data::password%]",
           "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::schlage::common::data_description_password%]",
+          "username": "[%key:component::schlage::common::data_description_username%]"
         }
       }
     }

--- a/script/hassfest/quality_scale.py
+++ b/script/hassfest/quality_scale.py
@@ -786,7 +786,6 @@ INTEGRATIONS_WITHOUT_QUALITY_SCALE_FILE = [
     "rympro",
     "saj",
     "sanix",
-    "schlage",
     "schluter",
     "scrape",
     "screenlogic",


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Adds a `quality_scale.yaml` for Schlage so progress against the quality scale is tracked, and adds the `data_description` strings that the `config-flow` rule requires.

This revives #131735, which was reviewed but went stale and was closed without merging. Following @joostlek's suggestion there — "note down the things you want to fix in the exempt, so we can merge the current state and improve from there" — this PR makes no tier claim. `schlage` stays in `INTEGRATIONS_WITHOUT_SCALE` and the manifest is untouched, so the file serves purely as a tracking document.

Rules with unresolved feedback from that review are recorded as `todo` with the reason, rather than optimistically marked done:

- `config-flow-test-coverage` — the error paths do not recover to a created config entry, and the unique ID is not asserted in the user flow test
- `docs-high-level-description` — the documentation does not explain what Schlage is or link to the manufacturer
- `entity-translations` — switch names are not sentence cased

The `discovery` and `discovery-update-info` exemptions were re-checked against hardware after the question raised in the earlier review: the locks announce nothing over mDNS or SSDP, and expose no local network service to match against. They are reachable only through the Schlage cloud API.

Fixes for the bronze-level `todo` items follow in a separate PR.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
