### PR TITLE
Migrate calls to async_get_device in tests (part 2)

### DIFF
--- a/tests/components/freebox/test_camera.py
+++ b/tests/components/freebox/test_camera.py
@@ -42,10 +42,12 @@ async def test_label_change_propagates(
     router: Mock,
 ) -> None:
     """Test camera label changes from the API update the device registry."""
-    await setup_platform(hass, CAMERA_DOMAIN)
+    mock_entry = await setup_platform(hass, CAMERA_DOMAIN)
 
     camera_node_id = 15  # Caméra I from fixture
-    device = device_registry.async_get_device(identifiers={(DOMAIN, camera_node_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, camera_node_id), mock_entry.entry_id
+    )
     assert device is not None
     assert device.name == "Caméra I"
 
@@ -60,7 +62,9 @@ async def test_label_change_propagates(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, camera_node_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, camera_node_id), mock_entry.entry_id
+    )
     assert device is not None
     assert device.name == "Caméra entrée"
 

--- a/tests/components/freebox/test_init.py
+++ b/tests/components/freebox/test_init.py
@@ -197,10 +197,12 @@ async def test_home_device_label_sync(
     router: Mock,
 ) -> None:
     """Test home device label changes propagate to the device registry."""
-    await setup_platform(hass, BINARY_SENSOR_DOMAIN)
+    entry = await setup_platform(hass, BINARY_SENSOR_DOMAIN)
 
     pir_node_id = 26  # Détecteur from fixture
-    device = device_registry.async_get_device(identifiers={(DOMAIN, pir_node_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, pir_node_id), entry.entry_id
+    )
     assert device is not None
     assert device.name == "Détecteur"
 
@@ -216,6 +218,8 @@ async def test_home_device_label_sync(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, pir_node_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, pir_node_id), entry.entry_id
+    )
     assert device is not None
     assert device.name == "Détecteur cuisine"

--- a/tests/components/freedompro/test_binary_sensor.py
+++ b/tests/components/freedompro/test_binary_sensor.py
@@ -56,7 +56,9 @@ async def test_binary_sensor_get_state(
 ) -> None:
     """Test states of the binary_sensor."""
 
-    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device_by_identifier(
+        ("freedompro", uid), init_integration.entry_id
+    )
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_climate.py
+++ b/tests/components/freedompro/test_climate.py
@@ -40,7 +40,9 @@ async def test_climate_get_state(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test states of the climate."""
-    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device_by_identifier(
+        ("freedompro", uid), init_integration.entry_id
+    )
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_cover.py
+++ b/tests/components/freedompro/test_cover.py
@@ -49,7 +49,9 @@ async def test_cover_get_state(
 ) -> None:
     """Test states of the cover."""
 
-    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device_by_identifier(
+        ("freedompro", uid), init_integration.entry_id
+    )
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_fan.py
+++ b/tests/components/freedompro/test_fan.py
@@ -33,7 +33,9 @@ async def test_fan_get_state(
 ) -> None:
     """Test states of the fan."""
 
-    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device_by_identifier(
+        ("freedompro", uid), init_integration.entry_id
+    )
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freedompro/test_lock.py
+++ b/tests/components/freedompro/test_lock.py
@@ -33,7 +33,9 @@ async def test_lock_get_state(
 ) -> None:
     """Test states of the lock."""
 
-    device = device_registry.async_get_device(identifiers={("freedompro", uid)})
+    device = device_registry.async_get_device_by_identifier(
+        ("freedompro", uid), init_integration.entry_id
+    )
     assert device is not None
     assert device.identifiers == {("freedompro", uid)}
     assert device.manufacturer == "Freedompro"

--- a/tests/components/freshr/test_init.py
+++ b/tests/components/freshr/test_init.py
@@ -84,14 +84,21 @@ async def test_stale_device_removed(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that a device absent from a successful poll is removed from the registry."""
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+    )
 
     mock_freshr_client.fetch_devices.return_value = []
     freezer.tick(DEVICES_SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+        )
+        is None
+    )
 
     call_count = mock_freshr_client.fetch_device_current.call_count
     freezer.tick(READINGS_SCAN_INTERVAL)
@@ -109,14 +116,18 @@ async def test_stale_device_not_removed_on_poll_error(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that a device is not removed when the devices poll fails."""
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
     mock_freshr_client.fetch_devices.side_effect = ApiResponseError("cloud error")
     freezer.tick(DEVICES_SCAN_INTERVAL)
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), hass.config_entries.async_entries(DOMAIN)[0].entry_id
+    )
 
 
 @pytest.mark.usefixtures("entity_registry_enabled_by_default", "init_integration")

--- a/tests/components/freshr/test_sensor.py
+++ b/tests/components/freshr/test_sensor.py
@@ -33,7 +33,9 @@ async def test_entities(
     """Test the sensor entities."""
     await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+    )
     assert device_entry
     entity_entries = er.async_entries_for_config_entry(
         entity_registry, mock_config_entry.entry_id
@@ -100,7 +102,9 @@ async def test_device_reappears_after_removal(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that entities are re-created when a previously removed device reappears."""
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+    )
 
     # Device disappears from the account
     mock_freshr_client.fetch_devices.return_value = []
@@ -108,7 +112,12 @@ async def test_device_reappears_after_removal(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+        )
+        is None
+    )
 
     # Device reappears
     mock_freshr_client.fetch_devices.return_value = [DeviceSummary(id=DEVICE_ID)]
@@ -117,7 +126,9 @@ async def test_device_reappears_after_removal(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID), mock_config_entry.entry_id
+    )
     t1_entity_id = entity_registry.async_get_entity_id(
         "sensor", DOMAIN, f"{DEVICE_ID}_t1"
     )
@@ -135,7 +146,12 @@ async def test_dynamic_device_added(
     freezer: FrozenDateTimeFactory,
 ) -> None:
     """Test that sensors are created for a device that appears after initial setup."""
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID_2)}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, DEVICE_ID_2), mock_config_entry.entry_id
+        )
+        is None
+    )
 
     mock_freshr_client.fetch_devices.return_value = [
         DeviceSummary(id=DEVICE_ID),
@@ -146,7 +162,9 @@ async def test_dynamic_device_added(
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, DEVICE_ID_2)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, DEVICE_ID_2), mock_config_entry.entry_id
+    )
     t1_entity_id = entity_registry.async_get_entity_id(
         "sensor", DOMAIN, f"{DEVICE_ID_2}_t1"
     )

--- a/tests/components/fritz/test_button.py
+++ b/tests/components/fritz/test_button.py
@@ -226,8 +226,8 @@ async def test_cleanup_button(
     assert entry.state is ConfigEntryState.LOADED
 
     # check if tracked device is registered properly
-    device = device_registry.async_get_device(
-        connections={("mac", "aa:bb:cc:00:11:22")}
+    device = device_registry.async_get_device_by_connection(
+        ("mac", "aa:bb:cc:00:11:22"), entry.entry_id
     )
     assert device
 
@@ -254,8 +254,8 @@ async def test_cleanup_button(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # check if orphan tracked device is removed
-    device = device_registry.async_get_device(
-        connections={("mac", "aa:bb:cc:00:11:22")}
+    device = device_registry.async_get_device_by_connection(
+        ("mac", "aa:bb:cc:00:11:22"), entry.entry_id
     )
     assert not device
 

--- a/tests/components/fritz/test_coordinator.py
+++ b/tests/components/fritz/test_coordinator.py
@@ -204,8 +204,8 @@ async def test_no_software_version(
 
     assert entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
     assert device.sw_version == "string_version_not_number"
@@ -615,8 +615,8 @@ async def test_async_trigger_cleanup(
     assert entry.state is ConfigEntryState.LOADED
 
     # Verify the printer is registered as tracked device
-    assert device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:00:11:22")}
+    assert device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:00:11:22"), entry.entry_id
     )
     assert entity_registry.async_get("device_tracker.printer")
     assert entity_registry.async_get("switch.printer_internet_access")
@@ -630,8 +630,8 @@ async def test_async_trigger_cleanup(
 
     # Verify the printer was removed from tracked devices
     assert (
-        device_registry.async_get_device(
-            connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:00:11:22")}
+        device_registry.async_get_device_by_connection(
+            (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:00:11:22"), entry.entry_id
         )
         is None
     )
@@ -649,8 +649,8 @@ async def test_async_trigger_cleanup(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # Verify the printer is registered again as tracked device
-    assert device_registry.async_get_device(
-        connections={(dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:00:11:22")}
+    assert device_registry.async_get_device_by_connection(
+        (dr.CONNECTION_NETWORK_MAC, "aa:bb:cc:00:11:22"), entry.entry_id
     )
     assert entity_registry.async_get("device_tracker.printer")
     assert entity_registry.async_get("switch.printer_internet_access")
@@ -673,8 +673,8 @@ async def test_async_trigger_cleanup_preserves_fritz_device(
     wrapper: AvmWrapper = entry.runtime_data
 
     # Verify the fritz box device was registered
-    fritz_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    fritz_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert fritz_device is not None
 
@@ -690,8 +690,8 @@ async def test_async_trigger_cleanup_preserves_fritz_device(
         await wrapper.async_trigger_cleanup()
 
     # The fritz box device must still be present in the registry
-    fritz_device_after = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    fritz_device_after = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert fritz_device_after is not None
     assert fritz_device_after.id == fritz_device.id

--- a/tests/components/fritz/test_services.py
+++ b/tests/components/fritz/test_services.py
@@ -49,8 +49,8 @@ async def test_service_set_guest_wifi_password(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
     with patch(
@@ -77,8 +77,8 @@ async def test_service_set_guest_wifi_password_unknown_parameter(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
 
@@ -108,8 +108,8 @@ async def test_service_set_guest_wifi_password_service_not_supported(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
 
@@ -161,8 +161,8 @@ async def test_service_dial(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
     with patch(
@@ -193,8 +193,8 @@ async def test_service_dial_unknown_parameter(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
 
@@ -226,8 +226,8 @@ async def test_service_dial_wrong_parameter(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
 
@@ -276,8 +276,8 @@ async def test_service_dial_service_not_supported(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
 
@@ -309,8 +309,8 @@ async def test_service_dial_failed(
     await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, MOCK_SERIAL_NUMBER)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, MOCK_SERIAL_NUMBER), entry.entry_id
     )
     assert device
 

--- a/tests/components/fronius/test_init.py
+++ b/tests/components/fronius/test_init.py
@@ -84,14 +84,18 @@ async def test_inverter_night_rescan(
     await hass.async_block_till_done()
 
     # We expect our inverter to be present now
-    inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "203200")})
+    inverter_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "203200"), config_entry.entry_id
+    )
     assert inverter_1.manufacturer == "Fronius"
 
     # After another re-scan we still only expect this inverter
     freezer.tick(timedelta(minutes=SOLAR_NET_RESCAN_TIMER))
     async_fire_time_changed(hass)
     await hass.async_block_till_done()
-    inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "203200")})
+    inverter_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "203200"), config_entry.entry_id
+    )
     assert inverter_1.manufacturer == "Fronius"
 
 
@@ -156,9 +160,13 @@ async def test_device_remove_devices(
         hass, is_logger=False, unique_id="12345678"
     )
 
-    inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "12345678")})
+    inverter_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12345678"), config_entry.entry_id
+    )
     client = await hass_ws_client(hass)
     response = await client.remove_device(inverter_1.id, config_entry.entry_id)
     assert response["success"]
 
-    assert not device_registry.async_get_device(identifiers={(DOMAIN, "12345678")})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12345678"), config_entry.entry_id
+    )

--- a/tests/components/fronius/test_sensor.py
+++ b/tests/components/fronius/test_sensor.py
@@ -322,31 +322,37 @@ async def test_gen24_storage(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
     # Devices
-    solar_net = device_registry.async_get_device(
-        identifiers={(DOMAIN, "solar_net_12345678")}
+    solar_net = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "solar_net_12345678"), config_entry.entry_id
     )
     assert solar_net.configuration_url == "http://fronius"
     assert solar_net.manufacturer == "Fronius"
     assert solar_net.name == "SolarNet"
 
-    inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "12345678")})
+    inverter_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "12345678"), config_entry.entry_id
+    )
     assert inverter_1.manufacturer == "Fronius"
     assert inverter_1.model == "Gen24"
     assert inverter_1.name == "Gen24 Storage"
 
-    meter = device_registry.async_get_device(identifiers={(DOMAIN, "1234567890")})
+    meter = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1234567890"), config_entry.entry_id
+    )
     assert meter.manufacturer == "Fronius"
     assert meter.model == "Smart Meter TS 65A-3"
     assert meter.name == "Smart Meter TS 65A-3"
 
-    ohmpilot = device_registry.async_get_device(identifiers={(DOMAIN, "23456789")})
+    ohmpilot = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "23456789"), config_entry.entry_id
+    )
     assert ohmpilot.manufacturer == "Fronius"
     assert ohmpilot.model == "Ohmpilot 6"
     assert ohmpilot.name == "Ohmpilot"
     assert ohmpilot.sw_version == "1.0.25-3"
 
-    storage = device_registry.async_get_device(
-        identifiers={(DOMAIN, "P030T020Z2001234567     ")}
+    storage = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "P030T020Z2001234567     "), config_entry.entry_id
     )
     assert storage.manufacturer == "BYD"
     assert storage.model == "BYD Battery-Box Premium HV"
@@ -376,8 +382,8 @@ async def test_primo_s0(
     await snapshot_platform(hass, entity_registry, snapshot, config_entry.entry_id)
 
     # Devices
-    solar_net = device_registry.async_get_device(
-        identifiers={(DOMAIN, "solar_net_123.4567890")}
+    solar_net = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "solar_net_123.4567890"), config_entry.entry_id
     )
     assert solar_net.configuration_url == "http://fronius"
     assert solar_net.manufacturer == "Fronius"
@@ -385,18 +391,22 @@ async def test_primo_s0(
     assert solar_net.name == "SolarNet"
     assert solar_net.sw_version == "3.18.7-1"
 
-    inverter_1 = device_registry.async_get_device(identifiers={(DOMAIN, "123456")})
+    inverter_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "123456"), config_entry.entry_id
+    )
     assert inverter_1.manufacturer == "Fronius"
     assert inverter_1.model == "Primo 5.0-1"
     assert inverter_1.name == "Primo 5.0-1"
 
-    inverter_2 = device_registry.async_get_device(identifiers={(DOMAIN, "234567")})
+    inverter_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "234567"), config_entry.entry_id
+    )
     assert inverter_2.manufacturer == "Fronius"
     assert inverter_2.model == "Primo 3.0-1"
     assert inverter_2.name == "Primo 3.0-1"
 
-    meter = device_registry.async_get_device(
-        identifiers={(DOMAIN, "solar_net_123.4567890:S0 Meter at inverter 1")}
+    meter = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "solar_net_123.4567890:S0 Meter at inverter 1"), config_entry.entry_id
     )
     assert meter.manufacturer == "Fronius"
     assert meter.model == "S0 Meter at inverter 1"

--- a/tests/components/fully_kiosk/test_diagnostics.py
+++ b/tests/components/fully_kiosk/test_diagnostics.py
@@ -24,7 +24,9 @@ async def test_diagnostics(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test Fully Kiosk diagnostics."""
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "abcdef-123456")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "abcdef-123456"), init_integration.entry_id
+    )
 
     diagnostics = await get_diagnostics_for_device(
         hass, hass_client, init_integration, device

--- a/tests/components/fully_kiosk/test_services.py
+++ b/tests/components/fully_kiosk/test_services.py
@@ -29,8 +29,8 @@ async def test_services(
     init_integration: MockConfigEntry,
 ) -> None:
     """Test the Fully Kiosk Browser services."""
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "abcdef-123456")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "abcdef-123456"), init_integration.entry_id
     )
 
     assert device_entry
@@ -127,8 +127,8 @@ async def test_service_unloaded_entry(
     """Test service not called when config entry unloaded."""
     await hass.config_entries.async_unload(init_integration.entry_id)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "abcdef-123456")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "abcdef-123456"), init_integration.entry_id
     )
 
     assert device_entry

--- a/tests/components/gardena_bluetooth/test_init.py
+++ b/tests/components/gardena_bluetooth/test_init.py
@@ -90,8 +90,8 @@ async def test_setup(
     mock_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(mock_entry.entry_id) is True
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, service_info.address)}
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, service_info.address), mock_entry.entry_id
     )
     assert device == snapshot
 

--- a/tests/components/gentex_homelink/test_init.py
+++ b/tests/components/gentex_homelink/test_init.py
@@ -31,8 +31,8 @@ async def test_device(
     """Test device is registered correctly."""
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(
-        identifiers={(DOMAIN, "TestDevice")},
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "TestDevice"), mock_config_entry.entry_id
     )
     assert device
     assert device == snapshot

--- a/tests/components/goalzero/test_init.py
+++ b/tests/components/goalzero/test_init.py
@@ -91,7 +91,9 @@ async def test_device_info(
     """Test device info."""
     entry = await async_init_integration(hass, aioclient_mock)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     assert device.connections == {("mac", "12:34:56:78:90:12")}
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/gogogate2/test_cover.py
+++ b/tests/components/gogogate2/test_cover.py
@@ -342,7 +342,9 @@ async def test_device_info_ismartgate(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "xyz")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "xyz"), config_entry.entry_id
+    )
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "mycontroller"
@@ -378,7 +380,9 @@ async def test_device_info_gogogate2(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "xyz")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "xyz"), config_entry.entry_id
+    )
     assert device
     assert device.manufacturer == MANUFACTURER
     assert device.name == "mycontroller"

--- a/tests/components/google_air_quality/test_services.py
+++ b/tests/components/google_air_quality/test_services.py
@@ -29,8 +29,9 @@ async def test_get_forecast_service(
     snapshot: SnapshotAssertion,
 ) -> None:
     """Test fetching a forecast for a subentry."""
-    device = dr.async_get(hass).async_get_device(  # pylint: disable=home-assistant-tests-registry-fixtures
-        identifiers={(DOMAIN, f"{mock_config_entry.entry_id}_home-subentry-id")}
+    device = dr.async_get(hass).async_get_device_by_identifier(  # pylint: disable=home-assistant-tests-registry-fixtures
+        (DOMAIN, f"{mock_config_entry.entry_id}_home-subentry-id"),
+        mock_config_entry.entry_id,
     )
     assert device is not None
 

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -191,12 +191,12 @@ async def test_migration_from_v1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device_by_identifier(
-            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -214,12 +214,12 @@ async def test_migration_from_v1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device_by_identifier(
-            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -448,11 +448,11 @@ async def test_migration_from_v1_disabled(
     assert stt_subentries[0].data == RECOMMENDED_STT_OPTIONS
     assert stt_subentries[0].title == DEFAULT_STT_NAME
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -464,9 +464,8 @@ async def test_migration_from_v1_disabled(
         assert entity.disabled_by is subentry_data["entity_disabled_by"]
 
         assert (
-            device := device_registry.async_get_device_by_identifier(
-                (DOMAIN, subentry.subentry_id),
-                mock_config_entries[main_config_entry].entry_id,
+            device := device_registry.async_get_device(
+                identifiers={(DOMAIN, subentry.subentry_id)}
             )
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -578,8 +577,8 @@ async def test_migration_from_v1_with_multiple_keys(
         assert subentry.data == RECOMMENDED_STT_OPTIONS
         assert subentry.title == DEFAULT_STT_NAME
 
-        dev = device_registry.async_get_device_by_identifier(
-            (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
+        dev = device_registry.async_get_device(
+            identifiers={(DOMAIN, list(entry.subentries.values())[0].subentry_id)}
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}
@@ -710,12 +709,12 @@ async def test_migration_from_v1_with_same_keys(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device_by_identifier(
-            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -733,12 +732,12 @@ async def test_migration_from_v1_with_same_keys(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device_by_identifier(
-            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -940,12 +939,12 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device_by_identifier(
-            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -963,12 +962,12 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device_by_identifier(
-        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
+    assert not device_registry.async_get_device(
+        identifiers={(DOMAIN, mock_config_entry.entry_id)}
     )
     assert (
-        device := device_registry.async_get_device_by_identifier(
-            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
+        device := device_registry.async_get_device(
+            identifiers={(DOMAIN, subentry.subentry_id)}
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}

--- a/tests/components/google_generative_ai_conversation/test_init.py
+++ b/tests/components/google_generative_ai_conversation/test_init.py
@@ -191,12 +191,12 @@ async def test_migration_from_v1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -214,12 +214,12 @@ async def test_migration_from_v1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -448,11 +448,11 @@ async def test_migration_from_v1_disabled(
     assert stt_subentries[0].data == RECOMMENDED_STT_OPTIONS
     assert stt_subentries[0].title == DEFAULT_STT_NAME
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
     )
 
     for idx, subentry in enumerate(conversation_subentries):
@@ -464,8 +464,9 @@ async def test_migration_from_v1_disabled(
         assert entity.disabled_by is subentry_data["entity_disabled_by"]
 
         assert (
-            device := device_registry.async_get_device(
-                identifiers={(DOMAIN, subentry.subentry_id)}
+            device := device_registry.async_get_device_by_identifier(
+                (DOMAIN, subentry.subentry_id),
+                mock_config_entries[main_config_entry].entry_id,
             )
         )
         assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -577,8 +578,8 @@ async def test_migration_from_v1_with_multiple_keys(
         assert subentry.data == RECOMMENDED_STT_OPTIONS
         assert subentry.title == DEFAULT_STT_NAME
 
-        dev = device_registry.async_get_device(
-            identifiers={(DOMAIN, list(entry.subentries.values())[0].subentry_id)}
+        dev = device_registry.async_get_device_by_identifier(
+            (DOMAIN, list(entry.subentries.values())[0].subentry_id), entry.entry_id
         )
         assert dev is not None
         assert dev.config_entries == {entry.entry_id}
@@ -709,12 +710,12 @@ async def test_migration_from_v1_with_same_keys(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -732,12 +733,12 @@ async def test_migration_from_v1_with_same_keys(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry_2.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry_2.entry_id), mock_config_entry_2.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -939,12 +940,12 @@ async def test_migration_from_v2_1(
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
 
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}
@@ -962,12 +963,12 @@ async def test_migration_from_v2_1(
     assert entity.unique_id == subentry.subentry_id
     assert entity.config_subentry_id == subentry.subentry_id
     assert entity.config_entry_id == entry.entry_id
-    assert not device_registry.async_get_device(
-        identifiers={(DOMAIN, mock_config_entry.entry_id)}
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, mock_config_entry.entry_id), mock_config_entry.entry_id
     )
     assert (
-        device := device_registry.async_get_device(
-            identifiers={(DOMAIN, subentry.subentry_id)}
+        device := device_registry.async_get_device_by_identifier(
+            (DOMAIN, subentry.subentry_id), mock_config_entry.entry_id
         )
     )
     assert device.identifiers == {(DOMAIN, subentry.subentry_id)}

--- a/tests/components/google_mail/test_init.py
+++ b/tests/components/google_mail/test_init.py
@@ -210,7 +210,9 @@ async def test_device_info(
     await setup_integration()
 
     entry = hass.config_entries.async_entries(DOMAIN)[0]
-    device = device_registry.async_get_device(identifiers={(DOMAIN, entry.entry_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, entry.entry_id), entry.entry_id
+    )
 
     assert device.entry_type is dr.DeviceEntryType.SERVICE
     assert device.identifiers == {(DOMAIN, entry.entry_id)}

--- a/tests/components/growatt_server/test_init.py
+++ b/tests/components/growatt_server/test_init.py
@@ -56,9 +56,12 @@ async def test_load_unload_config_entry(
 async def test_device_info(
     snapshot: SnapshotAssertion,
     device_registry: dr.DeviceRegistry,
+    mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test device registry integration."""
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
     assert device_entry == snapshot
 
@@ -303,7 +306,9 @@ async def test_classic_api_setup(
     mock_growatt_classic_api.login.assert_called()
 
     # Verify device was created
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "TLX123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "TLX123456"), mock_config_entry_classic.entry_id
+    )
     assert device_entry is not None
     assert device_entry == snapshot
 
@@ -834,10 +839,17 @@ async def test_dynamic_device_added(
     """Test that new devices are dynamically added when discovered during a scan."""
     # Initially only MIN123456 device exists
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+        )
         is not None
     )
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "NEW456789")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "NEW456789"), mock_config_entry.entry_id
+        )
+        is None
+    )
 
     # Mock a new device appearing in the device list
     mock_growatt_v1_api.device_list.return_value = {
@@ -858,7 +870,9 @@ async def test_dynamic_device_added(
 
     # New device should now be in the device registry
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "NEW456789")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "NEW456789"), mock_config_entry.entry_id
+        )
         is not None
     )
     # New device should be in runtime_data
@@ -868,8 +882,8 @@ async def test_dynamic_device_added(
     assert hass.states.get("switch.new456789_charge_from_grid") is not None
     # Additional check: verify entities exist in the entity registry
     entity_registry = er.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    new_device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, "NEW456789")}
+    new_device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "NEW456789"), mock_config_entry.entry_id
     )
     new_device_entities = er.async_entries_for_device(
         entity_registry, new_device_entry.id, include_disabled_entities=True
@@ -889,7 +903,9 @@ async def test_stale_device_removed(
     """Test that stale devices are removed from the device registry during a scan."""
     # Initially MIN123456 device exists with entities in the state machine
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+        )
         is not None
     )
     assert hass.states.get("switch.min123456_charge_from_grid") is not None
@@ -903,7 +919,12 @@ async def test_stale_device_removed(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # The device should be removed from HA
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+        )
+        is None
+    )
     # The coordinator should be removed from runtime_data
     assert "MIN123456" not in mock_config_entry.runtime_data.devices
     # Orphaned entities must also be gone from the entity registry and state machine
@@ -937,7 +958,9 @@ async def test_device_scan_error_is_silent(
     assert mock_config_entry.state is ConfigEntryState.LOADED
     # Existing device should still be present
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+        )
         is not None
     )
 
@@ -975,11 +998,18 @@ async def test_dynamic_device_refresh_fails_is_skipped(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # New device should NOT be added — its refresh failed
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "NEW456789")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "NEW456789"), mock_config_entry.entry_id
+        )
+        is None
+    )
     assert "NEW456789" not in mock_config_entry.runtime_data.devices
     # Existing device must be unaffected
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+        )
         is not None
     )
 
@@ -1018,7 +1048,9 @@ async def test_classic_api_device_scan(
 
     # New device should be added via the classic scan path
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "TLX999999")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "TLX999999"), mock_config_entry_classic.entry_id
+        )
         is not None
     )
     assert "TLX999999" in mock_config_entry_classic.runtime_data.devices
@@ -1045,7 +1077,9 @@ async def test_classic_api_stale_device_removed(
 
     # Verify device exists after setup
     assert (
-        device_registry.async_get_device(identifiers={(DOMAIN, "TLX123456")})
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "TLX123456"), mock_config_entry_classic.entry_id
+        )
         is not None
     )
     assert "TLX123456" in mock_config_entry_classic.runtime_data.devices
@@ -1059,6 +1093,11 @@ async def test_classic_api_stale_device_removed(
     await hass.async_block_till_done(wait_background_tasks=True)
 
     # The device should be removed from HA
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "TLX123456")}) is None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "TLX123456"), mock_config_entry_classic.entry_id
+        )
+        is None
+    )
     # The coordinator should be removed from runtime_data
     assert "TLX123456" not in mock_config_entry_classic.runtime_data.devices

--- a/tests/components/growatt_server/test_services.py
+++ b/tests/components/growatt_server/test_services.py
@@ -28,7 +28,9 @@ async def test_read_time_segments_single_device(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test service call
@@ -55,7 +57,9 @@ async def test_update_time_segment_charge_mode(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test successful update
@@ -89,7 +93,9 @@ async def test_update_time_segment_discharge_mode(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     await hass.services.async_call(
@@ -121,7 +127,9 @@ async def test_update_time_segment_standby_mode(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     await hass.services.async_call(
@@ -153,7 +161,9 @@ async def test_update_time_segment_disabled(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     await hass.services.async_call(
@@ -185,7 +195,9 @@ async def test_update_time_segment_with_seconds(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test with HH:MM:SS format (what the UI time selector sends)
@@ -218,7 +230,9 @@ async def test_update_time_segment_api_error(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Mock API error - the library raises an exception instead of returning error dict
@@ -270,7 +284,9 @@ async def test_no_min_devices_skips_service_registration(
     assert hass.services.has_service(DOMAIN, "read_time_segments")
 
     # Get the TLX device (non-MIN)
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "TLX123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "TLX123456"), mock_config_entry_classic.entry_id
+    )
     assert device_entry is not None
 
     # But calling them with a non-MIN device should fail with appropriate error
@@ -312,7 +328,9 @@ async def test_multiple_devices_with_valid_device_id_works(
     await hass.async_block_till_done()
 
     # Get the device registry ID for the first MIN device
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test update service with specific device_id (device registry ID)
@@ -357,7 +375,9 @@ async def test_update_time_segment_invalid_time_format(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test with invalid time format
@@ -391,7 +411,9 @@ async def test_update_time_segment_invalid_segment_id(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test segment_id too low
@@ -445,7 +467,9 @@ async def test_update_time_segment_invalid_batt_mode(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test invalid batt_mode
@@ -481,7 +505,9 @@ async def test_read_time_segments_api_error(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Mock API error by making coordinator.read_time_segments raise an exception
@@ -633,7 +659,9 @@ async def test_update_time_segment_invalid_end_time_format(
     await hass.async_block_till_done()
 
     # Get the device registry ID
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "MIN123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "MIN123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Test with invalid end_time format
@@ -672,7 +700,9 @@ async def test_service_with_unloaded_config_entry(
     await hass.async_block_till_done()
 
     # Get the device
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "TLX123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "TLX123456"), mock_config_entry_classic.entry_id
+    )
     assert device_entry is not None
 
     # Unload the config entry
@@ -726,7 +756,9 @@ async def test_read_ac_charge_times(
     """Test reading AC charge times from SPH device."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     response = await hass.services.async_call(
@@ -751,7 +783,9 @@ async def test_read_ac_discharge_times(
     """Test reading AC discharge times from SPH device."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     response = await hass.services.async_call(
@@ -774,7 +808,9 @@ async def test_write_ac_charge_times(
     """Test writing AC charge times to SPH device."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     await hass.services.async_call(
@@ -804,7 +840,9 @@ async def test_write_ac_charge_times_with_seconds_format(
     """Test writing AC charge times with HH:MM:SS format from UI time selector."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     await hass.services.async_call(
@@ -834,7 +872,9 @@ async def test_write_ac_discharge_times(
     """Test writing AC discharge times to SPH device."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     await hass.services.async_call(
@@ -863,7 +903,9 @@ async def test_write_ac_charge_times_api_error(
     """Test handling API error when writing AC charge times."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     mock_growatt_v1_api.sph_write_ac_charge_times.side_effect = (
@@ -893,7 +935,9 @@ async def test_write_ac_discharge_times_api_error(
     """Test handling API error when writing AC discharge times."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     mock_growatt_v1_api.sph_write_ac_discharge_times.side_effect = (
@@ -922,7 +966,9 @@ async def test_write_ac_charge_times_invalid_charge_power(
     """Test validation of charge_power range."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     with pytest.raises(ServiceValidationError) as excinfo:
@@ -951,7 +997,9 @@ async def test_write_ac_charge_times_invalid_charge_stop_soc(
     """Test validation of charge_stop_soc range."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     with pytest.raises(ServiceValidationError) as excinfo:
@@ -980,7 +1028,9 @@ async def test_write_ac_discharge_times_invalid_discharge_power(
     """Test validation of discharge_power range."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     with pytest.raises(ServiceValidationError) as excinfo:
@@ -1008,7 +1058,9 @@ async def test_write_ac_discharge_times_invalid_discharge_stop_soc(
     """Test validation of discharge_stop_soc range."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     with pytest.raises(ServiceValidationError) as excinfo:
@@ -1036,7 +1088,9 @@ async def test_write_ac_charge_times_invalid_period_time(
     """Test validation of invalid period time format."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     with pytest.raises(ServiceValidationError) as excinfo:
@@ -1076,7 +1130,9 @@ async def test_no_sph_devices_fails_gracefully(
     assert hass.services.has_service(DOMAIN, "write_ac_charge_times")
     assert hass.services.has_service(DOMAIN, "read_ac_charge_times")
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "TLX123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "TLX123456"), mock_config_entry_classic.entry_id
+    )
     assert device_entry is not None
 
     with pytest.raises(ServiceValidationError) as excinfo:
@@ -1140,7 +1196,9 @@ async def test_write_ac_charge_times_uses_cached_periods_for_unspecified(
     """Test that unspecified periods are filled from cached settings."""
     await _setup_sph_integration(hass, mock_config_entry, mock_growatt_v1_api)
 
-    device_entry = device_registry.async_get_device(identifiers={(DOMAIN, "SPH123456")})
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "SPH123456"), mock_config_entry.entry_id
+    )
     assert device_entry is not None
 
     # Only override period 1; periods 2 and 3 should come from cache (all 00:00)

--- a/tests/components/habitica/test_init.py
+++ b/tests/components/habitica/test_init.py
@@ -148,8 +148,8 @@ async def test_remove_party_and_reload(
     assert config_entry.state is ConfigEntryState.LOADED
 
     assert (
-        device_registry.async_get_device(
-            {(DOMAIN, f"{config_entry.unique_id}_{group_id}")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{config_entry.unique_id}_{group_id}"), config_entry.entry_id
         )
         is not None
     )
@@ -168,8 +168,8 @@ async def test_remove_party_and_reload(
     await hass.async_block_till_done()
 
     assert (
-        device_registry.async_get_device(
-            {(DOMAIN, f"{config_entry.unique_id}_{group_id}")}
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, f"{config_entry.unique_id}_{group_id}"), config_entry.entry_id
         )
         is None
     )

--- a/tests/components/harbor/test_init.py
+++ b/tests/components/harbor/test_init.py
@@ -140,5 +140,7 @@ async def test_device_registry(
 
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, SERIAL)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, SERIAL), mock_config_entry.entry_id
+    )
     assert device == snapshot

--- a/tests/components/hassio/test_init.py
+++ b/tests/components/hassio/test_init.py
@@ -1652,7 +1652,9 @@ async def mount_reload_test_setup(
         assert await hass.config_entries.async_setup(config_entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "mount_NAS")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "mount_NAS"), config_entry.entry_id
+    )
     assert device is not None
     return device
 

--- a/tests/components/heos/test_diagnostics.py
+++ b/tests/components/heos/test_diagnostics.py
@@ -72,7 +72,9 @@ async def test_device_diagnostics(
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     device_registry = dr.async_get(hass)  # pylint: disable=home-assistant-tests-registry-fixtures
-    device = device_registry.async_get_device({(DOMAIN, "1")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1"), config_entry.entry_id
+    )
     assert device is not None
     diagnostics = await get_diagnostics_for_device(
         hass, hass_client, config_entry, device

--- a/tests/components/heos/test_init.py
+++ b/tests/components/heos/test_init.py
@@ -183,14 +183,18 @@ async def test_device_info(
     """Test device information populates correctly."""
     config_entry.add_to_hass(hass)
     assert await hass.config_entries.async_setup(config_entry.entry_id)
-    device = device_registry.async_get_device({(DOMAIN, "1")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1"), config_entry.entry_id
+    )
     assert device is not None
     assert device.manufacturer == "HEOS"
     assert device.model == "Drive HS2"
     assert device.name == "Test Player"
     assert device.serial_number == "123456"
     assert device.sw_version == "1.0.0"
-    device = device_registry.async_get_device({(DOMAIN, "2")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "2"), config_entry.entry_id
+    )
     assert device is not None
     assert device.manufacturer == "HEOS"
     assert device.model == "Speaker"
@@ -214,10 +218,32 @@ async def test_device_id_migration(
     )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
-    assert device_registry.async_get_device({("Other", 1)}) is not None  # type: ignore[arg-type]
-    assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
-    assert device_registry.async_get_device({(DOMAIN, "1")}) is not None
-    assert device_registry.async_get_device({("Other", "1")}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            ("Other", 1),  # type: ignore[arg-type]
+            config_entry.entry_id,
+        )
+        is not None
+    )
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, 1),  # type: ignore[arg-type]
+            config_entry.entry_id,
+        )
+        is None
+    )
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "1"), config_entry.entry_id
+        )
+        is not None
+    )
+    assert (
+        device_registry.async_get_device_by_identifier(
+            ("Other", "1"), config_entry.entry_id
+        )
+        is not None
+    )
 
 
 async def test_device_id_migration_both_present(
@@ -237,8 +263,19 @@ async def test_device_id_migration_both_present(
     )
     assert await hass.config_entries.async_setup(config_entry.entry_id)
     await hass.async_block_till_done(wait_background_tasks=True)
-    assert device_registry.async_get_device({(DOMAIN, 1)}) is None  # type: ignore[arg-type]
-    assert device_registry.async_get_device({(DOMAIN, "1")}) is not None
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, 1),  # type: ignore[arg-type]
+            config_entry.entry_id,
+        )
+        is None
+    )
+    assert (
+        device_registry.async_get_device_by_identifier(
+            (DOMAIN, "1"), config_entry.entry_id
+        )
+        is not None
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/components/heos/test_media_player.py
+++ b/tests/components/heos/test_media_player.py
@@ -256,7 +256,9 @@ async def test_updates_from_players_changed_new_ids(
     assert await hass.config_entries.async_setup(config_entry.entry_id)
 
     # Assert device registry matches current id
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "1")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "1"), config_entry.entry_id
+    )
     # Assert entity registry matches current id
     assert (
         entity_registry.async_get_entity_id(MEDIA_PLAYER_DOMAIN, DOMAIN, "1")
@@ -272,7 +274,9 @@ async def test_updates_from_players_changed_new_ids(
 
     # Assert device registry identifiers were updated
     assert len(device_registry.devices) == 2
-    assert device_registry.async_get_device(identifiers={(DOMAIN, "101")})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, "101"), config_entry.entry_id
+    )
     # Assert entity registry unique id was updated
     assert len(entity_registry.entities) == 2
     assert (

--- a/tests/components/hikvision/test_binary_sensor.py
+++ b/tests/components/hikvision/test_binary_sensor.py
@@ -91,8 +91,8 @@ async def test_binary_sensor_device_info(
     """Test binary sensors are linked to device."""
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_ID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_ID), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.name == TEST_DEVICE_NAME
@@ -153,14 +153,14 @@ async def test_binary_sensor_nvr_device(
     )
     assert nvr_device is not None
 
-    channel_1_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_ID}_1")}
+    channel_1_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_DEVICE_ID}_1"), mock_config_entry.entry_id
     )
     assert channel_1_device is not None
     assert channel_1_device.via_device_id == nvr_device.id
 
-    channel_2_device = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_ID}_2")}
+    channel_2_device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_DEVICE_ID}_2"), mock_config_entry.entry_id
     )
     assert channel_2_device is not None
     assert channel_2_device.via_device_id == nvr_device.id

--- a/tests/components/hikvision/test_camera.py
+++ b/tests/components/hikvision/test_camera.py
@@ -72,14 +72,14 @@ async def test_nvr_entities_with_channel_names(
         await setup_integration(hass, mock_config_entry)
 
     # Verify device names use channel names instead of "Channel N"
-    device_1 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_ID}_1")}
+    device_1 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_DEVICE_ID}_1"), mock_config_entry.entry_id
     )
     assert device_1 is not None
     assert device_1.name == "Front Camera channel 1"
 
-    device_2 = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{TEST_DEVICE_ID}_2")}
+    device_2 = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{TEST_DEVICE_ID}_2"), mock_config_entry.entry_id
     )
     assert device_2 is not None
     assert device_2.name == "Front Camera channel 2"
@@ -94,8 +94,8 @@ async def test_camera_device_info(
     """Test camera is linked to device."""
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, TEST_DEVICE_ID)}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, TEST_DEVICE_ID), mock_config_entry.entry_id
     )
     assert device_entry is not None
     assert device_entry.name == TEST_DEVICE_NAME

--- a/tests/components/hive/test_init.py
+++ b/tests/components/hive/test_init.py
@@ -102,7 +102,9 @@ async def test_hub_device_registers_mac_connection(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "hive-hub-id")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "hive-hub-id"), entry.entry_id
+    )
     assert device is not None
     assert (dr.CONNECTION_NETWORK_MAC, "00:1c:2b:1c:2e:68") in device.connections
 
@@ -124,7 +126,9 @@ async def test_hub_device_no_mac_connection_when_absent(
         await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, "hive-hub-id")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, "hive-hub-id"), entry.entry_id
+    )
     assert device is not None
     assert not any(
         conn_type == dr.CONNECTION_NETWORK_MAC for conn_type, _ in device.connections

--- a/tests/components/home_connect/test_binary_sensor.py
+++ b/tests/components/home_connect/test_binary_sensor.py
@@ -54,7 +54,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -70,7 +72,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -87,7 +91,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -131,7 +137,9 @@ async def test_connected_devices(
     assert config_entry.state is ConfigEntryState.LOADED
     client.get_status = get_status_original_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     assert entity_registry.async_get_entity_id(
         Platform.BINARY_SENSOR,

--- a/tests/components/home_connect/test_button.py
+++ b/tests/components/home_connect/test_button.py
@@ -48,7 +48,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -64,7 +66,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -81,7 +85,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -137,7 +143,9 @@ async def test_connected_devices(
     client.get_available_commands = get_available_commands_original_mock
     client.get_all_programs = get_all_programs_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     assert entity_registry.async_get_entity_id(
         Platform.BUTTON,

--- a/tests/components/home_connect/test_climate.py
+++ b/tests/components/home_connect/test_climate.py
@@ -101,7 +101,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -117,7 +119,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -134,7 +138,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -178,7 +184,9 @@ async def test_connected_devices(
     client.get_settings = get_settings_original_mock
     client.get_all_programs = get_all_programs_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     assert not entity_registry.async_get_entity_id(
         Platform.CLIMATE,

--- a/tests/components/home_connect/test_config_flow.py
+++ b/tests/components/home_connect/test_config_flow.py
@@ -498,7 +498,9 @@ async def test_dhcp_flow_complete_device_information(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     assert device.connections == set()
 
@@ -510,7 +512,9 @@ async def test_dhcp_flow_complete_device_information(
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "already_configured"
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     assert device.connections == {
         (dr.CONNECTION_NETWORK_MAC, dr.format_mac(dhcp_discovery.macaddress))

--- a/tests/components/home_connect/test_coordinator.py
+++ b/tests/components/home_connect/test_coordinator.py
@@ -531,8 +531,12 @@ async def test_devices_updated_on_refresh(
     assert config_entry.state is ConfigEntryState.LOADED
 
     for appliance in appliances[:2]:
-        assert device_registry.async_get_device({(DOMAIN, appliance.ha_id)})
-    assert not device_registry.async_get_device({(DOMAIN, appliances[2].ha_id)})
+        assert device_registry.async_get_device_by_identifier(
+            (DOMAIN, appliance.ha_id), config_entry.entry_id
+        )
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliances[2].ha_id), config_entry.entry_id
+    )
 
     client.get_home_appliances = AsyncMock(
         return_value=ArrayOfHomeAppliances(appliances[1:3]),
@@ -547,9 +551,13 @@ async def test_devices_updated_on_refresh(
         await client.add_events([HomeConnectApiError("error.key", "error description")])
         await hass.async_block_till_done()
 
-    assert not device_registry.async_get_device({(DOMAIN, appliances[0].ha_id)})
+    assert not device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliances[0].ha_id), config_entry.entry_id
+    )
     for appliance in appliances[2:3]:
-        assert device_registry.async_get_device({(DOMAIN, appliance.ha_id)})
+        assert device_registry.async_get_device_by_identifier(
+            (DOMAIN, appliance.ha_id), config_entry.entry_id
+        )
 
 
 @pytest.mark.parametrize("appliance", ["Washer"], indirect=True)

--- a/tests/components/home_connect/test_fan.py
+++ b/tests/components/home_connect/test_fan.py
@@ -96,7 +96,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -112,7 +114,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -129,7 +133,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -174,7 +180,9 @@ async def test_connected_devices(
     client.get_settings = get_settings_original_mock
     client.get_all_programs = get_all_programs_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     assert not entity_registry.async_get_entity_id(
         Platform.FAN,

--- a/tests/components/home_connect/test_light.py
+++ b/tests/components/home_connect/test_light.py
@@ -67,7 +67,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -83,7 +85,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -100,7 +104,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -144,7 +150,9 @@ async def test_connected_devices(
     assert config_entry.state is ConfigEntryState.LOADED
     client.get_settings = get_settings_original_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     for key in keys_to_check:
         assert not entity_registry.async_get_entity_id(

--- a/tests/components/home_connect/test_number.py
+++ b/tests/components/home_connect/test_number.py
@@ -88,7 +88,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -104,7 +106,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -121,7 +125,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -167,7 +173,9 @@ async def test_connected_devices(
     assert config_entry.state is ConfigEntryState.LOADED
     client.get_settings = get_settings_original_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     for key in keys_to_check:
         assert not entity_registry.async_get_entity_id(

--- a/tests/components/home_connect/test_select.py
+++ b/tests/components/home_connect/test_select.py
@@ -90,7 +90,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -106,7 +108,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -123,7 +127,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -181,7 +187,9 @@ async def test_connected_devices(
     client.get_settings = get_settings_original_mock
     client.get_all_programs = get_all_programs_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     for key in keys_to_check:
         assert not entity_registry.async_get_entity_id(

--- a/tests/components/home_connect/test_sensor.py
+++ b/tests/components/home_connect/test_sensor.py
@@ -129,7 +129,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -145,7 +147,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -162,7 +166,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -206,7 +212,9 @@ async def test_connected_devices(
     assert config_entry.state is ConfigEntryState.LOADED
     client.get_status = get_status_original_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     for key in keys_to_check:
         assert not entity_registry.async_get_entity_id(

--- a/tests/components/home_connect/test_switch.py
+++ b/tests/components/home_connect/test_switch.py
@@ -73,7 +73,9 @@ async def test_paired_depaired_devices_flow(
     assert await integration_setup(client)
     assert config_entry.state is ConfigEntryState.LOADED
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     entity_entries = entity_registry.entities.get_entries_for_device_id(device.id)
     assert entity_entries
@@ -89,7 +91,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert not device
     for entity_entry in entity_entries:
         assert not entity_registry.async_get(entity_entry.entity_id)
@@ -106,7 +110,9 @@ async def test_paired_depaired_devices_flow(
     )
     await hass.async_block_till_done()
 
-    assert device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    assert device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     for entity_entry in entity_entries:
         assert entity_registry.async_get(entity_entry.entity_id)
 
@@ -153,7 +159,9 @@ async def test_connected_devices(
     assert config_entry.state is ConfigEntryState.LOADED
     client.get_settings = get_settings_original_mock
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, appliance.ha_id)})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, appliance.ha_id), config_entry.entry_id
+    )
     assert device
     for key in keys_to_check:
         assert not entity_registry.async_get_entity_id(

--- a/tests/components/homee/test_diagnostics.py
+++ b/tests/components/homee/test_diagnostics.py
@@ -58,8 +58,8 @@ async def test_diagnostics_device(
     """Test diagnostics for a device."""
     await setup_mock_homee(hass, mock_homee, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{HOMEE_ID}-1")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-1"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     result = await get_diagnostics_for_device(
@@ -83,8 +83,8 @@ async def test_diagnostics_homee_device(
     mock_homee.get_node_by_id.return_value = mock_homee.nodes[0]
     await setup_integration(hass, mock_config_entry)
 
-    device_entry = device_registry.async_get_device(
-        identifiers={(DOMAIN, f"{HOMEE_ID}")}
+    device_entry = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}"), mock_config_entry.entry_id
     )
     assert device_entry is not None
     result = await get_diagnostics_for_device(

--- a/tests/components/homee/test_init.py
+++ b/tests/components/homee/test_init.py
@@ -92,8 +92,12 @@ async def test_general_data(
     await setup_integration(hass, mock_config_entry)
 
     # Verify hub and device created correctly using snapshots.
-    hub = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}")})
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-3")})
+    hub = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}"), mock_config_entry.entry_id
+    )
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-3"), mock_config_entry.entry_id
+    )
 
     assert hub == snapshot
     assert device == snapshot
@@ -137,7 +141,9 @@ async def test_software_version(
     mock_homee.nodes = [build_mock_node("cover_without_position.json")]
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-2")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-2"), mock_config_entry.entry_id
+    )
     assert device.sw_version == "1.45"
 
 
@@ -153,7 +159,9 @@ async def test_invalid_profile(
     mock_homee.nodes[0].profile = 77
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-2")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-2"), mock_config_entry.entry_id
+    )
     assert device.model is None
 
 
@@ -214,7 +222,9 @@ async def test_remove_stale_device_on_startup(
     mock_homee.get_node_by_id = lambda node_id: mock_homee.nodes[node_id - 1]
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-3")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-3"), mock_config_entry.entry_id
+    )
     assert device is not None
 
     mock_homee.nodes.pop()  # Remove node with id 3
@@ -223,7 +233,9 @@ async def test_remove_stale_device_on_startup(
     await hass.async_block_till_done()
 
     # Stale device should be removed
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-3")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-3"), mock_config_entry.entry_id
+    )
     assert device is None
 
 
@@ -242,7 +254,9 @@ async def test_remove_node_callback(
     mock_homee.get_node_by_id = lambda node_id: mock_homee.nodes[node_id - 1]
     await setup_integration(hass, mock_config_entry)
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-3")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-3"), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Test device not removed when callback called with add=True
@@ -251,7 +265,9 @@ async def test_remove_node_callback(
     )
     await hass.async_block_till_done()
 
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-3")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-3"), mock_config_entry.entry_id
+    )
     assert device is not None
 
     # Simulate removal of node with id 3 in homee
@@ -261,5 +277,7 @@ async def test_remove_node_callback(
     await hass.async_block_till_done()
 
     # Device should be removed
-    device = device_registry.async_get_device(identifiers={(DOMAIN, f"{HOMEE_ID}-3")})
+    device = device_registry.async_get_device_by_identifier(
+        (DOMAIN, f"{HOMEE_ID}-3"), mock_config_entry.entry_id
+    )
     assert device is None


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->
Migrate calls to `async_get_device` in tests to `async_get_device_by_connection` or `async_get_device_by_identifier`

This PR contains trivial cases where the owning config entry is known

Background in https://developers.home-assistant.io/blog/2026/07/21/device-registry-single-config-entry/

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR. Please follow our AI policy:
  https://developers.home-assistant.io/docs/ai_policy
-->

- [ ] I understand the code I am submitting and can explain how it works.
- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
