### PR TITLE
Add WS command config/device_registry/remove

### DIFF
--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -1,5 +1,6 @@
 """HTTP views to interact with the device registry."""
 
+import logging
 from typing import Any, cast
 
 import voluptuous as vol
@@ -12,6 +13,8 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceEntryDisabler
 
+_LOGGER = logging.getLogger(__name__)
+
 
 @callback
 def async_setup(hass: HomeAssistant) -> bool:
@@ -22,6 +25,9 @@ def async_setup(hass: HomeAssistant) -> bool:
     websocket_api.async_register_command(hass, websocket_list_linked_devices)
     websocket_api.async_register_command(hass, websocket_update_device)
     websocket_api.async_register_command(hass, websocket_remove_device)
+    websocket_api.async_register_command(
+        hass, websocket_remove_config_entry_from_device
+    )
     return True
 
 
@@ -169,20 +175,20 @@ def websocket_update_device(
     connection.send_message(websocket_api.result_message(msg_id, entry.dict_repr))
 
 
-@websocket_api.require_admin
-@websocket_api.websocket_command(
-    {
-        "type": "config/device_registry/remove",
-        "device_id": str,
-    }
-)
-@websocket_api.async_response
-async def websocket_remove_device(
+async def _async_remove_device(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
+    *,
+    expected_config_entry_id: str | None = None,
 ) -> None:
-    """Remove a device."""
+    """Remove a device.
+
+    Shared implementation for the config/device_registry/remove command and its
+    deprecated config/device_registry/remove_config_entry alias. The alias passes
+    expected_config_entry_id, and the device is only removed if it belongs to that
+    config entry.
+    """
     registry = dr.async_get(hass)
     device_id = msg["device_id"]
 
@@ -192,6 +198,12 @@ async def websocket_remove_device(
 
     if (device_entry := registry.async_get(device_id)) is None:
         raise HomeAssistantError("Unknown device")
+
+    if (
+        expected_config_entry_id is not None
+        and expected_config_entry_id not in device_entry.config_entries
+    ):
+        raise HomeAssistantError("Config entry not in device")
 
     config_entry_id = device_entry.config_entry_id
     if (config_entry := hass.config_entries.async_get_entry(config_entry_id)) is None:
@@ -218,3 +230,50 @@ async def websocket_remove_device(
         registry.async_remove_device(device_id)
 
     connection.send_message(websocket_api.result_message(msg["id"], None))
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        "type": "config/device_registry/remove",
+        "device_id": str,
+    }
+)
+@websocket_api.async_response
+async def websocket_remove_device(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Remove a device."""
+    await _async_remove_device(hass, connection, msg)
+
+
+@websocket_api.require_admin
+@websocket_api.websocket_command(
+    {
+        "type": "config/device_registry/remove_config_entry",
+        "config_entry_id": str,
+        "device_id": str,
+    }
+)
+@websocket_api.async_response
+async def websocket_remove_config_entry_from_device(
+    hass: HomeAssistant,
+    connection: websocket_api.ActiveConnection,
+    msg: dict[str, Any],
+) -> None:
+    """Remove a device.
+
+    Deprecated alias of config/device_registry/remove. The config_entry_id
+    parameter is kept for backwards compatibility and must match the device's
+    config entry.
+    """
+    _LOGGER.warning(
+        "The websocket command config/device_registry/remove_config_entry is "
+        "deprecated and will be removed in Home Assistant 2027.9; use "
+        "config/device_registry/remove instead"
+    )
+    await _async_remove_device(
+        hass, connection, msg, expected_config_entry_id=msg["config_entry_id"]
+    )

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -201,7 +201,7 @@ async def _async_remove_device(
 
     if (
         expected_config_entry_id is not None
-        and expected_config_entry_id not in device_entry.config_entries
+        and expected_config_entry_id != device_entry.config_entry_id
     ):
         raise HomeAssistantError("Config entry not in device")
 

--- a/homeassistant/components/config/device_registry.py
+++ b/homeassistant/components/config/device_registry.py
@@ -21,9 +21,7 @@ def async_setup(hass: HomeAssistant) -> bool:
     websocket_api.async_register_command(hass, websocket_list_devices)
     websocket_api.async_register_command(hass, websocket_list_linked_devices)
     websocket_api.async_register_command(hass, websocket_update_device)
-    websocket_api.async_register_command(
-        hass, websocket_remove_config_entry_from_device
-    )
+    websocket_api.async_register_command(hass, websocket_remove_device)
     return True
 
 
@@ -174,37 +172,33 @@ def websocket_update_device(
 @websocket_api.require_admin
 @websocket_api.websocket_command(
     {
-        "type": "config/device_registry/remove_config_entry",
-        "config_entry_id": str,
+        "type": "config/device_registry/remove",
         "device_id": str,
     }
 )
 @websocket_api.async_response
-async def websocket_remove_config_entry_from_device(
+async def websocket_remove_device(
     hass: HomeAssistant,
     connection: websocket_api.ActiveConnection,
     msg: dict[str, Any],
 ) -> None:
-    """Remove config entry from a device."""
+    """Remove a device."""
     registry = dr.async_get(hass)
-    config_entry_id = msg["config_entry_id"]
     device_id = msg["device_id"]
 
     # A composite device id has no single underlying device to remove; reject it.
     if registry.async_is_composite_device_id(device_id):
         raise HomeAssistantError("Cannot remove a composite device")
 
+    if (device_entry := registry.async_get(device_id)) is None:
+        raise HomeAssistantError("Unknown device")
+
+    config_entry_id = device_entry.config_entry_id
     if (config_entry := hass.config_entries.async_get_entry(config_entry_id)) is None:
         raise HomeAssistantError("Unknown config entry")
 
     if not config_entry.supports_remove_device:
         raise HomeAssistantError("Config entry does not support device removal")
-
-    if (device_entry := registry.async_get(device_id)) is None:
-        raise HomeAssistantError("Unknown device")
-
-    if config_entry_id not in device_entry.config_entries:
-        raise HomeAssistantError("Config entry not in device")
 
     try:
         integration = await loader.async_get_integration(hass, config_entry.domain)

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -385,12 +385,12 @@ async def test_update_device_labels(
         assert getattr(device, key) == value
 
 
-async def test_remove_config_entry_from_device(
+async def test_remove_device(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test removing config entry from device."""
+    """Test removing a device."""
     assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
@@ -443,9 +443,8 @@ async def test_remove_config_entry_from_device(
     assert device_entry_1.id != device_entry.id
     assert device_entry.config_entries == {entry_2.entry_id}
 
-    # Try removing the config entry from the device, it should fail because
-    # async_remove_config_entry_device returns False
-    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
+    # Removal is rejected while async_remove_config_entry_device returns False
+    response = await ws_client.remove_device(device_entry.id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -453,14 +452,12 @@ async def test_remove_config_entry_from_device(
     # Make async_remove_config_entry_device return True
     can_remove = True
 
-    # Remove the config entry, this was the device's only config entry so the
-    # device is removed
-    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
+    # The device is removed
+    response = await ws_client.remove_device(device_entry.id)
 
     assert response["success"]
     assert response["result"] is None
 
-    # This was the only config entry, the device is removed
     assert not device_registry.async_get(device_entry.id)
 
     # The device belonging to the other config entry is untouched
@@ -469,12 +466,12 @@ async def test_remove_config_entry_from_device(
     }
 
 
-async def test_remove_config_entry_from_device_fails(
+async def test_remove_device_fails(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test removing config entry from device failing cases."""
+    """Test removing a device failing cases."""
     assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
@@ -535,20 +532,18 @@ async def test_remove_config_entry_from_device_fails(
     assert device_entry_2.config_entries == {entry_2.entry_id}
     assert device_entry_3.config_entries == {entry_3.entry_id}
 
-    fake_entry_id = "abc123"
-    assert entry_1.entry_id != fake_entry_id
     fake_device_id = "abc123"
     assert device_entry_3.id != fake_device_id
 
-    # Try removing a non existing config entry from the device
-    response = await ws_client.remove_device(device_entry_3.id, fake_entry_id)
+    # Try removing a device which does not exist
+    response = await ws_client.remove_device(fake_device_id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
-    assert response["error"]["message"] == "Unknown config entry"
+    assert response["error"]["message"] == "Unknown device"
 
-    # Try removing a config entry which does not support removal from the device
-    response = await ws_client.remove_device(device_entry_1.id, entry_1.entry_id)
+    # Try removing a device whose config entry does not support device removal
+    response = await ws_client.remove_device(device_entry_1.id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -556,44 +551,29 @@ async def test_remove_config_entry_from_device_fails(
         response["error"]["message"] == "Config entry does not support device removal"
     )
 
-    # Try removing a config entry from a device which does not exist
-    response = await ws_client.remove_device(fake_device_id, entry_2.entry_id)
-
-    assert not response["success"]
-    assert response["error"]["code"] == "home_assistant_error"
-    assert response["error"]["message"] == "Unknown device"
-
-    # Try removing a config entry from a device which it's not connected to
-    response = await ws_client.remove_device(device_entry_3.id, entry_2.entry_id)
-
-    assert not response["success"]
-    assert response["error"]["code"] == "home_assistant_error"
-    assert response["error"]["message"] == "Config entry not in device"
-
-    # Removing a config entry which supports removal removes the device, since it is
-    # the device's only config entry
-    response = await ws_client.remove_device(device_entry_2.id, entry_2.entry_id)
+    # Removing a device whose config entry supports removal removes the device
+    response = await ws_client.remove_device(device_entry_2.id)
 
     assert response["success"]
     assert response["result"] is None
     assert not device_registry.async_get(device_entry_2.id)
 
-    # Try removing a config entry which can't be loaded from a device - allowed
-    response = await ws_client.remove_device(device_entry_3.id, entry_3.entry_id)
+    # Try removing a device whose integration can't be loaded
+    response = await ws_client.remove_device(device_entry_3.id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
     assert response["error"]["message"] == "Integration not found"
 
 
-async def test_remove_config_entry_from_device_if_integration_remove(
+async def test_remove_device_if_integration_removes(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
 ) -> None:
-    """Test removing config entry from device.
+    """Test removing a device.
 
-    Should not error when the integration removes the entry.
+    Should not error when the integration removes the device itself.
     """
     assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
@@ -649,9 +629,8 @@ async def test_remove_config_entry_from_device_if_integration_remove(
     assert device_entry_1.id != device_entry.id
     assert device_entry.config_entries == {entry_2.entry_id}
 
-    # Try removing the config entry from the device, it should fail because
-    # async_remove_config_entry_device returns False
-    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
+    # Removal is rejected while async_remove_config_entry_device returns False
+    response = await ws_client.remove_device(device_entry.id)
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -659,14 +638,12 @@ async def test_remove_config_entry_from_device_if_integration_remove(
     # Make async_remove_config_entry_device return True
     can_remove = True
 
-    # Remove the config entry, this was the device's only config entry so the
-    # device is removed
-    response = await ws_client.remove_device(device_entry.id, entry_2.entry_id)
+    # The device is removed by the integration itself
+    response = await ws_client.remove_device(device_entry.id)
 
     assert response["success"]
     assert response["result"] is None
 
-    # This was the only config entry, the device is removed
     assert not device_registry.async_get(device_entry.id)
 
     # The device belonging to the other config entry is untouched
@@ -676,12 +653,12 @@ async def test_remove_config_entry_from_device_if_integration_remove(
 
 
 @pytest.mark.parametrize("load_registries", [False])
-async def test_remove_config_entry_from_composite_device(
+async def test_remove_device_composite(
     hass: HomeAssistant,
     client: MockHAClientWebSocket,
     hass_storage: dict[str, Any],
 ) -> None:
-    """Test removing a config entry from a pre-migration composite device id fails."""
+    """Test removing a pre-migration composite device id fails."""
     entry_1 = MockConfigEntry()
     entry_1.add_to_hass(hass)
     entry_2 = MockConfigEntry()
@@ -713,11 +690,14 @@ async def test_remove_config_entry_from_composite_device(
     registry = dr.async_get(hass)
     assert registry.async_is_composite_device_id(composite_id) is True
 
-    response = await client.remove_device(composite_id, entry_1.entry_id)
+    await client.send_json_auto_id(
+        {"type": "config/device_registry/remove", "device_id": composite_id}
+    )
+    msg = await client.receive_json()
 
-    assert not response["success"]
-    assert response["error"]["code"] == "home_assistant_error"
-    assert response["error"]["message"] == "Cannot remove a composite device"
+    assert not msg["success"]
+    assert msg["error"]["code"] == "home_assistant_error"
+    assert msg["error"]["message"] == "Cannot remove a composite device"
 
 
 async def test_list_linked_devices(

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -694,11 +694,15 @@ async def test_remove_device_if_integration_removes(
     }
 
 
+@pytest.mark.parametrize(("command", "deprecated"), _REMOVE_DEVICE_COMMANDS)
 @pytest.mark.parametrize("load_registries", [False])
 async def test_remove_device_composite(
     hass: HomeAssistant,
     client: MockHAClientWebSocket,
     hass_storage: dict[str, Any],
+    caplog: pytest.LogCaptureFixture,
+    command: str,
+    deprecated: bool,
 ) -> None:
     """Test removing a pre-migration composite device id fails."""
     entry_1 = MockConfigEntry()
@@ -732,14 +736,14 @@ async def test_remove_device_composite(
     registry = dr.async_get(hass)
     assert registry.async_is_composite_device_id(composite_id) is True
 
-    await client.send_json_auto_id(
-        {"type": "config/device_registry/remove", "device_id": composite_id}
+    response = await _send_remove_device(
+        client, command, composite_id, entry_1.entry_id
     )
-    msg = await client.receive_json()
 
-    assert not msg["success"]
-    assert msg["error"]["code"] == "home_assistant_error"
-    assert msg["error"]["message"] == "Cannot remove a composite device"
+    assert not response["success"]
+    assert response["error"]["code"] == "home_assistant_error"
+    assert response["error"]["message"] == "Cannot remove a composite device"
+    assert (_DEPRECATION_WARNING in caplog.text) is deprecated
 
 
 async def test_remove_config_entry_from_device_deprecated_config_entry_mismatch(

--- a/tests/components/config/test_device_registry.py
+++ b/tests/components/config/test_device_registry.py
@@ -385,12 +385,47 @@ async def test_update_device_labels(
         assert getattr(device, key) == value
 
 
+_DEPRECATION_WARNING = (
+    "The websocket command config/device_registry/remove_config_entry is "
+    "deprecated and will be removed in Home Assistant 2027.9"
+)
+
+# The new command and its deprecated alias share an implementation, so tests that
+# apply to both are parametrized over them. The alias still takes config_entry_id,
+# which must match the device's config entry, while the new command rejects it as an
+# unknown key.
+_REMOVE_DEVICE_COMMANDS = [
+    pytest.param("config/device_registry/remove", False, id="remove"),
+    pytest.param(
+        "config/device_registry/remove_config_entry", True, id="remove_config_entry"
+    ),
+]
+
+
+async def _send_remove_device(
+    ws_client: MockHAClientWebSocket,
+    command: str,
+    device_id: str,
+    config_entry_id: str,
+) -> dict[str, Any]:
+    """Send a device removal command and return the response."""
+    message: dict[str, Any] = {"type": command, "device_id": device_id}
+    if command == "config/device_registry/remove_config_entry":
+        message["config_entry_id"] = config_entry_id
+    await ws_client.send_json_auto_id(message)
+    return await ws_client.receive_json()
+
+
+@pytest.mark.parametrize(("command", "deprecated"), _REMOVE_DEVICE_COMMANDS)
 async def test_remove_device(
     hass: HomeAssistant,
     hass_ws_client: WebSocketGenerator,
     device_registry: dr.DeviceRegistry,
+    caplog: pytest.LogCaptureFixture,
+    command: str,
+    deprecated: bool,
 ) -> None:
-    """Test removing a device."""
+    """Test removing a device via the command and its deprecated alias."""
     assert await async_setup_component(hass, DOMAIN, {})
     ws_client = await hass_ws_client(hass)
 
@@ -444,7 +479,9 @@ async def test_remove_device(
     assert device_entry.config_entries == {entry_2.entry_id}
 
     # Removal is rejected while async_remove_config_entry_device returns False
-    response = await ws_client.remove_device(device_entry.id)
+    response = await _send_remove_device(
+        ws_client, command, device_entry.id, entry_2.entry_id
+    )
 
     assert not response["success"]
     assert response["error"]["code"] == "home_assistant_error"
@@ -453,7 +490,9 @@ async def test_remove_device(
     can_remove = True
 
     # The device is removed
-    response = await ws_client.remove_device(device_entry.id)
+    response = await _send_remove_device(
+        ws_client, command, device_entry.id, entry_2.entry_id
+    )
 
     assert response["success"]
     assert response["result"] is None
@@ -464,6 +503,9 @@ async def test_remove_device(
     assert device_registry.async_get(device_entry_1.id).config_entries == {
         entry_1.entry_id
     }
+
+    # Only the deprecated alias logs a deprecation warning
+    assert (_DEPRECATION_WARNING in caplog.text) is deprecated
 
 
 async def test_remove_device_fails(
@@ -698,6 +740,67 @@ async def test_remove_device_composite(
     assert not msg["success"]
     assert msg["error"]["code"] == "home_assistant_error"
     assert msg["error"]["message"] == "Cannot remove a composite device"
+
+
+async def test_remove_config_entry_from_device_deprecated_config_entry_mismatch(
+    hass: HomeAssistant,
+    hass_ws_client: WebSocketGenerator,
+    device_registry: dr.DeviceRegistry,
+) -> None:
+    """Test the deprecated alias fails if config_entry_id is not the device's."""
+    assert await async_setup_component(hass, DOMAIN, {})
+    ws_client = await hass_ws_client(hass)
+
+    async def async_remove_config_entry_device(
+        hass: HomeAssistant, config_entry: ConfigEntry, device_entry: dr.DeviceEntry
+    ) -> bool:
+        return True
+
+    mock_integration(
+        hass,
+        MockModule(
+            "comp1", async_remove_config_entry_device=async_remove_config_entry_device
+        ),
+    )
+
+    entry_1 = MockConfigEntry(domain="comp1", title="Test 1", source="bla")
+    entry_1.supports_remove_device = True
+    entry_1.add_to_hass(hass)
+
+    # A second, unrelated config entry
+    entry_2 = MockConfigEntry(domain="comp1", title="Test 2", source="bla")
+    entry_2.supports_remove_device = True
+    entry_2.add_to_hass(hass)
+
+    device_entry = device_registry.async_get_or_create(
+        config_entry_id=entry_1.entry_id,
+        connections={(dr.CONNECTION_NETWORK_MAC, "12:34:56:AB:CD:EF")},
+    )
+
+    # Passing a config entry which is not the device's fails, device is untouched
+    response = await _send_remove_device(
+        ws_client,
+        "config/device_registry/remove_config_entry",
+        device_entry.id,
+        entry_2.entry_id,
+    )
+
+    assert not response["success"]
+    assert response["error"]["code"] == "home_assistant_error"
+    assert response["error"]["message"] == "Config entry not in device"
+    assert device_registry.async_get(device_entry.id) is not None
+
+    # Passing the device's own config entry removes the device
+    response = await _send_remove_device(
+        ws_client,
+        "config/device_registry/remove_config_entry",
+        device_entry.id,
+        entry_1.entry_id,
+    )
+
+    assert response["success"]
+    assert response["result"] is None
+    assert not device_registry.async_get(device_entry.id)
 
 
 async def test_list_linked_devices(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -987,11 +987,14 @@ def hass_ws_client(
             data["id"] = next(id_generator)
             return websocket.send_json(data)
 
-        async def _remove_device(device_id: str, config_entry_id: str) -> Any:
+        # config_entry_id is accepted for backwards compatibility with existing
+        # callers but no longer sent: the command now removes the whole device.
+        async def _remove_device(
+            device_id: str, config_entry_id: str | None = None
+        ) -> Any:
             await _send_json_auto_id(
                 {
-                    "type": "config/device_registry/remove_config_entry",
-                    "config_entry_id": config_entry_id,
+                    "type": "config/device_registry/remove",
                     "device_id": device_id,
                 }
             )

--- a/tests/typing.py
+++ b/tests/typing.py
@@ -19,7 +19,7 @@ class MockHAClientWebSocket(ClientWebSocketResponse):
 
     client: TestClient
     send_json_auto_id: Callable[[dict[str, Any]], Coroutine[Any, Any, None]]
-    remove_device: Callable[[str, str], Coroutine[Any, Any, Any]]
+    remove_device: Callable[..., Coroutine[Any, Any, Any]]
 
 
 type ClientSessionGenerator = Callable[..., Coroutine[Any, Any, TestClient]]


### PR DESCRIPTION
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Add WS command `config/device_registry/remove` and deprecate `config/device_registry/remove_config_entry`

The test helper which helps removing devices in tests will be updated in a follow-up PR

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
