### PR TITLE
Always expose group members for Music Assistant players

### DIFF
--- a/homeassistant/components/music_assistant/media_player.py
+++ b/homeassistant/components/music_assistant/media_player.py
@@ -29,6 +29,7 @@ from homeassistant.components.media_player import (
     MediaPlayerEnqueue,
     MediaPlayerEntity,
     MediaPlayerEntityFeature,
+    MediaPlayerEntityStateAttribute,
     MediaPlayerState,
     MediaType as HAMediaType,
     RepeatMode,
@@ -196,6 +197,11 @@ class MusicAssistantPlayer(MusicAssistantEntity, MediaPlayerEntity):
             ATTR_ACTIVE_QUEUE: (
                 self.active_queue.queue_id if self.active_queue else None
             ),
+            # Every Music Assistant player reports its members, but the base entity
+            # only publishes them when GROUPING is supported. Groups with a fixed
+            # member list cannot be regrouped and so do not advertise GROUPING,
+            # which would otherwise hide their members entirely.
+            MediaPlayerEntityStateAttribute.GROUP_MEMBERS: self.group_members,
         }
 
     @override

--- a/tests/components/music_assistant/test_media_player.py
+++ b/tests/components/music_assistant/test_media_player.py
@@ -1244,6 +1244,38 @@ async def test_media_player_supported_features(
     assert state.attributes["supported_features"] == expected_features
 
 
+async def test_media_player_group_members_without_grouping(
+    hass: HomeAssistant,
+    music_assistant_client: MagicMock,
+) -> None:
+    """Test group members are published for a player that can not be regrouped."""
+    await setup_integration_from_fixtures(hass, music_assistant_client)
+    entity_id = "media_player.test_group_player_1"
+    mass_player_id = "test_group_player_1"
+    expected_members = [
+        "media_player.test_player_1",
+        "media_player.my_super_test_player_2",
+    ]
+    state = hass.states.get(entity_id)
+    assert state
+    assert state.attributes[ATTR_GROUP_MEMBERS] == expected_members
+
+    # a group with a fixed member list can not be regrouped and so drops GROUPING,
+    # but its members are still known and must remain readable
+    music_assistant_client.players._players[mass_player_id].supported_features.remove(
+        PlayerFeature.SET_MEMBERS
+    )
+    await trigger_subscription_callback(
+        hass, music_assistant_client, EventType.PLAYER_CONFIG_UPDATED, mass_player_id
+    )
+    state = hass.states.get(entity_id)
+    assert state
+    assert (
+        not state.attributes["supported_features"] & MediaPlayerEntityFeature.GROUPING
+    )
+    assert state.attributes[ATTR_GROUP_MEMBERS] == expected_members
+
+
 async def test_media_image_prefers_current_media(
     hass: HomeAssistant,
     music_assistant_client: MagicMock,


### PR DESCRIPTION
## Proposed change

Music Assistant group players lost their `group_members` attribute in Home Assistant, which broke automations and scripts that read the members of a group.

A Music Assistant group only advertises `SET_MEMBERS` when it is configured with dynamic members. A group with a fixed member list cannot be regrouped, so it correctly does not advertise it — which maps to no `MediaPlayerEntityFeature.GROUPING`. The base entity only publishes `group_members` when `GROUPING` is supported, so the member list disappeared from the state entirely, even though it is perfectly well known.

This publishes the member list from the integration, so it stays readable regardless of whether the player can be regrouped. Nothing changes for players that do support grouping — the value is identical to the one the base entity already publishes.

Reported on Discord: a user's script merges the members of two Music Assistant groups, and broke once those groups were switched to a fixed member list.

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
