### PR TITLE
Add reauthentication flow to ouman_eh_800

### DIFF
--- a/homeassistant/components/ouman_eh_800/config_flow.py
+++ b/homeassistant/components/ouman_eh_800/config_flow.py
@@ -15,6 +15,11 @@ from yarl import URL
 from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.selector import (
+    TextSelector,
+    TextSelectorConfig,
+    TextSelectorType,
+)
 
 from .const import DOMAIN
 
@@ -30,8 +35,10 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
 
 STEP_REAUTH_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_USERNAME): str,
-        vol.Required(CONF_PASSWORD): str,
+        vol.Required(CONF_USERNAME): TextSelector(),
+        vol.Required(CONF_PASSWORD): TextSelector(
+            TextSelectorConfig(type=TextSelectorType.PASSWORD)
+        ),
     }
 )
 
@@ -124,11 +131,7 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="reauth_confirm",
             data_schema=self.add_suggested_values_to_schema(
-                STEP_REAUTH_DATA_SCHEMA,
-                # The device has a single user whose username and password are
-                # both freely settable strings, so either one may be what
-                # changed. Suggest both so only the changed field needs typing.
-                user_input or reauth_entry.data,
+                STEP_REAUTH_DATA_SCHEMA, user_input or reauth_entry.data
             ),
             errors=errors,
         )

--- a/homeassistant/components/ouman_eh_800/config_flow.py
+++ b/homeassistant/components/ouman_eh_800/config_flow.py
@@ -1,5 +1,6 @@
 """Config flow for the Ouman EH-800 integration."""
 
+from collections.abc import Mapping
 import logging
 from typing import Any, override
 
@@ -27,6 +28,13 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
     }
 )
 
+STEP_REAUTH_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required(CONF_USERNAME): str,
+        vol.Required(CONF_PASSWORD): str,
+    }
+)
+
 
 def _normalize_url(url: str) -> str:
     """Reduce URL to scheme://host[:port], discarding any path, query, or fragment."""
@@ -37,6 +45,28 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Ouman EH-800."""
 
     VERSION = 1
+
+    async def _async_try_login(self, data: Mapping[str, Any]) -> dict[str, str]:
+        """Test the connection by logging in to the device.
+
+        Returns form errors, empty if the login succeeded.
+        """
+        client = OumanEh800Client(
+            session=async_get_clientsession(self.hass),
+            username=data[CONF_USERNAME],
+            password=data[CONF_PASSWORD],
+            address=data[CONF_URL],
+        )
+        try:
+            await client.login()
+        except OumanClientCommunicationError:
+            return {"base": "cannot_connect"}
+        except OumanClientAuthenticationError:
+            return {"base": "invalid_auth"}
+        except Exception:
+            _LOGGER.exception("Unexpected exception")
+            return {"base": "unknown"}
+        return {}
 
     async def _async_validate_input(self, user_input: dict[str, Any]) -> dict[str, str]:
         """Normalize the URL, check for duplicates and test the connection.
@@ -49,22 +79,7 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
         except ValueError:
             return {CONF_URL: "invalid_url"}
         self._async_abort_entries_match({CONF_URL: user_input[CONF_URL]})
-        client = OumanEh800Client(
-            session=async_get_clientsession(self.hass),
-            username=user_input[CONF_USERNAME],
-            password=user_input[CONF_PASSWORD],
-            address=user_input[CONF_URL],
-        )
-        try:
-            await client.login()
-        except OumanClientCommunicationError:
-            return {"base": "cannot_connect"}
-        except OumanClientAuthenticationError:
-            return {"base": "invalid_auth"}
-        except Exception:
-            _LOGGER.exception("Unexpected exception")
-            return {"base": "unknown"}
-        return {}
+        return await self._async_try_login(user_input)
 
     @override
     async def async_step_user(
@@ -80,6 +95,40 @@ class OumanEh800ConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 STEP_USER_DATA_SCHEMA, user_input
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        """Handle initiation of re-authentication."""
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Handle re-authentication with the device."""
+        reauth_entry = self._get_reauth_entry()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            if not (
+                errors := await self._async_try_login(
+                    {CONF_URL: reauth_entry.data[CONF_URL], **user_input}
+                )
+            ):
+                return self.async_update_reload_and_abort(
+                    reauth_entry, data_updates=user_input
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=self.add_suggested_values_to_schema(
+                STEP_REAUTH_DATA_SCHEMA,
+                # The device has a single user whose username and password are
+                # both freely settable strings, so either one may be what
+                # changed. Suggest both so only the changed field needs typing.
+                user_input or reauth_entry.data,
             ),
             errors=errors,
         )

--- a/homeassistant/components/ouman_eh_800/coordinator.py
+++ b/homeassistant/components/ouman_eh_800/coordinator.py
@@ -20,7 +20,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_URL, CONF_USERNAME
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import (
-    ConfigEntryError,
+    ConfigEntryAuthFailed,
     ConfigEntryNotReady,
     HomeAssistantError,
 )
@@ -103,7 +103,7 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
             await self.client.login()
             self._registry_set = await self.client.get_active_registries()
         except OumanClientAuthenticationError as err:
-            raise ConfigEntryError("Invalid credentials") from err
+            raise ConfigEntryAuthFailed("Invalid credentials") from err
         except OumanClientCommunicationError as err:
             raise ConfigEntryNotReady("Error communicating with API") from err
 
@@ -122,6 +122,9 @@ class OumanEh800Coordinator(DataUpdateCoordinator[dict[OumanEndpoint, OumanValue
         try:
             result = await self.client.set_endpoint_value(endpoint, value)
         except OumanClientAuthenticationError as err:
+            # Reload the config entry; setup re-validates the credentials and
+            # starts a reauth flow if they are no longer valid.
+            self.hass.config_entries.async_schedule_reload(self.config_entry.entry_id)
             raise HomeAssistantError("Authentication failed") from err
         except OumanClientCommunicationError as err:
             raise HomeAssistantError("Error communicating with API") from err

--- a/homeassistant/components/ouman_eh_800/quality_scale.yaml
+++ b/homeassistant/components/ouman_eh_800/quality_scale.yaml
@@ -42,7 +42,7 @@ rules:
   integration-owner: done
   log-when-unavailable: done
   parallel-updates: done
-  reauthentication-flow: todo
+  reauthentication-flow: done
   test-coverage: todo
 
   # Gold

--- a/homeassistant/components/ouman_eh_800/strings.json
+++ b/homeassistant/components/ouman_eh_800/strings.json
@@ -2,6 +2,7 @@
   "config": {
     "abort": {
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
       "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
     },
     "error": {
@@ -11,6 +12,17 @@
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "step": {
+      "reauth_confirm": {
+        "data": {
+          "password": "[%key:common::config_flow::data::password%]",
+          "username": "[%key:common::config_flow::data::username%]"
+        },
+        "data_description": {
+          "password": "[%key:component::ouman_eh_800::config::step::user::data_description::password%]",
+          "username": "[%key:component::ouman_eh_800::config::step::user::data_description::username%]"
+        },
+        "description": "Re-enter the credentials for the Ouman EH-800 web interface."
+      },
       "reconfigure": {
         "data": {
           "password": "[%key:common::config_flow::data::password%]",

--- a/tests/components/ouman_eh_800/test_config_flow.py
+++ b/tests/components/ouman_eh_800/test_config_flow.py
@@ -254,3 +254,68 @@ async def test_reconfigure_flow_already_configured(
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
+
+
+@pytest.mark.usefixtures("mock_ouman_client")
+async def test_reauth_flow_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful reauthentication updates the credentials."""
+    mock_config_entry.add_to_hass(hass)
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {}
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: "new-user", CONF_PASSWORD: "new-pass"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert mock_config_entry.data == {
+        CONF_URL: TEST_URL,
+        CONF_USERNAME: "new-user",
+        CONF_PASSWORD: "new-pass",
+    }
+
+
+@pytest.mark.parametrize(
+    ("error", "expected_error"),
+    [
+        (OumanClientCommunicationError("Connection failed"), "cannot_connect"),
+        (OumanClientAuthenticationError("Invalid credentials"), "invalid_auth"),
+        (RuntimeError("Unexpected"), "unknown"),
+    ],
+)
+async def test_reauth_flow_errors_recover(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_ouman_client: AsyncMock,
+    error: Exception,
+    expected_error: str,
+) -> None:
+    """Test that reauthentication errors are surfaced and the flow can recover."""
+    mock_config_entry.add_to_hass(hass)
+    mock_ouman_client.login.side_effect = error
+
+    result = await mock_config_entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: TEST_USERNAME, CONF_PASSWORD: "new-pass"},
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": expected_error}
+
+    mock_ouman_client.login.side_effect = None
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_USERNAME: TEST_USERNAME, CONF_PASSWORD: "new-pass"},
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"

--- a/tests/components/ouman_eh_800/test_init.py
+++ b/tests/components/ouman_eh_800/test_init.py
@@ -9,8 +9,15 @@ from ouman_eh_800_api import (
 import pytest
 
 from homeassistant.components.ouman_eh_800.const import DOMAIN, OumanDevice
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.components.select import (
+    ATTR_OPTION,
+    DOMAIN as SELECT_DOMAIN,
+    SERVICE_SELECT_OPTION,
+)
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigEntryState
+from homeassistant.const import ATTR_ENTITY_ID, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 
 from tests.common import MockConfigEntry
@@ -59,15 +66,19 @@ async def test_setup_unload_entry(
 
 
 @pytest.mark.parametrize(
-    ("error", "expected_state"),
+    ("error", "expected_state", "expected_reauth_flows"),
     [
-        (
+        pytest.param(
             OumanClientCommunicationError("Connection failed"),
             ConfigEntryState.SETUP_RETRY,
+            0,
+            id="communication_error",
         ),
-        (
+        pytest.param(
             OumanClientAuthenticationError("Invalid credentials"),
             ConfigEntryState.SETUP_ERROR,
+            1,
+            id="authentication_error",
         ),
     ],
 )
@@ -77,6 +88,7 @@ async def test_setup_error(
     mock_ouman_client: AsyncMock,
     error: Exception,
     expected_state: ConfigEntryState,
+    expected_reauth_flows: int,
 ) -> None:
     """Test that setup raises the correct config-entry exception on client errors."""
     mock_ouman_client.login.side_effect = error
@@ -85,3 +97,43 @@ async def test_setup_error(
     assert not await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
     assert mock_config_entry.state is expected_state
+
+    reauth_flows = hass.config_entries.flow.async_progress_by_handler(
+        DOMAIN, match_context={"source": SOURCE_REAUTH}
+    )
+    assert len(reauth_flows) == expected_reauth_flows
+
+
+@pytest.mark.parametrize("init_integration", [Platform.SELECT], indirect=True)
+@pytest.mark.usefixtures("init_integration")
+async def test_reauth_started_on_action_auth_failure(
+    hass: HomeAssistant,
+    mock_ouman_client: AsyncMock,
+) -> None:
+    """Test that an auth failure when setting a value starts a reauth flow.
+
+    All platforms set values through the same coordinator method, which
+    reloads the config entry on an authentication failure; setup then
+    re-validates the credentials and starts the reauth flow. The select
+    entity here is just one arbitrary way to trigger that shared path.
+    """
+    error = OumanClientAuthenticationError("Wrong username or password")
+    mock_ouman_client.set_endpoint_value.side_effect = error
+    mock_ouman_client.login.side_effect = error
+
+    with pytest.raises(HomeAssistantError, match="Authentication failed"):
+        await hass.services.async_call(
+            SELECT_DOMAIN,
+            SERVICE_SELECT_OPTION,
+            {
+                ATTR_ENTITY_ID: "select.ouman_eh_800_home_away_mode",
+                ATTR_OPTION: "away",
+            },
+            blocking=True,
+        )
+
+    await hass.async_block_till_done()
+    reauth_flows = hass.config_entries.flow.async_progress_by_handler(
+        DOMAIN, match_context={"source": SOURCE_REAUTH}
+    )
+    assert len(reauth_flows) == 1


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Add a reauthentication flow to the Ouman EH-800 integration, completing the `reauthentication-flow` quality scale rule (Silver).

The reauth form asks for the username and password and validates them by logging in against the entry's existing URL before accepting them. Both current credentials are pre-filled as suggested values: the device has a single user whose username and password are both freely settable strings, so either one may be what changed, and pre-filling both means only the changed field needs retyping.

The flow is triggered from two places. During setup, an authentication failure from the login check now raises `ConfigEntryAuthFailed` instead of `ConfigEntryError`. At runtime, only setting values authenticates (fetching values does not require login), so an authentication failure in `async_set_endpoint_value` schedules a reload of the config entry; setup then re-validates the credentials and starts the reauth flow if they are no longer valid, while the service call still raises `HomeAssistantError`. This mirrors the pattern used by the peblar integration.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
