### PR TITLE
Migrate calls to async_get_device in tests (part 1)

### DIFF
--- a/tests/components/acaia/test_init.py
+++ b/tests/components/acaia/test_init.py
@@ -57,9 +57,12 @@ async def test_device(
     mock_scale: MagicMock,
     device_registry: dr.DeviceRegistry,
     snapshot: SnapshotAssertion,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Snapshot the device from registry."""
 
-    device = device_registry.async_get_device({(DOMAIN, mock_scale.mac)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_scale.mac), mock_config_entry.entry_id
+    )
     assert device
     assert device == snapshot

--- a/tests/components/airgradient/test_init.py
+++ b/tests/components/airgradient/test_init.py
@@ -26,8 +26,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot
@@ -42,8 +42,8 @@ async def test_new_firmware_version(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.sw_version == "3.1.1"
@@ -51,8 +51,8 @@ async def test_new_firmware_version(
     freezer.tick(timedelta(minutes=1))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.sw_version == "3.1.2"

--- a/tests/components/airobot/test_init.py
+++ b/tests/components/airobot/test_init.py
@@ -85,12 +85,13 @@ async def test_unload_entry(
 async def test_device_entry(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device registry entry."""
     assert (
-        device_entry := device_registry.async_get_device(
-            identifiers={(DOMAIN, "T01A1B2C3")}
+        device_entry := device_registry.async_get_device_by_identifier(
+            (DOMAIN, "T01A1B2C3"), mock_config_entry.entry_id
         )
     )
     assert device_entry == snapshot

--- a/tests/components/airvisual_pro/test_init.py
+++ b/tests/components/airvisual_pro/test_init.py
@@ -23,5 +23,7 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "XXXXXXX")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "XXXXXXX"), config_entry.entry_id
+    )
     assert device_entry == snapshot

--- a/tests/components/alexa_devices/test_diagnostics.py
+++ b/tests/components/alexa_devices/test_diagnostics.py
@@ -52,7 +52,9 @@ async def test_device_diagnostics(
     """Test Amazon device diagnostics."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_1_SN)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
+    )
     assert device, repr(device_registry.devices)
 
     assert await get_diagnostics_for_device(

--- a/tests/components/alexa_devices/test_init.py
+++ b/tests/components/alexa_devices/test_init.py
@@ -57,8 +57,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_1_SN)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/alexa_devices/test_services.py
+++ b/tests/components/alexa_devices/test_services.py
@@ -48,8 +48,8 @@ async def test_info_skill_service(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_1_SN)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
     )
     assert device_entry
 
@@ -78,8 +78,8 @@ async def test_send_sound_service(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_1_SN)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
     )
     assert device_entry
 
@@ -108,8 +108,8 @@ async def test_send_text_service(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_1_SN)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
     )
     assert device_entry
 
@@ -253,8 +253,8 @@ async def test_config_entry_not_loaded(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_1_SN)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
     )
     assert device_entry
 
@@ -324,8 +324,8 @@ async def test_missing_config_entry(
 
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_1_SN)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_1_SN), mock_config_entry.entry_id
     )
     assert device_entry
 

--- a/tests/components/anthemav/test_init.py
+++ b/tests/components/anthemav/test_init.py
@@ -44,8 +44,8 @@ async def test_device_registry(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test the device registry entry, including the network MAC connection."""
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:01")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:01"), init_integration.entry_id
     )
     assert device_entry
     assert device_entry == snapshot

--- a/tests/components/anthropic/test_conversation.py
+++ b/tests/components/anthropic/test_conversation.py
@@ -131,7 +131,9 @@ async def test_device(
 ) -> None:
     """Test device parameters."""
     subentry = next(iter(mock_config_entry.subentries.values()))
-    device = device_registry.async_get_device({(DOMAIN, subentry.subentry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+    )
 
     assert device is not None
     assert device.name == "Claude conversation"

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -237,11 +237,8 @@ async def test_migration_from_v1_to_v2(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
-        )
-        is None
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
         migrated_device := device_registry.async_get_device_by_identifier(
@@ -439,17 +436,11 @@ async def test_migration_from_v1_disabled(
         assert subentry.data == options
         assert "Claude" in subentry.title
 
-    assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
-        )
-        is None
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
-    assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
-        )
-        is None
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -787,11 +778,8 @@ async def test_migration_from_v2_1_to_v2_2(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
-        )
-        is None
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
         device := device_registry.async_get_device_by_identifier(
@@ -811,11 +799,8 @@ async def test_migration_from_v2_1_to_v2_2(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert (
-        device_registry.async_get_device_by_identifier(
-            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
-        )
-        is None
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
         device := device_registry.async_get_device_by_identifier(

--- a/tests/components/anthropic/test_init.py
+++ b/tests/components/anthropic/test_init.py
@@ -237,12 +237,15 @@ async def test_migration_from_v1_to_v2(
     assert migrated_entity.unique_id == subentry.subentry_id
 
     # Check device migration
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+        )
+        is None
     )
     assert (
-        migrated_device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        migrated_device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert migrated_device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -436,11 +439,17 @@ async def test_migration_from_v1_disabled(
         assert subentry.data == options
         assert "Claude" in subentry.title
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+        )
+        is None
     )
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+        )
+        is None
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -452,8 +461,9 @@ async def test_migration_from_v1_disabled(
         assert entity.disabled_by is subentry_data["entity_disabled_by"]
 
         assert (
-            device := device_registry.async_get_device(
-                identifiers={(DOMAIN, subentry.subentry_id)}
+            device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, subentry.subentry_id),
+                mock_config_entries[main_config_entry].entry_id,
             )
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -549,8 +559,8 @@ async def test_migration_from_v1_to_v2_with_multiple_keys(
         assert subentry.data == options
         assert subentry.title == f"Claude {idx + 1}"
 
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, list(entry.subentries.values())[0].subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}
@@ -650,8 +660,8 @@ async def test_migration_from_v1_to_v2_with_same_keys(
         assert subentry.data == options
 
         # Check devices were migrated correctly
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {mock_config_entry.entry_id}
@@ -777,12 +787,15 @@ async def test_migration_from_v2_1_to_v2_2(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+        )
+        is None
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -798,12 +811,15 @@ async def test_migration_from_v2_1_to_v2_2(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+        )
+        is None
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}

--- a/tests/components/aosmith/test_device.py
+++ b/tests/components/aosmith/test_device.py
@@ -16,8 +16,8 @@ async def test_device(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test creation of the device."""
-    reg_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "junctionId")},
+    reg_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "junctionId"), init_integration.entry_id
     )
 
     assert reg_device == snapshot

--- a/tests/components/apcupsd/test_binary_sensor.py
+++ b/tests/components/apcupsd/test_binary_sensor.py
@@ -38,8 +38,9 @@ async def test_binary_sensor(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure entities are correctly assigned to device
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_request_status.return_value["SERIALNO"])}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_request_status.return_value["SERIALNO"]),
+        mock_config_entry.entry_id,
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/apcupsd/test_init.py
+++ b/tests/components/apcupsd/test_init.py
@@ -53,8 +53,9 @@ async def test_async_setup_entry(
     status = mock_request_status.return_value
     entry = init_integration
 
-    identifiers = {(DOMAIN, entry.unique_id or entry.entry_id)}
-    device_entry = device_registry.async_get_device(identifiers=identifiers)
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.unique_id or entry.entry_id), entry.entry_id
+    )
     name = f"device_{device_entry.name}_{status.get('SERIALNO', '<no serial>')}"
     assert device_entry == snapshot(name=name)
 

--- a/tests/components/apcupsd/test_sensor.py
+++ b/tests/components/apcupsd/test_sensor.py
@@ -51,8 +51,9 @@ async def test_sensor(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Ensure entities are correctly assigned to device
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_request_status.return_value["SERIALNO"])}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_request_status.return_value["SERIALNO"]),
+        mock_config_entry.entry_id,
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/aprilaire/test_init.py
+++ b/tests/components/aprilaire/test_init.py
@@ -46,7 +46,7 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "12:34:56:78:90:ab")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12:34:56:78:90:ab"), config_entry.entry_id
     )
     assert device_entry == snapshot

--- a/tests/components/assist_pipeline/test_select.py
+++ b/tests/components/assist_pipeline/test_select.py
@@ -107,7 +107,9 @@ async def test_select_entity_registering_device(
     device_registry: dr.DeviceRegistry,
 ) -> None:
     """Test entity registering as an assist device."""
-    device = device_registry.async_get_device(identifiers={("test", "test")})
+    device = device_registry.async_get_device_by_identifier(
+        ("test", "test"), init_select.entry_id
+    )
     assert device is not None
 
     # Test device is registered

--- a/tests/components/asuswrt/test_init.py
+++ b/tests/components/asuswrt/test_init.py
@@ -67,7 +67,7 @@ async def test_device_registry(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, ROUTER_MAC_ADDR)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, ROUTER_MAC_ADDR), config_entry.entry_id
     )
     assert device_entry == snapshot

--- a/tests/components/august/test_binary_sensor.py
+++ b/tests/components/august/test_binary_sensor.py
@@ -322,9 +322,11 @@ async def test_doorbell_device_registry(
 ) -> None:
     """Test creation of a lock with doorsense and bridge ands up in the registry."""
     doorbell_one = await _mock_doorbell_from_fixture(hass, "get_doorbell.offline.json")
-    await _create_august_with_devices(hass, [doorbell_one])
+    config_entry, _ = await _create_august_with_devices(hass, [doorbell_one])
 
-    reg_device = device_registry.async_get_device(identifiers={("august", "tmt100")})
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("august", "tmt100"), config_entry.entry_id
+    )
     assert reg_device == snapshot
 
 

--- a/tests/components/august/test_lock.py
+++ b/tests/components/august/test_lock.py
@@ -42,10 +42,10 @@ async def test_lock_device_registry(
 ) -> None:
     """Test creation of a lock with doorsense and bridge ands up in the registry."""
     lock_one = await _mock_doorsense_enabled_august_lock_detail(hass)
-    await _create_august_with_devices(hass, [lock_one])
+    entry, _ = await _create_august_with_devices(hass, [lock_one])
 
-    reg_device = device_registry.async_get_device(
-        identifiers={("august", "online_with_doorsense")}
+    reg_device = device_registry.async_get_device_by_identifier(
+        ("august", "online_with_doorsense"), entry.entry_id
     )
     assert reg_device == snapshot
 

--- a/tests/components/autoskope/test_device_tracker.py
+++ b/tests/components/autoskope/test_device_tracker.py
@@ -198,7 +198,9 @@ async def test_vehicle_name_update(
     await setup_integration(hass, mock_config_entry)
 
     device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "12345")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12345"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
     assert device_entry.name == "Test Vehicle"
 
@@ -227,6 +229,8 @@ async def test_vehicle_name_update(
     await hass.async_block_till_done()
 
     # Device registry should reflect the new name
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "12345")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12345"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
     assert device_entry.name == "Renamed Vehicle"

--- a/tests/components/avea/test_light.py
+++ b/tests/components/avea/test_light.py
@@ -77,12 +77,14 @@ async def test_init_state(
 
 async def test_device_info(
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
     setup_integration: MagicMock,
 ) -> None:
     """Test the device info."""
     bulb = setup_integration
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, AVEA_DISCOVERY_INFO.address)},
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, AVEA_DISCOVERY_INFO.address),
+        mock_config_entry.entry_id,
     )
 
     assert device is not None
@@ -125,8 +127,9 @@ async def test_device_info_populates_when_connect_fails(
     mock_bulb.get_serial_number.assert_called_once()
     mock_bulb.disconnect.assert_not_called()
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, AVEA_DISCOVERY_INFO.address)},
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, AVEA_DISCOVERY_INFO.address),
+        mock_config_entry.entry_id,
     )
 
     assert device is not None
@@ -160,8 +163,9 @@ async def test_device_info_ignores_unknown_values(
         assert await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, AVEA_DISCOVERY_INFO.address)},
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, AVEA_DISCOVERY_INFO.address),
+        mock_config_entry.entry_id,
     )
 
     assert device is not None

--- a/tests/components/axis/test_hub.py
+++ b/tests/components/axis/test_hub.py
@@ -43,8 +43,8 @@ async def test_device_registry_entry(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Successful setup."""
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_setup.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_setup.unique_id), config_entry_setup.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/bang_olufsen/test_init.py
+++ b/tests/components/bang_olufsen/test_init.py
@@ -31,8 +31,8 @@ async def test_setup_entry(
     assert mock_config_entry.state is ConfigEntryState.LOADED
 
     # Check that the device has been registered properly
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SERIAL_NUMBER), mock_config_entry.entry_id
     )
     assert device is not None
     # Device name is set from the config entry title (friendly name)

--- a/tests/components/bang_olufsen/test_media_player.py
+++ b/tests/components/bang_olufsen/test_media_player.py
@@ -640,8 +640,8 @@ async def test_async_update_name_and_beolink(
     # Check that device name has been changed
     assert mock_config_entry.unique_id
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_config_entry.unique_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
         )
     )
     assert device.name == TEST_FRIENDLY_NAME_2

--- a/tests/components/bang_olufsen/test_websocket.py
+++ b/tests/components/bang_olufsen/test_websocket.py
@@ -109,8 +109,8 @@ async def test_on_software_update_state(
 
     assert mock_config_entry.unique_id
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_config_entry.unique_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
         )
     )
     assert device.sw_version == "1.0.0"
@@ -131,7 +131,9 @@ async def test_on_remote_control_already_added(
 
     # Check device and API call count
     assert mock_mozart_client.get_bluetooth_remotes.call_count == 4
-    assert device_registry.async_get_device({(DOMAIN, TEST_REMOTE_SERIAL_PAIRED)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_REMOTE_SERIAL_PAIRED), mock_config_entry.entry_id
+    )
 
     # Check number of entities (remote and button events and media_player)
     assert list(entity_registry.entities.keys()) == unordered(
@@ -150,7 +152,9 @@ async def test_on_remote_control_already_added(
 
     # Check device and API call count (triggered once by the WebSocket notification)
     assert mock_mozart_client.get_bluetooth_remotes.call_count == 5
-    assert device_registry.async_get_device({(DOMAIN, TEST_REMOTE_SERIAL_PAIRED)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_REMOTE_SERIAL_PAIRED), mock_config_entry.entry_id
+    )
 
     # Check number of entities (remote and button events and media_player)
     entity_ids_available = list(entity_registry.entities.keys())
@@ -177,7 +181,9 @@ async def test_on_remote_control_paired(
 
     # Check device and API call count
     assert mock_mozart_client.get_bluetooth_remotes.call_count == 4
-    assert device_registry.async_get_device({(DOMAIN, TEST_REMOTE_SERIAL_PAIRED)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_REMOTE_SERIAL_PAIRED), mock_config_entry.entry_id
+    )
 
     # Check number of entities (button and remote events and media_player)
     assert list(entity_registry.entities.keys()) == unordered(
@@ -218,9 +224,11 @@ async def test_on_remote_control_paired(
 
     # Check device and API call count
     assert mock_mozart_client.get_bluetooth_remotes.call_count == 10
-    assert device_registry.async_get_device({(DOMAIN, TEST_REMOTE_SERIAL_PAIRED)})
-    assert device_registry.async_get_device(
-        {(DOMAIN, f"66666666_{TEST_SERIAL_NUMBER}")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_REMOTE_SERIAL_PAIRED), mock_config_entry.entry_id
+    )
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"66666666_{TEST_SERIAL_NUMBER}"), mock_config_entry.entry_id
     )
 
     # Check logger
@@ -259,7 +267,9 @@ async def test_on_remote_control_unpaired(
 
     # Check device and API call count
     assert mock_mozart_client.get_bluetooth_remotes.call_count == 4
-    assert device_registry.async_get_device({(DOMAIN, TEST_REMOTE_SERIAL_PAIRED)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_REMOTE_SERIAL_PAIRED), mock_config_entry.entry_id
+    )
 
     # Check number of entities (button and remote events and media_player)
     assert list(entity_registry.entities.keys()) == unordered(
@@ -283,7 +293,10 @@ async def test_on_remote_control_unpaired(
     # Check device and API call count
     assert mock_mozart_client.get_bluetooth_remotes.call_count == 8
     assert (
-        device_registry.async_get_device({(DOMAIN, TEST_REMOTE_SERIAL_PAIRED)}) is None
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, TEST_REMOTE_SERIAL_PAIRED), mock_config_entry.entry_id
+        )
+        is None
     )
 
     # Check logger
@@ -365,8 +378,8 @@ async def test_on_all_notifications_raw(
     # sent as an event and in the log
     assert mock_config_entry.unique_id
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_config_entry.unique_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
         )
     )
     raw_notification_full = {

--- a/tests/components/bluetooth/test_base_scanner.py
+++ b/tests/components/bluetooth/test_base_scanner.py
@@ -572,8 +572,8 @@ async def test_remote_scanner_bluetooth_config_entry(
     assert adapter_entry is not None
     assert adapter_entry.state is ConfigEntryState.LOADED
 
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, scanner.source)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, scanner.source), adapter_entry.entry_id
     )
     assert dev is not None
     assert dev.config_entries == {adapter_entry.entry_id}

--- a/tests/components/bluetooth/test_config_flow.py
+++ b/tests/components/bluetooth/test_config_flow.py
@@ -625,8 +625,8 @@ async def test_async_step_integration_discovery_remote_adapter(
     assert new_entry is not None
     assert new_entry.state is config_entries.ConfigEntryState.LOADED
 
-    ble_device_entry = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, scanner.source)}
+    ble_device_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, scanner.source), new_entry.entry_id
     )
     assert ble_device_entry is not None
     assert ble_device_entry.via_device_id == device_entry.id

--- a/tests/components/bosch_shc/test_entity.py
+++ b/tests/components/bosch_shc/test_entity.py
@@ -47,11 +47,13 @@ async def test_shc_entity_via_device_id(
     """SHCEntity links its device to the SHC hub via via_device_id."""
     await setup_integration(hass, mock_config_entry)
 
-    hub_device = device_registry.async_get_device(identifiers={HUB_IDENTIFIER})
+    hub_device = device_registry.async_get_device_by_identifier(
+        HUB_IDENTIFIER, mock_config_entry.entry_id
+    )
     assert hub_device is not None
 
-    child_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, motion_device.id)}
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, motion_device.id), mock_config_entry.entry_id
     )
     assert child_device is not None
     assert child_device.via_device_id == hub_device.id
@@ -78,8 +80,8 @@ async def test_shc_entity_via_device_id_mismatch(
 
     await setup_integration(hass, mock_config_entry)
 
-    child_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, motion_device.id)}
+    child_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, motion_device.id), mock_config_entry.entry_id
     )
     assert child_device is not None
     assert child_device.via_device_id is None

--- a/tests/components/bring/test_init.py
+++ b/tests/components/bring/test_init.py
@@ -197,8 +197,9 @@ async def test_coordinator_skips_deactivated(
 
     assert mock_bring_client.get_list.await_count == 2
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{UUID}_b4776778-7f6c-496e-951b-92a35d3db0dd")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{UUID}_b4776778-7f6c-496e-951b-92a35d3db0dd"),
+        bring_config_entry.entry_id,
     )
     device_registry.async_update_device(device.id, disabled_by=ConfigEntryDisabler.USER)
 
@@ -224,8 +225,9 @@ async def test_purge_devices(
 
     assert bring_config_entry.state is ConfigEntryState.LOADED
 
-    assert device_registry.async_get_device(
-        {(DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}"),
+        bring_config_entry.entry_id,
     )
 
     mock_bring_client.load_lists.return_value = BringListResponse.from_json(
@@ -237,8 +239,9 @@ async def test_purge_devices(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(
-            {(DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}"),
+            bring_config_entry.entry_id,
         )
         is None
     )
@@ -261,8 +264,9 @@ async def test_create_devices(
     assert bring_config_entry.state is ConfigEntryState.LOADED
 
     assert (
-        device_registry.async_get_device(
-            {(DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}"),
+            bring_config_entry.entry_id,
         )
         is None
     )
@@ -274,8 +278,9 @@ async def test_create_devices(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(
-        {(DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}")}
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{bring_config_entry.unique_id}_{list_uuid}"),
+        bring_config_entry.entry_id,
     )
 
 

--- a/tests/components/broadlink/test_climate.py
+++ b/tests/components/broadlink/test_climate.py
@@ -96,8 +96,8 @@ async def test_climate(
     mock_api.get_full_status.return_value = api_return_value
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]
@@ -134,8 +134,8 @@ async def test_climate_set_temperature_turn_off_turn_on(
     }
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     climates = [entry for entry in entries if entry.domain == Platform.CLIMATE]

--- a/tests/components/broadlink/test_device.py
+++ b/tests/components/broadlink/test_device.py
@@ -261,8 +261,8 @@ async def test_device_setup_registry(
 
     assert len(device_registry.devices) == 1
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     assert device_entry.identifiers == {(DOMAIN, device.mac)}
     assert device_entry.name == device.name
@@ -351,8 +351,8 @@ async def test_device_update_listener(
         hass.config_entries.async_update_entry(mock_setup.entry, title="New Name")
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     assert device_entry.name == "New Name"
     for entry in er.async_entries_for_device(entity_registry, device_entry.id):

--- a/tests/components/broadlink/test_infrared.py
+++ b/tests/components/broadlink/test_infrared.py
@@ -29,8 +29,8 @@ async def test_infrared_setup_works(
     for device in map(get_device, IR_DEVICES):
         mock_setup = await device.setup_entry(hass)
 
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         infrared_entities = [

--- a/tests/components/broadlink/test_radio_frequency.py
+++ b/tests/components/broadlink/test_radio_frequency.py
@@ -35,8 +35,8 @@ async def _setup_rf_device(hass: HomeAssistant) -> tuple[MagicMock, str]:
     mock_setup = await device.setup_entry(hass)
     entity_registry = er.async_get(hass)
     device_registry = dr.async_get(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     rf_entity = next(e for e in entries if e.domain == Platform.RADIO_FREQUENCY)
@@ -61,8 +61,8 @@ async def test_radio_frequency_setup(
     """RF entity is created only for RF-capable devices."""
     device = get_device(device_name)
     mock_setup = await device.setup_entry(hass)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     rf_entities = [e for e in entries if e.domain == Platform.RADIO_FREQUENCY]

--- a/tests/components/broadlink/test_remote.py
+++ b/tests/components/broadlink/test_remote.py
@@ -46,8 +46,8 @@ async def test_remote_setup_works(
     for device in map(get_device, REMOTE_DEVICES):
         mock_setup = await device.setup_entry(hass)
 
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
@@ -71,8 +71,8 @@ async def test_remote_send_command(
     for device in map(get_device, REMOTE_DEVICES):
         mock_setup = await device.setup_entry(hass)
 
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]
@@ -114,8 +114,8 @@ async def test_remote_availability(
     device = get_device("Garage")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     remote = next(entry for entry in entries if entry.domain == Platform.REMOTE)
@@ -154,8 +154,8 @@ async def test_remote_turn_off_turn_on(
     for device in map(get_device, REMOTE_DEVICES):
         mock_setup = await device.setup_entry(hass)
 
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
         )
         entries = er.async_entries_for_device(entity_registry, device_entry.id)
         remotes = [entry for entry in entries if entry.domain == Platform.REMOTE]

--- a/tests/components/broadlink/test_select.py
+++ b/tests/components/broadlink/test_select.py
@@ -25,8 +25,8 @@ async def test_select(
     device = get_device("Guest room")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     selects = [entry for entry in entries if entry.domain == Platform.SELECT]

--- a/tests/components/broadlink/test_sensor.py
+++ b/tests/components/broadlink/test_sensor.py
@@ -34,8 +34,8 @@ async def test_a1_sensor_setup(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors_raw.call_count == 1
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -75,8 +75,8 @@ async def test_a1_sensor_update(
 
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -121,8 +121,8 @@ async def test_rm_pro_sensor_setup(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count == 1
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -150,8 +150,8 @@ async def test_rm_pro_sensor_update(
 
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -186,8 +186,8 @@ async def test_rm_pro_filter_crazy_temperature(
 
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -220,8 +220,8 @@ async def test_rm_mini3_no_sensor(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count <= 1
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -241,8 +241,8 @@ async def test_rm4_pro_hts2_sensor_setup(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count == 1
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -273,8 +273,8 @@ async def test_rm4_pro_hts2_sensor_update(
 
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -310,8 +310,8 @@ async def test_rm4_pro_no_sensor(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.check_sensors.call_count <= 1
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = {entry for entry in entries if entry.domain == Platform.SENSOR}
@@ -341,8 +341,8 @@ async def test_scb1e_sensor_setup(
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
     assert mock_api.get_state.call_count == 1
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]
@@ -392,8 +392,8 @@ async def test_scb1e_sensor_update(
 
     mock_setup = await device.setup_entry(hass, mock_api=mock_api)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     sensors = [entry for entry in entries if entry.domain == Platform.SENSOR]

--- a/tests/components/broadlink/test_switch.py
+++ b/tests/components/broadlink/test_switch.py
@@ -22,8 +22,8 @@ async def test_switch_setup_works(
     device = get_device("Dining room")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]
@@ -46,8 +46,8 @@ async def test_switch_turn_off_turn_on(
     device = get_device("Dining room")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]
@@ -82,8 +82,8 @@ async def test_slots_switch_setup_works(
     device = get_device("Gaming room")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]
@@ -107,8 +107,8 @@ async def test_slots_switch_turn_off_turn_on(
     device = get_device("Gaming room")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     switches = [entry for entry in entries if entry.domain == Platform.SWITCH]

--- a/tests/components/broadlink/test_time.py
+++ b/tests/components/broadlink/test_time.py
@@ -25,8 +25,8 @@ async def test_time(
     device = get_device("Guest room")
     mock_setup = await device.setup_entry(hass)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_setup.entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_setup.entry.unique_id), mock_setup.entry.entry_id
     )
     entries = er.async_entries_for_device(entity_registry, device_entry.id)
     times = [entry for entry in entries if entry.domain == Platform.TIME]

--- a/tests/components/bsblan/test_init.py
+++ b/tests/components/bsblan/test_init.py
@@ -486,8 +486,8 @@ async def test_configuration_url_default_port(
     await hass.config_entries.async_setup(mock_config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "00:80:41:19:69:90")}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "00:80:41:19:69:90"), mock_config_entry.entry_id
     )
     assert device is not None
     assert device.configuration_url == "http://127.0.0.1"
@@ -515,8 +515,8 @@ async def test_configuration_url_non_default_port(
     await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "00:80:41:19:69:90")}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "00:80:41:19:69:90"), config_entry.entry_id
     )
     assert device is not None
     assert device.configuration_url == "http://192.168.1.100:8080"

--- a/tests/components/bsblan/test_services.py
+++ b/tests/components/bsblan/test_services.py
@@ -36,10 +36,13 @@ async def setup_integration(
 @pytest.fixture
 def device_entry(
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
     setup_integration: None,
 ) -> dr.DeviceEntry:
     """Get the device entry for testing."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), mock_config_entry.entry_id
+    )
     assert device is not None
     return device
 
@@ -47,11 +50,12 @@ def device_entry(
 @pytest.fixture
 def water_heater_device_entry(
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
     setup_integration: None,
 ) -> dr.DeviceEntry:
     """Get the water heater sub-device entry for testing."""
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_MAC}-water-heater")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_DEVICE_MAC}-water-heater"), mock_config_entry.entry_id
     )
     assert device is not None
     return device
@@ -466,7 +470,9 @@ async def test_sync_time_service(
     await hass.async_block_till_done()
 
     # Get the device
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Mock device time that differs from HA time
@@ -506,7 +512,9 @@ async def test_sync_time_service_no_update_when_same(
     await hass.async_block_till_done()
 
     # Get the device
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Mock device time that matches HA time
@@ -545,7 +553,9 @@ async def test_sync_time_service_error_handling(
     await hass.async_block_till_done()
 
     # Get the device
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Mock time() to raise an error
@@ -579,7 +589,9 @@ async def test_sync_time_service_set_time_error(
     await hass.async_block_till_done()
 
     # Get the device
-    device = device_registry.async_get_device(identifiers={(DOMAIN, TEST_DEVICE_MAC)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_MAC), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Mock device time that differs

--- a/tests/components/bthome/test_device_trigger.py
+++ b/tests/components/bthome/test_device_trigger.py
@@ -111,7 +111,9 @@ async def test_get_triggers_button(
     await hass.async_block_till_done()
     assert len(events) == 1
 
-    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(mac), entry.entry_id
+    )
     assert device
     expected_trigger = {
         CONF_PLATFORM: "device",
@@ -149,7 +151,9 @@ async def test_get_triggers_multiple_buttons(
     await hass.async_block_till_done()
     assert len(events) == 2
 
-    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(mac), entry.entry_id
+    )
     assert device
     expected_trigger1 = {
         CONF_PLATFORM: "device",
@@ -208,7 +212,9 @@ async def test_validate_trigger_config(
     # wait for the event
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(mac), entry.entry_id
+    )
 
     assert await async_setup_component(
         hass,
@@ -259,7 +265,9 @@ async def test_get_triggers_dimmer(
     await hass.async_block_till_done()
     assert len(events) == 1
 
-    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(mac), entry.entry_id
+    )
     assert device
     expected_trigger = {
         CONF_PLATFORM: "device",
@@ -358,7 +366,9 @@ async def test_if_fires_on_motion_detected(
     # wait for the event
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={get_device_id(mac)})
+    device = device_registry.async_get_device_by_identifier(
+        get_device_id(mac), entry.entry_id
+    )
     device_id = device.id
 
     assert await async_setup_component(

--- a/tests/components/cambridge_audio/test_init.py
+++ b/tests/components/cambridge_audio/test_init.py
@@ -40,8 +40,8 @@ async def test_device_info(
 ) -> None:
     """Test device registry integration."""
     await setup_integration(hass, mock_config_entry)
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.unique_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/canary/test_sensor.py
+++ b/tests/components/canary/test_sensor.py
@@ -47,7 +47,7 @@ async def test_sensors_pro(
     ]
 
     with patch("homeassistant.components.canary.PLATFORMS", ["sensor"]):
-        await init_integration(hass)
+        entry = await init_integration(hass)
 
     sensors = {
         "dining_room_home_dining_room_temperature": (
@@ -85,7 +85,9 @@ async def test_sensors_pro(
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "20")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "20"), entry.entry_id
+    )
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "Dining Room"
@@ -168,7 +170,7 @@ async def test_sensors_flex(
     ]
 
     with patch("homeassistant.components.canary.PLATFORMS", ["sensor"]):
-        await init_integration(hass)
+        entry = await init_integration(hass)
 
     sensors = {
         "dining_room_home_dining_room_battery": (
@@ -199,7 +201,9 @@ async def test_sensors_flex(
         assert state.attributes.get(ATTR_UNIT_OF_MEASUREMENT) == data[2]
         assert state.state == data[1]
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "20")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "20"), entry.entry_id
+    )
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "Dining Room"

--- a/tests/components/casper_glow/test_init.py
+++ b/tests/components/casper_glow/test_init.py
@@ -70,10 +70,9 @@ async def test_device_info(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test device info is correctly populated."""
-    device = device_registry.async_get_device(
-        connections={
-            (dr.CONNECTION_BLUETOOTH, format_mac(CASPER_GLOW_DISCOVERY_INFO.address))
-        }
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, format_mac(CASPER_GLOW_DISCOVERY_INFO.address)),
+        config_entry.entry_id,
     )
     assert device is not None
     assert device == snapshot

--- a/tests/components/chess_com/test_init.py
+++ b/tests/components/chess_com/test_init.py
@@ -22,6 +22,8 @@ async def test_device(
 ) -> None:
     """Test the Chess.com device."""
     await setup_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device({(DOMAIN, "532748851")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "532748851"), mock_config_entry.entry_id
+    )
     assert device
     assert device == snapshot

--- a/tests/components/coolmaster/test_init.py
+++ b/tests/components/coolmaster/test_init.py
@@ -60,7 +60,7 @@ async def test_registry_cleanup(
     assert await async_setup_component(hass, "config", {})
     client = await hass_ws_client(hass)
     # Try to remove "L1.100" - fails since it is live
-    device = device_registry.async_get_device(identifiers={(DOMAIN, live_id)})
+    device = device_registry.async_get_device_by_identifier((DOMAIN, live_id), entry_id)
     assert device is not None
     response = await client.remove_device(device.id, entry_id)
     assert not response["success"]
@@ -68,14 +68,20 @@ async def test_registry_cleanup(
         len(dr.async_entries_for_config_entry(device_registry, entry_id))
         == unit_count + 1
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, live_id)}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, live_id), entry_id)
+        is not None
+    )
 
     # Try to remove "L2.200" - succeeds since it is dead
-    device = device_registry.async_get_device(identifiers={(DOMAIN, dead_id)})
+    device = device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
     assert device is not None
     response = await client.remove_device(device.id, entry_id)
     assert response["success"]
     assert (
         len(dr.async_entries_for_config_entry(device_registry, entry_id)) == unit_count
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, dead_id)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, dead_id), entry_id)
+        is None
+    )

--- a/tests/components/daikin/test_init.py
+++ b/tests/components/daikin/test_init.py
@@ -85,11 +85,18 @@ async def test_duplicate_removal(
         await hass.async_block_till_done()
 
         assert (
-            device_registry.async_get_device({}, {(KEY_MAC, MAC)}).name
+            device_registry.async_get_device_by_connection(
+                (KEY_MAC, MAC), config_entry.entry_id
+            ).name
             == "DaikinAP00000"
         )
 
-        assert device_registry.async_get_device({}, {(KEY_MAC, HOST)}).name is None
+        assert (
+            device_registry.async_get_device_by_connection(
+                (KEY_MAC, HOST), config_entry.entry_id
+            ).name
+            is None
+        )
 
         assert entity_registry.async_get("climate.daikin_127_0_0_1").unique_id == HOST
         assert entity_registry.async_get("switch.zone_1").unique_id.startswith(HOST)
@@ -103,7 +110,10 @@ async def test_duplicate_removal(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device({}, {(KEY_MAC, MAC)}).name == "DaikinAP00000"
+        device_registry.async_get_device_by_connection(
+            (KEY_MAC, MAC), config_entry.entry_id
+        ).name
+        == "DaikinAP00000"
     )
 
     assert entity_registry.async_get("climate.daikinap00000") is None
@@ -136,7 +146,12 @@ async def test_unique_id_migrate(
 
     assert config_entry.unique_id == HOST
 
-    assert device_registry.async_get_device(connections={(KEY_MAC, HOST)}).name is None
+    assert (
+        device_registry.async_get_device_by_connection(
+            (KEY_MAC, HOST), config_entry.entry_id
+        ).name
+        is None
+    )
 
     entity = entity_registry.async_get("climate.daikin_127_0_0_1")
     assert entity.unique_id == HOST
@@ -155,7 +170,9 @@ async def test_unique_id_migrate(
     assert config_entry.unique_id == MAC
 
     assert (
-        device_registry.async_get_device(connections={(KEY_MAC, MAC)}).name
+        device_registry.async_get_device_by_connection(
+            (KEY_MAC, MAC), config_entry.entry_id
+        ).name
         == "DaikinAP00000"
     )
 

--- a/tests/components/deconz/test_deconz_event.py
+++ b/tests/components/deconz/test_deconz_event.py
@@ -93,8 +93,8 @@ async def test_deconz_events(
 
     await sensor_ws_data({"id": "1", "state": {"buttonevent": 2000}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:01")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:01"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 1
@@ -107,8 +107,8 @@ async def test_deconz_events(
 
     await sensor_ws_data({"id": "3", "state": {"buttonevent": 2000}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:03")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:03"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 2
@@ -122,8 +122,8 @@ async def test_deconz_events(
 
     await sensor_ws_data({"id": "4", "state": {"gesture": 0}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:04")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:04"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 3
@@ -141,8 +141,8 @@ async def test_deconz_events(
     }
     await sensor_ws_data(event_changed_sensor)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:05")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:05"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 4
@@ -249,8 +249,8 @@ async def test_deconz_alarm_events(
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.EMERGENCY}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:01")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:01"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 1
@@ -265,8 +265,8 @@ async def test_deconz_alarm_events(
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.FIRE}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:01")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:01"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 2
@@ -281,8 +281,8 @@ async def test_deconz_alarm_events(
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.INVALID_CODE}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:01")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:01"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 3
@@ -297,8 +297,8 @@ async def test_deconz_alarm_events(
 
     await sensor_ws_data({"state": {"action": AncillaryControlAction.PANIC}})
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:01")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:01"), config_entry_setup.entry_id
     )
 
     assert len(captured_events) == 4
@@ -365,8 +365,8 @@ async def test_deconz_presence_events(
         == 2
     )
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "xx:xx:xx:xx:xx:xx:xx:xx")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "xx:xx:xx:xx:xx:xx:xx:xx"), config_entry_setup.entry_id
     )
 
     captured_events = async_capture_events(hass, CONF_DECONZ_PRESENCE_EVENT)
@@ -442,8 +442,8 @@ async def test_deconz_relative_rotary_events(
         == 2
     )
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "xx:xx:xx:xx:xx:xx:xx:xx")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "xx:xx:xx:xx:xx:xx:xx:xx"), config_entry_setup.entry_id
     )
 
     captured_events = async_capture_events(hass, CONF_DECONZ_RELATIVE_ROTARY_EVENT)

--- a/tests/components/deconz/test_device_trigger.py
+++ b/tests/components/deconz/test_device_trigger.py
@@ -63,15 +63,15 @@ from tests.common import MockConfigEntry, async_get_device_automations
         }
     ],
 )
-@pytest.mark.usefixtures("config_entry_setup")
 async def test_get_triggers(
     hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test triggers work."""
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a"), config_entry_setup.entry_id
     )
     battery_sensor_entry = entity_registry.async_get(
         "sensor.tradfri_on_off_switch_battery"
@@ -174,15 +174,15 @@ async def test_get_triggers(
         }
     ],
 )
-@pytest.mark.usefixtures("config_entry_setup")
 async def test_get_triggers_for_alarm_event(
     hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     entity_registry: er.EntityRegistry,
 ) -> None:
     """Test triggers work."""
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "00:00:00:00:00:00:00:00")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "00:00:00:00:00:00:00:00"), config_entry_setup.entry_id
     )
     bat_entity = entity_registry.async_get("sensor.keypad_battery")
     low_bat_entity = entity_registry.async_get("binary_sensor.keypad_low_battery")
@@ -261,13 +261,14 @@ async def test_get_triggers_for_alarm_event(
         }
     ],
 )
-@pytest.mark.usefixtures("config_entry_setup")
 async def test_get_triggers_manage_unsupported_remotes(
-    hass: HomeAssistant, device_registry: dr.DeviceRegistry
+    hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
+    device_registry: dr.DeviceRegistry,
 ) -> None:
     """Verify no triggers for an unsupported remote."""
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a"), config_entry_setup.entry_id
     )
 
     triggers = await async_get_device_automations(
@@ -303,16 +304,16 @@ async def test_get_triggers_manage_unsupported_remotes(
         }
     ],
 )
-@pytest.mark.usefixtures("config_entry_setup")
 async def test_functional_device_trigger(
     hass: HomeAssistant,
+    config_entry_setup: MockConfigEntry,
     device_registry: dr.DeviceRegistry,
     service_calls: list[ServiceCall],
     sensor_ws_data: WebsocketDataType,
 ) -> None:
     """Test proper matching and attachment of device trigger automation."""
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a")}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "d0:cf:5e:ff:fe:71:a4:3a"), config_entry_setup.entry_id
     )
 
     assert await async_setup_component(

--- a/tests/components/deconz/test_hub.py
+++ b/tests/components/deconz/test_hub.py
@@ -30,8 +30,8 @@ async def test_device_registry_entry(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Successful setup."""
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry_setup.unique_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry_setup.unique_id), config_entry_setup.entry_id
     )
     assert device_entry == snapshot
 

--- a/tests/components/deconz/test_logbook.py
+++ b/tests/components/deconz/test_logbook.py
@@ -63,8 +63,8 @@ async def test_humanifying_deconz_alarm_event(
     """Test humanifying deCONZ alarm event."""
     keypad_event_id = slugify(sensor_payload["name"])
     keypad_serial = serial_from_unique_id(sensor_payload["uniqueid"])
-    keypad_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, keypad_serial)}
+    keypad_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, keypad_serial), hass.config_entries.async_entries(DOMAIN)[0].entry_id
     )
 
     removed_device_event_id = "removed_device"
@@ -156,26 +156,28 @@ async def test_humanifying_deconz_event(
     """Test humanifying deCONZ event."""
     switch_event_id = slugify(sensor_payload["1"]["name"])
     switch_serial = serial_from_unique_id(sensor_payload["1"]["uniqueid"])
-    switch_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, switch_serial)}
+    switch_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, switch_serial), hass.config_entries.async_entries(DOMAIN)[0].entry_id
     )
 
     hue_remote_event_id = slugify(sensor_payload["2"]["name"])
     hue_remote_serial = serial_from_unique_id(sensor_payload["2"]["uniqueid"])
-    hue_remote_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, hue_remote_serial)}
+    hue_remote_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, hue_remote_serial),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
 
     xiaomi_cube_event_id = slugify(sensor_payload["3"]["name"])
     xiaomi_cube_serial = serial_from_unique_id(sensor_payload["3"]["uniqueid"])
-    xiaomi_cube_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, xiaomi_cube_serial)}
+    xiaomi_cube_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, xiaomi_cube_serial),
+        hass.config_entries.async_entries(DOMAIN)[0].entry_id,
     )
 
     faulty_event_id = slugify(sensor_payload["4"]["name"])
     faulty_serial = serial_from_unique_id(sensor_payload["4"]["uniqueid"])
-    faulty_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, faulty_serial)}
+    faulty_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, faulty_serial), hass.config_entries.async_entries(DOMAIN)[0].entry_id
     )
 
     removed_device_event_id = "removed_device"

--- a/tests/components/devolo_home_control/test_binary_sensor.py
+++ b/tests/components/devolo_home_control/test_binary_sensor.py
@@ -66,7 +66,9 @@ async def test_binary_sensor(
     # Emulate websocket message: device was deleted
     test_gateway.publisher.dispatch("Test", ("Test", "del"))
     await hass.async_block_till_done()
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "Test")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "Test"), entry.entry_id
+    )
     assert not device
 
 

--- a/tests/components/devolo_home_control/test_init.py
+++ b/tests/components/devolo_home_control/test_init.py
@@ -112,11 +112,18 @@ async def test_remove_device(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "Test")})
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, "Test"), entry.entry_id
+        )
         assert device_entry
 
         client = await hass_ws_client(hass)
         response = await client.remove_device(device_entry.id, entry.entry_id)
         assert response["success"]
-        assert device_registry.async_get_device(identifiers={(DOMAIN, "Test")}) is None
+        assert (
+            device_registry.async_get_device_by_identifier(
+                (DOMAIN, "Test"), entry.entry_id
+            )
+            is None
+        )
         assert hass.states.get(f"{BINARY_SENSOR_DOMAIN}.test") is None

--- a/tests/components/devolo_home_control/test_sensor.py
+++ b/tests/components/devolo_home_control/test_sensor.py
@@ -204,10 +204,16 @@ async def test_deleted_device_removed_once(
 
     # The consumption device has several entities (power, energy), all subscribed
     # to the same device uid
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "Test")}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, "Test"), entry.entry_id)
+        is not None
+    )
 
     # Emulate websocket message: device was deleted
     test_gateway.publisher.dispatch("Test", ("Test", "del"))
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "Test")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier((DOMAIN, "Test"), entry.entry_id)
+        is None
+    )

--- a/tests/components/devolo_home_network/test_init.py
+++ b/tests/components/devolo_home_network/test_init.py
@@ -79,8 +79,8 @@ async def test_device(
     mock_device: MockDevice = request.getfixturevalue(device)
     entry = configure_integration(hass)
     assert await hass.config_entries.async_setup(entry.entry_id)
-    device_info = device_registry.async_get_device(
-        {(DOMAIN, mock_device.serial_number)}
+    device_info = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.serial_number), entry.entry_id
     )
     assert device_info == snapshot
 

--- a/tests/components/devolo_home_network/test_update.py
+++ b/tests/components/devolo_home_network/test_update.py
@@ -83,8 +83,8 @@ async def test_update_firmware(
     assert state is not None
     assert state.state == STATE_OFF
 
-    device_info = device_registry.async_get_device(
-        {(DOMAIN, mock_device.serial_number)}
+    device_info = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_device.serial_number), entry.entry_id
     )
     assert device_info is not None
     assert device_info.sw_version == mock_device.firmware_version

--- a/tests/components/dlink/test_init.py
+++ b/tests/components/dlink/test_init.py
@@ -68,7 +68,9 @@ async def test_device_info(
     await setup_integration()
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     assert device.connections == {("mac", "aa:bb:cc:dd:ee:ff")}
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/dlna_dmr/test_media_player.py
+++ b/tests/components/dlna_dmr/test_media_player.py
@@ -351,9 +351,8 @@ async def test_setup_entry_mac_address(
     await async_update_entity(hass, mock_entity_id)
     await hass.async_block_till_done()
     # Check the device registry connections for MAC address
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, MOCK_MAC_ADDRESS) in device.connections
@@ -373,9 +372,8 @@ async def test_setup_entry_no_mac_address(
     await async_update_entity(hass, mock_entity_id)
     await hass.async_block_till_done()
     # Check the device registry connections does not include the MAC address
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock_no_mac.entry_id
     )
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, MOCK_MAC_ADDRESS) not in device.connections
@@ -442,15 +440,15 @@ async def test_available_device(
     hass: HomeAssistant,
     device_registry: dr.DeviceRegistry,
     dmr_device_mock: Mock,
+    config_entry_mock: MockConfigEntry,
     mock_entity_id: str,
 ) -> None:
     """Test a DlnaDmrEntity with a connected DmrDevice."""
     # Check hass device information is filled in
     await async_update_entity(hass, mock_entity_id)
     await hass.async_block_till_done()
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
     # Device properties are set in dmr_device_mock before the entity gets constructed
@@ -1362,9 +1360,8 @@ async def test_unavailable_device(
         )
 
     # Check hass device information has not been filled in yet
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
     assert device.name is None
@@ -1409,9 +1406,8 @@ async def test_become_available(
     assert mock_state.state == ha_const.STATE_UNAVAILABLE
 
     # Check hass device information has not been filled in yet
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
 
@@ -1450,9 +1446,8 @@ async def test_become_available(
     assert mock_state is not None
     assert mock_state.state == MediaPlayerState.IDLE
     # Check hass device information is now filled in
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
     assert device.manufacturer == "device_manufacturer"
@@ -2298,9 +2293,8 @@ async def test_config_update_mac_address(
     domain_data_mock.upnp_factory.async_create_device.reset_mock()
 
     # Check the device registry connections does not include the MAC address
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock_no_mac.entry_id
     )
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, MOCK_MAC_ADDRESS) not in device.connections
@@ -2318,9 +2312,8 @@ async def test_config_update_mac_address(
     await hass.async_block_till_done()
 
     # Device registry connections should now include the MAC address
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock_no_mac.entry_id
     )
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, MOCK_MAC_ADDRESS) in device.connections
@@ -2351,9 +2344,8 @@ async def test_connections_restored(
     assert mock_state.state == ha_const.STATE_UNAVAILABLE
 
     # Check hass device information has not been filled in yet
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
 
@@ -2392,9 +2384,8 @@ async def test_connections_restored(
     assert mock_state is not None
     assert mock_state.state == MediaPlayerState.IDLE
     # Check hass device information is now filled in
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
     previous_connections = device.connections
@@ -2414,9 +2405,8 @@ async def test_connections_restored(
     dmr_device_mock.async_unsubscribe_services.assert_awaited_once()
 
     # Check hass device information has not been filled in yet
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_UPNP, MOCK_DEVICE_UDN)},
-        identifiers=set(),
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_UPNP, MOCK_DEVICE_UDN), config_entry_mock.entry_id
     )
     assert device is not None
     assert device.connections == previous_connections

--- a/tests/components/dremel_3d_printer/test_init.py
+++ b/tests/components/dremel_3d_printer/test_init.py
@@ -83,8 +83,8 @@ async def test_device_info(
     """Test device info."""
     await hass.config_entries.async_setup(config_entry.entry_id)
     assert await async_setup_component(hass, DOMAIN, {})
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, config_entry.unique_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, config_entry.unique_id), config_entry.entry_id
     )
 
     assert device.manufacturer == "Dremel"

--- a/tests/components/dwd_weather_warnings/test_init.py
+++ b/tests/components/dwd_weather_warnings/test_init.py
@@ -86,8 +86,8 @@ async def test_removing_old_device(
     )
 
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_identifier_entry.entry_id)}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_identifier_entry.entry_id), mock_identifier_entry.entry_id
         )
         is not None
     )
@@ -96,8 +96,8 @@ async def test_removing_old_device(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, mock_identifier_entry.entry_id)}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, mock_identifier_entry.entry_id), mock_identifier_entry.entry_id
         )
         is None
     )

--- a/tests/components/dyson_infrared/test_fan.py
+++ b/tests/components/dyson_infrared/test_fan.py
@@ -38,8 +38,8 @@ async def test_entities(
     """Test the fan entity is created with correct attributes and attached to a device."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={("dyson_infrared", mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        ("dyson_infrared", mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(

--- a/tests/components/earn_e_p1/test_init.py
+++ b/tests/components/earn_e_p1/test_init.py
@@ -68,7 +68,9 @@ async def test_device_info(
     trigger_callback(mock_listener)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device == snapshot
 
@@ -86,14 +88,18 @@ async def test_device_registry_not_updated_on_identical_callback(
     trigger_callback(mock_listener)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     first_modified = device.modified_at
 
     trigger_callback(mock_listener)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.modified_at == first_modified
 
@@ -111,13 +117,17 @@ async def test_device_registry_updated_on_sw_version_change(
     trigger_callback(mock_listener)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "1.0.0"
 
     trigger_callback(mock_listener, sw_version="2.0.0")
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, MOCK_SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL), mock_config_entry.entry_id
+    )
     assert device is not None
     assert device.sw_version == "2.0.0"

--- a/tests/components/ecovacs/test_init.py
+++ b/tests/components/ecovacs/test_init.py
@@ -155,13 +155,14 @@ async def test_migrate_entry_keeps_device_id(
 async def test_devices_in_dr(
     device_registry: dr.DeviceRegistry,
     controller: EcovacsController,
+    mock_config_entry: MockConfigEntry,
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test all devices are in the device registry."""
     for device in controller.devices:
         assert (
-            device_entry := device_registry.async_get_device(
-                identifiers={(DOMAIN, device.device_info["did"])}
+            device_entry := device_registry.async_get_device_by_identifier(
+                (DOMAIN, device.device_info["did"]), mock_config_entry.entry_id
             )
         )
         assert device_entry == snapshot(name=device.device_info["did"])

--- a/tests/components/efergy/test_init.py
+++ b/tests/components/efergy/test_init.py
@@ -55,7 +55,9 @@ async def test_device_info(
     """Test device info."""
     entry = await setup_platform(hass, aioclient_mock, SENSOR_DOMAIN)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     assert device.configuration_url == "https://engage.efergy.com/user/login"
     assert device.connections == {("mac", "ff:ff:ff:ff:ff:ff")}

--- a/tests/components/egauge/test_sensor.py
+++ b/tests/components/egauge/test_sensor.py
@@ -31,7 +31,9 @@ async def test_sensors(
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
     # Verify main device created with hostname
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "ABC123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "ABC123456"), mock_config_entry.entry_id
+    )
     assert device_entry
     assert device_entry == snapshot
 

--- a/tests/components/electrasmart/test_init.py
+++ b/tests/components/electrasmart/test_init.py
@@ -66,7 +66,7 @@ async def test_device_registry(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "a8032ab12345")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "a8032ab12345"), entry.entry_id
     )
     assert device_entry == snapshot

--- a/tests/components/energieleser/test_init.py
+++ b/tests/components/energieleser/test_init.py
@@ -87,8 +87,8 @@ async def test_device_exposes_discovery_sw_version(
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, STROMLESER_DEVICE_ID)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, STROMLESER_DEVICE_ID), entry.entry_id
     )
     assert device is not None
     assert device.sw_version == STROMLESER_SW_VERSION

--- a/tests/components/enigma2/test_init.py
+++ b/tests/components/enigma2/test_init.py
@@ -30,7 +30,12 @@ async def test_device_without_mac_address(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     assert entry.unique_id == "123456"
-    assert device_registry.async_get_device({(DOMAIN, entry.unique_id)}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.unique_id), entry.entry_id
+        )
+        is not None
+    )
 
 
 @pytest.mark.usefixtures("openwebif_device_mock")

--- a/tests/components/enphase_envoy/test_init.py
+++ b/tests/components/enphase_envoy/test_init.py
@@ -716,13 +716,9 @@ async def test_coordinator_interface_information_no_device(
     )
 
     # update device to force no device found in mac verification
-    envoy_device = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                mock_envoy.serial_number,
-            )
-        }
+    envoy_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_envoy.serial_number),
+        config_entry.entry_id,
     )
     device_registry.async_update_device(
         device_id=envoy_device.id,
@@ -764,13 +760,9 @@ async def test_coordinator_interface_information_mac_also_in_other_device(
         manufacturer="Enphase Energy",
     )
 
-    envoy_device = device_registry.async_get_device(
-        identifiers={
-            (
-                DOMAIN,
-                mock_envoy.serial_number,
-            )
-        }
+    envoy_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_envoy.serial_number),
+        config_entry.entry_id,
     )
     assert envoy_device
 

--- a/tests/components/esphome/test_assist_satellite.py
+++ b/tests/components/esphome/test_assist_satellite.py
@@ -108,8 +108,9 @@ async def test_pipeline_api_audio(
         },
     )
     await hass.async_block_till_done()
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id),
+        mock_device.entry.entry_id,
     )
 
     satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
@@ -779,8 +780,9 @@ async def test_timer_events(
         },
     )
     await hass.async_block_till_done()
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id),
+        mock_device.entry.entry_id,
     )
 
     total_seconds = (1 * 60 * 60) + (2 * 60) + 3
@@ -848,8 +850,9 @@ async def test_unknown_timer_event(
     )
     await hass.async_block_till_done()
     assert mock_device.entry.unique_id is not None
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id),
+        mock_device.entry.entry_id,
     )
     assert dev is not None
 
@@ -1189,8 +1192,9 @@ async def test_announce_media_id(
     )
     await hass.async_block_till_done()
 
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id),
+        mock_device.entry.entry_id,
     )
 
     satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)
@@ -1470,8 +1474,9 @@ async def test_start_conversation_media_id(
     )
     await hass.async_block_till_done()
 
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id),
+        mock_device.entry.entry_id,
     )
 
     satellite = get_satellite_entity(hass, mock_device.device_info.mac_address)

--- a/tests/components/esphome/test_bluetooth.py
+++ b/tests/components/esphome/test_bluetooth.py
@@ -79,17 +79,16 @@ async def test_bluetooth_device_linked_via_device(
         "bluetooth", "AA:BB:CC:DD:EE:FC"
     )
     assert entry is not None
-    esp_device = device_registry.async_get_device(
-        connections={
-            (
-                dr.CONNECTION_NETWORK_MAC,
-                mock_bluetooth_entry_with_raw_adv.device_info.mac_address,
-            )
-        }
+    esp_device = device_registry.async_get_device_by_connection(
+        (
+            dr.CONNECTION_NETWORK_MAC,
+            mock_bluetooth_entry_with_raw_adv.device_info.mac_address,
+        ),
+        mock_bluetooth_entry_with_raw_adv.entry.entry_id,
     )
     assert esp_device is not None
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_BLUETOOTH, "AA:BB:CC:DD:EE:FC")}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_BLUETOOTH, "AA:BB:CC:DD:EE:FC"), entry.entry_id
     )
     assert device is not None
     assert device.via_device_id == esp_device.id

--- a/tests/components/esphome/test_entity.py
+++ b/tests/components/esphome/test_entity.py
@@ -758,8 +758,9 @@ async def test_entity_assignment_to_sub_device(
     )
 
     # Check main device
-    main_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address)}
+    main_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address),
+        device.entry.entry_id,
     )
     assert main_device is not None
 
@@ -769,8 +770,8 @@ async def test_entity_assignment_to_sub_device(
     assert main_sensor.device_id == main_device.id
 
     # Check sub device 1 entity
-    sub_device_1 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+    sub_device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
     )
     assert sub_device_1 is not None
 
@@ -779,8 +780,8 @@ async def test_entity_assignment_to_sub_device(
     assert motion_sensor.device_id == sub_device_1.id
 
     # Check sub device 2 entity
-    sub_device_2 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+    sub_device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
     )
     assert sub_device_2 is not None
 
@@ -939,8 +940,9 @@ async def test_entity_switches_between_devices(
     )
 
     # Verify entity is on main device
-    main_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address)}
+    main_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address),
+        device.entry.entry_id,
     )
     assert main_device is not None
 
@@ -970,8 +972,8 @@ async def test_entity_switches_between_devices(
     await device.mock_connect()
 
     # Verify entity is now on sub device 1
-    sub_device_1 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+    sub_device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
     )
     assert sub_device_1 is not None
 
@@ -999,8 +1001,8 @@ async def test_entity_switches_between_devices(
     await device.mock_connect()
 
     # Verify entity is now on sub device 2
-    sub_device_2 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+    sub_device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
     )
     assert sub_device_2 is not None
 
@@ -1326,8 +1328,8 @@ async def test_unique_id_migration_when_entity_moves_between_devices(
     assert entity_entry.unique_id == expected_unique_id
 
     # Entity should now be associated with the sub-device
-    sub_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+    sub_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
     )
     assert sub_device is not None
     assert entity_entry.device_id == sub_device.id
@@ -1421,8 +1423,9 @@ async def test_unique_id_migration_sub_device_to_main_device(
     assert entity_entry.unique_id == expected_unique_id
 
     # Entity should now be associated with the main device
-    main_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address)}
+    main_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address),
+        device.entry.entry_id,
     )
     assert main_device is not None
     assert entity_entry.device_id == main_device.id
@@ -1517,8 +1520,8 @@ async def test_unique_id_migration_between_sub_devices(
     assert entity_entry.unique_id == expected_unique_id
 
     # Entity should now be associated with the second sub-device
-    bedroom_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_33333333")}
+    bedroom_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_33333333"), device.entry.entry_id
     )
     assert bedroom_device is not None
     assert entity_entry.device_id == bedroom_device.id
@@ -1643,8 +1646,8 @@ async def test_entity_device_id_rename_in_yaml(
     assert entity_entry.unique_id == expected_unique_id
 
     # Entity should be associated with the new device
-    renamed_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_99999999")}
+    renamed_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_99999999"), device.entry.entry_id
     )
     assert renamed_device is not None
     assert entity_entry.device_id == renamed_device.id

--- a/tests/components/esphome/test_manager.py
+++ b/tests/components/esphome/test_manager.py
@@ -1613,8 +1613,8 @@ async def test_esphome_device_with_suggested_area(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert dev.area_id == area_registry.async_get_area_by_name("kitchen").id
 
@@ -1636,8 +1636,8 @@ async def test_esphome_device_area_priority(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     # Should use device_info.area.name instead of suggested_area
     assert dev.area_id == area_registry.async_get_area_by_name("Living Room").id
@@ -1656,8 +1656,8 @@ async def test_esphome_device_with_project(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert dev.manufacturer == "mfr"
     assert dev.model == "model"
@@ -1677,8 +1677,8 @@ async def test_esphome_device_with_manufacturer(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert dev.manufacturer == "acme"
 
@@ -1696,8 +1696,8 @@ async def test_esphome_device_with_web_server(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert dev.configuration_url == "http://test.local:80"
 
@@ -1726,8 +1726,8 @@ async def test_esphome_device_with_ipv6_web_server(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert dev.configuration_url == "http://[fe80::1]:80"
 
@@ -1745,8 +1745,8 @@ async def test_esphome_device_with_compilation_time(
     )
     await hass.async_block_till_done()
     entry = device.entry
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, entry.unique_id), entry.entry_id
     )
     assert "comp_time" in dev.sw_version
 
@@ -1923,8 +1923,8 @@ async def test_device_adds_friendly_name(
     )
     await hass.async_block_till_done()
     dev_reg = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    dev = dev_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.entry.unique_id)}
+    dev = dev_reg.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.entry.unique_id), device.entry.entry_id
     )
     assert dev.name == "Nofriendlyname"
     assert (
@@ -1945,8 +1945,8 @@ async def test_device_adds_friendly_name(
     )
     await device.mock_connect()
     await hass.async_block_till_done()
-    dev = dev_reg.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.entry.unique_id)}
+    dev = dev_reg.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.entry.unique_id), device.entry.entry_id
     )
     assert dev.name == "I have a friendly name"
     assert (
@@ -2036,15 +2036,16 @@ async def test_sub_device_creation(
     )
 
     # Check main device is created
-    main_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address)}
+    main_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address),
+        device.entry.entry_id,
     )
     assert main_device is not None
     assert main_device.area_id == area_registry.async_get_area_by_name("Main Hub").id
 
     # Check sub devices are created
-    sub_device_1 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+    sub_device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
     )
     assert sub_device_1 is not None
     assert sub_device_1.name == "Motion Sensor"
@@ -2053,8 +2054,8 @@ async def test_sub_device_creation(
     )
     assert sub_device_1.via_device_id == main_device.id
 
-    sub_device_2 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+    sub_device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
     )
     assert sub_device_2 is not None
     assert sub_device_2.name == "Light Switch"
@@ -2063,8 +2064,8 @@ async def test_sub_device_creation(
     )
     assert sub_device_2.via_device_id == main_device.id
 
-    sub_device_3 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_33333333")}
+    sub_device_3 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_33333333"), device.entry.entry_id
     )
     assert sub_device_3 is not None
     assert sub_device_3.name == "Temperature Sensor"
@@ -2098,20 +2099,23 @@ async def test_sub_device_cleanup(
 
     # Verify all sub devices exist
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{device.device_info.mac_address}_11111111"),
+            device.entry.entry_id,
         )
         is not None
     )
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{device.device_info.mac_address}_22222222"),
+            device.entry.entry_id,
         )
         is not None
     )
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{device.device_info.mac_address}_33333333")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{device.device_info.mac_address}_33333333"),
+            device.entry.entry_id,
         )
         is not None
     )
@@ -2144,20 +2148,23 @@ async def test_sub_device_cleanup(
 
     # Verify device 2 was removed
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{device.device_info.mac_address}_11111111"),
+            device.entry.entry_id,
         )
         is not None
     )
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{device.device_info.mac_address}_22222222"),
+            device.entry.entry_id,
         )
         is None
     )  # Should be removed
     assert (
-        device_registry.async_get_device(
-            identifiers={(DOMAIN, f"{device.device_info.mac_address}_33333333")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{device.device_info.mac_address}_33333333"),
+            device.entry.entry_id,
         )
         is not None
     )
@@ -2188,19 +2195,20 @@ async def test_sub_device_with_empty_name(
     await hass.async_block_till_done()
 
     # Check sub device with empty name
-    sub_device_1 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+    sub_device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
     )
     assert sub_device_1 is not None
     # Empty sub-device names should fall back to main device name
-    main_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address)}
+    main_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address),
+        device.entry.entry_id,
     )
     assert sub_device_1.name == main_device.name
 
     # Check sub device with valid name
-    sub_device_2 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+    sub_device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
     )
     assert sub_device_2 is not None
     assert sub_device_2.name == "Valid Name"
@@ -2246,8 +2254,9 @@ async def test_sub_device_references_main_device_area(
     )
 
     # Check main device has correct area
-    main_device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address)}
+    main_device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, device.device_info.mac_address),
+        device.entry.entry_id,
     )
     assert main_device is not None
     assert (
@@ -2255,8 +2264,8 @@ async def test_sub_device_references_main_device_area(
     )
 
     # Check sub device 1 uses main device's area
-    sub_device_1 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_11111111")}
+    sub_device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_11111111"), device.entry.entry_id
     )
     assert sub_device_1 is not None
     assert (
@@ -2264,8 +2273,8 @@ async def test_sub_device_references_main_device_area(
     )
 
     # Check sub device 2 uses Living Room
-    sub_device_2 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_22222222")}
+    sub_device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_22222222"), device.entry.entry_id
     )
     assert sub_device_2 is not None
     assert (
@@ -2273,8 +2282,8 @@ async def test_sub_device_references_main_device_area(
     )
 
     # Check sub device 3 uses Bedroom
-    sub_device_3 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{device.device_info.mac_address}_33333333")}
+    sub_device_3 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{device.device_info.mac_address}_33333333"), device.entry.entry_id
     )
     assert sub_device_3 is not None
     assert sub_device_3.area_id == area_registry.async_get_area_by_name("Bedroom").id
@@ -3046,8 +3055,8 @@ async def test_dynamic_encryption_key_dashboard_sync_failure_is_not_fatal(
     # The flow must have run to completion — a sync exception escaping
     # _on_connect would skip the device-registry setup after the handoff.
     assert (
-        device_registry.async_get_device(
-            connections={(dr.CONNECTION_NETWORK_MAC, mac_address)}
+        device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, mac_address), entry.entry_id
         )
         is not None
     )

--- a/tests/components/esphome/test_media_player.py
+++ b/tests/components/esphome/test_media_player.py
@@ -468,8 +468,9 @@ async def test_media_player_proxy(
         ],
     )
     await hass.async_block_till_done()
-    dev = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id)}
+    dev = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, mock_device.entry.unique_id),
+        mock_device.entry.entry_id,
     )
     assert dev is not None
     state = hass.states.get("media_player.test_my_media_player")

--- a/tests/components/esphome/test_repairs.py
+++ b/tests/components/esphome/test_repairs.py
@@ -214,12 +214,14 @@ async def test_device_conflict_migration(
     for entry in entries:
         assert entry.unique_id.startswith("11:22:33:44:55:AB/")
 
-    dev_entry = device_registry.async_get_device(
-        identifiers={}, connections={(dr.CONNECTION_NETWORK_MAC, "11:22:33:44:55:ab")}
+    dev_entry = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "11:22:33:44:55:ab"), mock_config_entry.entry_id
     )
     assert dev_entry is not None
 
-    old_dev_entry = device_registry.async_get_device(
-        identifiers={}, connections={(dr.CONNECTION_NETWORK_MAC, "11:22:33:44:55:aa")}
+    assert (
+        device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, "11:22:33:44:55:aa"), mock_config_entry.entry_id
+        )
+        is None
     )
-    assert old_dev_entry is None

--- a/tests/components/essent/test_init.py
+++ b/tests/components/essent/test_init.py
@@ -47,8 +47,8 @@ async def test_device_registry(
     """Test device is registered correctly."""
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry == snapshot

--- a/tests/components/eurotronic_cometblue/test_init.py
+++ b/tests/components/eurotronic_cometblue/test_init.py
@@ -25,7 +25,9 @@ async def test_device_registry(
     """Test the device registry entry, including the Bluetooth connection."""
     await setup_with_selected_platforms(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, FIXTURE_MAC)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, FIXTURE_MAC), mock_config_entry.entry_id
+    )
     assert device_entry == snapshot
 
 

--- a/tests/components/feedreader/test_init.py
+++ b/tests/components/feedreader/test_init.py
@@ -423,8 +423,8 @@ async def test_feed_atom_htmlentities(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-        device_entry = device_registry.async_get_device(
-            identifiers={(DOMAIN, entry.entry_id)}
+        device_entry = device_registry.async_get_device_by_identifier(
+            (DOMAIN, entry.entry_id), entry.entry_id
         )
         assert device_entry.manufacturer == "Juan Pérez"
 

--- a/tests/components/fibaro/test_diagnostics.py
+++ b/tests/components/fibaro/test_diagnostics.py
@@ -87,7 +87,9 @@ async def test_device_diagnostics_for_hub(
     mock_fibaro_client.read_devices.return_value = [mock_light, mock_power_sensor]
     # Act
     await init_integration(hass, mock_config_entry)
-    device = device_registry.async_get_device({(DOMAIN, TEST_SERIALNUMBER)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_SERIALNUMBER), mock_config_entry.entry_id
+    )
     # Assert
     assert device
     assert (

--- a/tests/components/filesize/test_sensor.py
+++ b/tests/components/filesize/test_sensor.py
@@ -90,8 +90,8 @@ async def test_valid_path(
     assert state
     assert state.state == "0.0"
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert device.name == mock_config_entry.title
 

--- a/tests/components/fjaraskupan/test_init.py
+++ b/tests/components/fjaraskupan/test_init.py
@@ -55,8 +55,8 @@ async def test_setup(
     )
 
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address), config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.manufacturer == "Fjäråskupan"
@@ -95,8 +95,8 @@ async def test_setup_ignore_device(
     )
 
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address), config_entry.entry_id
     )
     assert device_entry is None
 
@@ -119,8 +119,8 @@ async def test_remove_device(
     inject_bluetooth_service_info(hass, MOCK_SERVICE_INFO_DISCOVERY)
 
     await hass.async_block_till_done()
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERVICE_INFO_DISCOVERY.address), config_entry.entry_id
     )
     assert device_entry
 

--- a/tests/components/flux_led/test_light.py
+++ b/tests/components/flux_led/test_light.py
@@ -189,8 +189,8 @@ async def test_light_device_registry(
         await async_setup_component(hass, flux_led.DOMAIN, {flux_led.DOMAIN: {}})
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS)}
+    device = device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, MAC_ADDRESS), config_entry.entry_id
     )
     assert device.sw_version == str(sw_version)
     assert device.model == model


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

This PR contains trivial cases where the owning config entry is known

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
